### PR TITLE
feat: Fork-based Swarm, Heartbeat, Signals, and Topology

### DIFF
--- a/lib/wurk/capsule.rb
+++ b/lib/wurk/capsule.rb
@@ -60,12 +60,31 @@ module Wurk
       chain
     end
 
+    # Pool size = concurrency + POOL_OVERHEAD. Every processor thread can
+    # be parked in a blocking BLMOVE (reliable fetch), holding its slot
+    # for ~3s. POOL_OVERHEAD reserves connections for the Launcher's
+    # heartbeat thread + the Scheduled::Poller so they can never be
+    # starved by busy fetchers. Without this, concurrency=1 deadlocks
+    # immediately (worker holds the only slot, heartbeat times out).
+    POOL_OVERHEAD = 2
+
     def redis_pool
-      @redis_pool ||= build_pool(size: @concurrency, name: "#{@name}-main")
+      @redis_pool ||= build_pool(size: @concurrency + POOL_OVERHEAD, name: "#{@name}-main")
     end
 
     def local_redis_pool
       @local_redis_pool ||= build_pool(size: @concurrency, name: "#{@name}-local")
+    end
+
+    # Disconnect and drop cached pools. Called by Wurk::Swarm just before
+    # fork (parent side: close inherited sockets) and just after fork
+    # (child side: rebuild lazily). Connection_pool#shutdown is terminal,
+    # so dropping the reference is required — `redis_pool` will rebuild.
+    def reset_redis_pools!
+      @redis_pool&.disconnect!
+      @redis_pool = nil
+      @local_redis_pool&.disconnect!
+      @local_redis_pool = nil
     end
 
     def redis(&)

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -11,7 +11,7 @@ module Wurk
   # for everything the swarm / managers / processors need to boot.
   #
   # Spec: docs/target/sidekiq-free.md §4 (Sidekiq::Config).
-  class Configuration
+  class Configuration # rubocop:disable Metrics/ClassLength
     # Mirrors Sidekiq::Config::DEFAULTS. Order and keys are part of the
     # drop-in contract — third-party gems read @options via [] / fetch / dig.
     DEFAULTS = {
@@ -149,6 +149,15 @@ module Wurk
 
     def local_redis_pool
       @local_redis_pool ||= build_redis_pool(size: 10, name: 'internal')
+    end
+
+    # Disconnect and drop every cached pool — the per-capsule mains plus
+    # the config-level internal pool. Used by Wurk::Swarm so the parent
+    # never leaks sockets into forks and each child can build fresh ones.
+    def reset_redis_pools!
+      @capsules.each_value(&:reset_redis_pools!)
+      @local_redis_pool&.disconnect!
+      @local_redis_pool = nil
     end
 
     def new_redis_pool(size, name = 'custom')

--- a/lib/wurk/heartbeat.rb
+++ b/lib/wurk/heartbeat.rb
@@ -1,11 +1,178 @@
 # frozen_string_literal: true
 
+require_relative 'component'
+require_relative 'keys'
+require_relative 'processor'
+
 module Wurk
-  # Process heartbeat written to Redis on a fixed interval. The dashboard
-  # process list reads this. Identical key shape to Sidekiq's processes set.
+  # Single-purpose owner of the Redis-side process heartbeat. Lifted out of
+  # Wurk::Launcher so the launcher can stay focused on lifecycle and so the
+  # heartbeat schema lives in one place readers can grep for.
+  #
+  # Each beat is one pipelined round-trip:
+  #   SADD   processes <identity>
+  #   HSET   <identity>          info concurrency busy beat quiet rss rtt_us
+  #   EXPIRE <identity>          60
+  #   UNLINK <identity>:work
+  #   HSET   <identity>:work     <tid> <json> ...    (only if WORK_STATE non-empty)
+  #   EXPIRE <identity>:work     60                  (only if WORK_STATE non-empty)
+  #   LPOP   <identity>-signals  × BEAT_PAUSE
+  #
+  # The work hash is UNLINK-then-rewritten on every beat — a dropped beat
+  # momentarily empties it, and ProcessSet#cleanup compensates by SREM-ing
+  # identities whose `info` field has expired.
+  #
+  # Heartbeat owns only the wire. Signals queued by the dashboard are pulled
+  # out of the pipelined results and returned to the caller for dispatch —
+  # TSTP/TERM semantics live in Launcher.
+  #
+  # `:heartbeat` fires once on the first successful beat and again after any
+  # network partition (rearmed when beat! rescues). `:beat` fires every tick.
+  #
+  # Spec: docs/target/sidekiq-free.md §12 (Launcher#❤️).
   class Heartbeat
-    def initialize(identity:); end
-    def beat!; end
-    def stop!; end
+    include Component
+
+    # Cadence in seconds. Key TTL is 60s — a process is dead after ~6 misses.
+    BEAT_PAUSE = 10
+    TTL_SECONDS = 60
+
+    attr_reader :identity, :rtt_us
+
+    # `quiet:` is a callable so Launcher can keep ownership of its `@done`
+    # flag without an awkward setter contract. `info_overrides:` lets the
+    # caller (Launcher#embedded, tests) inject fields without forcing
+    # Heartbeat to know about every flag the host process tracks.
+    def initialize(identity:, config:, started_at: nil, embedded: false, quiet: nil)
+      @identity = identity
+      @config = config
+      @started_at = started_at || Time.now.to_f
+      @embedded = embedded
+      @quiet_proc = quiet || -> { false }
+      @first_heartbeat = true
+      @rtt_us = 0
+    end
+
+    # Pipelined beat. Returns the drained signals as Array<String> on
+    # success, or nil if Redis raised — the next successful beat refires
+    # `:heartbeat` so partition recovery is observable.
+    def beat!
+      sigs, @rtt_us = pipelined_beat
+      if @first_heartbeat
+        @first_heartbeat = false
+        fire_event(:heartbeat)
+      end
+      fire_event(:beat, oneshot: false)
+      sigs.compact
+    rescue StandardError => e
+      @first_heartbeat = true
+      handle_exception(e, { context: 'heartbeat' })
+      nil
+    end
+
+    # Best-effort teardown. SREM removes us from the live list; UNLINK
+    # drops the identity hash and its work mirror. Idempotent: if Redis
+    # is down the next process boot's ProcessSet#cleanup prunes us.
+    def stop!
+      redis do |conn|
+        conn.pipelined do |pipe|
+          pipe.call('SREM', Keys::PROCESSES, @identity)
+          pipe.call('UNLINK', @identity, "#{@identity}:work")
+        end
+      end
+    rescue StandardError
+      nil
+    end
+
+    private
+
+    # Two extra writes (HSET + EXPIRE for the work mirror) when WORK_STATE
+    # has entries, so `lead` shifts to skip them when slicing signals out
+    # of the pipeline result.
+    def pipelined_beat
+      work_snapshot = Processor::WORK_STATE.dup
+      lead = 4 + (work_snapshot.empty? ? 0 : 2)
+      t0 = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC, :microsecond)
+      results = redis { |conn| conn.pipelined { |pipe| write_beat(pipe, work_snapshot) } }
+      rtt = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC, :microsecond) - t0
+      [results[lead, BEAT_PAUSE] || [], rtt]
+    end
+
+    def write_beat(pipe, work_snapshot)
+      pipe.call('SADD', Keys::PROCESSES, @identity)
+      pipe.call('HSET', @identity, *beat_hash_args(work_snapshot.size))
+      pipe.call('EXPIRE', @identity, TTL_SECONDS)
+      write_work_hash(pipe, work_snapshot)
+      drain_signals(pipe)
+    end
+
+    def beat_hash_args(busy)
+      [
+        'info', Wurk.dump_json(info_hash),
+        'concurrency', total_concurrency.to_s,
+        'busy', busy.to_s,
+        'beat', Time.now.to_f.to_s,
+        'quiet', @quiet_proc.call.to_s,
+        'rss', memory_usage_kb.to_s,
+        'rtt_us', @rtt_us.to_s
+      ]
+    end
+
+    def write_work_hash(pipe, work_snapshot)
+      work_key = "#{@identity}:work"
+      pipe.call('UNLINK', work_key)
+      return if work_snapshot.empty?
+
+      args = work_snapshot.flat_map { |tid, hash| [tid.to_s, Wurk.dump_json(hash)] }
+      pipe.call('HSET', work_key, *args)
+      pipe.call('EXPIRE', work_key, TTL_SECONDS)
+    end
+
+    # LPOP one entry per second of cadence so a flood of queued signals
+    # can't stall the beat; anything older drains on the next beat.
+    def drain_signals(pipe)
+      BEAT_PAUSE.times { pipe.call('LPOP', "#{@identity}-signals") }
+    end
+
+    def info_hash
+      caps = @config.capsules.each_value
+      {
+        'hostname' => hostname,
+        'started_at' => @started_at,
+        'pid' => ::Process.pid,
+        'tag' => @config[:tag] || default_tag,
+        'concurrency' => total_concurrency,
+        'capsules' => capsules_info,
+        'queues' => caps.flat_map(&:queues).uniq,
+        'weights' => caps.map(&:weights),
+        'labels' => Array(@config[:labels]),
+        'identity' => @identity,
+        'version' => Wurk::VERSION,
+        'embedded' => @embedded
+      }
+    end
+
+    def capsules_info
+      @config.capsules.transform_values do |cap|
+        { 'concurrency' => cap.concurrency, 'mode' => cap.mode.to_s, 'weights' => cap.weights }
+      end
+    end
+
+    def total_concurrency
+      @config.capsules.each_value.sum(&:concurrency)
+    end
+
+    # Linux first via /proc/self/statm[1] (resident pages × 4 KB);
+    # `ps` fallback for macOS/BSD test runners. Zero on failure — the
+    # dashboard shows "—" rather than crashing.
+    def memory_usage_kb
+      if ::File.exist?('/proc/self/statm')
+        ::File.read('/proc/self/statm').split[1].to_i * 4
+      else
+        `ps -o rss= -p #{::Process.pid}`.to_i
+      end
+    rescue StandardError
+      0
+    end
   end
 end

--- a/lib/wurk/launcher.rb
+++ b/lib/wurk/launcher.rb
@@ -3,11 +3,14 @@
 require_relative 'component'
 require_relative 'manager'
 require_relative 'processor'
+require_relative 'heartbeat'
 require_relative 'keys'
 
 module Wurk
   # Top-level supervisor inside each worker process. Owns the Manager pool
   # (one per Capsule), the scheduler poller, and the heartbeat thread.
+  # The heartbeat WIRE lives in Wurk::Heartbeat — Launcher owns lifecycle,
+  # signal dispatch, and stats rollup; Heartbeat owns the Redis writes.
   #
   # Lifecycle:
   #   * `run(async_beat:)` — freeze config, start heartbeat, poller, managers.
@@ -19,13 +22,6 @@ module Wurk
   # into the global + per-day Redis strings every beat. Per-day keys carry
   # `STATS_TTL` so old days expire automatically.
   #
-  # Heartbeat writes the `<identity>` HASH (info/concurrency/busy/beat/quiet/
-  # rss/rtt_us, EXPIRE 60s), adds identity to the `processes` SET, mirrors
-  # the in-process `WORK_STATE` into the `<identity>:work` HASH, and drains
-  # any signals queued at `<identity>-signals`. First successful beat (and
-  # any beat after a network partition) fires `:heartbeat`; every beat
-  # fires `:beat`.
-  #
   # Spec: docs/target/sidekiq-free.md §12 (Sidekiq::Launcher).
   class Launcher
     include Component
@@ -35,9 +31,9 @@ module Wurk
     # without manual cleanup.
     STATS_TTL = 5 * 365 * 24 * 60 * 60
 
-    # Heartbeat cadence in seconds. Key TTL on `<identity>` is 60s — a
-    # process is treated as dead after ~6 missed beats.
-    BEAT_PAUSE = 10
+    # Re-exported for test/third-party callers that read it off Launcher
+    # (Sidekiq's drop-in surface). The single source of truth is Heartbeat.
+    BEAT_PAUSE = Heartbeat::BEAT_PAUSE
 
     attr_accessor :managers, :poller
 
@@ -47,8 +43,8 @@ module Wurk
       @done = false
       @managers = config.capsules.values.map { |cap| Manager.new(cap) }
       @poller = build_poller
-      @first_heartbeat = true
       @started_at = nil
+      @heartbeat = nil
       @heartbeat_thread = nil
     end
 
@@ -138,104 +134,34 @@ module Wurk
       end
     end
 
-    # The actual `<identity>` write. Side-effects:
-    #   * SADD `processes` (membership for dashboards).
-    #   * HSET `<identity>` info/concurrency/busy/beat/quiet/rss/rtt_us.
-    #   * EXPIRE `<identity>` 60s.
-    #   * UNLINK + repopulate `<identity>:work` from WORK_STATE (so a lost
-    #     beat momentarily empties the work hash; ProcessSet#cleanup
-    #     compensates).
-    #   * Drain `<identity>-signals` (LPOP × BEAT_PAUSE) and dispatch any
-    #     TSTP/TERM the dashboard queued.
+    # Pipelined identity write via Heartbeat, then dispatch any signals
+    # the dashboard queued at `<identity>-signals`. Lazily builds the
+    # Heartbeat the first time we beat so callers that bypass `run`
+    # (embedded mode, tests) still work.
     def beat
-      sigs = nil
-      rtt_us = 0
-      begin
-        sigs, rtt_us = beat_pipeline
-        if @first_heartbeat
-          @first_heartbeat = false
-          fire_event(:heartbeat)
-        end
-        fire_event(:beat, oneshot: false)
-      rescue StandardError => e
-        # Partition: arm :heartbeat for the next successful beat so a
-        # recovery is observable.
-        @first_heartbeat = true
-        handle_exception(e, { context: 'heartbeat' })
-        return
-      end
-
-      sigs&.compact&.each { |sig| dispatch_signal(sig) }
-      rtt_us
+      ensure_heartbeat
+      sigs = @heartbeat.beat!
+      sigs&.each { |sig| dispatch_signal(sig) }
     end
 
-    # Runs the pipelined beat + signal drain. Splits into its own method so
-    # the rtt_us measurement scopes only the network call. Returns the
-    # signals tail and the elapsed microseconds.
-    def beat_pipeline
-      work_snapshot = Processor::WORK_STATE.dup
-      lead = 4 + (work_snapshot.empty? ? 0 : 2) # SADD,HSET,EXPIRE,UNLINK[,HSET,EXPIRE]
+    def ensure_heartbeat
+      return if @heartbeat
 
-      t0 = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC, :microsecond)
-      results = @config.redis { |conn| conn.pipelined { |pipe| write_beat(pipe, work_snapshot) } }
-      rtt_us = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC, :microsecond) - t0
-      [results[lead, BEAT_PAUSE] || [], rtt_us]
+      @heartbeat = Heartbeat.new(
+        identity: identity,
+        config: @config,
+        started_at: @started_at || Time.now.to_f,
+        embedded: @embedded,
+        quiet: -> { @done }
+      )
     end
 
-    # All pipelined writes that compose one beat. Order matters: the
-    # extract_signals math depends on the leading-writes count.
-    def write_beat(pipe, work_snapshot)
-      pipe.call('SADD', Keys::PROCESSES, identity)
-      pipe.call('HSET', identity, *beat_hash_args(work_snapshot.size))
-      pipe.call('EXPIRE', identity, 60)
-      write_work_hash(pipe, work_snapshot)
-      drain_signals(pipe)
-    end
-
-    def beat_hash_args(busy)
-      [
-        'info', build_info_json,
-        'concurrency', total_concurrency.to_s,
-        'busy', busy.to_s,
-        'beat', Time.now.to_f.to_s,
-        'quiet', @done.to_s,
-        'rss', memory_usage_kb.to_s,
-        'rtt_us', '0'
-      ]
-    end
-
-    # UNLINK the work hash and (if any in-flight) repopulate. UNLINK is
-    # non-blocking; HSET with the whole field set is atomic enough for
-    # readers since pipelining preserves order on a single connection.
-    def write_work_hash(pipe, work_snapshot)
-      work_key = "#{identity}:work"
-      pipe.call('UNLINK', work_key)
-      return if work_snapshot.empty?
-
-      args = work_snapshot.flat_map { |tid, hash| [tid.to_s, Wurk.dump_json(hash)] }
-      pipe.call('HSET', work_key, *args)
-      pipe.call('EXPIRE', work_key, 60)
-    end
-
-    # LPOP up to BEAT_PAUSE entries (one per second of cadence) so a flood
-    # of queued signals can't stall the beat. Anything older drains on the
-    # next beat.
-    def drain_signals(pipe)
-      BEAT_PAUSE.times { pipe.call('LPOP', "#{identity}-signals") }
-    end
-
-    # Erase the live-process footprint. Best-effort: if Redis is down on
-    # shutdown the next process boot's cleanup will prune us anyway.
+    # Erase the live-process footprint. flush_stats first so we don't drop
+    # the final batch of counters; then Heartbeat#stop! removes us from the
+    # `processes` SET and UNLINK-s the identity + work hashes.
     def clear_heartbeat
       flush_stats
-      @config.redis do |conn|
-        conn.pipelined do |pipe|
-          pipe.call('SREM', Keys::PROCESSES, identity)
-          pipe.call('UNLINK', identity, "#{identity}:work")
-        end
-      end
-    rescue StandardError
-      nil
+      @heartbeat&.stop!
     end
 
     # Heartbeat thread loop. `safe_thread` already wraps exceptions; we
@@ -255,57 +181,6 @@ module Wurk
       when 'TERM' then stop
       else
         logger.warn { "Unknown signal in #{identity}-signals: #{sig.inspect}" }
-      end
-    end
-
-    def total_concurrency
-      @config.capsules.each_value.sum(&:concurrency)
-    end
-
-    # Linux: /proc/self/statm[1] is resident pages; multiply by 4 for KB.
-    # Other platforms fall through to `ps`. Zero on failure — non-fatal,
-    # the dashboard just shows "—".
-    def memory_usage_kb
-      if ::File.exist?('/proc/self/statm')
-        ::File.read('/proc/self/statm').split[1].to_i * 4
-      else
-        `ps -o rss= -p #{::Process.pid}`.to_i
-      end
-    rescue StandardError
-      0
-    end
-
-    # JSON payload stored at `<identity>` HASH info field. Read by
-    # ProcessSet#each + the dashboard's process list.
-    def build_info_json
-      Wurk.dump_json(info_hash)
-    end
-
-    def info_hash
-      caps = @config.capsules.each_value
-      {
-        'hostname' => hostname,
-        'started_at' => @started_at || Time.now.to_f,
-        'pid' => ::Process.pid,
-        'tag' => @config[:tag] || default_tag,
-        'concurrency' => total_concurrency,
-        'capsules' => capsules_info,
-        'queues' => caps.flat_map(&:queues).uniq,
-        'weights' => caps.map(&:weights),
-        'labels' => Array(@config[:labels]),
-        'identity' => identity,
-        'version' => Wurk::VERSION,
-        'embedded' => @embedded
-      }
-    end
-
-    def capsules_info
-      @config.capsules.transform_values do |cap|
-        {
-          'concurrency' => cap.concurrency,
-          'mode' => cap.mode.to_s,
-          'weights' => cap.weights
-        }
       end
     end
 

--- a/lib/wurk/railtie.rb
+++ b/lib/wurk/railtie.rb
@@ -12,7 +12,7 @@ module Wurk
       next if defined?(::Rails::Console)
       next if ::Rails.env.test?
 
-      # TODO: Wurk::Swarm.new(topology: Wurk.configuration.topology).boot
+      Wurk::Swarm.new(topology: Wurk.configuration.topology).boot
     end
   end
 end

--- a/lib/wurk/railtie.rb
+++ b/lib/wurk/railtie.rb
@@ -12,7 +12,17 @@ module Wurk
       next if defined?(::Rails::Console)
       next if ::Rails.env.test?
 
-      Wurk::Swarm.new(topology: Wurk.configuration.topology).boot
+      swarm = Wurk::Swarm.new(topology: Wurk.configuration.topology)
+      swarm.boot
+      # Embedded mode keeps the Rails process serving HTTP; supervise must
+      # run somewhere or signal_queue never drains, crashed children never
+      # respawn, and memory pressure checks never fire. Background thread
+      # leaves the host's main thread free for Rails.
+      Thread.new do
+        swarm.supervise
+      rescue StandardError => e
+        Wurk.configuration.logger.error { "wurk supervisor thread died: #{e.class}: #{e.message}" }
+      end
     end
   end
 end

--- a/lib/wurk/swarm.rb
+++ b/lib/wurk/swarm.rb
@@ -1,15 +1,256 @@
 # frozen_string_literal: true
 
+require_relative 'component'
+require_relative 'launcher'
+require_relative 'fetcher/reliable'
+require_relative 'keys'
+require_relative 'swarm/child_boot'
+
 module Wurk
   # Parent supervisor. Forks N children per the worker topology, monitors
   # PIDs, relays signals, respawns crashed children, handles rolling
   # restart on SIGUSR1, recycles RSS-bloated children.
-  # See docs/idea/03-process-model.md and docs/idea/04-signals.md.
+  #
+  # Boot ordering (must be exact — see docs/idea/03-process-model.md):
+  #   1. Host app boots fully; eager loads done.
+  #   2. Railtie `after_initialize` fires.
+  #   3. `boot` closes parent-side connections (Redis, ActiveRecord).
+  #   4. `boot` forks N children.
+  #   5. Each child reconnects DB + opens a fresh Redis pool, then
+  #      installs its own signal handlers and starts the Launcher.
+  #   6. Parent calls `supervise` to enter the wait/relay loop.
+  #
+  # Signals (see docs/idea/04-signals.md):
+  #   TERM/INT  → `shutdown`           (graceful drain)
+  #   TSTP      → relay TSTP           (pause fetch)
+  #   CONT      → relay CONT           (resume fetch)
+  #   USR1      → `rolling_restart`    (zero-downtime cycle)
   class Swarm
-    def initialize(topology:); end
-    def boot; end
-    def supervise; end
-    def shutdown(timeout:); end
-    def rolling_restart; end
+    include Component
+
+    SUPERVISE_TICK = 0.2
+    RESPAWN_BACKOFF = 1.0
+    HEARTBEAT_WAIT = 30
+    MEMORY_CHECK_INTERVAL = 10
+    DEFAULT_SHUTDOWN_TIMEOUT = 25
+
+    attr_reader :topology, :children
+
+    def initialize(topology:, config: Wurk.configuration, memory_limit: nil,
+                   shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT)
+      @topology = topology
+      @config = config
+      @memory_limit = memory_limit
+      @shutdown_timeout = shutdown_timeout
+      @children = {}
+      @assignments = []
+      @stopping = false
+      @last_memory_check = 0
+      @signal_queue = ::Thread::Queue.new
+    end
+
+    # `install_signals:` is false in tests so the integration suite can
+    # drive `shutdown` / `rolling_restart` directly without poisoning the
+    # test process's signal handlers.
+    def boot(install_signals: true)
+      raise 'Wurk::Swarm already booted' unless @assignments.empty?
+      raise ArgumentError, 'Topology has no slots' if @topology.empty?
+
+      @assignments = @topology.assignments.freeze
+      close_parent_sockets
+      fork_children
+      install_signal_handlers if install_signals
+      @children.keys
+    end
+
+    def supervise
+      until done?
+        drain_signals
+        reap_one_child
+        check_memory_pressure
+        sleep SUPERVISE_TICK
+      end
+    end
+
+    def shutdown(timeout: @shutdown_timeout)
+      @stopping = true
+      relay_signal('TERM')
+      wait_for_children(timeout)
+      hard_kill_stragglers
+    end
+
+    # SIGUSR1. For each existing child, fork a replacement, wait for its
+    # first heartbeat, then TERM + drain the old one. Long-running jobs
+    # in the old slot get the full shutdown_timeout while the replacement
+    # is already serving new work.
+    def rolling_restart
+      @children.dup.each do |old_pid, meta|
+        replacement = fork_child(meta[:slot], meta[:index])
+        @children[replacement] = meta
+        wait_for_heartbeat(replacement)
+        safe_kill(old_pid, 'TERM')
+        wait_pid(old_pid, @shutdown_timeout)
+        @children.delete(old_pid)
+      end
+    end
+
+    private
+
+    # Step 3.
+    def close_parent_sockets
+      @config.reset_redis_pools! if @config.respond_to?(:reset_redis_pools!)
+      close_active_record_pool
+    end
+
+    def close_active_record_pool
+      return unless defined?(::ActiveRecord::Base)
+
+      ::ActiveRecord::Base.connection_handler.clear_active_connections!
+      ::ActiveRecord::Base.connection_handler.flush_idle_connections!
+    rescue StandardError => e
+      logger.warn { "swarm: ActiveRecord close failed: #{e.class}: #{e.message}" }
+    end
+
+    # Step 4.
+    def fork_children
+      @assignments.each_with_index do |slot, idx|
+        @children[fork_child(slot, idx)] = { slot: slot, index: idx }
+      end
+    end
+
+    def fork_child(slot, idx)
+      pid = ::Process.fork
+      return pid if pid
+
+      ChildBoot.new(@config, slot, idx).run
+      exit 0 # unreachable; ChildBoot exits explicitly
+    end
+
+    def install_signal_handlers
+      { 'TERM' => :term, 'INT' => :term, 'TSTP' => :tstp,
+        'CONT' => :cont, 'USR1' => :usr1 }.each do |sig, sym|
+        ::Signal.trap(sig) { @signal_queue << sym }
+      end
+    end
+
+    def drain_signals
+      until @signal_queue.empty?
+        sym = next_signal_symbol
+        next if sym.nil?
+
+        case sym
+        when :term then shutdown
+        when :tstp then relay_signal('TSTP')
+        when :cont then relay_signal('CONT')
+        when :usr1 then rolling_restart
+        end
+      end
+    end
+
+    def next_signal_symbol
+      @signal_queue.pop(true)
+    rescue ThreadError
+      nil
+    end
+
+    def reap_one_child
+      pid, status = ::Process.wait2(-1, ::Process::WNOHANG)
+      on_child_exit(pid, status) if pid
+    rescue Errno::ECHILD
+      @stopping = true
+    end
+
+    def on_child_exit(pid, status)
+      meta = @children.delete(pid)
+      return unless meta
+
+      if @stopping
+        logger.info { "swarm: child #{pid} exited (status=#{status.exitstatus})" }
+      else
+        logger.warn { "swarm: child #{pid} died (status=#{status.exitstatus}); respawning slot #{meta[:index]}" }
+        sleep RESPAWN_BACKOFF
+        @children[fork_child(meta[:slot], meta[:index])] = meta
+      end
+    end
+
+    def check_memory_pressure
+      return unless @memory_limit
+
+      now = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+      return if now - @last_memory_check < MEMORY_CHECK_INTERVAL
+
+      @last_memory_check = now
+      @children.dup.each_key { |pid| recycle_if_bloated(pid) }
+    end
+
+    def recycle_if_bloated(pid)
+      rss = pid_rss_kb(pid)
+      return if rss.nil? || rss < @memory_limit
+
+      logger.warn { "swarm: child #{pid} RSS #{rss}KB >= #{@memory_limit}KB; recycling" }
+      safe_kill(pid, 'TERM')
+    end
+
+    def pid_rss_kb(pid)
+      return nil unless ::File.exist?("/proc/#{pid}/statm")
+
+      ::File.read("/proc/#{pid}/statm").split[1].to_i * 4
+    rescue StandardError
+      nil
+    end
+
+    def relay_signal(sig)
+      @children.each_key { |pid| safe_kill(pid, sig) }
+    end
+
+    def safe_kill(pid, sig)
+      ::Process.kill(sig, pid)
+    rescue Errno::ESRCH, Errno::EPERM
+      nil
+    end
+
+    def wait_pid(pid, timeout)
+      deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + timeout
+      while ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) < deadline
+        return true if ::Process.wait(pid, ::Process::WNOHANG)
+
+        sleep 0.1
+      end
+      false
+    rescue Errno::ECHILD
+      true
+    end
+
+    def wait_for_children(timeout)
+      deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + timeout
+      while ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) < deadline && @children.any?
+        reap_one_child
+        sleep 0.1
+      end
+    end
+
+    def hard_kill_stragglers
+      @children.each_key { |pid| safe_kill(pid, 'KILL') }
+      @children.clear
+    end
+
+    # Identity is `<hostname>:<pid>:<nonce>`. PROCESS_NONCE is set when
+    # Component loads in the parent and inherited by every fork — the
+    # parent can compute a child's identity from its PID alone.
+    # Returns true if the heartbeat was observed before the deadline.
+    def wait_for_heartbeat(pid) # rubocop:disable Naming/PredicateMethod
+      identity = "#{hostname}:#{pid}:#{Component::PROCESS_NONCE}"
+      deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + HEARTBEAT_WAIT
+      while ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) < deadline
+        return true if @config.redis { |c| c.call('SISMEMBER', Keys::PROCESSES, identity) } == 1
+
+        sleep 0.5
+      end
+      false
+    end
+
+    def done?
+      @stopping && @children.empty?
+    end
   end
 end

--- a/lib/wurk/swarm.rb
+++ b/lib/wurk/swarm.rb
@@ -87,7 +87,11 @@ module Wurk
       @children.dup.each do |old_pid, meta|
         replacement = fork_child(meta[:slot], meta[:index])
         @children[replacement] = meta
-        wait_for_heartbeat(replacement)
+        unless wait_for_heartbeat(replacement)
+          logger.warn do
+            "swarm: replacement #{replacement} heartbeat not seen within #{HEARTBEAT_WAIT}s; proceeding anyway"
+          end
+        end
         safe_kill(old_pid, 'TERM')
         wait_pid(old_pid, @shutdown_timeout)
         @children.delete(old_pid)
@@ -98,7 +102,7 @@ module Wurk
 
     # Step 3.
     def close_parent_sockets
-      @config.reset_redis_pools! if @config.respond_to?(:reset_redis_pools!)
+      @config.reset_redis_pools!
       close_active_record_pool
     end
 

--- a/lib/wurk/swarm/child_boot.rb
+++ b/lib/wurk/swarm/child_boot.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require_relative '../launcher'
+require_relative '../fetcher/reliable'
+
+module Wurk
+  class Swarm
+    # Step 5 of the boot ordering. Runs inside each forked child:
+    #   * reset signal traps inherited from the parent,
+    #   * reconnect ActiveRecord (if loaded) + open a fresh Redis pool,
+    #   * apply the slot's queues + concurrency to the default capsule,
+    #   * install child signal handlers (TERM/INT drain, TSTP quiet,
+    #     USR2 reopen logs),
+    #   * launch the Wurk::Launcher and block until shutdown.
+    #
+    # Kept separate from Wurk::Swarm so the parent supervisor stays
+    # focused on PID supervision (SRP).
+    class ChildBoot
+      CHILD_SIGNALS = { 'TERM' => :term, 'INT' => :term, 'TSTP' => :tstp, 'USR2' => :usr2 }.freeze
+
+      def initialize(config, slot, index)
+        @config = config
+        @slot = slot
+        @index = index
+        @signal_queue = ::Thread::Queue.new
+      end
+
+      def run
+        reset_inherited_signals
+        reconnect_after_fork
+        Wurk.server = true
+        apply_slot_to_config
+        launcher = Wurk::Launcher.new(@config)
+        install_signal_handlers(launcher)
+        launcher.run
+        wait_loop(launcher)
+        exit 0
+      rescue StandardError, ::Wurk::Shutdown => e
+        @config.logger.error { "swarm child ##{@index} (#{::Process.pid}) crashed: #{e.class}: #{e.message}" }
+        exit 1
+      end
+
+      private
+
+      # Parent installed traps for TERM/INT/TSTP/CONT/USR1 — the child
+      # needs its own behavior, not the parent's.
+      def reset_inherited_signals
+        %w[TERM INT TSTP CONT USR1 USR2].each { |s| ::Signal.trap(s, 'DEFAULT') }
+      end
+
+      def reconnect_after_fork
+        @config.reset_redis_pools! if @config.respond_to?(:reset_redis_pools!)
+        return unless defined?(::ActiveRecord::Base)
+
+        begin
+          ::ActiveRecord::Base.establish_connection
+        rescue StandardError
+          nil
+        end
+      end
+
+      def apply_slot_to_config
+        cap = @config.default_capsule
+        cap.queues = @slot.queues
+        cap.concurrency = @slot.concurrency
+        cap.fetcher = Wurk::Fetcher::Reliable.new(cap)
+        # Configuration#freeze! (called by Launcher#run) freezes every
+        # capsule. Capsule's `redis_pool`, `local_redis_pool`,
+        # `server_middleware`, and `client_middleware` lazy-init their
+        # ivars via `||=` — that mutation would FrozenError after
+        # freeze, the first time the processor hit them. Materialize
+        # them now so the post-freeze code paths only read.
+        cap.redis_pool
+        cap.local_redis_pool
+        cap.client_middleware
+        cap.server_middleware
+      end
+
+      def install_signal_handlers(launcher)
+        CHILD_SIGNALS.each { |sig, sym| ::Signal.trap(sig) { @signal_queue << sym } }
+        Thread.new { dispatch_signals(launcher) }
+      end
+
+      # Drains the queue forever; launcher.stop is the exit condition
+      # (the wait_loop watches launcher.stopping?). TERM/INT both trigger
+      # the stop sequence; subsequent signals are no-ops once stopped.
+      def dispatch_signals(launcher)
+        loop do
+          case @signal_queue.pop
+          when :term then launcher.stop
+          when :tstp then launcher.quiet
+          when :usr2 then reopen_logs
+          end
+        end
+      end
+
+      def reopen_logs
+        log = @config.logger
+        log.reopen if log.respond_to?(:reopen)
+      rescue StandardError
+        nil
+      end
+
+      def wait_loop(launcher)
+        sleep 0.5 until launcher.stopping?
+      end
+    end
+  end
+end

--- a/lib/wurk/swarm/child_boot.rb
+++ b/lib/wurk/swarm/child_boot.rb
@@ -49,7 +49,7 @@ module Wurk
       end
 
       def reconnect_after_fork
-        @config.reset_redis_pools! if @config.respond_to?(:reset_redis_pools!)
+        @config.reset_redis_pools!
         return unless defined?(::ActiveRecord::Base)
 
         begin

--- a/lib/wurk/swarm/child_boot.rb
+++ b/lib/wurk/swarm/child_boot.rb
@@ -78,16 +78,20 @@ module Wurk
 
       def install_signal_handlers(launcher)
         CHILD_SIGNALS.each { |sig, sym| ::Signal.trap(sig) { @signal_queue << sym } }
-        Thread.new { dispatch_signals(launcher) }
+        @dispatcher = Thread.new { dispatch_signals(launcher) }
       end
 
-      # Drains the queue forever; launcher.stop is the exit condition
-      # (the wait_loop watches launcher.stopping?). TERM/INT both trigger
-      # the stop sequence; subsequent signals are no-ops once stopped.
+      # TSTP/USR2 keep looping; TERM/INT run the full launcher.stop
+      # (which blocks on manager drain) and then return — wait_loop
+      # joins this thread, so the main child thread can't `exit 0`
+      # mid-drain. Otherwise quiet would flip launcher.stopping? true
+      # and the main thread would race past the unfinished managers.
       def dispatch_signals(launcher)
         loop do
           case @signal_queue.pop
-          when :term then launcher.stop
+          when :term
+            launcher.stop
+            return
           when :tstp then launcher.quiet
           when :usr2 then reopen_logs
           end
@@ -101,8 +105,8 @@ module Wurk
         nil
       end
 
-      def wait_loop(launcher)
-        sleep 0.5 until launcher.stopping?
+      def wait_loop(_launcher)
+        @dispatcher.join
       end
     end
   end

--- a/lib/wurk/topology.rb
+++ b/lib/wurk/topology.rb
@@ -5,9 +5,70 @@ module Wurk
   # Lets users declare specialized slots: e.g. 2 forks dedicated to the
   # critical queue with low concurrency, 2 forks for bulk + low with high
   # concurrency. Stronger queue isolation than a flat swarm.
+  #
+  # Each Slot describes a *kind* of fork; `count` is how many identical
+  # forks of that kind to spawn. Swarm consumes `assignments` (the flat
+  # list of forks to spawn, in order) so a slot with count=2 yields two
+  # assignment entries pointing at the same Slot.
+  #
+  # See docs/idea/03-process-model.md §Worker topology.
   class Topology
-    def initialize; end
-    def slot(count:, queues:, concurrency:); end
-    def slots; end
+    # `:count` shadows Struct#count by design — Slot is a kw-init data
+    # carrier and the slot's child-count is the field users read.
+    Slot = Struct.new(:count, :queues, :concurrency, keyword_init: true) do # rubocop:disable Lint/StructNewOverride
+      def to_h
+        { count: count, queues: queues, concurrency: concurrency }
+      end
+    end
+
+    def initialize
+      @slots = []
+    end
+
+    # Declare one slot kind. Returns self so calls chain.
+    def slot(count:, queues:, concurrency:)
+      queue_list = validate_slot!(count, queues, concurrency)
+      @slots << Slot.new(count: count, queues: queue_list, concurrency: concurrency).freeze
+      self
+    end
+
+    def slots
+      @slots.dup.freeze
+    end
+
+    def empty?
+      @slots.empty?
+    end
+
+    # Flat ordered list of slots to fork, one per child process. A slot
+    # with count=N contributes N entries.
+    def assignments
+      @slots.flat_map { |s| Array.new(s.count, s) }
+    end
+
+    def total_processes
+      @slots.sum(&:count)
+    end
+
+    # Convenience: build a flat topology of `count` identical forks
+    # consuming `queues` with `concurrency` threads each. Used by the
+    # railtie when the host hasn't declared a custom topology.
+    def self.flat(count:, queues:, concurrency:)
+      new.slot(count: count, queues: queues, concurrency: concurrency)
+    end
+
+    private
+
+    def validate_slot!(count, queues, concurrency)
+      raise ArgumentError, "count must be > 0 (got #{count.inspect})" unless count.is_a?(Integer) && count.positive?
+      unless concurrency.is_a?(Integer) && concurrency.positive?
+        raise ArgumentError, "concurrency must be > 0 (got #{concurrency.inspect})"
+      end
+
+      queue_list = Array(queues).map(&:to_s)
+      raise ArgumentError, 'queues cannot be empty' if queue_list.empty?
+
+      queue_list.freeze
+    end
   end
 end

--- a/test/integration/graceful_shutdown_test.rb
+++ b/test/integration/graceful_shutdown_test.rb
@@ -27,9 +27,13 @@ end
 # install_signals: true, enqueue an in-flight job, SIGTERM the parent,
 # assert the job finishes within shutdown_timeout.
 #
-# Not parallelized — the test forks a swarm subprocess and waits on it,
-# and child reaping is global per-process state.
+# Safe under the file-level parallel runner: the supervisor runs in a
+# forked subprocess, and the test only waits on its specific PID
+# (Process.wait(parent_pid, …)) — no global -1 reap that could steal a
+# sibling test's child.
 class GracefulShutdownTest < Wurk::Test::UnitCase
+  parallelize_me!
+
   REDIS_URL = ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')
   POLL_TIMEOUT = 30.0
   POLL_INTERVAL = 0.1

--- a/test/integration/graceful_shutdown_test.rb
+++ b/test/integration/graceful_shutdown_test.rb
@@ -1,9 +1,170 @@
 # frozen_string_literal: true
 
-require_relative "../test_helper"
+require_relative '../test_helper'
 
+# Top-level so the constant resolves identically in the forked
+# subprocess (Object inherits via fork; lexically nested classes do not
+# round-trip cleanly through Marshal/const_get).
+class GracefulShutdownSentinelWorker
+  include Wurk::Job
+
+  # Reports its PID into `started_key` immediately, sleeps, then reports
+  # into `done_key`. Tests assert that `done_key` is written even after
+  # SIGTERM hits the parent mid-sleep.
+  def perform(redis_url, started_key, done_key, sleep_seconds)
+    client = RedisClient.config(url: redis_url).new_client
+    client.call('SET', started_key, ::Process.pid.to_s)
+    client.call('EXPIRE', started_key, 60)
+    sleep sleep_seconds
+    client.call('SET', done_key, ::Process.pid.to_s)
+    client.call('EXPIRE', done_key, 60)
+  ensure
+    client&.close
+  end
+end
+
+# Real fork, real signal, real Redis. Boot a swarm in a subprocess with
+# install_signals: true, enqueue an in-flight job, SIGTERM the parent,
+# assert the job finishes within shutdown_timeout.
+#
+# Not parallelized — the test forks a swarm subprocess and waits on it,
+# and child reaping is global per-process state.
 class GracefulShutdownTest < Wurk::Test::UnitCase
-  def test_skeleton
-    skip "implementation pending — SIGTERM the parent, assert in-flight jobs finish within shutdown_timeout"
+  REDIS_URL = ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')
+  POLL_TIMEOUT = 30.0
+  POLL_INTERVAL = 0.1
+  SHUTDOWN_TIMEOUT = 15
+
+  def setup
+    super
+    @ns = "gshut-#{::Process.pid}-#{object_id}"
+    @queue_name = "#{@ns}-q"
+    @started_key = "#{@ns}-started"
+    @done_key = "#{@ns}-done"
+    @observer = RedisClient.config(url: REDIS_URL).new_client
+  end
+
+  def teardown
+    cleanup_observer_keys
+    @observer&.close
+  ensure
+    super
+  end
+
+  def test_sigterm_to_parent_lets_in_flight_job_drain # rubocop:disable Minitest/MultipleAssertions
+    push_job(sleep_seconds: 2)
+    parent_pid = fork_swarm_supervisor(count: 1)
+
+    begin
+      assert wait_for_key(@started_key), 'in-flight job never started within poll timeout'
+      assert_nil @observer.call('GET', @done_key), 'job finished before we could SIGTERM (raise sleep_seconds)'
+
+      ::Process.kill('TERM', parent_pid)
+
+      assert wait_for_pid_exit(parent_pid, timeout: SHUTDOWN_TIMEOUT + 5),
+             "supervisor pid #{parent_pid} did not exit within shutdown_timeout"
+      assert @observer.call('GET', @done_key),
+             'in-flight job did not finish — graceful drain should have let it complete'
+    ensure
+      reap_supervisor(parent_pid)
+    end
+  end
+
+  private
+
+  def push_job(sleep_seconds:)
+    config = build_config
+    client = Wurk::Client.new(pool: capsule_pool(config), config: config)
+    client.push('class' => GracefulShutdownSentinelWorker.name,
+                'args' => [REDIS_URL, @started_key, @done_key, sleep_seconds],
+                'queue' => @queue_name)
+  ensure
+    config&.reset_redis_pools!
+  end
+
+  def build_config
+    config = Wurk::Configuration.new
+    config.logger = ::Logger.new(IO::NULL)
+    config[:timeout] = SHUTDOWN_TIMEOUT
+    config
+  end
+
+  def capsule_pool(config)
+    cap = config.default_capsule
+    cap.queues = [@queue_name]
+    cap.redis_pool
+  end
+
+  # Boots the swarm inside a subprocess so SIGTERM exercises the real
+  # signal handler. install_signals: true is what we want to test.
+  def fork_swarm_supervisor(count:)
+    ::Process.fork do
+      $stdout.reopen(IO::NULL)
+      $stderr.reopen(IO::NULL)
+      config = build_config
+      topology = Wurk::Topology.flat(count: count, queues: [@queue_name], concurrency: 1)
+      swarm = Wurk::Swarm.new(topology: topology, config: config, shutdown_timeout: SHUTDOWN_TIMEOUT)
+      swarm.boot(install_signals: true)
+      swarm.supervise
+      exit 0
+    end
+  end
+
+  def wait_for_key(key) # rubocop:disable Naming/PredicateMethod
+    deadline = monotonic_now + POLL_TIMEOUT
+    while monotonic_now < deadline
+      return true if @observer.call('GET', key)
+
+      sleep POLL_INTERVAL
+    end
+    false
+  end
+
+  def wait_for_pid_exit(pid, timeout:)
+    deadline = monotonic_now + timeout
+    while monotonic_now < deadline
+      return true if ::Process.wait(pid, ::Process::WNOHANG)
+
+      sleep POLL_INTERVAL
+    end
+    false
+  rescue Errno::ECHILD
+    true
+  end
+
+  def reap_supervisor(pid)
+    return unless pid_alive?(pid)
+
+    ::Process.kill('KILL', pid)
+    begin
+      ::Process.wait(pid)
+    rescue Errno::ECHILD
+      nil
+    end
+  end
+
+  def pid_alive?(pid)
+    ::Process.kill(0, pid)
+    true
+  rescue Errno::ESRCH, Errno::EPERM
+    false
+  end
+
+  def cleanup_observer_keys
+    return unless @observer
+
+    @observer.call('DEL', @started_key, @done_key, "queue:#{@queue_name}")
+    cursor = '0'
+    loop do
+      cursor, keys = @observer.call('SCAN', cursor, 'MATCH', "queue:#{@queue_name}|*", 'COUNT', 100)
+      @observer.call('DEL', *keys) unless keys.empty?
+      break if cursor == '0'
+    end
+  rescue StandardError
+    nil
+  end
+
+  def monotonic_now
+    ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
   end
 end

--- a/test/integration/rolling_restart_test.rb
+++ b/test/integration/rolling_restart_test.rb
@@ -1,9 +1,232 @@
 # frozen_string_literal: true
 
-require_relative "../test_helper"
+require_relative '../test_helper'
 
+# Top-level so the constant resolves in the forked subprocess.
+class RollingRestartIdleWorker
+  include Wurk::Job
+
+  # Stamps the current PID into a per-job sentinel key the test can
+  # observe to confirm the new slot actually picked up work.
+  def perform(redis_url, sentinel_prefix, jid)
+    client = RedisClient.config(url: redis_url).new_client
+    client.call('SET', "#{sentinel_prefix}:#{jid}", ::Process.pid.to_s)
+    client.call('EXPIRE', "#{sentinel_prefix}:#{jid}", 60)
+  ensure
+    client&.close
+  end
+end
+
+# SIGUSR1 to the swarm parent → rolling_restart: each slot is replaced
+# in turn. After the cycle, every child PID must be new and the swarm
+# must still be servicing jobs (no dropped work). Real fork, real Redis.
+#
+# Not parallelized — forks a supervisor subprocess and waits on it.
 class RollingRestartTest < Wurk::Test::UnitCase
-  def test_skeleton
-    skip "implementation pending — send SIGUSR1 to parent, assert each child cycles in turn with no dropped jobs"
+  REDIS_URL = ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')
+  POLL_TIMEOUT = 60.0
+  POLL_INTERVAL = 0.1
+  CHILD_COUNT = 2
+  SHUTDOWN_TIMEOUT = 10
+
+  def setup
+    super
+    @ns = "rrestart-#{::Process.pid}-#{object_id}"
+    @queue_name = "#{@ns}-q"
+    @sentinel_prefix = "#{@ns}-sentinel"
+    @observer = RedisClient.config(url: REDIS_URL).new_client
+  end
+
+  def teardown
+    cleanup_observer_keys
+    @observer&.close
+  ensure
+    super
+  end
+
+  # rubocop:disable Minitest/MultipleAssertions, Metrics/AbcSize
+  def test_sigusr1_cycles_each_slot_in_turn
+    parent_pid, pipe_read = fork_swarm_supervisor
+
+    begin
+      initial_children = read_child_pids(pipe_read)
+
+      assert_equal CHILD_COUNT, initial_children.size,
+                   "expected #{CHILD_COUNT} initial children, got #{initial_children.inspect}"
+
+      ::Process.kill('USR1', parent_pid)
+
+      new_children = wait_for_children_to_cycle(parent_pid, initial_children)
+
+      assert_equal CHILD_COUNT, new_children.size,
+                   "expected #{CHILD_COUNT} children after cycle, got #{new_children.inspect}"
+      refute new_children.intersect?(initial_children),
+             "PIDs should be fully replaced, but overlap remained: #{initial_children & new_children}"
+
+      jid = push_followup_job
+      stamped_pid = wait_for_sentinel("#{@sentinel_prefix}:#{jid}")
+
+      assert stamped_pid, 'follow-up job never ran after rolling restart'
+      assert_includes new_children.map(&:to_s), stamped_pid,
+                      "follow-up job ran on #{stamped_pid}, not a post-restart child #{new_children}"
+    ensure
+      pipe_read&.close
+      shutdown_supervisor(parent_pid)
+    end
+  end
+  # rubocop:enable Minitest/MultipleAssertions, Metrics/AbcSize
+
+  private
+
+  def fork_swarm_supervisor
+    read_io, write_io = ::IO.pipe
+    pid = ::Process.fork { run_supervisor_subprocess(read_io, write_io) }
+    write_io.close
+    [pid, read_io]
+  end
+
+  def run_supervisor_subprocess(read_io, write_io)
+    read_io.close
+    $stdout.reopen(IO::NULL)
+    $stderr.reopen(IO::NULL)
+    config = build_config
+    topology = Wurk::Topology.flat(count: CHILD_COUNT, queues: [@queue_name], concurrency: 1)
+    swarm = Wurk::Swarm.new(topology: topology, config: config, shutdown_timeout: SHUTDOWN_TIMEOUT)
+    swarm.boot(install_signals: true)
+    write_io.puts(swarm.children.keys.join(','))
+    write_io.close
+    swarm.supervise
+    exit 0
+  end
+
+  def build_config
+    config = Wurk::Configuration.new
+    config.logger = ::Logger.new(IO::NULL)
+    config[:timeout] = SHUTDOWN_TIMEOUT
+    config
+  end
+
+  def read_child_pids(pipe)
+    pipe.readline.strip.split(',').map(&:to_i)
+  end
+
+  # /proc/<pid>/task/*/children lists every child reaped through this
+  # process. We poll until the original PIDs are gone and CHILD_COUNT
+  # fresh PIDs are running — that's "cycle complete".
+  def wait_for_children_to_cycle(parent_pid, initial_pids)
+    deadline = monotonic_now + POLL_TIMEOUT
+    while monotonic_now < deadline
+      current = live_children_of(parent_pid)
+      return current if current.size == CHILD_COUNT && !current.intersect?(initial_pids)
+
+      sleep POLL_INTERVAL
+    end
+    live_children_of(parent_pid)
+  end
+
+  def live_children_of(parent_pid)
+    ::Dir["/proc/#{parent_pid}/task/*/children"].flat_map do |path|
+      ::File.read(path).split.map(&:to_i)
+    end.uniq
+  rescue Errno::ENOENT
+    []
+  end
+
+  def push_followup_job
+    config = build_config
+    client = Wurk::Client.new(pool: capsule_pool(config), config: config)
+    jid = client.push('class' => RollingRestartIdleWorker.name,
+                      'args' => [REDIS_URL, @sentinel_prefix, 'placeholder'],
+                      'queue' => @queue_name)
+    # placeholder arg must equal jid so the worker stamps the right key
+    repush_with_correct_jid(client, jid)
+    jid
+  ensure
+    config&.reset_redis_pools!
+  end
+
+  # Two-step push avoids racing on jid generation: we push, get the jid,
+  # remove that payload, then push the canonical one with the jid baked
+  # into args. Cleaner than re-implementing jid generation outside Client.
+  def repush_with_correct_jid(client, jid)
+    pop_existing(jid)
+    client.push('class' => RollingRestartIdleWorker.name,
+                'args' => [REDIS_URL, @sentinel_prefix, jid],
+                'queue' => @queue_name,
+                'jid' => jid)
+  end
+
+  def pop_existing(jid)
+    deadline = monotonic_now + 1.0
+    while monotonic_now < deadline
+      raw = @observer.call('LPOP', "queue:#{@queue_name}")
+      return unless raw
+
+      parsed = JSON.parse(raw)
+      return if parsed['jid'] == jid
+
+      @observer.call('LPUSH', "queue:#{@queue_name}", raw)
+      sleep 0.01
+    end
+  end
+
+  def capsule_pool(config)
+    cap = config.default_capsule
+    cap.queues = [@queue_name]
+    cap.redis_pool
+  end
+
+  def wait_for_sentinel(key)
+    deadline = monotonic_now + POLL_TIMEOUT
+    while monotonic_now < deadline
+      val = @observer.call('GET', key)
+      return val if val
+
+      sleep POLL_INTERVAL
+    end
+    nil
+  end
+
+  def shutdown_supervisor(pid)
+    return unless pid_alive?(pid)
+
+    ::Process.kill('TERM', pid)
+    deadline = monotonic_now + SHUTDOWN_TIMEOUT + 5
+    while monotonic_now < deadline
+      return if ::Process.wait(pid, ::Process::WNOHANG)
+
+      sleep POLL_INTERVAL
+    end
+    ::Process.kill('KILL', pid) if pid_alive?(pid)
+    begin
+      ::Process.wait(pid)
+    rescue Errno::ECHILD
+      nil
+    end
+  end
+
+  def pid_alive?(pid)
+    ::Process.kill(0, pid)
+    true
+  rescue Errno::ESRCH, Errno::EPERM
+    false
+  end
+
+  def cleanup_observer_keys
+    return unless @observer
+
+    cursor = '0'
+    loop do
+      cursor, keys = @observer.call('SCAN', cursor, 'MATCH', "#{@ns}*", 'COUNT', 100)
+      @observer.call('DEL', *keys) unless keys.empty?
+      break if cursor == '0'
+    end
+    @observer.call('DEL', "queue:#{@queue_name}")
+  rescue StandardError
+    nil
+  end
+
+  def monotonic_now
+    ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
   end
 end

--- a/test/integration/rolling_restart_test.rb
+++ b/test/integration/rolling_restart_test.rb
@@ -21,8 +21,11 @@ end
 # in turn. After the cycle, every child PID must be new and the swarm
 # must still be servicing jobs (no dropped work). Real fork, real Redis.
 #
-# Not parallelized — forks a supervisor subprocess and waits on it.
+# Safe under the file-level parallel runner: the supervisor runs in a
+# forked subprocess and only specific PIDs are waited on.
 class RollingRestartTest < Wurk::Test::UnitCase
+  parallelize_me!
+
   REDIS_URL = ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')
   POLL_TIMEOUT = 60.0
   POLL_INTERVAL = 0.1

--- a/test/integration/swarm_boot_test.rb
+++ b/test/integration/swarm_boot_test.rb
@@ -1,10 +1,133 @@
 # frozen_string_literal: true
 
-require_relative "../test_helper"
+require_relative '../test_helper'
 
-# Real forks, real Redis, real perform. NEVER mock Redis here.
+# Defined at the top level so Object.const_get(name) resolves the same
+# way inside the forked child (which inherits the constant table but
+# has no Minitest test-class lexical scope set up).
+class SwarmBootSentinelWorker
+  include Wurk::Job
+
+  def perform(redis_url, sentinel_key)
+    client = RedisClient.config(url: redis_url).new_client
+    client.call('SET', sentinel_key, ::Process.pid.to_s)
+    client.call('EXPIRE', sentinel_key, 60)
+  ensure
+    client&.close
+  end
+end
+
+# Real forks, real Redis, real perform. Boot a 2-child swarm, push a job,
+# assert a child runs it. NEVER mock Redis here.
+#
+# Not parallelized — fork-from-thread is hazardous, and the swarm globally
+# manipulates SIGTERM/INT handlers when signal install is enabled (the
+# test opts out via `install_signals: false`).
 class SwarmBootTest < Wurk::Test::UnitCase
-  def test_skeleton
-    skip "implementation pending — boot the swarm with N=2, push a job, assert it runs in a child"
+  REDIS_URL = ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')
+  POLL_TIMEOUT = 15.0
+  POLL_INTERVAL = 0.1
+
+  def setup
+    super
+    @ns = "swarmboot-#{Process.pid}-#{object_id}"
+    @queue_name = "#{@ns}-q"
+    @sentinel_key = "#{@ns}-sentinel"
+    @config = Wurk::Configuration.new
+    @config.logger = ::Logger.new(IO::NULL)
+    @config[:timeout] = 5
+    @observer_pool = RedisClient.config(url: REDIS_URL).new_client
+  end
+
+  def teardown
+    @observer_pool&.call('DEL', @sentinel_key, "queue:#{@queue_name}",
+                         private_queue_key(@queue_name))
+    @observer_pool&.close
+  ensure
+    super
+  end
+
+  def test_swarm_boots_forks_and_runs_a_job_in_a_child # rubocop:disable Metrics/AbcSize,Minitest/MultipleAssertions
+    push_sentinel_job
+    swarm = Wurk::Swarm.new(topology: topology_n(2), config: @config, shutdown_timeout: 5)
+
+    pids = swarm.boot(install_signals: false)
+
+    begin
+      assert_equal 2, pids.size, 'boot should return one PID per slot assignment'
+      pids.each { |pid| assert pid_alive?(pid), "expected child #{pid} to be alive after boot" }
+
+      supervisor = Thread.new { swarm.supervise }
+      sentinel_pid = wait_for_sentinel
+
+      assert sentinel_pid, "sentinel key #{@sentinel_key} was never written within #{POLL_TIMEOUT}s"
+      refute_equal ::Process.pid.to_s, sentinel_pid,
+                   'sentinel should have been written by a forked child, not the test process'
+      assert_includes pids.map(&:to_s), sentinel_pid,
+                      "sentinel writer #{sentinel_pid} should be one of the spawned children #{pids}"
+    ensure
+      swarm.shutdown(timeout: 5)
+      supervisor&.join(10)
+    end
+  end
+
+  def test_boot_raises_when_topology_is_empty
+    swarm = Wurk::Swarm.new(topology: Wurk::Topology.new, config: @config)
+    assert_raises(ArgumentError) { swarm.boot(install_signals: false) }
+  end
+
+  def test_boot_is_not_re_entrant
+    swarm = Wurk::Swarm.new(topology: topology_n(1), config: @config, shutdown_timeout: 5)
+    swarm.boot(install_signals: false)
+    begin
+      assert_raises(RuntimeError) { swarm.boot(install_signals: false) }
+    ensure
+      swarm.shutdown(timeout: 5)
+    end
+  end
+
+  private
+
+  def topology_n(count)
+    Wurk::Topology.flat(count: count, queues: [@queue_name], concurrency: 1)
+  end
+
+  def push_sentinel_job
+    client = Wurk::Client.new(pool: capsule_pool, config: @config)
+    client.push('class' => SwarmBootSentinelWorker.name,
+                'args' => [REDIS_URL, @sentinel_key],
+                'queue' => @queue_name)
+  end
+
+  def capsule_pool
+    cap = @config.default_capsule
+    cap.queues = [@queue_name]
+    cap.redis_pool
+  end
+
+  def wait_for_sentinel
+    deadline = monotonic_now + POLL_TIMEOUT
+    while monotonic_now < deadline
+      val = @observer_pool.call('GET', @sentinel_key)
+      return val if val
+
+      sleep POLL_INTERVAL
+    end
+    nil
+  end
+
+  def pid_alive?(pid)
+    ::Process.kill(0, pid)
+    true
+  rescue Errno::ESRCH, Errno::EPERM
+    false
+  end
+
+  def monotonic_now
+    ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+  end
+
+  def private_queue_key(queue_name)
+    Wurk::Fetcher::Reliable.private_queue_name("queue:#{queue_name}")
   end
 end

--- a/test/integration/swarm_boot_test.rb
+++ b/test/integration/swarm_boot_test.rb
@@ -20,10 +20,13 @@ end
 # Real forks, real Redis, real perform. Boot a 2-child swarm, push a job,
 # assert a child runs it. NEVER mock Redis here.
 #
-# Not parallelized — fork-from-thread is hazardous, and the swarm globally
-# manipulates SIGTERM/INT handlers when signal install is enabled (the
-# test opts out via `install_signals: false`).
+# `install_signals: false` so the swarm doesn't poison the test process's
+# SIGTERM/INT handlers. The supervisor thread calls Process.wait(-1, …),
+# so tests inside this class must run sequentially (parallelize_me! is a
+# file-level marker; minitest/parallel_fork forks per file, not per test).
 class SwarmBootTest < Wurk::Test::UnitCase
+  parallelize_me!
+
   REDIS_URL = ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')
   POLL_TIMEOUT = 15.0
   POLL_INTERVAL = 0.1
@@ -43,6 +46,7 @@ class SwarmBootTest < Wurk::Test::UnitCase
     @observer_pool&.call('DEL', @sentinel_key, "queue:#{@queue_name}",
                          private_queue_key(@queue_name))
     @observer_pool&.close
+    @config&.reset_redis_pools!
   ensure
     super
   end

--- a/test/unit/capsule_test.rb
+++ b/test/unit/capsule_test.rb
@@ -131,10 +131,13 @@ class CapsuleTest < Wurk::Test::UnitCase
 
   # --- redis pools -------------------------------------------------------
 
-  def test_redis_pool_size_matches_concurrency
+  def test_redis_pool_size_is_concurrency_plus_overhead
     @capsule.concurrency = 7
 
-    assert_equal 7, @capsule.redis_pool.size
+    # Heartbeat thread + scheduled poller each need an unstarvable slot
+    # while every worker thread can be parked in BLMOVE — see the
+    # POOL_OVERHEAD comment in Wurk::Capsule.
+    assert_equal 7 + Wurk::Capsule::POOL_OVERHEAD, @capsule.redis_pool.size
   end
 
   def test_redis_pool_is_memoized
@@ -158,6 +161,22 @@ class CapsuleTest < Wurk::Test::UnitCase
     assert_equal 'redis://127.0.0.1:6379/0', cap.redis_pool.url
   ensure
     cap&.redis_pool&.disconnect!
+  end
+
+  def test_reset_redis_pools_drops_cached_pools
+    pool = @capsule.redis_pool
+    local = @capsule.local_redis_pool
+
+    @capsule.reset_redis_pools!
+
+    refute_same pool, @capsule.redis_pool, 'main pool should be rebuilt after reset'
+    refute_same local, @capsule.local_redis_pool, 'local pool should be rebuilt after reset'
+  end
+
+  def test_reset_redis_pools_is_safe_when_pools_were_never_built
+    cap = Wurk::Capsule.new('untouched', @config)
+
+    cap.reset_redis_pools! # must not raise
   end
 
   # --- fetcher slot ------------------------------------------------------

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -193,6 +193,8 @@ class ConfigurationTest < Wurk::Test::UnitCase
 
     refute_same cap_pool, @config.default_capsule.redis_pool
     refute_same local_pool, @config.local_redis_pool
+  ensure
+    @config.reset_redis_pools!
   end
 
   def test_reset_redis_pools_calls_through_to_every_capsule
@@ -204,6 +206,8 @@ class ConfigurationTest < Wurk::Test::UnitCase
 
     refute_same main_pool, @config.default_capsule.redis_pool
     refute_same extra_pool, extra.redis_pool
+  ensure
+    @config.reset_redis_pools!
   end
 
   # --- service locator ---------------------------------------------------

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -185,6 +185,27 @@ class ConfigurationTest < Wurk::Test::UnitCase
     @config.local_redis_pool&.disconnect!
   end
 
+  def test_reset_redis_pools_resets_capsules_and_local_pool
+    cap_pool = @config.default_capsule.redis_pool
+    local_pool = @config.local_redis_pool
+
+    @config.reset_redis_pools!
+
+    refute_same cap_pool, @config.default_capsule.redis_pool
+    refute_same local_pool, @config.local_redis_pool
+  end
+
+  def test_reset_redis_pools_calls_through_to_every_capsule
+    extra = @config.capsule('extra') { |c| c.concurrency = 1 }
+    main_pool = @config.default_capsule.redis_pool
+    extra_pool = extra.redis_pool
+
+    @config.reset_redis_pools!
+
+    refute_same main_pool, @config.default_capsule.redis_pool
+    refute_same extra_pool, extra.redis_pool
+  end
+
   # --- service locator ---------------------------------------------------
 
   def test_register_and_lookup

--- a/test/unit/heartbeat_test.rb
+++ b/test/unit/heartbeat_test.rb
@@ -1,0 +1,306 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Drives Wurk::Heartbeat against real Redis. Each test owns a unique
+# identity so parallel runs can't collide on the global `processes` SET
+# or per-identity HASH/LIST keys.
+class HeartbeatTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @ns = "hb-#{Process.pid}-#{object_id}"
+    @config = Wurk::Configuration.new
+    @config.logger = ::Logger.new(IO::NULL)
+    cap = @config.default_capsule
+    cap.queues = ['default']
+    cap.concurrency = 3
+    @config[:tag] = @ns
+    @pool = cap.redis_pool
+    @identity = "host-#{@ns}:1234:#{object_id.to_s(16)}"
+    @cleanup_keys = [@identity, "#{@identity}:work", "#{@identity}-signals"]
+  end
+
+  def teardown
+    @pool.with do |c|
+      c.call('SREM', Wurk::Keys::PROCESSES, @identity)
+      @cleanup_keys.each { |k| c.call('UNLINK', k) }
+    end
+  ensure
+    super
+  end
+
+  # --- shape ----------------------------------------------------------
+
+  def test_constants
+    assert_equal 10, Wurk::Heartbeat::BEAT_PAUSE
+    assert_equal 60, Wurk::Heartbeat::TTL_SECONDS
+  end
+
+  def test_includes_component
+    assert_includes Wurk::Heartbeat.ancestors, Wurk::Component
+  end
+
+  # --- beat! writes -----------------------------------------------------
+
+  def test_beat_adds_identity_to_processes_set
+    hb = build_heartbeat
+
+    hb.beat!
+    member = @pool.with { |c| c.call('SISMEMBER', Wurk::Keys::PROCESSES, @identity) }
+
+    assert_equal 1, member
+  end
+
+  def test_beat_sets_ttl_on_identity_hash
+    hb = build_heartbeat
+
+    hb.beat!
+    ttl = @pool.with { |c| c.call('TTL', @identity).to_i }
+
+    assert_operator ttl, :>, 0
+    assert_operator ttl, :<=, Wurk::Heartbeat::TTL_SECONDS
+  end
+
+  def test_beat_writes_info_version_and_identity
+    hb = build_heartbeat
+
+    hb.beat!
+    info = read_info
+
+    assert_equal Wurk::VERSION, info['version']
+    assert_equal @identity, info['identity']
+  end
+
+  def test_beat_writes_info_tag_and_embedded_default
+    hb = build_heartbeat
+
+    hb.beat!
+    info = read_info
+
+    assert_equal @ns, info['tag']
+    refute info['embedded']
+  end
+
+  def test_beat_writes_embedded_flag_when_set
+    hb = build_heartbeat(embedded: true)
+
+    hb.beat!
+    info = read_info
+
+    assert info['embedded']
+  end
+
+  def test_beat_writes_beat_fields
+    hb = build_heartbeat
+
+    hb.beat!
+    fields = read_beat_fields
+
+    assert_equal '3', fields[0]     # concurrency (cap.concurrency=3)
+    assert_equal '0', fields[1]     # busy (WORK_STATE empty)
+    assert_equal 'false', fields[3] # quiet (default callable)
+  end
+
+  def test_beat_writes_quiet_true_when_callable_returns_true
+    flag = true
+    hb = build_heartbeat(quiet: -> { flag })
+
+    hb.beat!
+    fields = read_beat_fields
+
+    assert_equal 'true', fields[3]
+  end
+
+  # --- :heartbeat / :beat events ---------------------------------------
+
+  def test_beat_fires_heartbeat_event_only_on_first_beat
+    fires = 0
+    @config.on(:heartbeat) { fires += 1 }
+    hb = build_heartbeat
+
+    hb.beat!
+    hb.beat!
+
+    assert_equal 1, fires
+  end
+
+  def test_beat_fires_beat_event_every_call
+    fires = 0
+    @config.on(:beat) { fires += 1 }
+    hb = build_heartbeat
+
+    hb.beat!
+    hb.beat!
+    hb.beat!
+
+    assert_equal 3, fires
+  end
+
+  def test_beat_rearms_first_heartbeat_after_redis_error
+    hb = build_heartbeat
+
+    hb.beat!
+
+    refute hb.instance_variable_get(:@first_heartbeat),
+           'first beat must clear @first_heartbeat'
+
+    hb.define_singleton_method(:redis) { |&_blk| raise 'down' }
+    hb.beat!
+
+    assert hb.instance_variable_get(:@first_heartbeat),
+           '@first_heartbeat must be re-armed when beat raises'
+  end
+
+  def test_beat_refires_heartbeat_on_recovery_with_fresh_hook
+    fires = 0
+    hb = build_heartbeat
+
+    @config.on(:heartbeat) { fires += 1 }
+    hb.beat!  # fires :heartbeat, oneshot clears the bucket
+
+    hb.define_singleton_method(:redis) { |&_blk| raise 'down' }
+    hb.beat!  # raises → @first_heartbeat re-armed
+    hb.singleton_class.send(:remove_method, :redis)
+
+    @config.on(:heartbeat) { fires += 1 }
+    hb.beat!  # recovers → :heartbeat fires again
+
+    assert_equal 2, fires
+  end
+
+  def test_beat_returns_nil_on_redis_error
+    hb = build_heartbeat
+    hb.define_singleton_method(:redis) { |&_blk| raise 'down' }
+
+    assert_nil hb.beat!
+  end
+
+  # --- work hash mirror ------------------------------------------------
+
+  def test_beat_unlinks_work_hash_when_no_in_flight
+    Wurk::Processor::WORK_STATE.clear
+    @pool.with { |c| c.call('HSET', "#{@identity}:work", 'stale-tid', '{}') }
+    hb = build_heartbeat
+
+    hb.beat!
+    exists = @pool.with { |c| c.call('EXISTS', "#{@identity}:work") }
+
+    assert_equal 0, exists
+  end
+
+  def test_beat_repopulates_work_hash_from_work_state
+    tid = "hb-tid-#{object_id}"
+    Wurk::Processor::WORK_STATE.set(tid, queue: 'q', payload: 'p', run_at: 1)
+    hb = build_heartbeat
+
+    begin
+      hb.beat!
+      hash = work_hash
+
+      assert_includes hash.keys, tid
+    ensure
+      Wurk::Processor::WORK_STATE.delete(tid)
+    end
+  end
+
+  def test_beat_sets_ttl_on_work_hash_when_populated
+    tid = "hb-tid-ttl-#{object_id}"
+    Wurk::Processor::WORK_STATE.set(tid, queue: 'q', payload: 'p', run_at: 1)
+    hb = build_heartbeat
+
+    begin
+      hb.beat!
+      ttl = @pool.with { |c| c.call('TTL', "#{@identity}:work").to_i }
+
+      assert_operator ttl, :>, 0
+      assert_operator ttl, :<=, Wurk::Heartbeat::TTL_SECONDS
+    ensure
+      Wurk::Processor::WORK_STATE.delete(tid)
+    end
+  end
+
+  # --- signal drain ----------------------------------------------------
+
+  def test_beat_drains_signal_list_and_returns_signals
+    sig_key = "#{@identity}-signals"
+    @pool.with do |c|
+      c.call('LPUSH', sig_key, 'TERM')
+      c.call('LPUSH', sig_key, 'TSTP')
+    end
+    hb = build_heartbeat
+
+    sigs = hb.beat!
+    remaining = @pool.with { |c| c.call('LLEN', sig_key) }
+
+    assert_equal 0, remaining.to_i
+    assert_equal %w[TSTP TERM], sigs
+  end
+
+  def test_beat_returns_empty_array_when_no_signals
+    hb = build_heartbeat
+
+    sigs = hb.beat!
+
+    assert_equal [], sigs
+  end
+
+  # --- stop! -----------------------------------------------------------
+
+  def test_stop_removes_identity_from_processes_set
+    hb = build_heartbeat
+    hb.beat!
+
+    hb.stop!
+    member = @pool.with { |c| c.call('SISMEMBER', Wurk::Keys::PROCESSES, @identity) }
+
+    assert_equal 0, member
+  end
+
+  def test_stop_unlinks_identity_and_work_hashes
+    hb = build_heartbeat
+    hb.beat!
+    @pool.with { |c| c.call('HSET', "#{@identity}:work", 't', '{}') }
+
+    hb.stop!
+    exists_id, exists_work = @pool.with do |c|
+      [c.call('EXISTS', @identity), c.call('EXISTS', "#{@identity}:work")]
+    end
+
+    assert_equal 0, exists_id
+    assert_equal 0, exists_work
+  end
+
+  def test_stop_is_safe_when_redis_raises
+    hb = build_heartbeat
+    hb.define_singleton_method(:redis) { |&_blk| raise 'down' }
+
+    assert_nil hb.stop!
+  end
+
+  private
+
+  def build_heartbeat(embedded: false, quiet: nil)
+    Wurk::Heartbeat.new(
+      identity: @identity,
+      config: @config,
+      started_at: Time.now.to_f,
+      embedded: embedded,
+      quiet: quiet
+    )
+  end
+
+  def read_info
+    Wurk.load_json(@pool.with { |c| c.call('HGET', @identity, 'info') })
+  end
+
+  def read_beat_fields
+    @pool.with { |c| c.call('HMGET', @identity, 'concurrency', 'busy', 'beat', 'quiet', 'rss', 'rtt_us') }
+  end
+
+  def work_hash
+    raw = @pool.with { |c| c.call('HGETALL', "#{@identity}:work") }
+    raw.is_a?(Hash) ? raw : Hash[*raw]
+  end
+end

--- a/test/unit/swarm_test.rb
+++ b/test/unit/swarm_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Pure-Ruby surface of Wurk::Swarm — initialization, validation, and the
+# parts that DON'T fork. The fork-real integration sits in
+# test/integration/swarm_boot_test.rb.
+class SwarmTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @config = Wurk::Configuration.new
+    @config.logger = ::Logger.new(IO::NULL)
+  end
+
+  # --- initialization --------------------------------------------------
+
+  def test_initialize_with_empty_topology
+    swarm = Wurk::Swarm.new(topology: Wurk::Topology.new, config: @config)
+
+    assert_empty swarm.children
+    assert_kind_of Wurk::Topology, swarm.topology
+  end
+
+  def test_initialize_defaults_shutdown_timeout
+    swarm = Wurk::Swarm.new(topology: topology, config: @config)
+
+    assert_equal Wurk::Swarm::DEFAULT_SHUTDOWN_TIMEOUT,
+                 swarm.instance_variable_get(:@shutdown_timeout)
+  end
+
+  def test_initialize_accepts_memory_limit
+    swarm = Wurk::Swarm.new(topology: topology, config: @config, memory_limit: 500_000)
+
+    assert_equal 500_000, swarm.instance_variable_get(:@memory_limit)
+  end
+
+  # --- boot validation --------------------------------------------------
+
+  def test_boot_raises_on_empty_topology
+    swarm = Wurk::Swarm.new(topology: Wurk::Topology.new, config: @config)
+
+    assert_raises(ArgumentError) { swarm.boot(install_signals: false) }
+  end
+
+  # --- includes -----------------------------------------------------
+
+  def test_includes_component
+    assert_includes Wurk::Swarm.ancestors, Wurk::Component
+  end
+
+  # --- constants ---------------------------------------------------------
+
+  def test_default_shutdown_timeout_matches_sidekiq
+    assert_equal 25, Wurk::Swarm::DEFAULT_SHUTDOWN_TIMEOUT
+  end
+
+  def test_supervisor_tunables_are_numeric # rubocop:disable Minitest/MultipleAssertions
+    assert_kind_of Numeric, Wurk::Swarm::SUPERVISE_TICK
+    assert_kind_of Numeric, Wurk::Swarm::RESPAWN_BACKOFF
+    assert_kind_of Numeric, Wurk::Swarm::HEARTBEAT_WAIT
+    assert_kind_of Numeric, Wurk::Swarm::MEMORY_CHECK_INTERVAL
+  end
+
+  private
+
+  def topology
+    Wurk::Topology.flat(count: 1, queues: ['default'], concurrency: 1)
+  end
+end

--- a/test/unit/topology_test.rb
+++ b/test/unit/topology_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Wurk::Topology is a pure-data DSL — no Redis. Parallel-safe.
+class TopologyTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def test_starts_empty # rubocop:disable Minitest/MultipleAssertions
+    t = Wurk::Topology.new
+
+    assert_empty t.slots
+    assert_predicate t, :empty?
+    assert_equal 0, t.total_processes
+    assert_empty t.assignments
+  end
+
+  def test_slot_appends_and_chains
+    t = Wurk::Topology.new
+
+    result = t.slot(count: 2, queues: ['critical'], concurrency: 5)
+
+    assert_same t, result, 'slot should return self for chaining'
+    assert_equal 1, t.slots.size
+    refute_predicate t, :empty?
+  end
+
+  def test_slot_records_count_queues_concurrency
+    t = Wurk::Topology.new.slot(count: 2, queues: %w[critical default], concurrency: 5)
+    slot = t.slots.first
+
+    assert_equal 2, slot.count
+    assert_equal %w[critical default], slot.queues
+    assert_equal 5, slot.concurrency
+  end
+
+  def test_slot_stringifies_queue_symbols
+    t = Wurk::Topology.new.slot(count: 1, queues: %i[high low], concurrency: 1)
+
+    assert_equal %w[high low], t.slots.first.queues
+  end
+
+  def test_slot_rejects_zero_or_negative_count
+    t = Wurk::Topology.new
+
+    assert_raises(ArgumentError) { t.slot(count: 0, queues: ['q'], concurrency: 1) }
+    assert_raises(ArgumentError) { t.slot(count: -1, queues: ['q'], concurrency: 1) }
+  end
+
+  def test_slot_rejects_empty_queues
+    t = Wurk::Topology.new
+
+    assert_raises(ArgumentError) { t.slot(count: 1, queues: [], concurrency: 1) }
+  end
+
+  def test_slot_rejects_zero_or_negative_concurrency
+    t = Wurk::Topology.new
+
+    assert_raises(ArgumentError) { t.slot(count: 1, queues: ['q'], concurrency: 0) }
+    assert_raises(ArgumentError) { t.slot(count: 1, queues: ['q'], concurrency: -1) }
+  end
+
+  def test_slots_is_frozen
+    t = Wurk::Topology.new.slot(count: 1, queues: ['q'], concurrency: 1)
+
+    assert_predicate t.slots, :frozen?
+  end
+
+  def test_assignments_expands_count_in_order
+    t = Wurk::Topology.new
+    t.slot(count: 2, queues: ['critical'], concurrency: 1)
+    t.slot(count: 3, queues: ['default'],  concurrency: 5)
+
+    assignments = t.assignments
+
+    assert_equal 5, assignments.size
+    assert_equal(%w[critical critical default default default], assignments.map { |s| s.queues.first })
+  end
+
+  def test_total_processes_sums_counts
+    t = Wurk::Topology.new
+    t.slot(count: 2, queues: ['a'], concurrency: 1)
+    t.slot(count: 3, queues: ['b'], concurrency: 1)
+
+    assert_equal 5, t.total_processes
+  end
+
+  def test_flat_builds_single_slot_topology # rubocop:disable Minitest/MultipleAssertions
+    t = Wurk::Topology.flat(count: 4, queues: %w[default low], concurrency: 10)
+
+    assert_equal 1, t.slots.size
+    assert_equal 4, t.total_processes
+
+    slot = t.slots.first
+
+    assert_equal 4, slot.count
+    assert_equal %w[default low], slot.queues
+    assert_equal 10, slot.concurrency
+  end
+end


### PR DESCRIPTION
## Summary

Complete implementation of the fork-based process model for Wurk:

- **Swarm supervisor**: Parent process forks N children, manages PID supervision, handles rolling restart
- **Heartbeat**: Per-child heartbeat mechanism for liveness monitoring
- **Signal handling**: SIGTERM/INT (graceful drain), SIGTSTP (pause), SIGUSR1 (rolling restart), SIGUSR2 (reopen logs)
- **Topology DSL**: Configuration for process count, timeout, memory limits
- **Railtie boot**: Swarm initialized after Rails initialization, respects WURK_DISABLED flag and test env

Boot ordering preserved: host app → railtie `after_initialize` → close parent sockets → fork children → child reconnect → parent supervise.

## Tests
- 792 runs, 1442 assertions, 0 failures
- Full test suite passes (parallel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full process supervisor with graceful shutdown and zero-downtime rolling restarts
  * Redis-backed heartbeat for process health, RTT and signal handling
  * Worker topology DSL and automated startup hook for background supervision
  * Safer Redis pool handling across forks/shutdowns

* **Tests**
  * Extensive new unit and integration tests covering swarm, heartbeat, topology, shutdown, and rolling restart scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/developerz-ai/wurk/pull/7?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->