### PR TITLE
feat: Pro parity — Batches, reliable client, pause, expires_in, statsd, fast Lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ Wire-compatible: same Redis keys, same job JSON, same Ruby DSL. Swap one gem lin
 
 ---
 
+## 📋 Requirements
+
+| Component | Minimum |
+|---|---|
+| Ruby   | `>= 3.2.0` |
+| Redis  | `>= 7.0.0` (uses `ZRANGE ... REV` introduced in 6.2 and other 7.x server features) |
+
+JRuby / TruffleRuby / Windows fall back to threads-only mode (no fork) — behaviorally equivalent to stock Sidekiq.
+
+---
+
 ## 🏃 Quick start
 
 ```sh

--- a/lib/wurk.rb
+++ b/lib/wurk.rb
@@ -206,6 +206,16 @@ require_relative 'wurk/batch/death_handler'
 # Spec: docs/target/sidekiq-pro.md §7.
 require_relative 'wurk/middleware/expiry'
 
+# Poison-pill detection — orphan recovery counter + dead set on threshold.
+# Spec: docs/target/sidekiq-pro.md §3.2.
+require_relative 'wurk/middleware/poison_pill'
+
+# Pro Fast API: Lua-backed Queue#delete_job / #delete_by_class plus
+# SortedSet#scan { |JobRecord| … }. Mixed in via include/prepend on the
+# existing data API classes so the surface is wire-compat with Sidekiq Pro.
+# Spec: docs/target/sidekiq-pro.md §11.
+require_relative 'wurk/api/fast'
+
 # Sidekiq aliases load last — every Wurk::* constant they reference must be
 # fully defined first. compat.rb only redefines names, it does not gate
 # behavior, so trailing the load order is safe.

--- a/lib/wurk.rb
+++ b/lib/wurk.rb
@@ -48,6 +48,7 @@ require_relative 'wurk/swarm'
 require_relative 'wurk/topology'
 require_relative 'wurk/batch'
 require_relative 'wurk/batch/status'
+require_relative 'wurk/batch_set'
 require_relative 'wurk/limiter'
 require_relative 'wurk/cron'
 require_relative 'wurk/leader'
@@ -188,6 +189,16 @@ module Wurk
     end
   end
 end
+
+# Batch worker classes (Empty, CallbackJob) and middleware load AFTER the
+# Wurk module class << self block — they instantiate workers at load time
+# via `sidekiq_options`, which reads Wurk.default_job_options.
+require_relative 'wurk/batch/empty'
+require_relative 'wurk/batch/callback_job'
+require_relative 'wurk/batch/callbacks'
+require_relative 'wurk/batch/client_middleware'
+require_relative 'wurk/batch/server_middleware'
+require_relative 'wurk/batch/death_handler'
 
 # Sidekiq aliases load last — every Wurk::* constant they reference must be
 # fully defined first. compat.rb only redefines names, it does not gate

--- a/lib/wurk.rb
+++ b/lib/wurk.rb
@@ -200,6 +200,12 @@ require_relative 'wurk/batch/client_middleware'
 require_relative 'wurk/batch/server_middleware'
 require_relative 'wurk/batch/death_handler'
 
+# Expiry must register AFTER Batch::ServerMiddleware so it sits inside that
+# middleware's onion — a skipped (expired) job then unwinds back through
+# batch's `yield` and gets counted as a batch success on the way out.
+# Spec: docs/target/sidekiq-pro.md §7.
+require_relative 'wurk/middleware/expiry'
+
 # Sidekiq aliases load last — every Wurk::* constant they reference must be
 # fully defined first. compat.rb only redefines names, it does not gate
 # behavior, so trailing the load order is safe.

--- a/lib/wurk/api/fast.rb
+++ b/lib/wurk/api/fast.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require_relative '../lua'
+require_relative '../job_record'
+
+module Wurk
+  module API
+    # Pro parity (§11): Lua-backed O(1)-round-trip replacements for the
+    # ruby-side LRANGE / ZSCAN loops in Queue and SortedSet. Mixed into the
+    # existing data API classes so the surface is `Sidekiq::Queue#delete_job(jid)`,
+    # `Sidekiq::DeadSet#scan(pattern) { |JobRecord| … }` etc. — wire-compat
+    # with Pro consumer code that drops in on a one-line require swap.
+    #
+    # We don't reimplement `Queue#size` (already LLEN, unchanged per spec).
+    module Fast
+      # Extension to Wurk::Queue. Pure server-side delete by jid / class — no
+      # network round-trips per match. Returns the count of payloads removed.
+      module QueueExt
+        # @return [Integer] payloads removed (0 when jid absent; >0 only in
+        #   the corner case of duplicate-jid corruption).
+        def delete_job(jid)
+          raise ArgumentError, 'jid required' if jid.nil? || jid.to_s.empty?
+
+          Wurk.redis do |conn|
+            Wurk::Lua::Loader.eval_cached(
+              conn,
+              :fast_delete_job,
+              keys: [Keys.queue(name)],
+              argv: [jid.to_s]
+            )
+          end.to_i
+        end
+
+        # @param klass [Class, String, Symbol]
+        # @return [Integer] payloads removed.
+        def delete_by_class(klass)
+          klass_name = klass.is_a?(Class) ? klass.name : klass.to_s
+          raise ArgumentError, 'class name required' if klass_name.empty?
+
+          Wurk.redis do |conn|
+            Wurk::Lua::Loader.eval_cached(
+              conn,
+              :fast_delete_by_class,
+              keys: [Keys.queue(name)],
+              argv: [klass_name]
+            )
+          end.to_i
+        end
+      end
+
+      # Extension to Wurk::SortedSet / JobSet. The base `scan(match, count)`
+      # already yields `(value, score)` pairs via ZSCAN — Pro promotes the
+      # surface to yield `JobRecord` directly so callers can `entry.delete`
+      # / `entry.retry` without re-parsing JSON.
+      #
+      # The new behavior is enabled by *block arity*: a 1-arg block (or
+      # block.lambda? + a 1-param signature) receives `JobRecord`; legacy
+      # 2-arg blocks (`|value, score|`) keep the raw shape. This preserves
+      # the existing two-arg contract used by JobSet#find_job internally.
+      module SortedSetExt
+        def scan(match, count = 100, &block)
+          return enum_for(:scan, match, count) unless block
+
+          if block.arity == 1
+            super do |value, score|
+              block.call(Wurk::SortedEntry.new(self, score, value))
+            end
+          else
+            super
+          end
+        end
+      end
+    end
+  end
+end
+
+Wurk::Queue.include(Wurk::API::Fast::QueueExt)
+Wurk::SortedSet.prepend(Wurk::API::Fast::SortedSetExt)

--- a/lib/wurk/batch.rb
+++ b/lib/wurk/batch.rb
@@ -1,12 +1,288 @@
 # frozen_string_literal: true
 
+require 'json'
+require 'securerandom'
+require_relative 'lua'
+
 module Wurk
-  # Sidekiq Pro Batches. Group jobs, attach success/complete/death
-  # callbacks, track progress. Spec: docs/target/sidekiq-pro.md.
+  # Sidekiq Pro Batches. Group jobs, attach success/complete/death callbacks,
+  # track progress. Spec: docs/target/sidekiq-pro.md §2.
+  #
+  # Lifecycle:
+  #   1. `Batch.new` allocates a fresh BID; the batch is `mutable?` until the
+  #      first `#jobs` block flushes — that flush HSETs the core hash, ZADDs
+  #      to `batches`, and writes tag indexes.
+  #   2. `Batch.new(bid)` reopens an existing batch (legal from inside a job
+  #      or callback only). `mutable?` is false because reopening implies the
+  #      first flush already happened.
+  #   3. `#jobs { ... }` collects `Job.perform_async` calls via the client
+  #      middleware (Thread.current[:wurk_current_batch] is the signal),
+  #      atomically registering each via BATCH_PUSH.
+  #   4. Workers ack on success → BATCH_ACK_SUCCESS → pending--.
+  #      Death handler acks on permanent failure → BATCH_ACK_COMPLETE.
+  #   5. When live jids hits zero → fire `:complete`. When pending also
+  #      hits zero with zero deaths → fire `:success`.
+  #
+  # Nested batches: a job opening its OWN batch (`batch.jobs { ... }`)
+  # increments live counters on the existing batch. A callback opening its
+  # PARENT batch links via parent_bid and adds child BID to b-<bid>-kids.
   class Batch
-    def initialize(bid = nil); end
-    def jobs(&block); end
-    def on(event, callback_class, options = {}); end
-    def status; end
+    DEFAULT_EXPIRY_SECONDS = 30 * 24 * 60 * 60
+    POST_SUCCESS_EXPIRY_SECONDS = 24 * 60 * 60
+    CALLBACK_NOTIFY_TTL = 30 * 24 * 60 * 60
+
+    # Bid is URL-safe base64 of 10 random bytes — matches Sidekiq Pro's BID
+    # generator. Length matters: third-party gems that key off bid prefix
+    # (sharded batches in Pro 8) inspect the first character.
+    BID_BYTES = 10
+
+    VALID_EVENTS = %i[success complete death].freeze
+
+    # The 'live' set tracks jobs that have not yet reached a terminal state.
+    # When it's empty, every job has either succeeded or died → `:complete`
+    # is allowed to fire.
+    KEY_SUFFIXES = %w[jids failed died notify cbsucc kids pkids tags].freeze
+
+    THREAD_KEY = :wurk_current_batch
+
+    attr_reader :bid, :parent_bid
+    attr_accessor :description, :callback_queue, :callback_class, :autoflush
+
+    def self.keys_for(bid)
+      base = "b-#{bid}"
+      [base, *KEY_SUFFIXES.map { |s| "#{base}-#{s}" }]
+    end
+
+    def initialize(bid = nil)
+      @bid              = bid || SecureRandom.urlsafe_base64(BID_BYTES)
+      @existing         = !bid.nil?
+      @description      = nil
+      @callback_queue   = 'default'
+      @callback_class   = nil
+      @tags             = []
+      @autoflush        = nil
+      @parent_bid       = nil
+      @callbacks        = []
+      @expires_in       = DEFAULT_EXPIRY_SECONDS
+      @mutable          = !@existing
+      @flushed_once     = @existing
+      load_existing! if @existing
+    end
+
+    # Hash assignment writes strings — Sidekiq's UI / third-party gems
+    # expect String tags. Array-coercion lets callers pass a String or Set.
+    def tags=(value)
+      @tags = Array(value).map(&:to_s)
+    end
+
+    def tags
+      @tags.dup
+    end
+
+    def parent
+      return nil if @parent_bid.nil? || @parent_bid.empty?
+
+      Batch.new(@parent_bid)
+    end
+
+    def mutable?
+      @mutable
+    end
+
+    def include?(jid)
+      Wurk.redis { |conn| conn.call('SISMEMBER', "b-#{@bid}-jids", jid) }.to_i.positive?
+    end
+
+    # Remove jobs from the batch. Decrements pending/total by exactly the
+    # count of jids actually removed (idempotent for repeated calls).
+    def remove_jobs(*jids)
+      return 0 if jids.empty?
+
+      Wurk.redis do |conn|
+        removed = conn.call('SREM', "b-#{@bid}-jids", *jids).to_i
+        if removed.positive?
+          conn.call('HINCRBY', "b-#{@bid}", 'pending', -removed)
+          conn.call('HINCRBY', "b-#{@bid}", 'total', -removed)
+        end
+        removed
+      end
+    end
+
+    # Mark batch invalid. Pending jobs still exist in their queues; the
+    # server middleware short-circuits them when it observes the flag.
+    # Cascades to descendant batches via b-<bid>-kids.
+    def invalidate_all
+      cascade_invalidate(@bid)
+      nil
+    end
+
+    def valid?
+      Wurk.redis { |conn| conn.call('HGET', "b-#{@bid}", 'invalidated') } != '1'
+    end
+
+    def status
+      Status.new(@bid)
+    end
+
+    def expires_in(duration)
+      @expires_in = duration.to_i
+      self
+    end
+
+    # Register a callback. Multiple callbacks of the same event are allowed.
+    # The callback target may be a Class, "Foo#bar" string spec, or anything
+    # responding to `name`. `options` must be JSON-serializable.
+    def on(event, callback, options = {})
+      sym = event.to_sym
+      raise ArgumentError, "invalid event #{event.inspect}" unless VALID_EVENTS.include?(sym)
+      raise ArgumentError, 'callback options must be a Hash' unless options.is_a?(Hash)
+
+      @callbacks << [sym.to_s, callback_target(callback), options]
+      self
+    end
+
+    # Atomic enqueue block. Inside the block, `Job.perform_async` finds
+    # this batch via Thread.current[THREAD_KEY] and stamps `bid` onto the
+    # payload — the client middleware then uses BATCH_PUSH to register and
+    # push atomically. Empty blocks synthesise a Batch::Empty no-op so
+    # callbacks still fire.
+    def jobs(&block)
+      raise ArgumentError, 'jobs requires a block' unless block
+
+      ensure_first_flush!
+
+      previous = Thread.current[THREAD_KEY]
+      Thread.current[THREAD_KEY] = self
+      pre_count = job_count
+      begin
+        block.call
+      ensure
+        Thread.current[THREAD_KEY] = previous
+      end
+
+      enqueue_empty_marker if job_count == pre_count
+      @mutable = false
+      self
+    end
+
+    private
+
+    # First flush writes the core hash, registers in the global `batches`
+    # zset, and links tag indexes. Subsequent #jobs invocations skip this
+    # — `total` is already there and BATCH_PUSH only increments deltas.
+    def ensure_first_flush!
+      return if @flushed_once
+
+      now = ::Process.clock_gettime(::Process::CLOCK_REALTIME)
+      Wurk.redis { |conn| conn.pipelined { |pipe| pipelined_first_flush(pipe, now) } }
+      @parent_bid = current_parent_bid
+      @flushed_once = true
+    end
+
+    def pipelined_first_flush(pipe, now)
+      pipe.call('HSET', "b-#{@bid}", *first_flush_hash(now).flatten)
+      pipe.call('EXPIRE', "b-#{@bid}", @expires_in)
+      pipe.call('ZADD', 'batches', now.to_s, @bid)
+      @tags.each { |t| pipe.call('SADD', "tags:#{t}", @bid) }
+      link_to_parent(pipe) if current_parent_bid
+    end
+
+    def first_flush_hash(now)
+      {
+        'created_at' => now.to_s,
+        'description' => @description.to_s,
+        'callback_queue' => @callback_queue.to_s,
+        'callback_class' => @callback_class.to_s,
+        'parent_bid' => current_parent_bid.to_s,
+        'tags' => @tags.to_json,
+        'callbacks' => @callbacks.to_json,
+        'total' => '0',
+        'pending' => '0',
+        'failures' => '0'
+      }
+    end
+
+    # If we're flushing from inside another batch's #jobs block, that
+    # parent batch's BID becomes our parent_bid and we get registered into
+    # its kids/pkids sets so cascade success/failure is correctly tracked.
+    def current_parent_bid
+      outer = Thread.current[THREAD_KEY]
+      return nil if outer.nil? || outer.bid == @bid
+
+      outer.bid
+    end
+
+    def link_to_parent(pipe)
+      pipe.call('SADD', "b-#{current_parent_bid}-kids", @bid)
+      pipe.call('SADD', "b-#{current_parent_bid}-pkids", @bid)
+    end
+
+    def job_count
+      Wurk.redis { |conn| conn.call('HGET', "b-#{@bid}", 'total') }.to_i
+    end
+
+    def enqueue_empty_marker
+      require_relative 'batch/empty'
+      previous = Thread.current[THREAD_KEY]
+      Thread.current[THREAD_KEY] = self
+      begin
+        Wurk::Batch::Empty.perform_async
+      ensure
+        Thread.current[THREAD_KEY] = previous
+      end
+    end
+
+    def cascade_invalidate(bid)
+      Wurk.redis do |conn|
+        Wurk::Lua::Loader.eval_cached(conn, :batch_invalidate, keys: ["b-#{bid}", "b-#{bid}-jids"], argv: [])
+        kids = conn.call('SMEMBERS', "b-#{bid}-kids") || []
+        kids.each { |child| cascade_invalidate(child) }
+      end
+    end
+
+    def load_existing!
+      data = fetch_hash
+      @description    = nil_if_empty(data['description'])
+      @callback_queue = data['callback_queue'].to_s.empty? ? 'default' : data['callback_queue']
+      @callback_class = nil_if_empty(data['callback_class'])
+      @parent_bid     = nil_if_empty(data['parent_bid'])
+      @tags           = parse_json_array(data['tags'])
+      @callbacks      = parse_json_callbacks(data['callbacks'])
+    end
+
+    def fetch_hash
+      raw = Wurk.redis { |conn| conn.call('HGETALL', "b-#{@bid}") }
+      raw.is_a?(Hash) ? raw : raw.each_slice(2).to_h
+    end
+
+    def callback_target(callback)
+      case callback
+      when Class then callback.name
+      when String, Symbol then callback.to_s
+      else
+        raise ArgumentError, "callback must be Class or String: #{callback.inspect}" unless callback.respond_to?(:name)
+
+        callback.name
+      end
+    end
+
+    def nil_if_empty(val)
+      val.nil? || val.to_s.empty? ? nil : val
+    end
+
+    def parse_json_array(raw)
+      return [] if raw.nil? || raw.empty?
+
+      JSON.parse(raw)
+    rescue JSON::ParserError
+      []
+    end
+
+    def parse_json_callbacks(raw)
+      arr = parse_json_array(raw)
+      arr.is_a?(Array) ? arr : []
+    end
   end
 end
+
+require_relative 'batch/status'

--- a/lib/wurk/batch/callback_job.rb
+++ b/lib/wurk/batch/callback_job.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative '../worker'
+
+module Wurk
+  class Batch
+    # Worker that runs a single batch callback. Target may be a Class name
+    # ("MyCallback" → `MyCallback.new.on_<event>(status, options)`) or a
+    # "Klass#method" spec ("Foo#bar" → `Foo.new.bar(status, options)`).
+    # Failures retry like any ordinary job — callbacks MUST be idempotent.
+    #
+    # Spec: docs/target/sidekiq-pro.md §2.4.
+    class CallbackJob
+      include Wurk::Job
+
+      sidekiq_options retry: true
+
+      def perform(bid, target_spec, event, options)
+        klass, method = resolve(target_spec, event)
+        instance = klass.new
+        status   = Wurk::Batch::Status.new(bid)
+        instance.public_send(method, status, options || {})
+      end
+
+      private
+
+      def resolve(spec, event)
+        if spec.include?('#')
+          klass_name, method_name = spec.split('#', 2)
+          [Object.const_get(klass_name), method_name.to_sym]
+        else
+          [Object.const_get(spec), :"on_#{event}"]
+        end
+      end
+    end
+  end
+end

--- a/lib/wurk/batch/callbacks.rb
+++ b/lib/wurk/batch/callbacks.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Wurk
+  class Batch
+    # Fires batch callbacks (`:success`, `:complete`, `:death`) by enqueuing
+    # them as ordinary jobs on the batch's `callback_queue`. Dedup is via
+    # b-<bid>-notify so the same callback can't be enqueued twice even
+    # if multiple workers race to ack the final job.
+    #
+    # Callback wrapper job: Wurk::Batch::CallbackJob — given a target spec
+    # ("Klass" or "Klass#method") and options hash, it instantiates and
+    # invokes on_<event> (or the named method) with the Status snapshot.
+    module Callbacks
+      module_function
+
+      # Called from the server middleware after BATCH_ACK_SUCCESS. Fires
+      # `:complete` when live jids hit 0; fires `:success` when pending
+      # also hits 0 and there have been no deaths.
+      def maybe_fire(bid, pending:, live:)
+        return unless live.zero?
+
+        fire_complete(bid)
+        fire_success(bid) if pending.zero? && deaths_for(bid).zero?
+        propagate_to_parent(bid)
+      end
+
+      # Fired from Wurk::Batch::DeathHandler on the FIRST permanent death
+      # in the batch only. Subsequent deaths bump the counter but do not
+      # re-enqueue the callback.
+      def fire_death(bid)
+        return unless dedup_set(bid, 'death')
+
+        record_event(bid, 'death_at')
+        Wurk.redis { |conn| conn.call('ZADD', 'dead-batches', Time.now.to_f.to_s, bid) }
+        enqueue_callbacks(bid, 'death')
+      end
+
+      def fire_complete(bid)
+        return unless dedup_set(bid, 'complete')
+
+        record_event(bid, 'complete_at')
+        enqueue_callbacks(bid, 'complete')
+      end
+
+      def fire_success(bid)
+        return unless dedup_set(bid, 'success')
+
+        record_event(bid, 'success_at')
+        enqueue_callbacks(bid, 'success')
+      end
+
+      # Atomically marks `bid` as having fired `event`. Returns true the
+      # first time, false thereafter — caller skips the enqueue when false.
+      # SET NX makes this safe under racing acks.
+      def dedup_set(bid, event)
+        Wurk.redis do |conn|
+          ok = conn.call('SET', "b-#{bid}-#{event}", '1', 'NX', 'EX', Batch::CALLBACK_NOTIFY_TTL)
+          ok == 'OK'
+        end
+      end
+
+      def record_event(bid, field)
+        now = ::Process.clock_gettime(::Process::CLOCK_REALTIME)
+        Wurk.redis do |conn|
+          conn.call('HSET', "b-#{bid}", field, now.to_s)
+          conn.call('HSET', "b-#{bid}", field.to_s.sub('_at', ''), '1')
+        end
+      end
+
+      def deaths_for(bid)
+        Wurk.redis { |conn| conn.call('SCARD', "b-#{bid}-died") }.to_i
+      end
+
+      def enqueue_callbacks(bid, event)
+        callbacks, queue = callback_specs_for(bid)
+        return if callbacks.empty?
+
+        callbacks.each do |(cb_event, target, options)|
+          next unless cb_event == event
+
+          enqueue_callback_job(bid, target, event, options, queue)
+        end
+      end
+
+      def callback_specs_for(bid)
+        raw = Wurk.redis { |conn| conn.call('HMGET', "b-#{bid}", 'callbacks', 'callback_queue') }
+        callbacks_json, queue = raw
+        queue = 'default' if queue.nil? || queue.empty?
+        parsed = parse_callbacks(callbacks_json)
+        [parsed, queue]
+      end
+
+      def parse_callbacks(raw)
+        return [] if raw.nil? || raw.empty?
+
+        JSON.parse(raw)
+      rescue JSON::ParserError
+        []
+      end
+
+      def enqueue_callback_job(bid, target, event, options, queue)
+        Wurk::Client.push(
+          'class' => 'Wurk::Batch::CallbackJob',
+          'args' => [bid, target, event, options],
+          'queue' => queue,
+          'retry' => true
+        )
+      end
+
+      # When a child batch's `:success` fires, decrement the parent's pkids
+      # set so the parent's own `:success` waits on the full subtree. When
+      # parent's pkids hits 0 *and* its own pending is 0, parent's success
+      # fires too.
+      def propagate_to_parent(bid)
+        parent_bid = parent_bid_for(bid)
+        return if parent_bid.nil? || parent_bid.empty?
+        return unless pkids_drained?(parent_bid, bid)
+
+        maybe_fire(parent_bid, pending: pending_for(parent_bid), live: live_for(parent_bid))
+      end
+
+      def parent_bid_for(bid)
+        Wurk.redis { |conn| conn.call('HGET', "b-#{bid}", 'parent_bid') }
+      end
+
+      def pkids_drained?(parent_bid, child_bid)
+        Wurk.redis do |conn|
+          conn.call('SREM', "b-#{parent_bid}-pkids", child_bid)
+          conn.call('SCARD', "b-#{parent_bid}-pkids").to_i.zero?
+        end
+      end
+
+      def pending_for(bid) = Wurk.redis { |conn| conn.call('HGET', "b-#{bid}", 'pending') }.to_i
+      def live_for(bid)    = Wurk.redis { |conn| conn.call('SCARD', "b-#{bid}-jids") }.to_i
+    end
+  end
+end

--- a/lib/wurk/batch/client_middleware.rb
+++ b/lib/wurk/batch/client_middleware.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative '../middleware'
+
+module Wurk
+  class Batch
+    # Client middleware. When a `Job.perform_async` runs inside a
+    # `batch.jobs { ... }` block, Thread.current[Batch::THREAD_KEY] holds
+    # the active batch — we stamp `bid` onto the payload so the worker
+    # can re-open the batch and Client#raw_push can route through
+    # BATCH_PUSH for atomic increment+LPUSH.
+    #
+    # Auto-registered at the head of the client chain when this file is
+    # required.
+    class ClientMiddleware
+      include Wurk::Middleware::ClientMiddleware
+
+      def call(_worker, job, _queue, _redis_pool)
+        batch = Thread.current[Batch::THREAD_KEY]
+        job['bid'] = batch.bid if batch
+        yield
+      end
+    end
+  end
+end
+
+Wurk.configuration.client_middleware.prepend(Wurk::Batch::ClientMiddleware)

--- a/lib/wurk/batch/death_handler.rb
+++ b/lib/wurk/batch/death_handler.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative '../lua'
+require_relative 'callbacks'
+
+module Wurk
+  class Batch
+    # Registered as a config death_handler. Fires for every job that
+    # exhausts retries or carries `dead: false` and discards. If the job
+    # carries a `bid`, we BATCH_ACK_COMPLETE → record the death → fire
+    # `:death` callback exactly once per batch (first death only).
+    #
+    # Spec: docs/target/sidekiq-pro.md §2.4 (`:death`).
+    class DeathHandler
+      def self.call(job, _exception)
+        bid = job['bid']
+        return unless bid
+
+        result = Wurk.redis do |conn|
+          Wurk::Lua::Loader.eval_cached(
+            conn,
+            :batch_ack_complete,
+            keys: ["b-#{bid}", "b-#{bid}-jids", "b-#{bid}-died", "b-#{bid}-failed"],
+            argv: [job['jid']]
+          )
+        end
+        live, _died, first_death = Array(result).map(&:to_i)
+
+        Wurk::Batch::Callbacks.fire_death(bid) if first_death == 1
+        return unless live.zero?
+
+        Wurk::Batch::Callbacks.fire_complete(bid)
+        Wurk::Batch::Callbacks.propagate_to_parent(bid)
+      end
+    end
+  end
+end
+
+Wurk.configuration.death_handlers << Wurk::Batch::DeathHandler

--- a/lib/wurk/batch/empty.rb
+++ b/lib/wurk/batch/empty.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative '../worker'
+
+module Wurk
+  class Batch
+    # No-op marker job inserted into an empty `batch.jobs { }` block so
+    # `:complete` and `:success` callbacks still fire. Pro 7.1+ behaviour:
+    # without this marker, total=0 means no batch_push ever ran and the
+    # callback path can't tell "empty batch" from "never flushed batch".
+    #
+    # Spec: docs/target/sidekiq-pro.md §2.3 / §12.
+    class Empty
+      include Wurk::Job
+
+      sidekiq_options retry: false, queue: 'default'
+
+      def perform; end
+    end
+  end
+end

--- a/lib/wurk/batch/server_middleware.rb
+++ b/lib/wurk/batch/server_middleware.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'json'
+require_relative '../middleware'
+require_relative '../lua'
+
+module Wurk
+  class Batch
+    # Server middleware. Runs around `perform` for any job carrying a `bid`.
+    # On success → BATCH_ACK_SUCCESS → if pending hit zero and no deaths,
+    # enqueue `:success` callback jobs; if live jids hit zero, enqueue
+    # `:complete` callback jobs.
+    #
+    # Invalidated batches short-circuit: the job is skipped without
+    # raising — counts as a "success" for batch purposes per spec §12.
+    #
+    # Death handling lives in Wurk::Batch::DeathHandler (registered as a
+    # config death_handler) because death is signalled from the retry layer,
+    # not from this middleware's rescue path.
+    class ServerMiddleware
+      include Wurk::Middleware::ServerMiddleware
+
+      def call(_worker, job, _queue)
+        bid = job['bid']
+        return yield unless bid
+
+        if invalidated?(bid)
+          ack_success(bid, job['jid'])
+          return
+        end
+
+        yield
+        ack_success(bid, job['jid'])
+      end
+
+      private
+
+      def invalidated?(bid)
+        redis_pool.with { |conn| conn.call('HGET', "b-#{bid}", 'invalidated') } == '1'
+      end
+
+      def ack_success(bid, jid)
+        result = redis_pool.with do |conn|
+          Wurk::Lua::Loader.eval_cached(
+            conn,
+            :batch_ack_success,
+            keys: ["b-#{bid}", "b-#{bid}-jids"],
+            argv: [jid]
+          )
+        end
+        pending, live = Array(result).map(&:to_i)
+        return if pending.negative?
+
+        Wurk::Batch::Callbacks.maybe_fire(bid, pending: pending, live: live)
+      end
+    end
+  end
+end
+
+require_relative 'callbacks'
+
+Wurk.configuration.server_middleware.add(Wurk::Batch::ServerMiddleware)

--- a/lib/wurk/batch/status.rb
+++ b/lib/wurk/batch/status.rb
@@ -1,15 +1,135 @@
 # frozen_string_literal: true
 
+require 'json'
+
 module Wurk
   class Batch
-    # Snapshot of a batch's progress: total, pending, failures, completed,
-    # parent_bid, etc. Same fields as Sidekiq::Batch::Status.
+    # Snapshot of a batch's state — read-only view backed by HGETALL of
+    # `b-<bid>` plus the supporting JIDs/failed/died sets. Mirrors the
+    # Sidekiq::Batch::Status surface from docs/target/sidekiq-pro.md §2.5.
+    #
+    # `#data` returns the JSON-friendly hash served by the polling endpoint.
+    # `#join` blocks the current thread until `complete?` — test/util only.
+    # `#delete` UNLINKs every key associated with the batch.
     class Status
-      def initialize(bid); end
-      def total; end
-      def pending; end
-      def failures; end
-      def complete?; end
+      JOIN_POLL_INTERVAL = 0.5
+
+      attr_reader :bid
+
+      def initialize(bid)
+        raise ArgumentError, 'bid required' if bid.nil? || bid.to_s.empty?
+
+        @bid = bid.to_s
+        reload!
+      end
+
+      def total            = @data['total'].to_i
+      def pending          = @data['pending'].to_i
+      def failures         = @data['failures'].to_i
+      def created_at       = numeric_or_nil(@data['created_at'])
+      def complete_at      = numeric_or_nil(@data['complete_at'])
+      def success_at       = numeric_or_nil(@data['success_at'])
+      def death_at         = numeric_or_nil(@data['death_at'])
+      def description      = @data['description']
+      def parent_bid       = @data['parent_bid']
+      def callback_queue   = @data['callback_queue']
+      def invalidated?     = @data['invalidated'] == '1'
+
+      # `:complete` fires when the live jids set is empty (every job has
+      # either succeeded or died). Hash field is set by the server callback;
+      # falling back to a recompute keeps Status accurate even if the
+      # callback dispatch is in flight.
+      def complete?
+        return true if @data['complete'] == '1'
+
+        total.positive? && live_jids_count.zero?
+      end
+
+      def failed_jids
+        Wurk.redis { |conn| conn.call('SMEMBERS', "b-#{@bid}-failed") }
+      end
+
+      def dead_jids
+        Wurk.redis { |conn| conn.call('SMEMBERS', "b-#{@bid}-died") }
+      end
+
+      def child_count
+        Wurk.redis { |conn| conn.call('SCARD', "b-#{@bid}-kids") }.to_i
+      end
+
+      def tags
+        raw = @data['tags']
+        return [] if raw.nil? || raw.empty?
+
+        JSON.parse(raw)
+      rescue JSON::ParserError
+        []
+      end
+
+      # JSON-serializable snapshot used by the polling middleware / web UI.
+      # Field names are wire-compat with Sidekiq Pro's BatchStatus.
+      def data
+        {
+          'bid' => @bid,
+          'total' => total,
+          'pending' => pending,
+          'failures' => failures,
+          'created_at' => created_at,
+          'complete_at' => complete_at,
+          'success_at' => success_at,
+          'death_at' => death_at,
+          'complete' => complete?,
+          'invalidated' => invalidated?,
+          'description' => description,
+          'parent_bid' => parent_bid,
+          'tags' => tags,
+          'failed_jids' => failed_jids,
+          'dead_jids' => dead_jids,
+          'child_count' => child_count
+        }
+      end
+
+      # Blocks the current thread until `complete?` is true. Test/util only —
+      # polling Redis from a worker thread would defeat the whole point of
+      # asynchronous batches.
+      def join
+        loop do
+          reload!
+          break if complete?
+
+          sleep JOIN_POLL_INTERVAL
+        end
+      end
+
+      # Nukes every key for this batch. Dangerous if jobs are still in flight
+      # — they'll succeed/fail without a batch to ack against, callbacks won't
+      # fire, and counts get permanently inconsistent. Caller's problem.
+      def delete
+        Wurk.redis do |conn|
+          conn.call('UNLINK', *Batch.keys_for(@bid))
+          conn.call('ZREM', 'batches', @bid)
+          conn.call('ZREM', 'dead-batches', @bid)
+        end
+        nil
+      end
+
+      def reload!
+        raw = Wurk.redis { |conn| conn.call('HGETALL', "b-#{@bid}") }
+        @data = raw.is_a?(Hash) ? raw : raw.each_slice(2).to_h
+        self
+      end
+
+      private
+
+      def live_jids_count
+        Wurk.redis { |conn| conn.call('SCARD', "b-#{@bid}-jids") }.to_i
+      end
+
+      def numeric_or_nil(val)
+        return nil if val.nil? || val.to_s.empty?
+
+        val.to_f
+      end
     end
   end
 end

--- a/lib/wurk/batch_set.rb
+++ b/lib/wurk/batch_set.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require_relative 'batch'
+
+module Wurk
+  # Discovery API over the global `batches` sorted set. `size`, `each` (yields
+  # Status), `scan_tags(tag)` for tag-indexed lookup.
+  #
+  # Spec: docs/target/sidekiq-pro.md §2.7.
+  class BatchSet
+    include Enumerable
+
+    PAGE_SIZE = 100
+
+    def initialize(key: 'batches')
+      @key = key
+    end
+
+    def size
+      Wurk.redis { |conn| conn.call('ZCARD', @key) }.to_i
+    end
+
+    # Newest-first iteration of every batch indexed in the set. Yields
+    # `Wurk::Batch::Status` instances — they HGETALL on construction so
+    # the caller pays one Redis round-trip per batch.
+    def each
+      return enum_for(:each) unless block_given?
+
+      page = 0
+      loop do
+        start = page * PAGE_SIZE
+        stop  = start + PAGE_SIZE - 1
+        bids  = Wurk.redis { |conn| conn.call('ZRANGE', @key, start, stop, 'REV') }
+        bids.each { |bid| yield Wurk::Batch::Status.new(bid) }
+        break if bids.size < PAGE_SIZE
+
+        page += 1
+      end
+    end
+
+    # Yields each BID indexed under the given tag (set at `tags:<tag>`).
+    # No JSON parsing; cheap iteration. Caller wraps in `Status.new(bid)`
+    # if it needs full state.
+    def scan_tags(tag, &block)
+      return enum_for(:scan_tags, tag) unless block_given?
+
+      cursor = '0'
+      Wurk.redis do |conn|
+        loop do
+          cursor, members = conn.call('SSCAN', "tags:#{tag}", cursor, 'COUNT', PAGE_SIZE)
+          members.each(&block)
+          break if cursor == '0'
+        end
+      end
+    end
+  end
+
+  class Batch
+    # Discovery view over batches that triggered `:death`. Iterates Status
+    # instances newest-first.
+    class DeadSet < ::Wurk::BatchSet
+      def initialize
+        super(key: 'dead-batches')
+      end
+    end
+  end
+end

--- a/lib/wurk/client.rb
+++ b/lib/wurk/client.rb
@@ -2,6 +2,7 @@
 
 require_relative 'iterable_job'
 require_relative 'job_util'
+require_relative 'lua'
 
 module Wurk
   # Enqueue interface. Pipelined LPUSH / ZADD writes against the canonical
@@ -214,7 +215,13 @@ module Wurk
     end
 
     def push_immediate(conn, payloads)
-      now     = now_in_millis
+      now = now_in_millis
+      batched, plain = payloads.partition { |j| j['bid'] }
+      push_plain(conn, plain, now) unless plain.empty?
+      push_batched(conn, batched, now) unless batched.empty?
+    end
+
+    def push_plain(conn, payloads, now)
       grouped = payloads.group_by { |j| j['queue'] }
       conn.call('SADD', 'queues', *grouped.keys)
       grouped.each do |queue, jobs|
@@ -223,6 +230,23 @@ module Wurk
           Wurk.dump_json(j)
         end
         conn.call('LPUSH', "queue:#{queue}", *serialized)
+      end
+    end
+
+    # Batched jobs route through BATCH_PUSH: increments b-<bid> total+pending,
+    # SADDs jid into the live set, registers the queue, LPUSHes the payload —
+    # all atomically. One Redis round-trip per job (no pipeline grouping)
+    # because the lua needs per-job KEYS bound. Acceptable cost: batch
+    # enqueue is not the hot path; correctness is.
+    def push_batched(conn, payloads, now)
+      payloads.each do |j|
+        j['enqueued_at'] = now
+        Wurk::Lua::Loader.eval_cached(
+          conn,
+          :batch_push,
+          keys: ["b-#{j['bid']}", "b-#{j['bid']}-jids", "queue:#{j['queue']}", 'queues'],
+          argv: [j['queue'], j['jid'], Wurk.dump_json(j)]
+        )
       end
     end
 

--- a/lib/wurk/client.rb
+++ b/lib/wurk/client.rb
@@ -193,32 +193,13 @@ module Wurk
       Array.new(count) { now + (rand * window) }
     end
 
-    # `eval_cached` recovers from `NOSCRIPT` on its own — but only when the
-    # EVALSHA is a top-level call. Inside this `pipelined` block the error
-    # surfaces from `call_pipelined` AFTER `eval_cached` has returned, so its
-    # internal rescue never sees it. We catch it here, eagerly upload every
-    # registered script on this connection (idempotent in Redis), and retry
-    # the pipeline exactly once. Outside of test boots and `SCRIPT FLUSH`
-    # this branch is dead code.
     def raw_push(payloads)
-      pool.with do |conn|
-        attempts = 0
-        begin
-          conn.pipelined { |pipe| atomic_push(pipe, payloads) }
-        rescue RedisClient::CommandError => e
-          raise unless e.message.to_s.start_with?('NOSCRIPT')
-          raise if attempts.positive?
-
-          attempts += 1
-          Wurk::Lua::Loader.script_load_all(conn)
-          retry
-        end
-      end
+      pool.with { |conn| atomic_push(conn, payloads) }
     end
 
     def atomic_push(conn, payloads)
       if payloads.first['at']
-        push_scheduled(conn, payloads)
+        conn.pipelined { |pipe| push_scheduled(pipe, payloads) }
       else
         push_immediate(conn, payloads)
       end
@@ -231,11 +212,34 @@ module Wurk
       conn.call('ZADD', 'schedule', *args)
     end
 
+    # Plain SADD/LPUSH and Lua BATCH_PUSH must live in separate pipelines.
+    # A `NOSCRIPT` from EVALSHA surfaces only at pipeline finalize — never
+    # to `eval_cached`'s inline rescue — so an outer retry of a unified
+    # pipeline would replay the already-applied plain commands and
+    # duplicate non-batched enqueues. Splitting the phases means a Lua
+    # script reload only replays the batched pipeline.
     def push_immediate(conn, payloads)
       now = now_in_millis
       batched, plain = payloads.partition { |j| j['bid'] }
-      push_plain(conn, plain, now) unless plain.empty?
-      push_batched(conn, batched, now) unless batched.empty?
+      conn.pipelined { |pipe| push_plain(pipe, plain, now) } unless plain.empty?
+      push_batched_pipelined(conn, batched, now) unless batched.empty?
+    end
+
+    # Outside of test boots and `SCRIPT FLUSH` the rescue branch is dead
+    # code; the eager `script_load_all` after fork keeps the script cache
+    # hot for the life of the connection.
+    def push_batched_pipelined(conn, batched, now)
+      attempts = 0
+      begin
+        conn.pipelined { |pipe| push_batched(pipe, batched, now) }
+      rescue RedisClient::CommandError => e
+        raise unless e.message.to_s.start_with?('NOSCRIPT')
+        raise if attempts.positive?
+
+        attempts += 1
+        Wurk::Lua::Loader.script_load_all(conn)
+        retry
+      end
     end
 
     def push_plain(conn, payloads, now)

--- a/lib/wurk/client.rb
+++ b/lib/wurk/client.rb
@@ -193,9 +193,26 @@ module Wurk
       Array.new(count) { now + (rand * window) }
     end
 
+    # `eval_cached` recovers from `NOSCRIPT` on its own — but only when the
+    # EVALSHA is a top-level call. Inside this `pipelined` block the error
+    # surfaces from `call_pipelined` AFTER `eval_cached` has returned, so its
+    # internal rescue never sees it. We catch it here, eagerly upload every
+    # registered script on this connection (idempotent in Redis), and retry
+    # the pipeline exactly once. Outside of test boots and `SCRIPT FLUSH`
+    # this branch is dead code.
     def raw_push(payloads)
       pool.with do |conn|
-        conn.pipelined { |pipe| atomic_push(pipe, payloads) }
+        attempts = 0
+        begin
+          conn.pipelined { |pipe| atomic_push(pipe, payloads) }
+        rescue RedisClient::CommandError => e
+          raise unless e.message.to_s.start_with?('NOSCRIPT')
+          raise if attempts.positive?
+
+          attempts += 1
+          Wurk::Lua::Loader.script_load_all(conn)
+          retry
+        end
       end
     end
 

--- a/lib/wurk/client/buffered.rb
+++ b/lib/wurk/client/buffered.rb
@@ -2,9 +2,168 @@
 
 module Wurk
   class Client
-    # Pro feature parity: when Redis is unreachable, buffer enqueues
-    # in-process and flush on reconnect. Bounded; opt-in via config.
-    class Buffered < Client
+    # Pro feature parity: in-process ring buffer that catches enqueue
+    # failures during a Redis outage and replays them on the next push.
+    # Activated globally — `Wurk::Client.reliable_push!`. Buffer is
+    # per-process, in-memory only; crash = lost. Does NOT cover batch
+    # creation or batch-context pushes (`bid` on payload): BATCH_PUSH has
+    # atomic counter side-effects we can't safely replay.
+    #
+    # Spec: docs/target/sidekiq-pro.md §5.
+    module Buffered
+      DEFAULT_BUFFER_CAP = 1_000
+      DRAINING_KEY = :wurk_reliable_push_draining
+
+      class << self
+        # Idempotent. Prepends the wrapper module into Wurk::Client so push /
+        # push_bulk drain the buffer before each call and raw_push catches
+        # connection errors. Safe to call from multiple threads.
+        def install!
+          install_mutex.synchronize do
+            return if @installed
+
+            Wurk::Client.prepend(InstanceMethods)
+            @installed = true
+          end
+        end
+
+        def installed?
+          @installed == true
+        end
+
+        def buffer_cap
+          @buffer_cap ||= DEFAULT_BUFFER_CAP
+        end
+
+        def buffer_cap=(value)
+          unless value.is_a?(Integer) && value.positive?
+            raise ArgumentError, 'reliable_push_buffer must be a positive Integer'
+          end
+
+          @buffer_cap = value
+        end
+
+        def buffer_size
+          buffer_mutex.synchronize { buffer.size }
+        end
+
+        def reset!
+          buffer_mutex.synchronize do
+            @buffer = []
+            @buffer_cap = nil
+          end
+        end
+
+        # Append payloads to the ring; oldest evicted when over cap.
+        # Drops batched payloads — caller is expected to re-raise for those.
+        def enbuffer(payloads)
+          cap = buffer_cap
+          buffer_mutex.synchronize do
+            payloads.each do |p|
+              buffer << p
+              buffer.shift while buffer.size > cap
+            end
+          end
+        end
+
+        # Drain payloads through `raw_push` on the given client. Stops on
+        # the first ConnectionError, preserving order at the head of the
+        # buffer so the next push retries the same payload. Emits statsd
+        # `jobs.recovered.push` per drained payload.
+        def drain!(client)
+          drained = 0
+          while (payload = pop_head)
+            unless attempt_replay(client, payload)
+              buffer_mutex.synchronize { buffer.unshift(payload) }
+              break
+            end
+
+            Wurk::Metrics::Statsd.increment('jobs.recovered.push')
+            drained += 1
+          end
+          drained
+        end
+
+        # Internal — visible for tests. Treat as private.
+        def buffer
+          @buffer ||= []
+        end
+
+        private
+
+        def install_mutex
+          @install_mutex ||= Mutex.new
+        end
+
+        def buffer_mutex
+          @buffer_mutex ||= Mutex.new
+        end
+
+        def pop_head
+          buffer_mutex.synchronize { buffer.shift }
+        end
+
+        # Drain marks the thread so our prepended raw_push re-raises
+        # ConnectionError back here instead of swallowing it into the buffer
+        # (which would spin forever).
+        def attempt_replay(client, payload)
+          Thread.current[DRAINING_KEY] = true
+          client.send(:raw_push, [payload])
+          true
+        rescue RedisClient::ConnectionError
+          false
+        ensure
+          Thread.current[DRAINING_KEY] = false
+        end
+      end
+
+      # Wraps Wurk::Client. push / push_bulk drain the buffer first;
+      # raw_push catches ConnectionError and buffers non-batched payloads.
+      module InstanceMethods
+        def push(item)
+          Buffered.drain!(self)
+          super
+        end
+
+        def push_bulk(items)
+          Buffered.drain!(self)
+          super
+        end
+
+        private
+
+        def raw_push(payloads)
+          super
+        rescue RedisClient::ConnectionError
+          raise if Thread.current[Buffered::DRAINING_KEY]
+
+          bidless, batched = payloads.partition { |p| !p['bid'] }
+          Buffered.enbuffer(bidless) if bidless.any?
+          raise unless batched.empty?
+        end
+      end
+    end
+
+    class << self
+      # Activate reliable_push! mode globally. Idempotent — call from the
+      # top level of an initializer (NOT inside Wurk.configure_*). Spec:
+      # docs/target/sidekiq-pro.md §5.
+      def reliable_push! # rubocop:disable Naming/PredicateMethod
+        Buffered.install!
+        true
+      end
+
+      def reliable_push?
+        Buffered.installed?
+      end
+
+      def reliable_push_buffer
+        Buffered.buffer_cap
+      end
+
+      def reliable_push_buffer=(value)
+        Buffered.buffer_cap = value
+      end
     end
   end
 end

--- a/lib/wurk/client/buffered.rb
+++ b/lib/wurk/client/buffered.rb
@@ -14,6 +14,12 @@ module Wurk
       DEFAULT_BUFFER_CAP = 1_000
       DRAINING_KEY = :wurk_reliable_push_draining
 
+      # Eagerly initialized: `||=` inside an accessor is not atomic — two
+      # threads racing first-touch could end up holding distinct Mutex
+      # instances and lose all synchronization on the shared buffer.
+      INSTALL_MUTEX = Mutex.new
+      BUFFER_MUTEX  = Mutex.new
+
       class << self
         # Idempotent. Prepends the wrapper module into Wurk::Client so push /
         # push_bulk drain the buffer before each call and raw_push catches
@@ -92,11 +98,11 @@ module Wurk
         private
 
         def install_mutex
-          @install_mutex ||= Mutex.new
+          INSTALL_MUTEX
         end
 
         def buffer_mutex
-          @buffer_mutex ||= Mutex.new
+          BUFFER_MUTEX
         end
 
         def pop_head

--- a/lib/wurk/compat.rb
+++ b/lib/wurk/compat.rb
@@ -23,6 +23,7 @@ module Sidekiq
 
   BasicFetch       = Wurk::Fetcher::Reliable
   Batch            = Wurk::Batch
+  BatchSet         = Wurk::BatchSet
   Capsule          = Wurk::Capsule
   CLI              = Wurk::CLI
   Client           = Wurk::Client

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -63,6 +63,15 @@ module Wurk
     attr_reader :capsules, :directory, :redis_config
     attr_accessor :thread_priority
 
+    # Pro parity: callable that builds the statsd / dogstatsd client.
+    # Invoked once per process AFTER fork; see Wurk::Metrics::Statsd.client.
+    # Assignable as a Proc, lambda, or any object responding to #call:
+    #
+    #   config.dogstatsd = -> { Datadog::Statsd.new('host', 8125) }
+    #
+    # Spec: docs/target/sidekiq-pro.md §9.1.
+    attr_accessor :dogstatsd
+
     def initialize(options = {})
       @options = deep_dup_defaults.merge(options)
       @options[:error_handlers] << ERROR_HANDLER if @options[:error_handlers].empty?

--- a/lib/wurk/fetcher/reliable.rb
+++ b/lib/wurk/fetcher/reliable.rb
@@ -94,10 +94,14 @@ module Wurk
       # Prefixed queue keys (`queue:<name>`) in fetch order. Strict mode
       # preserves declaration order. Random/weighted shuffle each call —
       # @queues is pre-expanded by weight in Capsule#queues=, so uniform
-      # shuffle yields weighted fairness; .uniq trims duplicates.
+      # shuffle yields weighted fairness; .uniq trims duplicates. Paused
+      # queues are filtered after shuffle so the membership test runs on
+      # the smallest possible set.
       def queues_cmd
-        prefixed = config.queues.map { |q| "#{Keys::QUEUE_PREFIX}#{q}" }
-        config.mode == :strict ? prefixed : prefixed.shuffle.uniq
+        names = config.mode == :strict ? config.queues : config.queues.shuffle.uniq
+        paused = paused_names
+        names = names.reject { |q| paused.include?(q) } unless paused.empty?
+        names.map { |q| "#{Keys::QUEUE_PREFIX}#{q}" }
       end
 
       def terminate
@@ -105,6 +109,14 @@ module Wurk
       end
 
       private
+
+      # SMEMBERS of the `paused` SET. One round-trip per fetch pass; the
+      # set is tiny in practice (one entry per paused queue) so the cost
+      # is dominated by the BLMOVE that follows. Returns a Set for O(1)
+      # lookup against the (often weighted-expanded) queue list.
+      def paused_names
+        config.redis { |conn| conn.call('SMEMBERS', Keys::PAUSED_SET) }.to_set
+      end
 
       def lmove(public_q)
         priv = self.class.private_queue_name(public_q)

--- a/lib/wurk/job_util.rb
+++ b/lib/wurk/job_util.rb
@@ -8,7 +8,7 @@ module Wurk
   # and JSON-verify job payloads before they hit Redis.
   #
   # Spec: docs/target/sidekiq-free.md §9 (Sidekiq::JobUtil).
-  module JobUtil
+  module JobUtil # rubocop:disable Metrics/ModuleLength
     # Top-level keys stripped from every payload before raw_push. Mutable so
     # Pro/Ent/extension code (e.g. TransactionAwareClient adding "client_class")
     # can append at load time without monkey-patching.
@@ -60,6 +60,7 @@ module Wurk
     def valid_class?(klass) = klass.is_a?(Class) || klass.is_a?(String)
     def valid_at?(item) = !item.key?('at') || item['at'].is_a?(Numeric)
     def valid_tags?(item) = !item.key?('tags') || item['tags'].is_a?(Array)
+
     def valid_retry_for?(item)
       return true unless item.key?('retry_for')
 
@@ -104,7 +105,19 @@ module Wurk
       normalized['jid'] ||= SecureRandom.hex(12)
       normalized['retry_for'] = numeric_retry_for(normalized['retry_for']) if normalized.key?('retry_for')
       normalized['created_at'] ||= now_in_millis
+      stamp_expiry(normalized)
       normalized
+    end
+
+    # Pro `expires_in:` → absolute epoch-float `expiry` resolved once at push,
+    # so the server middleware doesn't redo the math. Spec: sidekiq-pro.md §7.
+    # nil.respond_to?(:to_f) is true on modern Ruby (returns 0.0), so we must
+    # gate on a non-nil duration before coercing.
+    def stamp_expiry(item)
+      d = item['expires_in']
+      return if d.nil?
+
+      item['expiry'] ||= (item['created_at'].to_f / 1000.0) + d.to_f if d.respond_to?(:to_f)
     end
 
     def report_unsafe(item, offender, mode)

--- a/lib/wurk/keys.rb
+++ b/lib/wurk/keys.rb
@@ -17,6 +17,10 @@ module Wurk
     # Set of known queue names, without the `queue:` prefix.
     QUEUES_SET     = 'queues'
 
+    # Set of paused queue names (Pro feature; Wurk ships it free).
+    # Members are unprefixed queue names. Fetchers exclude these on each pass.
+    PAUSED_SET     = 'paused'
+
     # Sorted sets keyed by score = unix epoch float seconds.
     SCHEDULE       = 'schedule'
     RETRY          = 'retry'

--- a/lib/wurk/lua.rb
+++ b/lib/wurk/lua.rb
@@ -70,18 +70,41 @@ module Wurk
       return 1
     LUA
 
-    # Pro Batch: mark one job complete. Decrements pending iff the jid
-    # was actually a member of the batch (prevents double-decrement on
-    # retries that already succeeded).
+    # Pro Batch: ACK a job that completed successfully. SREM from the live
+    # jids set and decrement pending iff the jid was a member (idempotent
+    # against double-success on a flaky retry).
     # KEYS = [b-<bid>, b-<bid>-jids]
     # ARGV = [jid]
-    # Returns new pending count, or -1 if the jid was not in the batch.
-    BATCH_COMPLETE = <<~LUA
+    # Returns [new_pending, live_jids_remaining], or [-1, -1] when the jid
+    # was not a member (treat as already acked).
+    BATCH_ACK_SUCCESS = <<~LUA
       local removed = redis.call("srem", KEYS[2], ARGV[1])
       if removed == 1 then
-        return redis.call("hincrby", KEYS[1], "pending", -1)
+        local pending = redis.call("hincrby", KEYS[1], "pending", -1)
+        return { pending, redis.call("scard", KEYS[2]) }
       end
-      return -1
+      return { -1, -1 }
+    LUA
+
+    # Pro Batch: ACK a job that exhausted retries and died. Records death,
+    # bumps failures, and SREMs from live jids so the batch can fire
+    # `:complete` even with terminally failed jobs.
+    # KEYS = [b-<bid>, b-<bid>-jids, b-<bid>-died, b-<bid>-failed]
+    # ARGV = [jid]
+    # Returns [live_jids_remaining, died_count, first_death]. `first_death`
+    # is 1 the first time *any* jid is SADDed into the died set, 0 thereafter
+    # — caller uses it to fire `:death` exactly once per batch.
+    BATCH_ACK_COMPLETE = <<~LUA
+      local was_pre_existing_death = redis.call("scard", KEYS[3])
+      redis.call("srem", KEYS[2], ARGV[1])
+      redis.call("sadd", KEYS[4], ARGV[1])
+      local died_added = redis.call("sadd", KEYS[3], ARGV[1])
+      redis.call("hincrby", KEYS[1], "failures", 1)
+      local first_death = 0
+      if was_pre_existing_death == 0 and died_added == 1 then
+        first_death = 1
+      end
+      return { redis.call("scard", KEYS[2]), redis.call("scard", KEYS[3]), first_death }
     LUA
 
     # Pro Batch: invalidate all pending jobs. The jobs themselves stay
@@ -102,7 +125,8 @@ module Wurk
       bulk_push: BULK_PUSH,
       reliable_schedule_promote: RELIABLE_SCHEDULE_PROMOTE,
       batch_push: BATCH_PUSH,
-      batch_complete: BATCH_COMPLETE,
+      batch_ack_success: BATCH_ACK_SUCCESS,
+      batch_ack_complete: BATCH_ACK_COMPLETE,
       batch_invalidate: BATCH_INVALIDATE
     }.freeze
 

--- a/lib/wurk/lua.rb
+++ b/lib/wurk/lua.rb
@@ -120,6 +120,42 @@ module Wurk
       return 1
     LUA
 
+    # Pro Fast API (§11): server-side LRANGE+LREM to delete a single job by
+    # jid from a queue list. Pure-Ruby Queue#find_job + JobRecord#delete is
+    # O(N) round-trips; this is O(1) round-trip with O(N) Lua work.
+    # KEYS = [queue:<name>]
+    # ARGV = [jid]
+    # Returns the number of payloads removed (0 or 1; can be >1 in pathological
+    # duplicate-jid corruption — caller doesn't rely on the value).
+    FAST_DELETE_JOB = <<~LUA
+      local items = redis.call("lrange", KEYS[1], 0, -1)
+      local removed = 0
+      for i = 1, #items do
+        if string.find(items[i], '"jid":"' .. ARGV[1] .. '"', 1, true) then
+          removed = removed + redis.call("lrem", KEYS[1], 1, items[i])
+        end
+      end
+      return removed
+    LUA
+
+    # Pro Fast API (§11): server-side LRANGE+LREM removing every payload whose
+    # `"class":"<klass>"` field matches. Plain-text scan (no JSON parse) so
+    # it tolerates partial corruption — caller drops only well-formed matches.
+    # KEYS = [queue:<name>]
+    # ARGV = [klass]
+    # Returns the number of payloads removed.
+    FAST_DELETE_BY_CLASS = <<~LUA
+      local items = redis.call("lrange", KEYS[1], 0, -1)
+      local removed = 0
+      local needle = '"class":"' .. ARGV[1] .. '"'
+      for i = 1, #items do
+        if string.find(items[i], needle, 1, true) then
+          removed = removed + redis.call("lrem", KEYS[1], 1, items[i])
+        end
+      end
+      return removed
+    LUA
+
     SCRIPTS = {
       zpopbyscore: ZPOPBYSCORE,
       bulk_push: BULK_PUSH,
@@ -127,7 +163,9 @@ module Wurk
       batch_push: BATCH_PUSH,
       batch_ack_success: BATCH_ACK_SUCCESS,
       batch_ack_complete: BATCH_ACK_COMPLETE,
-      batch_invalidate: BATCH_INVALIDATE
+      batch_invalidate: BATCH_INVALIDATE,
+      fast_delete_job: FAST_DELETE_JOB,
+      fast_delete_by_class: FAST_DELETE_BY_CLASS
     }.freeze
 
     # SHA1 of each script source — matches what `SCRIPT LOAD` returns.

--- a/lib/wurk/metrics/statsd.rb
+++ b/lib/wurk/metrics/statsd.rb
@@ -2,17 +2,179 @@
 
 module Wurk
   module Metrics
-    # Pro feature parity: per-job timing + counters to a statsd endpoint.
+    # Pro parity (§9): emits per-job timing + counters to a statsd / dogstatsd
+    # client. The client itself is plumbed in by the host app via:
+    #
+    #   Wurk.configure_server do |config|
+    #     config.dogstatsd = -> { Datadog::Statsd.new('metrics.example.com', 8125) }
+    #     config.server_middleware { |chain| chain.add Wurk::Metrics::Statsd }
+    #   end
+    #
+    # The `dogstatsd` accessor is a *callable* — invoked once per process,
+    # memoized — so the client is built lazily AFTER fork. Sharing a UDP
+    # socket across forks is fine, but `Datadog::Statsd` keeps thread-locals
+    # that must be initialized inside the child.
+    #
+    # Per-job tuning via `Statsd.options = ->(klass, job, queue) { {tags:, sample_rate:} }`.
+    # Default options: tags `["worker:<klass>", "queue:<q>"]`, sample_rate 1.0.
+    # The `dd_rate` job option, when present, overrides sample_rate.
+    #
+    # Metric naming follows Sidekiq Pro 8+: every metric prefixed `sidekiq.`
+    # (the prefix is hardcoded, not configurable — third-party dashboards
+    # built for Sidekiq Pro work unchanged).
+    #
+    # `Statsd.increment(metric, tags:)` is the class-level fast path used by
+    # other Wurk components (Buffered client, Expiry middleware, super_fetch
+    # recovery, Batch lifecycle). No-op when no client is configured so
+    # callers never have to guard.
+    #
+    # Spec: docs/target/sidekiq-pro.md §9.
     class Statsd
-      def initialize(host:, port: 8125, prefix: 'wurk'); end
-      def record(job_class, duration_ms, status:); end
+      include Wurk::Middleware::ServerMiddleware
 
-      # Class-level metric increment. Hook for the dogstatsd integration
-      # (docs/target/sidekiq-pro.md §9.1) that lands with the Statsd task.
-      # No-op when no client is configured so callers in Wurk::Client::Buffered
-      # and other Pro features don't crash in test/dev environments.
-      def self.increment(_metric, tags: nil) # rubocop:disable Lint/UnusedMethodArgument
-        nil
+      METRIC_PREFIX = 'sidekiq.'
+      DEFAULT_SAMPLE_RATE = 1.0
+
+      class << self
+        attr_accessor :options
+
+        # Counter shortcut used across the codebase. Tags are forwarded as
+        # given — caller's job to namespace them (`"class:Foo"`, `"queue:bar"`).
+        # No-op when no client is wired up.
+        def increment(metric, tags: nil, sample_rate: DEFAULT_SAMPLE_RATE)
+          client = self.client
+          return nil unless client
+
+          opts = sample_rate_kw(sample_rate)
+          opts[:tags] = tags if tags
+          client.increment("#{METRIC_PREFIX}#{metric}", **opts)
+          nil
+        rescue StandardError => e
+          handle_error(e)
+          nil
+        end
+
+        def gauge(metric, value, tags: nil, sample_rate: DEFAULT_SAMPLE_RATE)
+          client = self.client
+          return nil unless client
+
+          opts = sample_rate_kw(sample_rate)
+          opts[:tags] = tags if tags
+          client.gauge("#{METRIC_PREFIX}#{metric}", value, **opts)
+          nil
+        rescue StandardError => e
+          handle_error(e)
+          nil
+        end
+
+        # Distribution send. Some statsd clients lack `distribution` (vanilla
+        # statsd-ruby, for example) — fall back to `histogram` so the metric
+        # still lands somewhere. `dogstatsd-ruby` always has `distribution`.
+        def distribution(metric, value, tags: nil, sample_rate: DEFAULT_SAMPLE_RATE)
+          client = self.client
+          return nil unless client
+
+          opts = sample_rate_kw(sample_rate)
+          opts[:tags] = tags if tags
+          name = "#{METRIC_PREFIX}#{metric}"
+          if client.respond_to?(:distribution)
+            client.distribution(name, value, **opts)
+          elsif client.respond_to?(:histogram)
+            client.histogram(name, value, **opts)
+          end
+          nil
+        rescue StandardError => e
+          handle_error(e)
+          nil
+        end
+
+        # Resolves the live client: invokes the configured `dogstatsd` proc
+        # exactly once per process and memoizes. Returns nil when no proc
+        # is configured, so callers get a clean no-op without raising.
+        def client
+          return @client if defined?(@client) && !@client.nil?
+
+          builder = Wurk.configuration.respond_to?(:dogstatsd) ? Wurk.configuration.dogstatsd : nil
+          return nil if builder.nil?
+
+          @client = builder.respond_to?(:call) ? builder.call : builder
+        end
+
+        # Test/lifecycle hook. Reset between specs and after fork so the
+        # parent's socket doesn't bleed into children.
+        def reset!
+          @client = nil
+        end
+
+        private
+
+        def sample_rate_kw(rate)
+          rate == DEFAULT_SAMPLE_RATE ? {} : { sample_rate: rate }
+        end
+
+        def handle_error(err)
+          Wurk.configuration.handle_exception(err, context: 'Wurk::Metrics::Statsd')
+        end
+      end
+
+      def call(_worker, job, queue)
+        client = self.class.client
+        return yield if client.nil?
+
+        klass = job['class']
+        opts  = per_job_options(klass, job, queue)
+        tags  = opts[:tags]
+        rate  = opts.fetch(:sample_rate, DEFAULT_SAMPLE_RATE)
+
+        emit(:increment, 'jobs.count', tags: tags, sample_rate: rate)
+        started = monotonic_ms
+        success = false
+        begin
+          yield
+          success = true
+        ensure
+          duration = monotonic_ms - started
+          finalize(success, duration, tags: tags, sample_rate: rate)
+        end
+      end
+
+      private
+
+      # Per-spec §9.2: caller-supplied proc may override tags / sample_rate
+      # on a per-job basis. The job's own `dd_rate` field, when present,
+      # always wins — it's the per-push override hinted in §8.
+      def per_job_options(klass, job, queue)
+        base = { tags: default_tags(klass, queue), sample_rate: DEFAULT_SAMPLE_RATE }
+        proc = self.class.options
+        if proc.respond_to?(:call)
+          custom = proc.call(klass, job, queue)
+          base = base.merge(custom) if custom.is_a?(Hash)
+        end
+        base[:sample_rate] = job['dd_rate'].to_f if job.key?('dd_rate')
+        base
+      end
+
+      def default_tags(klass, queue)
+        ["worker:#{klass}", "queue:#{queue}"]
+      end
+
+      def finalize(success, duration, tags:, sample_rate:)
+        metric = success ? 'jobs.success' : 'jobs.failure'
+        emit(:increment, metric, tags: tags, sample_rate: sample_rate)
+        emit(:gauge, 'jobs.perform', duration, tags: tags, sample_rate: sample_rate)
+        emit(:distribution, 'jobs.perform_dist', duration, tags: tags, sample_rate: sample_rate)
+      end
+
+      def emit(kind, metric, value = nil, tags:, sample_rate:)
+        case kind
+        when :increment    then self.class.increment(metric, tags: tags, sample_rate: sample_rate)
+        when :gauge        then self.class.gauge(metric, value, tags: tags, sample_rate: sample_rate)
+        when :distribution then self.class.distribution(metric, value, tags: tags, sample_rate: sample_rate)
+        end
+      end
+
+      def monotonic_ms
+        ::Process.clock_gettime(::Process::CLOCK_MONOTONIC, :float_millisecond)
       end
     end
   end

--- a/lib/wurk/metrics/statsd.rb
+++ b/lib/wurk/metrics/statsd.rb
@@ -117,8 +117,8 @@ module Wurk
         end
       end
 
-      def call(_worker, job, queue)
-        client = self.class.client
+      def call(_worker, job, queue) # rubocop:disable Metrics/AbcSize
+        client = safe_client
         return yield if client.nil?
 
         klass = job['class']
@@ -134,11 +134,27 @@ module Wurk
           success = true
         ensure
           duration = monotonic_ms - started
-          finalize(success, duration, tags: tags, sample_rate: rate)
+          # Metrics are best-effort: an emit failure mid-finalize must not
+          # corrupt the job result the caller already produced.
+          begin
+            finalize(success, duration, tags: tags, sample_rate: rate)
+          rescue StandardError => e
+            self.class.send(:handle_error, e)
+          end
         end
       end
 
       private
+
+      # Wraps `self.class.client` so a misconfigured builder proc never turns
+      # a metrics-init failure into a job failure. Returns nil on error (the
+      # caller falls through to a plain `yield`).
+      def safe_client
+        self.class.client
+      rescue StandardError => e
+        self.class.send(:handle_error, e)
+        nil
+      end
 
       # Per-spec §9.2: caller-supplied proc may override tags / sample_rate
       # on a per-job basis. The job's own `dd_rate` field, when present,

--- a/lib/wurk/metrics/statsd.rb
+++ b/lib/wurk/metrics/statsd.rb
@@ -4,8 +4,16 @@ module Wurk
   module Metrics
     # Pro feature parity: per-job timing + counters to a statsd endpoint.
     class Statsd
-      def initialize(host:, port: 8125, prefix: "wurk"); end
+      def initialize(host:, port: 8125, prefix: 'wurk'); end
       def record(job_class, duration_ms, status:); end
+
+      # Class-level metric increment. Hook for the dogstatsd integration
+      # (docs/target/sidekiq-pro.md §9.1) that lands with the Statsd task.
+      # No-op when no client is configured so callers in Wurk::Client::Buffered
+      # and other Pro features don't crash in test/dev environments.
+      def self.increment(_metric, tags: nil) # rubocop:disable Lint/UnusedMethodArgument
+        nil
+      end
     end
   end
 end

--- a/lib/wurk/middleware/expiry.rb
+++ b/lib/wurk/middleware/expiry.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative '../middleware'
+require_relative '../metrics/statsd'
+
+module Wurk
+  module Middleware
+    # Server middleware. Drops jobs whose `expiry` timestamp (stamped at push
+    # by the client from `sidekiq_options expires_in:`) has passed before
+    # `perform` gets a chance to start. Once `perform` is invoked, expiry no
+    # longer preempts — long-running jobs that started in time finish.
+    #
+    # The skip path:
+    #   * emits `jobs.expired` via Wurk::Metrics::Statsd (no-op when no client
+    #     is configured)
+    #   * returns without yielding — no exception, so JobRetry treats it as a
+    #     clean exit and the processor acks the UoW
+    #   * counts as a batch success: because this middleware is registered
+    #     AFTER `Wurk::Batch::ServerMiddleware`, returning unwinds back through
+    #     batch's `yield`, and batch's `ack_success` still runs on the way out
+    #
+    # Spec: docs/target/sidekiq-pro.md §7.
+    class Expiry
+      include Wurk::Middleware::ServerMiddleware
+
+      def call(_job_instance, job, _queue)
+        expiry = job['expiry']
+        return yield unless expiry
+
+        if ::Time.now.to_f > expiry.to_f
+          Wurk::Metrics::Statsd.increment('jobs.expired', tags: ["class:#{job['class']}"])
+          return
+        end
+
+        yield
+      end
+    end
+  end
+end
+
+Wurk.configuration.server_middleware.add(Wurk::Middleware::Expiry)

--- a/lib/wurk/middleware/poison_pill.rb
+++ b/lib/wurk/middleware/poison_pill.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require 'json'
+require_relative '../middleware'
+require_relative '../metrics/statsd'
+require_relative '../keys'
+require_relative '../dead_set'
+
+module Wurk
+  module Middleware
+    # Pro parity (§3.2): poison-pill detection for reliable-fetch orphans.
+    # When a job is recovered out of a dead process's private list, we
+    # INCR a per-jid counter at `super_fetch:recovered:<jid>` with a 72h
+    # TTL. Once the counter crosses RECOVERY_THRESHOLD (3) the next recovery
+    # is treated as a poison pill: the payload is moved to the dead set,
+    # `jobs.poison` is emitted to statsd, and recovery callbacks fire so
+    # operators can be paged.
+    #
+    # Counter key TTL is wire-compat with Sidekiq Pro — third-party tooling
+    # that watches `super_fetch:recovered:*` expects 72h.
+    #
+    # No server-middleware registration: callers are reaper / bulk_requeue
+    # paths that drive the lifecycle directly via `track!(payload, queue:)`.
+    # When that integration lands, it just calls `PoisonPill.track!` on each
+    # orphan it about to RPUSH back to the public queue.
+    module PoisonPill
+      RECOVERY_THRESHOLD = 3
+      RECOVERY_TTL = 72 * 60 * 60
+      KEY_PREFIX = 'super_fetch:recovered:'
+      DEAD_RECORD_LIMIT = 100
+
+      module_function
+
+      # Called per recovered orphan job. Returns `:poison` when the threshold
+      # was crossed and the job was killed; `:recovered` when the job is
+      # being re-pushed (caller's responsibility — we don't touch the queue
+      # here). Emits `jobs.recovered.fetch` on every call, `jobs.poison`
+      # only on the kill path.
+      #
+      # @param payload [String, Hash] the job JSON or pre-parsed hash.
+      # @param queue   [String, nil] the public queue name (without `queue:`).
+      # @return [Symbol] :recovered | :poison
+      def track!(payload, queue: nil)
+        job = parse(payload)
+        return :recovered unless job
+
+        jid = job['jid']
+        klass = job['class']
+        emit_recovered_fetch(klass, queue)
+        return :recovered if jid.nil? || jid.empty?
+
+        count = bump_counter(jid)
+        if count >= RECOVERY_THRESHOLD
+          mark_poison(payload, job, queue: queue, count: count)
+          :poison
+        else
+          :recovered
+        end
+      end
+
+      # Reads the current recovery counter without bumping it. Used by tests
+      # and dashboards; returns 0 for jobs that have never been recovered.
+      def recovery_count(jid)
+        return 0 if jid.nil? || jid.to_s.empty?
+
+        Wurk.redis { |conn| conn.call('GET', "#{KEY_PREFIX}#{jid}") }.to_i
+      end
+
+      # Resets the counter for a jid — call after a successful perform so a
+      # job that recovered twice and then completed doesn't accumulate state.
+      def clear!(jid)
+        return if jid.nil? || jid.to_s.empty?
+
+        Wurk.redis { |conn| conn.call('DEL', "#{KEY_PREFIX}#{jid}") }
+      end
+
+      # Register a callback fired when a poison pill is detected. Callbacks
+      # receive a single Hash `{jid:, klass:, count:, queue:}` — matches
+      # Sidekiq Pro's documented shape so consumers can drop in unchanged.
+      def on_poison(&block)
+        raise ArgumentError, 'block required' unless block
+
+        callbacks << block
+        block
+      end
+
+      def callbacks
+        @callbacks ||= []
+      end
+
+      # Test-only reset.
+      def reset!
+        @callbacks = []
+      end
+
+      # ---- internals --------------------------------------------------
+
+      def parse(payload)
+        case payload
+        when Hash then payload
+        when String
+          begin
+            Wurk.load_json(payload)
+          rescue ::JSON::ParserError
+            nil
+          end
+        end
+      end
+
+      def bump_counter(jid)
+        key = "#{KEY_PREFIX}#{jid}"
+        Wurk.redis do |conn|
+          count = conn.call('INCR', key).to_i
+          conn.call('EXPIRE', key, RECOVERY_TTL)
+          count
+        end
+      end
+
+      def emit_recovered_fetch(klass, queue)
+        tags = []
+        tags << "class:#{klass}" if klass
+        tags << "queue:#{queue}" if queue
+        Wurk::Metrics::Statsd.increment('jobs.recovered.fetch', tags: tags.empty? ? nil : tags)
+      end
+
+      def mark_poison(payload, job, queue:, count:)
+        emit_poison(job['class'], queue)
+        json = payload.is_a?(String) ? payload : Wurk.dump_json(job)
+        Wurk::DeadSet.new.kill(json, notify_failure: false)
+        fire_callbacks(jid: job['jid'], klass: job['class'], count: count, queue: queue)
+      end
+
+      def emit_poison(klass, queue)
+        tags = []
+        tags << "class:#{klass}" if klass
+        tags << "queue:#{queue}" if queue
+        Wurk::Metrics::Statsd.increment('jobs.poison', tags: tags.empty? ? nil : tags)
+      end
+
+      def fire_callbacks(pill)
+        callbacks.each do |cb|
+          cb.call(pill)
+        rescue StandardError => e
+          Wurk.configuration.handle_exception(e, context: 'Wurk::Middleware::PoisonPill')
+        end
+      end
+    end
+  end
+end

--- a/lib/wurk/processor.rb
+++ b/lib/wurk/processor.rb
@@ -209,6 +209,7 @@ module Wurk
                 klass = Object.const_get(job_hash['class'])
                 instance = klass.new
                 instance.jid = job_hash['jid']
+                instance.bid = job_hash['bid'] if instance.respond_to?(:bid=)
                 instance._context = self
                 @retrier.local(instance, jobstr, queue) do
                   yield instance

--- a/lib/wurk/queue.rb
+++ b/lib/wurk/queue.rb
@@ -7,10 +7,12 @@ module Wurk
   # schema: LIST at `queue:<name>`, membership in the `queues` SET.
   # Wire-compat is sacred — every Redis call below matches OSS exactly.
   #
-  # Pause/unpause is a Pro extension; OSS `paused?` always returns false
-  # (the `paused` set exists for Pro's UI but OSS never writes to it).
+  # Pause/unpause is a Pro feature upstream; Wurk ships it free. Membership
+  # of the `paused` SET drives both `paused?` and the fetcher's queue filter
+  # (see `Wurk::Fetcher::Reliable#queues_cmd`). In-flight jobs continue to
+  # completion — pausing only stops new fetches.
   #
-  # Spec: docs/target/sidekiq-free.md §19.2.
+  # Spec: docs/target/sidekiq-free.md §19.2, sidekiq-pro.md §6.
   class Queue
     include Enumerable
 
@@ -46,11 +48,23 @@ module Wurk
       0.0
     end
 
-    # OSS does not implement queue pausing; Pro overrides. Matches
-    # docs/target/sidekiq-free.md §31.14 — `paused` set is read but
-    # never written in OSS, and this predicate is hardcoded false.
+    # True iff this queue's name is a member of the `paused` SET. Wurk
+    # implements the Pro contract for free; fetchers consult the same set.
     def paused?
-      false
+      Wurk.redis { |conn| conn.call('SISMEMBER', Keys::PAUSED_SET, @name) } == 1
+    end
+
+    # Pause new fetches against this queue. Idempotent — `SADD` returns
+    # 0 when the name was already present. In-flight jobs are untouched.
+    def pause! # rubocop:disable Naming/PredicateMethod
+      Wurk.redis { |conn| conn.call('SADD', Keys::PAUSED_SET, @name) }
+      true
+    end
+
+    # Resume fetches. Idempotent.
+    def unpause! # rubocop:disable Naming/PredicateMethod
+      Wurk.redis { |conn| conn.call('SREM', Keys::PAUSED_SET, @name) }
+      true
     end
 
     # Paged LRANGE traversal. Yields JobRecord per payload. Continues

--- a/lib/wurk/worker.rb
+++ b/lib/wurk/worker.rb
@@ -33,6 +33,31 @@ module Wurk
       ctx.respond_to?(:stopping?) && ctx.stopping?
     end
 
+    # Batch helpers (Pro). Available on every worker — return nil when the
+    # current job did not originate from a batch.
+    #
+    # Spec: docs/target/sidekiq-pro.md §2.6.
+    def bid
+      @bid
+    end
+
+    # @api private — Processor sets this from job_hash['bid'] before perform.
+    attr_writer :bid
+
+    def batch
+      return nil if @bid.nil?
+
+      Wurk::Batch.new(@bid)
+    end
+
+    # False if the batch was invalidated. Workers should `return unless
+    # valid_within_batch?` to short-circuit work for cancelled batches.
+    def valid_within_batch?
+      return true if @bid.nil?
+
+      batch.valid?
+    end
+
     module ClassMethods
       def sidekiq_options(opts = {})
         merged = get_sidekiq_options.merge(opts.transform_keys(&:to_s))

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,6 +30,13 @@ require_relative "support/redis_namespace"
 
 module Wurk
   module Test
+    # Suite-wide mutex for tests that mutate process-global `Wurk::Metrics::Statsd`
+    # singletons (`.options`, the `increment` method itself) or
+    # `Wurk.configuration.dogstatsd`. A class-level mutex doesn't serialize
+    # across parallel test classes that touch the same globals — this one does.
+    # Pair with a `#run` override on each such class.
+    STATSD_MUTEX = Mutex.new
+
     # Base class for non-engine tests.
     class UnitCase < ::Minitest::Test
       include RedisNamespace

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,6 +37,13 @@ module Wurk
     # Pair with a `#run` override on each such class.
     STATSD_MUTEX = Mutex.new
 
+    # Suite-wide mutex for tests that destructively wipe the globally-shared
+    # `processes` SET (e.g. `DEL processes`) or read it back and assert a
+    # lower bound on its contents. Without this, a `DEL` in ProcessSetTest can
+    # land between another test's SADD-identity and its SCARD/SMEMBERS, making
+    # the reader see 0 instead of the identity it just registered.
+    PROCESSES_MUTEX = Mutex.new
+
     # Base class for non-engine tests.
     class UnitCase < ::Minitest::Test
       include RedisNamespace

--- a/test/unit/api_fast_test.rb
+++ b/test/unit/api_fast_test.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'securerandom'
+
+# Lua-backed Pro fast API:
+#   Queue#delete_job(jid)
+#   Queue#delete_by_class(klass)
+#   SortedSet#scan(pattern) { |SortedEntry| … }   # arity-1 form
+#   SortedSet#scan(pattern) { |value, score| … }  # legacy arity-2 form (unchanged)
+#
+# Spec: docs/target/sidekiq-pro.md §11.
+class APIFastTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @ns       = "#{Process.pid}-#{object_id}"
+    @qname    = "fastq-#{@ns}"
+    @rqname   = "queue:#{@qname}"
+    @set_name = "retry-fast-#{@ns}"
+    @set      = Wurk::RetrySet.new(@set_name)
+    @pool     = Wurk.configuration.redis_pool
+    clean
+  end
+
+  def teardown
+    clean
+  ensure
+    super
+  end
+
+  # --- Queue#delete_job ---------------------------------------------------
+
+  def test_delete_job_removes_matching_payload
+    jid = push_job
+    push_job
+
+    removed = Wurk::Queue.new(@qname).delete_job(jid)
+
+    assert_equal 1, removed
+    assert_equal 1, queue_size
+  end
+
+  def test_delete_job_returns_zero_when_jid_absent
+    push_job
+
+    assert_equal 0, Wurk::Queue.new(@qname).delete_job(SecureRandom.hex(12))
+    assert_equal 1, queue_size
+  end
+
+  def test_delete_job_raises_on_empty_jid
+    assert_raises(ArgumentError) { Wurk::Queue.new(@qname).delete_job(nil) }
+    assert_raises(ArgumentError) { Wurk::Queue.new(@qname).delete_job('') }
+  end
+
+  def test_delete_job_handles_empty_queue
+    assert_equal 0, Wurk::Queue.new(@qname).delete_job(SecureRandom.hex(12))
+  end
+
+  # --- Queue#delete_by_class ---------------------------------------------
+
+  def test_delete_by_class_removes_all_matching_payloads
+    3.times { push_job(klass: 'TargetJob') }
+    2.times { push_job(klass: 'OtherJob') }
+
+    removed = Wurk::Queue.new(@qname).delete_by_class('TargetJob')
+
+    assert_equal 3, removed
+    assert_equal 2, queue_size
+  end
+
+  def test_delete_by_class_accepts_class_constant
+    klass = Class.new
+    Object.const_set("ApiFastJob_#{@ns.tr('-', '_')}", klass)
+    push_job(klass: klass.name)
+
+    assert_equal 1, Wurk::Queue.new(@qname).delete_by_class(klass)
+  ensure
+    name = "ApiFastJob_#{@ns.tr('-', '_')}"
+    Object.send(:remove_const, name) if Object.const_defined?(name)
+  end
+
+  def test_delete_by_class_returns_zero_for_unknown_class
+    push_job(klass: 'A')
+
+    assert_equal 0, Wurk::Queue.new(@qname).delete_by_class('B')
+    assert_equal 1, queue_size
+  end
+
+  def test_delete_by_class_raises_on_empty_input
+    assert_raises(ArgumentError) { Wurk::Queue.new(@qname).delete_by_class('') }
+  end
+
+  # --- SortedSet#scan (arity-1 sorted entry form) ------------------------
+
+  def test_scan_yields_sorted_entry_for_arity_one_block
+    jid = SecureRandom.hex(12)
+    add_member(jid: jid)
+    yielded = []
+    @set.scan(jid) { |entry| yielded << entry }
+
+    assert_equal 1, yielded.size
+    assert_kind_of Wurk::SortedEntry, yielded.first
+    assert_equal jid, yielded.first.jid
+  end
+
+  def test_scan_arity_one_entry_can_be_deleted
+    jid = SecureRandom.hex(12)
+    add_member(jid: jid)
+    # rubocop:disable Style/SymbolProc -- explicit 1-arg block exercises arity dispatch.
+    @set.scan(jid) { |entry| entry.delete }
+    # rubocop:enable Style/SymbolProc
+
+    assert_equal 0, @set.size
+  end
+
+  def test_scan_legacy_arity_two_block_still_yields_value_score
+    jid = SecureRandom.hex(12)
+    add_member(jid: jid, score: 1234.5)
+    yielded = []
+    @set.scan(jid) { |value, score| yielded << [value, score] }
+
+    assert_equal 1, yielded.size
+    refute_nil yielded.first[0]
+    assert_in_delta 1234.5, yielded.first[1], 0.0001
+  end
+
+  def test_scan_without_block_returns_enumerator
+    assert_kind_of Enumerator, @set.scan('nope')
+  end
+
+  def test_scan_is_available_on_scheduled_and_dead
+    assert_respond_to Wurk::ScheduledSet.new, :scan
+    assert_respond_to Wurk::DeadSet.new, :scan
+  end
+
+  private
+
+  def push_job(klass: 'FastApiJob', jid: nil)
+    jid ||= SecureRandom.hex(12)
+    payload = Wurk.dump_json('class' => klass, 'args' => [], 'queue' => @qname, 'jid' => jid)
+    @pool.with do |c|
+      c.call('SADD', 'queues', @qname)
+      c.call('LPUSH', @rqname, payload)
+    end
+    jid
+  end
+
+  def add_member(jid:, score: 100.0)
+    payload = Wurk.dump_json('class' => 'X', 'args' => [], 'jid' => jid, 'queue' => 'q')
+    @pool.with { |c| c.call('ZADD', @set_name, score, payload) }
+    payload
+  end
+
+  def queue_size
+    @pool.with { |c| c.call('LLEN', @rqname) }
+  end
+
+  def clean
+    @pool.with do |c|
+      c.call('DEL', @rqname, @set_name)
+      c.call('SREM', 'queues', @qname)
+    end
+  end
+end

--- a/test/unit/batch_set_test.rb
+++ b/test/unit/batch_set_test.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'json'
+
+# Drives Wurk::BatchSet + Wurk::Batch::DeadSet against real Redis. Asserts
+# on the discovery surface (docs/target/sidekiq-pro.md §2.7): size, each
+# yielding Status, scan_tags by tag → BID.
+class BatchSetTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @pool = Wurk.configuration.redis_pool
+    @ns   = "bset-#{Process.pid}-#{object_id}"
+    @bids = []
+  end
+
+  def teardown
+    @pool.with do |conn|
+      @bids.uniq.each do |bid|
+        conn.call('UNLINK', *Wurk::Batch.keys_for(bid))
+        conn.call('ZREM', 'batches', bid)
+        conn.call('ZREM', 'dead-batches', bid)
+        conn.call('SREM', "tags:#{tag_for(bid)}", bid)
+      end
+      tag_for_each_seeded { |tag| conn.call('UNLINK', "tags:#{tag}") }
+    end
+  ensure
+    super
+  end
+
+  # --- BatchSet ---------------------------------------------------------
+
+  def test_size_returns_count_of_indexed_batches
+    pre = Wurk::BatchSet.new.size
+    seed(2)
+
+    assert_equal pre + 2, Wurk::BatchSet.new.size
+  end
+
+  def test_each_yields_status_objects
+    seed(1)
+    matched = nil
+    Wurk::BatchSet.new.each do |status|
+      matched = status if @bids.include?(status.bid)
+    end
+
+    refute_nil matched
+    assert_kind_of Wurk::Batch::Status, matched
+  end
+
+  def test_each_returns_enumerator_without_block
+    assert_kind_of Enumerator, Wurk::BatchSet.new.each
+  end
+
+  # --- scan_tags --------------------------------------------------------
+
+  def test_scan_tags_yields_bids_for_tag
+    bid = seed(1).first
+    tag = tag_for(bid)
+    found = []
+    Wurk::BatchSet.new.scan_tags(tag) { |b| found << b }
+
+    assert_includes found, bid
+  end
+
+  def test_scan_tags_no_match_yields_nothing
+    found = []
+    Wurk::BatchSet.new.scan_tags("absent-#{@ns}") { |b| found << b }
+
+    assert_empty found
+  end
+
+  def test_scan_tags_returns_enumerator_without_block
+    assert_kind_of Enumerator, Wurk::BatchSet.new.scan_tags('x')
+  end
+
+  # --- DeadSet ----------------------------------------------------------
+
+  def test_dead_set_is_a_batch_set
+    assert_kind_of Wurk::BatchSet, Wurk::Batch::DeadSet.new
+  end
+
+  def test_dead_set_uses_dead_batches_zset
+    bid = "dead-#{@ns}-1"
+    @pool.with do |c|
+      c.call('ZADD', 'dead-batches', '1.0', bid)
+      c.call('HSET', "b-#{bid}", 'total', '1')
+    end
+    @bids << bid
+    found = Wurk::Batch::DeadSet.new.map(&:bid)
+
+    assert_includes found, bid
+  ensure
+    @pool.with { |c| c.call('ZREM', 'dead-batches', bid) }
+  end
+
+  private
+
+  def seed(count)
+    count.times.map do
+      bid = "#{@ns}-#{SecureRandom.hex(4)}"
+      @bids << bid
+      tag = tag_for(bid)
+      @pool.with do |c|
+        c.call('HSET', "b-#{bid}", 'total', '1', 'pending', '0', 'tags', [tag].to_json)
+        c.call('ZADD', 'batches', Time.now.to_f.to_s, bid)
+        c.call('SADD', "tags:#{tag}", bid)
+      end
+      bid
+    end
+  end
+
+  def tag_for(bid)
+    "#{@ns}-tag-#{bid[-4..]}"
+  end
+
+  def tag_for_each_seeded
+    @bids.each { |bid| yield tag_for(bid) }
+  end
+end

--- a/test/unit/batch_set_test.rb
+++ b/test/unit/batch_set_test.rb
@@ -33,10 +33,19 @@ class BatchSetTest < Wurk::Test::UnitCase
   # --- BatchSet ---------------------------------------------------------
 
   def test_size_returns_count_of_indexed_batches
-    pre = Wurk::BatchSet.new.size
-    seed(2)
+    # `batches` ZSET is globally shared — siblings may both add AND remove
+    # entries between our reads. A `pre + 2` snapshot-and-diff is brittle:
+    # if a sibling's teardown ZREMs between snapshot and re-read, the diff
+    # underflows. Instead: verify our 2 seeded bids are members of the set,
+    # and that `size` is at least their count.
+    bids = seed(2)
+    set  = Wurk::BatchSet.new
+    scores = @pool.with do |c|
+      bids.map { |bid| c.call('ZSCORE', 'batches', bid) }
+    end
 
-    assert_equal pre + 2, Wurk::BatchSet.new.size
+    refute_includes scores, nil, 'expected all seeded bids in `batches` ZSET'
+    assert_operator set.size, :>=, bids.size
   end
 
   def test_each_yields_status_objects

--- a/test/unit/batch_status_test.rb
+++ b/test/unit/batch_status_test.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'json'
+
+# Drives Wurk::Batch::Status against real Redis. Asserts on the spec
+# (docs/target/sidekiq-pro.md §2.5): hash field reads, derived booleans
+# (complete?, invalidated?), data/JSON shape, delete behaviour.
+class BatchStatusTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @pool = Wurk.configuration.redis_pool
+    @bid  = "test-#{Process.pid}-#{object_id}"
+    @qname = "bsq-#{Process.pid}-#{object_id}"
+  end
+
+  def teardown
+    @pool.with do |conn|
+      conn.call('UNLINK', *Wurk::Batch.keys_for(@bid))
+      conn.call('ZREM', 'batches', @bid)
+      conn.call('ZREM', 'dead-batches', @bid)
+      conn.call('DEL', "queue:#{@qname}")
+    end
+  ensure
+    super
+  end
+
+  # --- ctor --------------------------------------------------------------
+
+  def test_initialize_requires_non_empty_bid
+    assert_raises(ArgumentError) { Wurk::Batch::Status.new(nil) }
+    assert_raises(ArgumentError) { Wurk::Batch::Status.new('') }
+  end
+
+  def test_bid_round_trips
+    seed_batch
+
+    assert_equal @bid, Wurk::Batch::Status.new(@bid).bid
+  end
+
+  # --- numeric counters --------------------------------------------------
+
+  def test_total_pending_failures_read_hash_fields
+    seed_batch(total: 5, pending: 3, failures: 1)
+    status = Wurk::Batch::Status.new(@bid)
+
+    assert_equal 5, status.total
+    assert_equal 3, status.pending
+    assert_equal 1, status.failures
+  end
+
+  def test_total_missing_field_returns_zero
+    seed_batch(total: nil, pending: nil)
+
+    assert_equal 0, Wurk::Batch::Status.new(@bid).total
+  end
+
+  # --- timestamps --------------------------------------------------------
+
+  def test_created_at_returns_float
+    seed_batch(created_at: '1700000000.5')
+
+    assert_in_delta 1_700_000_000.5, Wurk::Batch::Status.new(@bid).created_at, 0.01
+  end
+
+  def test_complete_at_nil_when_absent
+    seed_batch
+
+    assert_nil Wurk::Batch::Status.new(@bid).complete_at
+  end
+
+  def test_complete_at_returns_float_when_set
+    seed_batch(complete_at: '1700001000.0')
+
+    assert_in_delta 1_700_001_000.0, Wurk::Batch::Status.new(@bid).complete_at, 0.01
+  end
+
+  # --- complete? & invalidated? -----------------------------------------
+
+  def test_complete_false_when_jids_remain
+    seed_batch(total: 2, pending: 2)
+    @pool.with { |c| c.call('SADD', "b-#{@bid}-jids", 'A', 'B') }
+
+    refute_predicate Wurk::Batch::Status.new(@bid), :complete?
+  end
+
+  def test_complete_true_when_jids_drained
+    seed_batch(total: 2, pending: 0)
+
+    assert_predicate Wurk::Batch::Status.new(@bid), :complete?
+  end
+
+  def test_complete_true_when_hash_flag_set
+    seed_batch
+    @pool.with { |c| c.call('HSET', "b-#{@bid}", 'complete', '1') }
+
+    assert_predicate Wurk::Batch::Status.new(@bid), :complete?
+  end
+
+  def test_invalidated_false_default
+    seed_batch
+
+    refute_predicate Wurk::Batch::Status.new(@bid), :invalidated?
+  end
+
+  def test_invalidated_true_when_flag_set
+    seed_batch
+    @pool.with { |c| c.call('HSET', "b-#{@bid}", 'invalidated', '1') }
+
+    assert_predicate Wurk::Batch::Status.new(@bid), :invalidated?
+  end
+
+  # --- jid arrays --------------------------------------------------------
+
+  def test_failed_jids_reads_set
+    seed_batch
+    @pool.with { |c| c.call('SADD', "b-#{@bid}-failed", 'jidA', 'jidB') }
+
+    assert_equal %w[jidA jidB].sort, Wurk::Batch::Status.new(@bid).failed_jids.sort
+  end
+
+  def test_dead_jids_reads_set
+    seed_batch
+    @pool.with { |c| c.call('SADD', "b-#{@bid}-died", 'jidX') }
+
+    assert_equal ['jidX'], Wurk::Batch::Status.new(@bid).dead_jids
+  end
+
+  def test_failed_jids_empty_when_set_missing
+    seed_batch
+
+    assert_empty Wurk::Batch::Status.new(@bid).failed_jids
+  end
+
+  # --- tags --------------------------------------------------------------
+
+  def test_tags_round_trips_json
+    seed_batch(tags: ['customer:1', 'kind:fulfill'].to_json)
+
+    assert_equal ['customer:1', 'kind:fulfill'], Wurk::Batch::Status.new(@bid).tags
+  end
+
+  def test_tags_empty_when_missing
+    seed_batch
+
+    assert_empty Wurk::Batch::Status.new(@bid).tags
+  end
+
+  # --- child_count -------------------------------------------------------
+
+  def test_child_count_reads_kids_set
+    seed_batch
+    @pool.with { |c| c.call('SADD', "b-#{@bid}-kids", 'child1', 'child2') }
+
+    assert_equal 2, Wurk::Batch::Status.new(@bid).child_count
+  end
+
+  # --- #data hash --------------------------------------------------------
+
+  def test_data_includes_bid
+    seed_batch
+
+    assert_equal @bid, Wurk::Batch::Status.new(@bid).data['bid']
+  end
+
+  def test_data_keys_match_spec_surface
+    seed_batch
+    keys = Wurk::Batch::Status.new(@bid).data.keys.sort
+    required = %w[total pending failures complete invalidated tags]
+
+    required.each { |k| assert_includes keys, k }
+  end
+
+  # --- #delete -----------------------------------------------------------
+
+  def test_delete_unlinks_all_keys
+    seed_batch
+    @pool.with do |c|
+      c.call('SADD', "b-#{@bid}-jids", 'X')
+      c.call('SADD', "b-#{@bid}-kids", 'child')
+      c.call('ZADD', 'batches', '1.0', @bid)
+    end
+
+    Wurk::Batch::Status.new(@bid).delete
+
+    assert_equal(0, @pool.with { |c| c.call('EXISTS', "b-#{@bid}") })
+    assert_equal(0, @pool.with { |c| c.call('EXISTS', "b-#{@bid}-jids") })
+    refute_includes @pool.with { |c| c.call('ZRANGE', 'batches', 0, -1) }, @bid
+  end
+
+  # --- #join (smoke) -----------------------------------------------------
+
+  def test_join_returns_immediately_when_complete
+    seed_batch(total: 1, pending: 0)
+    # No jids set → complete? is true → join returns without sleeping.
+    Wurk::Batch::Status.new(@bid).join
+  end
+
+  private
+
+  def seed_batch(fields = {})
+    defaults = {
+      'created_at' => Time.now.to_f.to_s,
+      'description' => 'test',
+      'callback_queue' => 'default',
+      'tags' => '[]',
+      'callbacks' => '[]',
+      'total' => '0',
+      'pending' => '0',
+      'failures' => '0'
+    }
+    merged = defaults.merge(fields.transform_keys(&:to_s)).compact
+    @pool.with do |conn|
+      conn.call('HSET', "b-#{@bid}", *merged.flatten) unless merged.empty?
+    end
+  end
+end

--- a/test/unit/batch_test.rb
+++ b/test/unit/batch_test.rb
@@ -18,7 +18,11 @@ class BatchTest < Wurk::Test::UnitCase
     super
     @pool = Wurk.configuration.redis_pool
     @class_name = "BatchJob@#{Process.pid}-#{object_id}"
-    @queue     = "bq-#{Process.pid}-#{object_id}"
+    @queue = "bq-#{Process.pid}-#{object_id}"
+    # Tags must be per-test namespaced too — `tags:customer:42` is a shared
+    # Redis Set; parallel tests touching it cross-contaminate.
+    @tag_customer = "customer:42:#{Process.pid}:#{object_id}"
+    @tag_job      = "job:fulfill:#{Process.pid}:#{object_id}"
     @bids      = []
   end
 
@@ -31,6 +35,7 @@ class BatchTest < Wurk::Test::UnitCase
       end
       conn.call('DEL', "queue:#{@queue}")
       conn.call('SREM', 'queues', @queue) if @queue
+      [@tag_customer, @tag_job].each { |tag| conn.call('UNLINK', "tags:#{tag}") }
     end
   ensure
     super
@@ -98,12 +103,12 @@ class BatchTest < Wurk::Test::UnitCase
 
   def test_tags_round_trip
     batch = track(Wurk::Batch.new)
-    batch.tags = ['customer:42', 'job:fulfill']
+    batch.tags = [@tag_customer, @tag_job]
     batch.jobs { perform_one(batch) }
 
     reopened = track(Wurk::Batch.new(batch.bid))
 
-    assert_equal ['customer:42', 'job:fulfill'], reopened.tags
+    assert_equal [@tag_customer, @tag_job], reopened.tags
   end
 
   def test_tags_coerces_to_strings
@@ -157,10 +162,10 @@ class BatchTest < Wurk::Test::UnitCase
 
   def test_jobs_block_indexes_each_tag
     batch = track(Wurk::Batch.new)
-    batch.tags = ['customer:42']
+    batch.tags = [@tag_customer]
     batch.jobs { perform_one(batch) }
 
-    assert_includes @pool.with { |c| c.call('SMEMBERS', 'tags:customer:42') }, batch.bid
+    assert_includes @pool.with { |c| c.call('SMEMBERS', "tags:#{@tag_customer}") }, batch.bid
   end
 
   def test_empty_jobs_block_enqueues_marker_job

--- a/test/unit/batch_test.rb
+++ b/test/unit/batch_test.rb
@@ -1,11 +1,331 @@
 # frozen_string_literal: true
 
-require_relative "../test_helper"
+require_relative '../test_helper'
+require 'json'
 
+# Drives Wurk::Batch against real Redis. Asserts on the Sidekiq Pro contract
+# (docs/target/sidekiq-pro.md §2): BID shape, hash schema, jobs block atomic
+# enqueue, callbacks registry, tag indexing, invalidation cascade.
+#
+# Parallel safety: every test scopes its own BID via `Process.pid:object_id`
+# and cleans those keys in teardown. No test touches another's BIDs.
 class BatchTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  def test_skeleton
-    skip "implementation pending — see docs/target/sidekiq-pro.md (Sidekiq::Batch)"
+  BID_PATTERN = /\A[A-Za-z0-9_-]+\z/
+
+  def setup
+    super
+    @pool = Wurk.configuration.redis_pool
+    @class_name = "BatchJob@#{Process.pid}-#{object_id}"
+    @queue     = "bq-#{Process.pid}-#{object_id}"
+    @bids      = []
+  end
+
+  def teardown
+    @pool.with do |conn|
+      @bids.uniq.each do |bid|
+        conn.call('UNLINK', *Wurk::Batch.keys_for(bid))
+        conn.call('ZREM', 'batches', bid)
+        conn.call('ZREM', 'dead-batches', bid)
+      end
+      conn.call('DEL', "queue:#{@queue}")
+      conn.call('SREM', 'queues', @queue) if @queue
+    end
+  ensure
+    super
+  end
+
+  # --- BID + ctor --------------------------------------------------------
+
+  def test_new_assigns_url_safe_base64_bid
+    batch = track(Wurk::Batch.new)
+
+    assert_match BID_PATTERN, batch.bid
+  end
+
+  def test_new_assigns_distinct_bids
+    a = track(Wurk::Batch.new)
+    b = track(Wurk::Batch.new)
+
+    refute_equal a.bid, b.bid
+  end
+
+  def test_reopen_with_bid_preserves_identity
+    a = track(Wurk::Batch.new)
+    a.description = 'overall'
+    a.jobs { perform_one(a) }
+
+    reopened = Wurk::Batch.new(a.bid)
+    track(reopened)
+
+    assert_equal a.bid, reopened.bid
+    assert_equal 'overall', reopened.description
+  end
+
+  def test_fresh_batch_is_mutable
+    assert_predicate track(Wurk::Batch.new), :mutable?
+  end
+
+  def test_reopened_batch_is_not_mutable
+    a = track(Wurk::Batch.new)
+    a.jobs { perform_one(a) }
+
+    refute_predicate track(Wurk::Batch.new(a.bid)), :mutable?
+  end
+
+  # --- attribute setters -------------------------------------------------
+
+  def test_description_round_trips
+    batch = track(Wurk::Batch.new)
+    batch.description = 'overall fulfillment'
+    batch.jobs { perform_one(batch) }
+
+    reopened = track(Wurk::Batch.new(batch.bid))
+
+    assert_equal 'overall fulfillment', reopened.description
+  end
+
+  def test_callback_queue_round_trips
+    batch = track(Wurk::Batch.new)
+    batch.callback_queue = 'cb-q'
+    batch.jobs { perform_one(batch) }
+
+    reopened = track(Wurk::Batch.new(batch.bid))
+
+    assert_equal 'cb-q', reopened.callback_queue
+  end
+
+  def test_tags_round_trip
+    batch = track(Wurk::Batch.new)
+    batch.tags = ['customer:42', 'job:fulfill']
+    batch.jobs { perform_one(batch) }
+
+    reopened = track(Wurk::Batch.new(batch.bid))
+
+    assert_equal ['customer:42', 'job:fulfill'], reopened.tags
+  end
+
+  def test_tags_coerces_to_strings
+    batch = track(Wurk::Batch.new)
+    batch.tags = [:sym, 7]
+
+    assert_equal %w[sym 7], batch.tags
+  end
+
+  # --- #jobs block -------------------------------------------------------
+
+  def test_jobs_block_increments_total_and_pending
+    batch = track(Wurk::Batch.new)
+    batch.jobs { 3.times { perform_one(batch) } }
+
+    assert_equal 3, Wurk::Batch::Status.new(batch.bid).total
+    assert_equal 3, Wurk::Batch::Status.new(batch.bid).pending
+  end
+
+  def test_jobs_block_lpushes_to_target_queue
+    batch = track(Wurk::Batch.new)
+    batch.jobs { perform_one(batch) }
+
+    assert_equal(1, @pool.with { |c| c.call('LLEN', "queue:#{@queue}") })
+  end
+
+  def test_jobs_block_payload_carries_bid
+    batch = track(Wurk::Batch.new)
+    batch.jobs { perform_one(batch) }
+
+    payload = JSON.parse(@pool.with { |c| c.call('LRANGE', "queue:#{@queue}", 0, -1) }.first)
+
+    assert_equal batch.bid, payload['bid']
+  end
+
+  def test_jobs_block_registers_jid_into_live_set
+    batch = track(Wurk::Batch.new)
+    batch.jobs { perform_one(batch) }
+
+    jid = JSON.parse(@pool.with { |c| c.call('LRANGE', "queue:#{@queue}", 0, -1) }.first)['jid']
+
+    assert_equal(1, @pool.with { |c| c.call('SISMEMBER', "b-#{batch.bid}-jids", jid) })
+  end
+
+  def test_jobs_block_indexes_batch_in_global_set
+    batch = track(Wurk::Batch.new)
+    batch.jobs { perform_one(batch) }
+
+    assert_includes @pool.with { |c| c.call('ZRANGE', 'batches', 0, -1) }, batch.bid
+  end
+
+  def test_jobs_block_indexes_each_tag
+    batch = track(Wurk::Batch.new)
+    batch.tags = ['customer:42']
+    batch.jobs { perform_one(batch) }
+
+    assert_includes @pool.with { |c| c.call('SMEMBERS', 'tags:customer:42') }, batch.bid
+  end
+
+  def test_empty_jobs_block_enqueues_marker_job
+    batch = track(Wurk::Batch.new)
+    batch.jobs {} # rubocop:disable Lint/EmptyBlock
+
+    assert_operator Wurk::Batch::Status.new(batch.bid).total, :>=, 1
+  end
+
+  def test_jobs_block_raises_without_block
+    batch = track(Wurk::Batch.new)
+
+    assert_raises(ArgumentError) { batch.jobs }
+  end
+
+  def test_repeated_jobs_block_accumulates_total
+    batch = track(Wurk::Batch.new)
+    batch.jobs { perform_one(batch) }
+    batch.jobs { perform_one(batch) }
+
+    assert_equal 2, Wurk::Batch::Status.new(batch.bid).total
+  end
+
+  # --- include? / remove_jobs -------------------------------------------
+
+  def test_include_returns_true_for_member_jid
+    batch = track(Wurk::Batch.new)
+    batch.jobs { perform_one(batch) }
+    jid = JSON.parse(@pool.with { |c| c.call('LRANGE', "queue:#{@queue}", 0, -1) }.first)['jid']
+
+    assert_includes batch, jid
+  end
+
+  def test_include_returns_false_for_unknown_jid
+    batch = track(Wurk::Batch.new)
+    batch.jobs { perform_one(batch) }
+
+    refute_includes batch, 'deadbeef'
+  end
+
+  def test_remove_jobs_decrements_total_and_pending # rubocop:disable Metrics/AbcSize
+    batch = track(Wurk::Batch.new)
+    batch.jobs { 3.times { perform_one(batch) } }
+    jids = queued_jids
+
+    removed = batch.remove_jobs(jids[0], jids[1])
+
+    assert_equal 2, removed
+    assert_equal 1, Wurk::Batch::Status.new(batch.bid).total
+    assert_equal 1, Wurk::Batch::Status.new(batch.bid).pending
+  end
+
+  def test_remove_jobs_returns_zero_for_unknown
+    batch = track(Wurk::Batch.new)
+    batch.jobs { perform_one(batch) }
+
+    assert_equal 0, batch.remove_jobs('aaa', 'bbb')
+  end
+
+  # --- invalidation ------------------------------------------------------
+
+  def test_invalidate_all_sets_flag
+    batch = track(Wurk::Batch.new)
+    batch.jobs { perform_one(batch) }
+    batch.invalidate_all
+
+    refute_predicate batch, :valid?
+  end
+
+  def test_invalidate_all_clears_live_jids_set
+    batch = track(Wurk::Batch.new)
+    batch.jobs { 2.times { perform_one(batch) } }
+    batch.invalidate_all
+
+    assert_equal(0, @pool.with { |c| c.call('SCARD', "b-#{batch.bid}-jids") })
+  end
+
+  def test_valid_default_true
+    batch = track(Wurk::Batch.new)
+    batch.jobs { perform_one(batch) }
+
+    assert_predicate batch, :valid?
+  end
+
+  # --- callbacks ---------------------------------------------------------
+
+  def test_on_registers_callback
+    batch = track(Wurk::Batch.new)
+    batch.on(:success, 'MyCallback', 'k' => 1)
+    batch.jobs { perform_one(batch) }
+
+    persisted = JSON.parse(@pool.with { |c| c.call('HGET', "b-#{batch.bid}", 'callbacks') })
+
+    assert_equal [['success', 'MyCallback', { 'k' => 1 }]], persisted
+  end
+
+  def test_on_accepts_class_target
+    klass = Class.new { def self.name = 'BatchTestCb' }
+    batch = track(Wurk::Batch.new)
+    batch.on(:complete, klass)
+    batch.jobs { perform_one(batch) }
+
+    persisted = JSON.parse(@pool.with { |c| c.call('HGET', "b-#{batch.bid}", 'callbacks') })
+
+    assert_equal 'BatchTestCb', persisted.first[1]
+  end
+
+  def test_on_rejects_unknown_event
+    batch = track(Wurk::Batch.new)
+
+    assert_raises(ArgumentError) { batch.on(:nope, 'X') }
+  end
+
+  def test_on_rejects_non_hash_options
+    batch = track(Wurk::Batch.new)
+
+    assert_raises(ArgumentError) { batch.on(:success, 'X', 'not-a-hash') }
+  end
+
+  # --- expires_in --------------------------------------------------------
+
+  def test_expires_in_returns_self
+    batch = track(Wurk::Batch.new)
+
+    assert_same batch, batch.expires_in(60)
+  end
+
+  # --- parent / parent_bid ----------------------------------------------
+
+  def test_nested_batch_records_parent_bid
+    parent = track(Wurk::Batch.new)
+    child  = nil
+    parent.jobs do
+      child = Wurk::Batch.new
+      track(child)
+      child.jobs { perform_one(child) }
+    end
+
+    reopened = track(Wurk::Batch.new(child.bid))
+
+    assert_equal parent.bid, reopened.parent_bid
+  end
+
+  def test_status_returns_status_object
+    batch = track(Wurk::Batch.new)
+    batch.jobs { perform_one(batch) }
+
+    assert_kind_of Wurk::Batch::Status, batch.status
+  end
+
+  private
+
+  def track(batch)
+    @bids << batch.bid
+    batch
+  end
+
+  # Test stub — push through Wurk::Client so client middleware runs and
+  # BATCH_PUSH atomically registers each push. `bid` propagates from the
+  # active Thread.current[Wurk::Batch::THREAD_KEY] (set inside #jobs).
+  def perform_one(_batch)
+    Wurk::Client.push('class' => @class_name, 'args' => [], 'queue' => @queue)
+  end
+
+  def queued_jids
+    @pool.with { |c| c.call('LRANGE', "queue:#{@queue}", 0, -1) }.map { |s| JSON.parse(s)['jid'] }
   end
 end

--- a/test/unit/client_buffered_test.rb
+++ b/test/unit/client_buffered_test.rb
@@ -9,11 +9,20 @@ require 'json'
 # outage, (b) on next push the buffer drains oldest-first, (c) cap eviction
 # behavior, (d) batched payloads bypass the buffer and raise immediately.
 #
-# This test mutates global state on Wurk::Client (prepends the InstanceMethods
-# module once; resets the buffer between tests). It cannot safely parallelize
-# with sibling tests that depend on the Client singleton state — so no
-# `parallelize_me!`. Buffer is reset in teardown to keep tests isolated.
+# Mutates global state on Wurk::Client (prepends InstanceMethods once; resets
+# the buffer between tests). Opts into the parallel runner per the project
+# contract, but a class-level mutex around #run serializes execution *within*
+# this class so the global Client/Buffered singleton state can't race. Other
+# test classes still run in parallel with this one.
 class ClientBufferedTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  MUTEX = Mutex.new
+
+  def run(*args, &)
+    MUTEX.synchronize { super }
+  end
+
   def setup
     super
     @pool = Wurk.configuration.redis_pool

--- a/test/unit/client_buffered_test.rb
+++ b/test/unit/client_buffered_test.rb
@@ -186,15 +186,21 @@ class ClientBufferedTest < Wurk::Test::UnitCase
 
   private
 
+  # Statsd singletons are process-global — serialize against every other test
+  # class that also rewrites `Wurk::Metrics::Statsd.increment`.
   def with_statsd_capture
-    calls = []
-    Wurk::Metrics::Statsd.singleton_class.alias_method(:__increment_real, :increment)
-    Wurk::Metrics::Statsd.define_singleton_method(:increment) { |metric, **| calls << metric }
-    yield
-    calls
-  ensure
-    Wurk::Metrics::Statsd.singleton_class.send(:alias_method, :increment, :__increment_real)
-    Wurk::Metrics::Statsd.singleton_class.send(:remove_method, :__increment_real)
+    Wurk::Test::STATSD_MUTEX.synchronize do
+      calls = []
+      Wurk::Metrics::Statsd.singleton_class.alias_method(:__increment_real, :increment)
+      Wurk::Metrics::Statsd.define_singleton_method(:increment) { |metric, **| calls << metric }
+      begin
+        yield
+        calls
+      ensure
+        Wurk::Metrics::Statsd.singleton_class.send(:alias_method, :increment, :__increment_real)
+        Wurk::Metrics::Statsd.singleton_class.send(:remove_method, :__increment_real)
+      end
+    end
   end
 
   def base_item(overrides = {})

--- a/test/unit/client_buffered_test.rb
+++ b/test/unit/client_buffered_test.rb
@@ -1,0 +1,232 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'json'
+
+# Drives Wurk::Client::Buffered against real Redis. Simulates Redis-outage
+# behavior by routing pushes through a fake pool that raises
+# RedisClient::ConnectionError. Verifies: (a) push returns a jid even on
+# outage, (b) on next push the buffer drains oldest-first, (c) cap eviction
+# behavior, (d) batched payloads bypass the buffer and raise immediately.
+#
+# This test mutates global state on Wurk::Client (prepends the InstanceMethods
+# module once; resets the buffer between tests). It cannot safely parallelize
+# with sibling tests that depend on the Client singleton state — so no
+# `parallelize_me!`. Buffer is reset in teardown to keep tests isolated.
+class ClientBufferedTest < Wurk::Test::UnitCase
+  def setup
+    super
+    @pool = Wurk.configuration.redis_pool
+    @class_name = "BufferedJob@#{Process.pid}-#{object_id}"
+    @queue      = "bq-#{Process.pid}-#{object_id}"
+    Wurk::Client.reliable_push!
+    Wurk::Client::Buffered.reset!
+  end
+
+  def teardown
+    Wurk::Client::Buffered.reset!
+    @pool.with do |conn|
+      conn.call('DEL', "queue:#{@queue}")
+      conn.call('SREM', 'queues', @queue) if @queue
+    end
+  ensure
+    super
+  end
+
+  # --- activation & config ----------------------------------------------
+
+  def test_reliable_push_is_idempotent
+    Wurk::Client.reliable_push!
+    Wurk::Client.reliable_push!
+
+    assert_predicate Wurk::Client, :reliable_push?
+  end
+
+  def test_default_buffer_cap_is_1000
+    assert_equal 1_000, Wurk::Client::Buffered::DEFAULT_BUFFER_CAP
+    assert_equal 1_000, Wurk::Client.reliable_push_buffer
+  end
+
+  def test_reliable_push_buffer_setter_accepts_positive_integer
+    Wurk::Client.reliable_push_buffer = 50
+
+    assert_equal 50, Wurk::Client.reliable_push_buffer
+  end
+
+  def test_reliable_push_buffer_rejects_non_positive
+    assert_raises(ArgumentError) { Wurk::Client.reliable_push_buffer = 0 }
+    assert_raises(ArgumentError) { Wurk::Client.reliable_push_buffer = -1 }
+    assert_raises(ArgumentError) { Wurk::Client.reliable_push_buffer = 'big' }
+  end
+
+  # --- buffer on outage --------------------------------------------------
+
+  def test_push_buffers_payload_on_connection_error
+    client = build_client(failing_pool)
+    jid = client.push(base_item)
+
+    assert_match(/\A[0-9a-f]{24}\z/, jid)
+    assert_equal 1, Wurk::Client::Buffered.buffer_size
+  end
+
+  def test_push_returns_jid_even_when_buffered
+    client = build_client(failing_pool)
+
+    refute_nil client.push(base_item)
+  end
+
+  def test_push_bulk_buffers_all_payloads_on_outage
+    client = build_client(failing_pool)
+    client.push_bulk(base_item('args' => [[1], [2], [3]]))
+
+    assert_equal 3, Wurk::Client::Buffered.buffer_size
+  end
+
+  def test_buffered_payloads_drain_on_next_successful_push
+    failing = build_client(failing_pool)
+    3.times { |i| failing.push(base_item('args' => [i])) }
+
+    assert_equal 3, Wurk::Client::Buffered.buffer_size
+
+    good = Wurk::Client.new
+    good.push(base_item('args' => [99]))
+
+    assert_equal 0, Wurk::Client::Buffered.buffer_size
+    # 3 buffered + 1 new = 4 jobs in queue
+    assert_equal 4, queue_length
+  end
+
+  def test_drain_preserves_oldest_first_order
+    failing = build_client(failing_pool)
+    failing.push(base_item('args' => ['first']))
+    failing.push(base_item('args' => ['second']))
+    failing.push(base_item('args' => ['third']))
+
+    Wurk::Client.new.push(base_item('args' => ['fourth']))
+
+    # LPUSH puts newest at head → reversing gives push order:
+    assert_equal [['first'], ['second'], ['third'], ['fourth']], queued_args.reverse
+  end
+
+  def test_drain_emits_statsd_per_job
+    calls = with_statsd_capture do
+      failing = build_client(failing_pool)
+      failing.push(base_item)
+      failing.push(base_item)
+      Wurk::Client.new.push(base_item)
+    end
+
+    assert_equal %w[jobs.recovered.push jobs.recovered.push], calls
+  end
+
+  # --- ring cap ----------------------------------------------------------
+
+  def test_buffer_drops_oldest_when_cap_exceeded
+    Wurk::Client.reliable_push_buffer = 2
+    failing = build_client(failing_pool)
+    failing.push(base_item('args' => ['oldest']))
+    failing.push(base_item('args' => ['middle']))
+    failing.push(base_item('args' => ['newest']))
+
+    assert_equal 2, Wurk::Client::Buffered.buffer_size
+  end
+
+  # rubocop:disable Metrics/AbcSize, Minitest/MultipleAssertions
+  def test_drain_after_cap_eviction_replays_surviving_entries
+    Wurk::Client.reliable_push_buffer = 2
+    failing = build_client(failing_pool)
+    failing.push(base_item('args' => ['oldest']))
+    failing.push(base_item('args' => ['middle']))
+    failing.push(base_item('args' => ['newest']))
+
+    Wurk::Client.new.push(base_item('args' => ['fresh']))
+
+    queued = queued_args
+
+    refute_includes queued, ['oldest']
+    assert_includes queued, ['middle']
+    assert_includes queued, ['newest']
+    assert_includes queued, ['fresh']
+  end
+  # rubocop:enable Metrics/AbcSize, Minitest/MultipleAssertions
+
+  # --- batch bypass ------------------------------------------------------
+
+  def test_batched_payload_does_not_buffer_and_re_raises
+    client = build_client(failing_pool)
+
+    assert_raises(RedisClient::ConnectionError) do
+      client.push(base_item('bid' => 'B12345'))
+    end
+    assert_equal 0, Wurk::Client::Buffered.buffer_size
+  end
+
+  # --- partial drain on persistent outage --------------------------------
+
+  def test_drain_re_buffers_payload_when_redis_still_down
+    failing = build_client(failing_pool)
+    failing.push(base_item('args' => [1]))
+    failing.push(base_item('args' => [2]))
+
+    # Next push also fails — buffer should preserve head order, no dupes.
+    failing.push(base_item('args' => [3]))
+
+    assert_equal 3, Wurk::Client::Buffered.buffer_size
+    assert_equal [[1], [2], [3]], Wurk::Client::Buffered.buffer.map { |p| p['args'] } # rubocop:disable Lint/AmbiguousBlockAssociation
+  end
+
+  private
+
+  def with_statsd_capture
+    calls = []
+    Wurk::Metrics::Statsd.singleton_class.alias_method(:__increment_real, :increment)
+    Wurk::Metrics::Statsd.define_singleton_method(:increment) { |metric, **| calls << metric }
+    yield
+    calls
+  ensure
+    Wurk::Metrics::Statsd.singleton_class.send(:alias_method, :increment, :__increment_real)
+    Wurk::Metrics::Statsd.singleton_class.send(:remove_method, :__increment_real)
+  end
+
+  def base_item(overrides = {})
+    { 'class' => @class_name, 'args' => [], 'queue' => @queue }.merge(overrides)
+  end
+
+  def build_client(pool)
+    Wurk::Client.new(pool: pool)
+  end
+
+  # Pool that yields a connection always raising ConnectionError on the
+  # pipelined write path Wurk::Client#raw_push uses.
+  def failing_pool
+    pool = Object.new
+    pool.define_singleton_method(:with) do |&blk|
+      blk.call(FailingConn.new)
+    end
+    pool
+  end
+
+  def queued_payloads
+    @pool.with { |c| c.call('LRANGE', "queue:#{@queue}", 0, -1) }.map { |s| JSON.parse(s) }
+  end
+
+  def queued_args
+    queued_payloads.map { |p| p['args'] }
+  end
+
+  def queue_length
+    @pool.with { |c| c.call('LLEN', "queue:#{@queue}") }
+  end
+
+  # Fake connection that raises on any pipeline operation. Mimics a dead
+  # socket: pipelined block runs, the first call inside raises.
+  class FailingConn
+    def pipelined
+      yield self
+    end
+
+    def call(*)
+      raise RedisClient::ConnectionError, 'simulated outage'
+    end
+  end
+end

--- a/test/unit/compat_aliases_test.rb
+++ b/test/unit/compat_aliases_test.rb
@@ -62,6 +62,10 @@ class CompatAliasesTest < Wurk::Test::UnitCase
     assert_same Wurk::Batch, Sidekiq::Batch
   end
 
+  def test_batch_set_alias
+    assert_same Wurk::BatchSet, Sidekiq::BatchSet
+  end
+
   def test_capsule_alias
     assert_same Wurk::Capsule, Sidekiq::Capsule
   end

--- a/test/unit/lua_test.rb
+++ b/test/unit/lua_test.rb
@@ -33,7 +33,8 @@ class LuaTest < Wurk::Test::UnitCase
   def test_scripts_registry_holds_expected_keys
     assert_equal(
       %i[zpopbyscore bulk_push reliable_schedule_promote
-         batch_push batch_ack_success batch_ack_complete batch_invalidate].sort,
+         batch_push batch_ack_success batch_ack_complete batch_invalidate
+         fast_delete_job fast_delete_by_class].sort,
       Wurk::Lua::SCRIPTS.keys.sort
     )
   end

--- a/test/unit/lua_test.rb
+++ b/test/unit/lua_test.rb
@@ -33,7 +33,7 @@ class LuaTest < Wurk::Test::UnitCase
   def test_scripts_registry_holds_expected_keys
     assert_equal(
       %i[zpopbyscore bulk_push reliable_schedule_promote
-         batch_push batch_complete batch_invalidate].sort,
+         batch_push batch_ack_success batch_ack_complete batch_invalidate].sort,
       Wurk::Lua::SCRIPTS.keys.sort
     )
   end
@@ -160,22 +160,52 @@ class LuaTest < Wurk::Test::UnitCase
     end
   end
 
-  def test_batch_complete_decrements_pending_only_for_known_jid
+  def test_batch_ack_success_decrements_pending_only_for_known_jid
     bkey = "#{@ns}:b-y"
     jids = "#{@ns}:b-y-jids"
     @pool.with do |c|
       c.call('HSET', bkey, 'total', 2, 'pending', 2)
       c.call('SADD', jids, 'A', 'B')
 
-      remaining = Wurk::Lua::Loader.eval_cached(c, :batch_complete, keys: [bkey, jids], argv: ['A'])
+      pending, live = Wurk::Lua::Loader.eval_cached(c, :batch_ack_success, keys: [bkey, jids], argv: ['A'])
 
-      assert_equal 1, remaining
+      assert_equal 1, pending
+      assert_equal 1, live
       assert_equal '1', c.call('HGET', bkey, 'pending')
 
-      unknown = Wurk::Lua::Loader.eval_cached(c, :batch_complete, keys: [bkey, jids], argv: ['ZZZ'])
+      pending, live = Wurk::Lua::Loader.eval_cached(c, :batch_ack_success, keys: [bkey, jids], argv: ['ZZZ'])
 
-      assert_equal(-1, unknown)
+      assert_equal(-1, pending)
+      assert_equal(-1, live)
       assert_equal '1', c.call('HGET', bkey, 'pending')
+    end
+  end
+
+  def test_batch_ack_complete_records_death_and_signals_first # rubocop:disable Metrics/AbcSize
+    bkey   = "#{@ns}:b-d"
+    jids   = "#{@ns}:b-d-jids"
+    died   = "#{@ns}:b-d-died"
+    failed = "#{@ns}:b-d-failed"
+    @pool.with do |c|
+      c.call('HSET', bkey, 'total', 2, 'pending', 2, 'failures', 0)
+      c.call('SADD', jids, 'A', 'B')
+
+      live, died_n, first = Wurk::Lua::Loader.eval_cached(
+        c, :batch_ack_complete, keys: [bkey, jids, died, failed], argv: ['A']
+      )
+
+      assert_equal 1, live
+      assert_equal 1, died_n
+      assert_equal 1, first
+      assert_equal '1', c.call('HGET', bkey, 'failures')
+      assert_equal 1, c.call('SISMEMBER', died, 'A')
+      assert_equal 1, c.call('SISMEMBER', failed, 'A')
+
+      _live, _died_n, second_first = Wurk::Lua::Loader.eval_cached(
+        c, :batch_ack_complete, keys: [bkey, jids, died, failed], argv: ['B']
+      )
+
+      assert_equal 0, second_first
     end
   end
   # rubocop:enable Minitest/MultipleAssertions

--- a/test/unit/metrics_statsd_test.rb
+++ b/test/unit/metrics_statsd_test.rb
@@ -7,17 +7,16 @@ require_relative '../test_helper'
 # Pro per-job `options` proc + `dd_rate` override, and acts as a clean
 # server middleware around `yield`.
 #
-# Mutates global Wurk.configuration.dogstatsd / Statsd.options, so the class
-# opts into the parallel runner per the project contract but holds a
-# class-level mutex around #run to serialize execution *within* the class.
-# Other test classes still run in parallel with this one.
+# Mutates global Wurk.configuration.dogstatsd / Statsd.options. The class opts
+# into the parallel runner per the project contract but holds the suite-wide
+# `Wurk::Test::STATSD_MUTEX` around #run — required because other test classes
+# (client_buffered, middleware_expiry, middleware_poison_pill) also rewrite
+# Statsd singletons, and a per-class mutex doesn't protect against them.
 class MetricsStatsdTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  MUTEX = Mutex.new
-
   def run(*args, &)
-    MUTEX.synchronize { super }
+    Wurk::Test::STATSD_MUTEX.synchronize { super }
   end
 
   # In-memory client that records every call. Mirrors the surface

--- a/test/unit/metrics_statsd_test.rb
+++ b/test/unit/metrics_statsd_test.rb
@@ -1,0 +1,263 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Pins the Wurk::Metrics::Statsd contract: no-op when no client wired,
+# emits prefixed metrics through the configured callable, supports the
+# Pro per-job `options` proc + `dd_rate` override, and acts as a clean
+# server middleware around `yield`.
+#
+# Tests mutate global Wurk.configuration.dogstatsd / Statsd.options, so the
+# class can't be parallelized — `Statsd.reset!` runs between tests and the
+# absence of `parallelize_me!` keeps execution serial within the file.
+class MetricsStatsdTest < Wurk::Test::UnitCase
+  # In-memory client that records every call. Mirrors the surface
+  # Wurk::Metrics::Statsd reaches for: increment / gauge / distribution.
+  class FakeClient
+    attr_reader :calls
+
+    def initialize
+      @calls = []
+    end
+
+    def increment(metric, **opts)
+      @calls << [:increment, metric, opts]
+    end
+
+    def gauge(metric, value, **opts)
+      @calls << [:gauge, metric, value, opts]
+    end
+
+    def distribution(metric, value, **opts)
+      @calls << [:distribution, metric, value, opts]
+    end
+  end
+
+  # Mirror without #distribution so the fallback path (histogram) is exercised.
+  class StatsdOnlyClient
+    attr_reader :calls
+
+    def initialize
+      @calls = []
+    end
+
+    def increment(metric, **opts)
+      @calls << [:increment, metric, opts]
+    end
+
+    def gauge(metric, value, **opts)
+      @calls << [:gauge, metric, value, opts]
+    end
+
+    def histogram(metric, value, **opts)
+      @calls << [:histogram, metric, value, opts]
+    end
+  end
+
+  def setup
+    super
+    @prev_builder = Wurk.configuration.dogstatsd
+    @prev_options = Wurk::Metrics::Statsd.options
+    Wurk::Metrics::Statsd.reset!
+  end
+
+  def teardown
+    Wurk.configuration.dogstatsd = @prev_builder
+    Wurk::Metrics::Statsd.options = @prev_options
+    Wurk::Metrics::Statsd.reset!
+  ensure
+    super
+  end
+
+  # --- client wiring ------------------------------------------------------
+
+  def test_increment_no_op_when_no_client_configured
+    Wurk.configuration.dogstatsd = nil
+
+    assert_nil Wurk::Metrics::Statsd.increment('jobs.poison')
+  end
+
+  def test_increment_invokes_configured_proc_once
+    invocations = 0
+    Wurk.configuration.dogstatsd = lambda {
+      invocations += 1
+      FakeClient.new
+    }
+
+    Wurk::Metrics::Statsd.increment('jobs.poison')
+    Wurk::Metrics::Statsd.increment('jobs.poison')
+
+    assert_equal 1, invocations, 'dogstatsd builder must be invoked exactly once per process'
+  end
+
+  def test_increment_accepts_non_callable_client
+    fake = FakeClient.new
+    Wurk.configuration.dogstatsd = fake
+
+    Wurk::Metrics::Statsd.increment('jobs.poison')
+
+    assert_equal 1, fake.calls.size
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def test_metric_names_get_sidekiq_prefix
+    fake = FakeClient.new
+    Wurk.configuration.dogstatsd = fake
+
+    Wurk::Metrics::Statsd.increment('jobs.poison', tags: ['class:X'])
+
+    assert_equal :increment, fake.calls.first[0]
+    assert_equal 'sidekiq.jobs.poison', fake.calls.first[1]
+    assert_equal ['class:X'], fake.calls.first[2][:tags]
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  def test_increment_swallows_client_errors
+    boom = Object.new
+    boom.define_singleton_method(:increment) { |*_, **_| raise 'boom' }
+    Wurk.configuration.dogstatsd = boom
+
+    assert_silent { Wurk::Metrics::Statsd.increment('jobs.poison') }
+  end
+
+  def test_distribution_falls_back_to_histogram
+    fake = StatsdOnlyClient.new
+    Wurk.configuration.dogstatsd = fake
+
+    Wurk::Metrics::Statsd.distribution('jobs.perform_dist', 12.5, tags: ['queue:x'])
+
+    assert_equal :histogram, fake.calls.first[0]
+    assert_equal 'sidekiq.jobs.perform_dist', fake.calls.first[1]
+    assert_in_delta 12.5, fake.calls.first[2], 0.0001
+  end
+
+  def test_sample_rate_omitted_when_default
+    fake = FakeClient.new
+    Wurk.configuration.dogstatsd = fake
+
+    Wurk::Metrics::Statsd.increment('jobs.count', tags: ['x:1'])
+
+    refute_includes fake.calls.first[2].keys, :sample_rate
+  end
+
+  def test_sample_rate_passed_through_when_overridden
+    fake = FakeClient.new
+    Wurk.configuration.dogstatsd = fake
+
+    Wurk::Metrics::Statsd.increment('jobs.count', tags: ['x:1'], sample_rate: 0.5)
+
+    assert_in_delta 0.5, fake.calls.first[2][:sample_rate], 0.0001
+  end
+
+  # --- server middleware behavior ----------------------------------------
+
+  def test_call_yields_when_no_client
+    Wurk.configuration.dogstatsd = nil
+    middleware = build_middleware
+    yielded = false
+    middleware.call(nil, { 'class' => 'X' }, 'default') { yielded = true }
+
+    assert yielded
+  end
+
+  # rubocop:disable Minitest/MultipleAssertions
+  def test_call_emits_count_success_perform_perform_dist_on_success
+    fake = FakeClient.new
+    Wurk.configuration.dogstatsd = fake
+
+    build_middleware.call(nil, { 'class' => 'MyJob' }, 'critical') { :ok }
+
+    metrics = fake.calls.map { |c| c[1] }
+
+    assert_includes metrics, 'sidekiq.jobs.count'
+    assert_includes metrics, 'sidekiq.jobs.success'
+    assert_includes metrics, 'sidekiq.jobs.perform'
+    assert_includes metrics, 'sidekiq.jobs.perform_dist'
+    refute_includes metrics, 'sidekiq.jobs.failure'
+  end
+  # rubocop:enable Minitest/MultipleAssertions
+
+  def test_call_emits_failure_on_raise_and_rebubbles
+    fake = FakeClient.new
+    Wurk.configuration.dogstatsd = fake
+
+    assert_raises(RuntimeError) do
+      build_middleware.call(nil, { 'class' => 'MyJob' }, 'q') { raise 'boom' }
+    end
+
+    metrics = fake.calls.map { |c| c[1] }
+
+    assert_includes metrics, 'sidekiq.jobs.failure'
+    refute_includes metrics, 'sidekiq.jobs.success'
+  end
+
+  def test_default_tags_include_worker_and_queue
+    fake = FakeClient.new
+    Wurk.configuration.dogstatsd = fake
+    build_middleware.call(nil, { 'class' => 'MyJob' }, 'critical') { :ok }
+    count_call = fake.calls.find { |c| c[1] == 'sidekiq.jobs.count' }
+
+    assert_equal ['worker:MyJob', 'queue:critical'], count_call[2][:tags]
+  end
+
+  def test_options_proc_overrides_tags
+    fake = FakeClient.new
+    Wurk.configuration.dogstatsd = fake
+    Wurk::Metrics::Statsd.options = ->(klass, _job, queue) { { tags: ["override:#{klass}:#{queue}"] } }
+
+    build_middleware.call(nil, { 'class' => 'MyJob' }, 'q') { :ok }
+    count = fake.calls.find { |c| c[1] == 'sidekiq.jobs.count' }
+
+    assert_equal ['override:MyJob:q'], count[2][:tags]
+  end
+
+  def test_options_proc_sets_sample_rate
+    fake = FakeClient.new
+    Wurk.configuration.dogstatsd = fake
+    Wurk::Metrics::Statsd.options = ->(_k, _j, _q) { { sample_rate: 0.25 } }
+
+    build_middleware.call(nil, { 'class' => 'MyJob' }, 'q') { :ok }
+    count = fake.calls.find { |c| c[1] == 'sidekiq.jobs.count' }
+
+    assert_in_delta 0.25, count[2][:sample_rate], 0.0001
+  end
+
+  def test_dd_rate_on_job_overrides_options_proc
+    fake = FakeClient.new
+    Wurk.configuration.dogstatsd = fake
+    Wurk::Metrics::Statsd.options = ->(_k, _j, _q) { { sample_rate: 0.25 } }
+
+    build_middleware.call(nil, { 'class' => 'MyJob', 'dd_rate' => 0.1 }, 'q') { :ok }
+    count = fake.calls.find { |c| c[1] == 'sidekiq.jobs.count' }
+
+    assert_in_delta 0.1, count[2][:sample_rate], 0.0001
+  end
+
+  def test_module_inclusion
+    assert_includes Wurk::Metrics::Statsd.ancestors, Wurk::Middleware::ServerMiddleware
+  end
+
+  def test_perform_gauge_is_milliseconds
+    fake = FakeClient.new
+    Wurk.configuration.dogstatsd = fake
+
+    build_middleware.call(nil, { 'class' => 'MyJob' }, 'q') { sleep(0.01) }
+    perform = fake.calls.find { |c| c[0] == :gauge && c[1] == 'sidekiq.jobs.perform' }
+
+    refute_nil perform
+    assert_operator perform[2], :>=, 8.0, 'gauge must be in milliseconds'
+  end
+
+  private
+
+  def build_middleware
+    middleware = Wurk::Metrics::Statsd.new
+    middleware.config = FakeConfig.new
+    middleware
+  end
+
+  class FakeConfig
+    def redis_pool = nil
+    def logger = ::Logger.new(IO::NULL)
+  end
+end

--- a/test/unit/metrics_statsd_test.rb
+++ b/test/unit/metrics_statsd_test.rb
@@ -7,10 +7,19 @@ require_relative '../test_helper'
 # Pro per-job `options` proc + `dd_rate` override, and acts as a clean
 # server middleware around `yield`.
 #
-# Tests mutate global Wurk.configuration.dogstatsd / Statsd.options, so the
-# class can't be parallelized — `Statsd.reset!` runs between tests and the
-# absence of `parallelize_me!` keeps execution serial within the file.
+# Mutates global Wurk.configuration.dogstatsd / Statsd.options, so the class
+# opts into the parallel runner per the project contract but holds a
+# class-level mutex around #run to serialize execution *within* the class.
+# Other test classes still run in parallel with this one.
 class MetricsStatsdTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  MUTEX = Mutex.new
+
+  def run(*args, &)
+    MUTEX.synchronize { super }
+  end
+
   # In-memory client that records every call. Mirrors the surface
   # Wurk::Metrics::Statsd reaches for: increment / gauge / distribution.
   class FakeClient

--- a/test/unit/middleware_expiry_test.rb
+++ b/test/unit/middleware_expiry_test.rb
@@ -45,15 +45,22 @@ class MiddlewareExpiryTest < Wurk::Test::UnitCase
     end
   end
 
+  # `Wurk::Metrics::Statsd.increment` is a process-global singleton method —
+  # serialize against every other test class that rewrites it (metrics_statsd,
+  # client_buffered, middleware_poison_pill).
   def with_statsd_recorder
-    real = Wurk::Metrics::Statsd.method(:increment)
-    Wurk::Metrics::Statsd.singleton_class.send(:define_method, :increment) do |metric, tags: nil|
-      StatsdRecorder.increment(metric, tags: tags)
+    Wurk::Test::STATSD_MUTEX.synchronize do
+      real = Wurk::Metrics::Statsd.method(:increment)
+      Wurk::Metrics::Statsd.singleton_class.send(:define_method, :increment) do |metric, tags: nil|
+        StatsdRecorder.increment(metric, tags: tags)
+      end
+      StatsdRecorder.reset!
+      begin
+        yield StatsdRecorder
+      ensure
+        Wurk::Metrics::Statsd.singleton_class.send(:define_method, :increment, real)
+      end
     end
-    StatsdRecorder.reset!
-    yield StatsdRecorder
-  ensure
-    Wurk::Metrics::Statsd.singleton_class.send(:define_method, :increment, real)
   end
 
   def build_middleware

--- a/test/unit/middleware_expiry_test.rb
+++ b/test/unit/middleware_expiry_test.rb
@@ -62,6 +62,20 @@ class MiddlewareExpiryTest < Wurk::Test::UnitCase
     m
   end
 
+  # Minitest 6 dropped minitest/mock, so we hand-roll a Time.now override.
+  # Yields the pinned epoch-float; restores the original Time.now in ensure.
+  def with_time_now(epoch_f)
+    frozen = ::Time.at(epoch_f)
+    sc = ::Time.singleton_class
+    original = ::Time.method(:now)
+    sc.define_method(:now) { frozen }
+    begin
+      yield frozen.to_f
+    ensure
+      sc.define_method(:now) { |*a, &b| original.call(*a, &b) }
+    end
+  end
+
   # =====================================================================
   # Middleware behavior
   # =====================================================================
@@ -139,10 +153,14 @@ class MiddlewareExpiryTest < Wurk::Test::UnitCase
 
   def test_expiry_at_exactly_now_does_not_skip
     # Strict `>` per spec §7: equal timestamps aren't expired yet.
+    # Minitest 6 dropped `Time.stub`; hand-rolled override pins Time.now
+    # so `expiry == now` deterministically (no narrow real-clock window).
     yielded = false
-    build_middleware.call(nil, { 'class' => 'X', 'expiry' => ::Time.now.to_f - 0.0001 }, 'q') { yielded = true }
+    with_time_now(1_700_000_000.0) do |frozen|
+      build_middleware.call(nil, { 'class' => 'X', 'expiry' => frozen }, 'q') { yielded = true }
+    end
 
-    refute yielded, 'expiry just past now must skip'
+    assert yielded, 'expiry equal to now must not skip'
   end
 
   def test_coerces_string_expiry_via_to_f

--- a/test/unit/middleware_expiry_test.rb
+++ b/test/unit/middleware_expiry_test.rb
@@ -1,0 +1,311 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Coverage for `expires_in` end-to-end:
+#   * Wurk::JobUtil#stamp_expiry — client-side stamping of the absolute
+#     `expiry` epoch-float on the payload at push.
+#   * Wurk::Middleware::Expiry — server-side check immediately before perform,
+#     drops the job (statsd + clean ack) when expired; no preemption mid-run.
+#
+# These run in isolation (no Redis, no chain) so the assertions pin the
+# middleware contract directly. Chain composition (Batch ack still firing on
+# expired job) is covered separately in middleware_chain_test.rb if needed.
+class MiddlewareExpiryTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  # --- fakes ---------------------------------------------------------------
+
+  class FakeConfig
+    attr_reader :redis_pool, :logger
+
+    def initialize
+      @redis_pool = nil
+      @logger = ::Logger.new(IO::NULL)
+    end
+  end
+
+  # Capturing shim for Wurk::Metrics::Statsd.increment. The real method is a
+  # `nil`-returning no-op (statsd client is plumbed in by a host integration);
+  # we swap in a recorder for the duration of one test.
+  module StatsdRecorder
+    @calls = []
+
+    class << self
+      attr_reader :calls
+
+      def increment(metric, tags: nil)
+        @calls << [metric, tags]
+        nil
+      end
+
+      def reset!
+        @calls = []
+      end
+    end
+  end
+
+  def with_statsd_recorder
+    real = Wurk::Metrics::Statsd.method(:increment)
+    Wurk::Metrics::Statsd.singleton_class.send(:define_method, :increment) do |metric, tags: nil|
+      StatsdRecorder.increment(metric, tags: tags)
+    end
+    StatsdRecorder.reset!
+    yield StatsdRecorder
+  ensure
+    Wurk::Metrics::Statsd.singleton_class.send(:define_method, :increment, real)
+  end
+
+  def build_middleware
+    m = Wurk::Middleware::Expiry.new
+    m.config = FakeConfig.new
+    m
+  end
+
+  # =====================================================================
+  # Middleware behavior
+  # =====================================================================
+
+  def test_yields_when_no_expiry_set
+    yielded = false
+    result = build_middleware.call(nil, { 'class' => 'X' }, 'q') do
+      yielded = true
+      :ok
+    end
+
+    assert yielded
+    assert_equal :ok, result
+  end
+
+  def test_yields_when_expiry_in_future
+    future = ::Time.now.to_f + 60
+    yielded = false
+    build_middleware.call(nil, { 'class' => 'X', 'expiry' => future }, 'q') { yielded = true }
+
+    assert yielded
+  end
+
+  def test_skips_when_expiry_in_past
+    past = ::Time.now.to_f - 60
+    yielded = false
+    build_middleware.call(nil, { 'class' => 'X', 'expiry' => past }, 'q') { yielded = true }
+
+    refute yielded
+  end
+
+  def test_skip_returns_nil_not_raises
+    past = ::Time.now.to_f - 60
+    result = nil
+    assert_silent do
+      result = build_middleware.call(nil, { 'class' => 'X', 'expiry' => past }, 'q') { :body }
+    end
+
+    assert_nil result
+  end
+
+  # rubocop:disable Minitest/MultipleAssertions
+  # One test pinning the entire statsd wire shape (count + metric + tags);
+  # splitting would obscure the contract.
+  def test_skip_emits_statsd_jobs_expired
+    past = ::Time.now.to_f - 60
+    with_statsd_recorder do |recorder|
+      build_middleware.call(nil, { 'class' => 'MyJob', 'expiry' => past }, 'q') { flunk 'must not yield' }
+
+      assert_equal 1, recorder.calls.size
+      metric, tags = recorder.calls.first
+
+      assert_equal 'jobs.expired', metric
+      assert_equal ['class:MyJob'], tags
+    end
+  end
+  # rubocop:enable Minitest/MultipleAssertions
+
+  def test_no_statsd_call_on_non_expired_job
+    future = ::Time.now.to_f + 60
+    with_statsd_recorder do |recorder|
+      build_middleware.call(nil, { 'class' => 'X', 'expiry' => future }, 'q') { :ok }
+
+      assert_empty recorder.calls
+    end
+  end
+
+  def test_no_statsd_call_when_no_expiry
+    with_statsd_recorder do |recorder|
+      build_middleware.call(nil, { 'class' => 'X' }, 'q') { :ok }
+
+      assert_empty recorder.calls
+    end
+  end
+
+  def test_expiry_at_exactly_now_does_not_skip
+    # Strict `>` per spec §7: equal timestamps aren't expired yet.
+    yielded = false
+    build_middleware.call(nil, { 'class' => 'X', 'expiry' => ::Time.now.to_f - 0.0001 }, 'q') { yielded = true }
+
+    refute yielded, 'expiry just past now must skip'
+  end
+
+  def test_coerces_string_expiry_via_to_f
+    # JSON round-trips numbers to Float, but some callers (cron, retries) may
+    # send a String. to_f keeps the middleware tolerant.
+    past = (::Time.now.to_f - 60).to_s
+    yielded = false
+    build_middleware.call(nil, { 'class' => 'X', 'expiry' => past }, 'q') { yielded = true }
+
+    refute yielded
+  end
+
+  def test_does_not_preempt_during_perform
+    # Once the block starts running, an expiry that elapses mid-perform must
+    # not interrupt — middleware only checks before yield.
+    expiry = ::Time.now.to_f + 0.05
+    completed = false
+    build_middleware.call(nil, { 'class' => 'X', 'expiry' => expiry }, 'q') do
+      sleep(0.1)
+      completed = true
+    end
+
+    assert completed, 'in-flight perform must finish even when expiry passes mid-run'
+  end
+
+  def test_module_inclusion
+    assert_includes Wurk::Middleware::Expiry.ancestors, Wurk::Middleware::ServerMiddleware
+  end
+
+  def test_auto_registered_on_default_server_chain
+    assert Wurk.configuration.server_middleware.exists?(Wurk::Middleware::Expiry)
+  end
+
+  def test_registered_after_batch_server_middleware
+    chain = Wurk.configuration.server_middleware
+    entries = chain.entries.map(&:klass)
+    batch_idx = entries.index(Wurk::Batch::ServerMiddleware)
+    expiry_idx = entries.index(Wurk::Middleware::Expiry)
+
+    refute_nil batch_idx, 'Batch::ServerMiddleware must be registered'
+    refute_nil expiry_idx, 'Expiry must be registered'
+    assert_operator expiry_idx, :>, batch_idx, 'Expiry must follow Batch so batch ack_success still fires on skip'
+  end
+
+  # =====================================================================
+  # Client-side stamping (JobUtil#stamp_expiry)
+  # =====================================================================
+
+  # A tiny harness exposing JobUtil's private finalize so we can pin the
+  # stamping contract without booting the full client + Redis stack.
+  class Stamper
+    include Wurk::JobUtil
+
+    def stamp(item)
+      finalize(item)
+    end
+  end
+
+  def test_client_stamps_absolute_expiry_from_expires_in
+    created_at_ms = 1_700_000_000_000
+    item = { 'created_at' => created_at_ms, 'expires_in' => 3600, 'class' => 'X', 'args' => [] }
+    Stamper.new.stamp(item)
+
+    assert_in_delta((created_at_ms / 1000.0) + 3600, item['expiry'], 0.001)
+  end
+
+  def test_client_does_not_overwrite_caller_supplied_expiry
+    item = {
+      'created_at' => 1_700_000_000_000,
+      'expires_in' => 3600,
+      'expiry' => 42.0,
+      'class' => 'X',
+      'args' => []
+    }
+    Stamper.new.stamp(item)
+
+    assert_in_delta 42.0, item['expiry'], 0.001
+  end
+
+  def test_client_no_op_when_expires_in_missing
+    item = { 'created_at' => 1_700_000_000_000, 'class' => 'X', 'args' => [] }
+    Stamper.new.stamp(item)
+
+    refute item.key?('expiry')
+  end
+
+  def test_client_accepts_float_duration
+    created_at_ms = 1_700_000_000_000
+    item = { 'created_at' => created_at_ms, 'expires_in' => 1.5, 'class' => 'X', 'args' => [] }
+    Stamper.new.stamp(item)
+
+    assert_in_delta((created_at_ms / 1000.0) + 1.5, item['expiry'], 0.001)
+  end
+
+  def test_client_skips_when_duration_does_not_respond_to_to_f
+    weird = Object.new
+    item = { 'created_at' => 1_700_000_000_000, 'expires_in' => weird, 'class' => 'X', 'args' => [] }
+    Stamper.new.stamp(item)
+
+    refute item.key?('expiry')
+  end
+
+  # =====================================================================
+  # Integration: Worker.sidekiq_options(expires_in:) flows to payload
+  # =====================================================================
+
+  def test_worker_sidekiq_options_carries_expires_in
+    klass = Class.new do
+      include Wurk::Worker
+
+      sidekiq_options expires_in: 600
+      def perform; end
+    end
+
+    assert_equal 600, klass.get_sidekiq_options['expires_in']
+  end
+
+  def test_client_push_stamps_expiry_from_class_sidekiq_options
+    with_expiry_job(3600) do |klass, queue, pool|
+      before_s = ::Process.clock_gettime(::Process::CLOCK_REALTIME)
+      Wurk::Client.new.push('class' => klass, 'args' => [], 'queue' => queue)
+      after_s = ::Process.clock_gettime(::Process::CLOCK_REALTIME)
+
+      expiry = fetch_pushed_expiry(pool, queue)
+
+      assert_expiry_in_window(expiry, before_s, after_s, 3600)
+    end
+  end
+
+  private
+
+  def with_expiry_job(duration)
+    klass_name = "ExpiryJob_#{Process.pid}_#{object_id}"
+    klass = Class.new do
+      include Wurk::Worker
+
+      sidekiq_options expires_in: duration
+      def perform; end
+    end
+    Object.const_set(klass_name, klass)
+    queue = "q-#{Process.pid}-#{object_id}"
+    pool  = Wurk.configuration.redis_pool
+    begin
+      yield klass, queue, pool
+    ensure
+      pool.with do |c|
+        c.call('DEL', "queue:#{queue}")
+        c.call('SREM', 'queues', queue)
+      end
+      Object.send(:remove_const, klass_name) if Object.const_defined?(klass_name)
+    end
+  end
+
+  def fetch_pushed_expiry(pool, queue)
+    raw = pool.with { |c| c.call('LRANGE', "queue:#{queue}", 0, -1) }.first
+
+    refute_nil raw, 'expected a payload in the test queue'
+    JSON.parse(raw)['expiry']
+  end
+
+  def assert_expiry_in_window(expiry, before_s, after_s, duration)
+    refute_nil expiry, 'expiry must be stamped onto the wire payload'
+    assert_operator expiry, :>=, before_s + duration - 0.01
+    assert_operator expiry, :<=, after_s  + duration + 0.01
+  end
+end

--- a/test/unit/middleware_poison_pill_test.rb
+++ b/test/unit/middleware_poison_pill_test.rb
@@ -1,0 +1,199 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'securerandom'
+
+# Pins Wurk::Middleware::PoisonPill:
+#   * INCR + EXPIRE 72h at `super_fetch:recovered:<jid>` per orphan
+#   * <3 → return :recovered, emit `jobs.recovered.fetch`
+#   * ≥3 → kill into dead set, emit `jobs.poison`, fire callbacks
+#
+# Spec: docs/target/sidekiq-pro.md §3.2.
+class MiddlewarePoisonPillTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @ns       = "#{Process.pid}-#{object_id}"
+    @jid      = SecureRandom.hex(12)
+    @queue    = "ppq-#{@ns}"
+    @pool     = Wurk.configuration.redis_pool
+    @key      = "super_fetch:recovered:#{@jid}"
+    @stub_increments = []
+    Wurk::Middleware::PoisonPill.reset!
+    clean
+  end
+
+  def teardown
+    Wurk::Middleware::PoisonPill.reset!
+    clean
+  ensure
+    super
+  end
+
+  # --- counter lifecycle -------------------------------------------------
+
+  def test_first_recovery_increments_to_one
+    result = Wurk::Middleware::PoisonPill.track!(payload_json, queue: @queue)
+
+    assert_equal :recovered, result
+    assert_equal 1, Wurk::Middleware::PoisonPill.recovery_count(@jid)
+  end
+
+  def test_counter_expires_at_72_hours
+    Wurk::Middleware::PoisonPill.track!(payload_json, queue: @queue)
+    ttl = @pool.with { |c| c.call('TTL', @key) }.to_i
+
+    assert_operator ttl, :<=, Wurk::Middleware::PoisonPill::RECOVERY_TTL
+    assert_operator ttl, :>=, Wurk::Middleware::PoisonPill::RECOVERY_TTL - 5
+  end
+
+  def test_second_recovery_does_not_yet_poison
+    2.times { Wurk::Middleware::PoisonPill.track!(payload_json, queue: @queue) }
+
+    assert_equal 2, Wurk::Middleware::PoisonPill.recovery_count(@jid)
+    assert_equal 0, dead_size
+  end
+
+  def test_third_recovery_returns_poison_and_writes_to_dead
+    json = payload_json
+    2.times { Wurk::Middleware::PoisonPill.track!(json, queue: @queue) }
+    result = Wurk::Middleware::PoisonPill.track!(json, queue: @queue)
+
+    assert_equal :poison, result
+    assert_equal 1, dead_for_jid_count
+  end
+
+  def test_clear_resets_counter
+    Wurk::Middleware::PoisonPill.track!(payload_json, queue: @queue)
+    Wurk::Middleware::PoisonPill.clear!(@jid)
+
+    assert_equal 0, Wurk::Middleware::PoisonPill.recovery_count(@jid)
+  end
+
+  def test_recovery_count_returns_zero_for_unknown_jid
+    assert_equal 0, Wurk::Middleware::PoisonPill.recovery_count(SecureRandom.hex(12))
+  end
+
+  def test_recovery_count_handles_empty_input
+    assert_equal 0, Wurk::Middleware::PoisonPill.recovery_count(nil)
+    assert_equal 0, Wurk::Middleware::PoisonPill.recovery_count('')
+  end
+
+  # --- malformed payload --------------------------------------------------
+
+  def test_unparseable_payload_returns_recovered_without_state
+    assert_equal :recovered, Wurk::Middleware::PoisonPill.track!('not-json{{')
+  end
+
+  def test_payload_without_jid_skips_counter
+    json = Wurk.dump_json('class' => 'X', 'args' => [])
+
+    assert_equal :recovered, Wurk::Middleware::PoisonPill.track!(json, queue: @queue)
+  end
+
+  def test_accepts_pre_parsed_hash
+    Wurk::Middleware::PoisonPill.track!({ 'jid' => @jid, 'class' => 'X' }, queue: @queue)
+
+    assert_equal 1, Wurk::Middleware::PoisonPill.recovery_count(@jid)
+  end
+
+  # --- statsd integration -------------------------------------------------
+
+  def test_emits_jobs_recovered_fetch_on_normal_recovery
+    metrics = with_statsd_recorder do
+      Wurk::Middleware::PoisonPill.track!(payload_json, queue: @queue)
+    end
+
+    assert_equal [['jobs.recovered.fetch', ['class:PoisonPillTestJob', "queue:#{@queue}"]]], metrics
+  end
+
+  def test_emits_jobs_poison_on_threshold_crossing
+    json = payload_json
+    metrics = with_statsd_recorder do
+      3.times { Wurk::Middleware::PoisonPill.track!(json, queue: @queue) }
+    end
+
+    poison = metrics.select { |m| m[0] == 'jobs.poison' }
+
+    assert_equal 1, poison.size
+    assert_equal ['class:PoisonPillTestJob', "queue:#{@queue}"], poison.first[1]
+  end
+
+  # --- callback hooks -----------------------------------------------------
+
+  # rubocop:disable Minitest/MultipleAssertions
+  # One test pinning the entire callback contract — splitting would
+  # obscure the pill-hash shape vs. fire-count constraint.
+  def test_on_poison_fires_with_pill_hash
+    pill = nil
+    Wurk::Middleware::PoisonPill.on_poison { |p| pill = p }
+    json = payload_json
+    3.times { Wurk::Middleware::PoisonPill.track!(json, queue: @queue) }
+
+    refute_nil pill
+    assert_equal @jid, pill[:jid]
+    assert_equal 'PoisonPillTestJob', pill[:klass]
+    assert_equal @queue, pill[:queue]
+    assert_equal 3, pill[:count]
+  end
+  # rubocop:enable Minitest/MultipleAssertions
+
+  def test_on_poison_swallows_callback_errors
+    Wurk::Middleware::PoisonPill.on_poison { |_| raise 'boom' }
+    json = payload_json
+
+    assert_silent do
+      3.times { Wurk::Middleware::PoisonPill.track!(json, queue: @queue) }
+    end
+  end
+
+  def test_on_poison_requires_block
+    assert_raises(ArgumentError) { Wurk::Middleware::PoisonPill.on_poison }
+  end
+
+  private
+
+  def payload_json(extra = {})
+    Wurk.dump_json({
+      'class' => 'PoisonPillTestJob',
+      'args' => [],
+      'queue' => @queue,
+      'jid' => @jid,
+      'enqueued_at' => Time.now.to_f
+    }.merge(extra))
+  end
+
+  def with_statsd_recorder
+    calls = []
+    real = Wurk::Metrics::Statsd.method(:increment)
+    Wurk::Metrics::Statsd.singleton_class.send(:define_method, :increment) do |metric, tags: nil, **_|
+      calls << [metric, tags]
+      nil
+    end
+    yield
+    calls
+  ensure
+    Wurk::Metrics::Statsd.singleton_class.send(:define_method, :increment, real)
+  end
+
+  def dead_size
+    @pool.with { |c| c.call('ZCARD', Wurk::Keys::DEAD) }.to_i
+  end
+
+  def dead_for_jid_count
+    @pool.with do |c|
+      members = c.call('ZRANGE', Wurk::Keys::DEAD, 0, -1)
+      members.count { |m| m.include?(@jid) }
+    end
+  end
+
+  def clean
+    @pool.with do |c|
+      c.call('DEL', @key)
+      members = c.call('ZRANGE', Wurk::Keys::DEAD, 0, -1)
+      mine = members.select { |m| m.include?(@jid) }
+      mine.each { |m| c.call('ZREM', Wurk::Keys::DEAD, m) }
+    end
+  end
+end

--- a/test/unit/middleware_poison_pill_test.rb
+++ b/test/unit/middleware_poison_pill_test.rb
@@ -164,17 +164,24 @@ class MiddlewarePoisonPillTest < Wurk::Test::UnitCase
     }.merge(extra))
   end
 
+  # `Wurk::Metrics::Statsd.increment` is a process-global singleton method —
+  # serialize against every other test class that rewrites it (metrics_statsd,
+  # client_buffered, middleware_expiry).
   def with_statsd_recorder
-    calls = []
-    real = Wurk::Metrics::Statsd.method(:increment)
-    Wurk::Metrics::Statsd.singleton_class.send(:define_method, :increment) do |metric, tags: nil, **_|
-      calls << [metric, tags]
-      nil
+    Wurk::Test::STATSD_MUTEX.synchronize do
+      calls = []
+      real = Wurk::Metrics::Statsd.method(:increment)
+      Wurk::Metrics::Statsd.singleton_class.send(:define_method, :increment) do |metric, tags: nil, **_|
+        calls << [metric, tags]
+        nil
+      end
+      begin
+        yield
+        calls
+      ensure
+        Wurk::Metrics::Statsd.singleton_class.send(:define_method, :increment, real)
+      end
     end
-    yield
-    calls
-  ensure
-    Wurk::Metrics::Statsd.singleton_class.send(:define_method, :increment, real)
   end
 
   def dead_size

--- a/test/unit/process_set_test.rb
+++ b/test/unit/process_set_test.rb
@@ -136,10 +136,12 @@ class ProcessSetTest < Wurk::Test::UnitCase
   end
 
   def test_total_rss_aliases_total_rss_in_kb
-    register!(info: base_info, rss: '1024')
-    set = Wurk::ProcessSet.new(false)
-
-    assert_equal set.total_rss_in_kb, set.total_rss
+    # Method-identity check, not call-result comparison. Both methods iterate
+    # `each`, which re-fetches Redis on every call — under parallel siblings
+    # the two reads can return different sums even though the methods are
+    # the same. `alias` makes UnboundMethods equal.
+    assert_equal Wurk::ProcessSet.instance_method(:total_rss_in_kb),
+                 Wurk::ProcessSet.instance_method(:total_rss)
   end
 
   # --- leader ------------------------------------------------------------
@@ -196,13 +198,18 @@ class ProcessSetTest < Wurk::Test::UnitCase
 
   def test_cleanup_returns_zero_when_processes_set_empty
     # `processes` is shared globally — snapshot and restore so parallel
-    # siblings keep their registered identities intact.
-    snapshot = @pool.with { |c| c.call('SMEMBERS', 'processes') }
-    @pool.with { |c| c.call('DEL', 'processes') }
-    begin
-      assert_equal 0, Wurk::ProcessSet.new(false).cleanup
-    ensure
-      @pool.with { |c| c.call('SADD', 'processes', *snapshot) } unless snapshot.empty?
+    # siblings keep their registered identities intact. Snapshot+restore
+    # alone isn't enough: a sibling test could SADD between SMEMBERS and
+    # DEL (lost on restore) or read the empty set mid-window. The mutex
+    # serializes against any other test that asserts on `processes`.
+    Wurk::Test::PROCESSES_MUTEX.synchronize do
+      snapshot = @pool.with { |c| c.call('SMEMBERS', 'processes') }
+      @pool.with { |c| c.call('DEL', 'processes') }
+      begin
+        assert_equal 0, Wurk::ProcessSet.new(false).cleanup
+      ensure
+        @pool.with { |c| c.call('SADD', 'processes', *snapshot) } unless snapshot.empty?
+      end
     end
   end
 

--- a/test/unit/queue_pause_test.rb
+++ b/test/unit/queue_pause_test.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Drives Wurk::Queue pause/unpause + fetcher filter against real Redis.
+# Membership of the `paused` SET is the single source of truth: Queue
+# methods read/write it, and the reliable fetcher skips any queue whose
+# unprefixed name is a member.
+#
+# Spec: docs/target/sidekiq-pro.md §6 (Queue pause/resume).
+class QueuePauseTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @ns       = "#{Process.pid}-#{object_id}"
+    @qname    = "qpause-#{@ns}"
+    @other    = "qpause-other-#{@ns}"
+    @rqname   = "queue:#{@qname}"
+    @rotherq  = "queue:#{@other}"
+    @pool     = Wurk.configuration.redis_pool
+    clean_keys
+  end
+
+  def teardown
+    clean_keys
+  ensure
+    super
+  end
+
+  # --- pause! / unpause! / paused? ----------------------------------
+
+  def test_paused_predicate_false_when_set_empty
+    refute_predicate Wurk::Queue.new(@qname), :paused?
+  end
+
+  def test_pause_adds_name_to_paused_set
+    Wurk::Queue.new(@qname).pause!
+
+    assert_includes paused_members, @qname
+  end
+
+  def test_pause_flips_paused_predicate
+    q = Wurk::Queue.new(@qname)
+    q.pause!
+
+    assert_predicate q, :paused?
+  end
+
+  def test_pause_returns_true
+    assert(Wurk::Queue.new(@qname).pause!)
+  end
+
+  def test_pause_is_idempotent
+    q = Wurk::Queue.new(@qname)
+    q.pause!
+    q.pause!
+
+    assert_equal 1, paused_members.count(@qname)
+  end
+
+  def test_unpause_removes_name_from_paused_set
+    q = Wurk::Queue.new(@qname)
+    q.pause!
+    q.unpause!
+
+    refute_includes paused_members, @qname
+  end
+
+  def test_unpause_flips_paused_predicate
+    q = Wurk::Queue.new(@qname)
+    q.pause!
+    q.unpause!
+
+    refute_predicate q, :paused?
+  end
+
+  def test_unpause_returns_true
+    assert(Wurk::Queue.new(@qname).unpause!)
+  end
+
+  def test_unpause_is_idempotent_when_not_paused
+    assert(Wurk::Queue.new(@qname).unpause!)
+    refute_predicate Wurk::Queue.new(@qname), :paused?
+  end
+
+  def test_pause_only_affects_named_queue
+    Wurk::Queue.new(@qname).pause!
+
+    refute_predicate Wurk::Queue.new(@other), :paused?
+  end
+
+  # --- fetcher integration -------------------------------------------
+
+  def test_fetcher_queues_cmd_excludes_paused_queue
+    fetcher, capsule = build_fetcher(%W[#{@qname} #{@other}])
+    Wurk::Queue.new(@qname).pause!
+
+    refute_includes fetcher.queues_cmd, @rqname
+    assert_includes fetcher.queues_cmd, @rotherq
+  ensure
+    capsule&.stop
+  end
+
+  def test_fetcher_queues_cmd_returns_empty_when_all_paused
+    fetcher, capsule = build_fetcher(%W[#{@qname} #{@other}])
+    Wurk::Queue.new(@qname).pause!
+    Wurk::Queue.new(@other).pause!
+
+    assert_empty fetcher.queues_cmd
+  ensure
+    capsule&.stop
+  end
+
+  def test_fetcher_skips_paused_queue_on_retrieve_work
+    fetcher, capsule = build_fetcher(%W[#{@qname} #{@other}])
+    @pool.with do |c|
+      c.call('LPUSH', @rqname, 'paused-payload')
+      c.call('LPUSH', @rotherq, 'live-payload')
+    end
+    Wurk::Queue.new(@qname).pause!
+
+    uow = fetcher.retrieve_work
+
+    refute_nil uow
+    assert_equal @rotherq, uow.queue
+    assert_equal 'live-payload', uow.job
+  ensure
+    capsule&.stop
+  end
+
+  def test_fetcher_resumes_paused_queue_after_unpause
+    fetcher, capsule = build_fetcher(%W[#{@qname}])
+    @pool.with { |c| c.call('LPUSH', @rqname, 'job-1') }
+    q = Wurk::Queue.new(@qname)
+    q.pause!
+
+    assert_empty fetcher.queues_cmd
+
+    q.unpause!
+
+    assert_includes fetcher.queues_cmd, @rqname
+  ensure
+    capsule&.stop
+  end
+
+  private
+
+  def build_fetcher(queues)
+    config  = Wurk::Configuration.new
+    capsule = Wurk::Capsule.new('test', config)
+    capsule.queues = queues
+    [Wurk::Fetcher::Reliable.new(capsule), capsule]
+  end
+
+  def paused_members
+    @pool.with { |c| c.call('SMEMBERS', Wurk::Keys::PAUSED_SET) }
+  end
+
+  def clean_keys
+    @pool.with do |c|
+      c.call('SREM', Wurk::Keys::PAUSED_SET, @qname, @other)
+      c.call('DEL', @rqname, @rotherq)
+      private_q = Wurk::Fetcher::Reliable.private_queue_name(@rqname)
+      private_other = Wurk::Fetcher::Reliable.private_queue_name(@rotherq)
+      c.call('DEL', private_q, private_other)
+    end
+  end
+end

--- a/test/unit/queue_test.rb
+++ b/test/unit/queue_test.rb
@@ -51,13 +51,8 @@ class QueueTest < Wurk::Test::UnitCase
     assert_includes Wurk::Queue.ancestors, Enumerable
   end
 
-  def test_paused_is_always_false_in_oss
-    @pool.with { |c| c.call('SADD', 'paused', @qname) }
-    begin
-      refute_predicate Wurk::Queue.new(@qname), :paused?
-    ensure
-      @pool.with { |c| c.call('SREM', 'paused', @qname) }
-    end
+  def test_paused_is_false_by_default
+    refute_predicate Wurk::Queue.new(@qname), :paused?
   end
 
   def test_as_json_returns_name_only

--- a/test/unit/stats_test.rb
+++ b/test/unit/stats_test.rb
@@ -118,9 +118,13 @@ class StatsTest < Wurk::Test::UnitCase
   end
 
   def test_processes_size_counts_set_members
-    register_identity!
+    # Serialize against ProcessSetTest's `DEL processes` test — without
+    # this, the SCARD inside `Stats.new` can land mid-DEL and read 0.
+    Wurk::Test::PROCESSES_MUTEX.synchronize do
+      register_identity!
 
-    assert_operator Wurk::Stats.new.processes_size, :>=, 1
+      assert_operator Wurk::Stats.new.processes_size, :>=, 1
+    end
   end
 
   def test_workers_size_returns_integer
@@ -128,9 +132,14 @@ class StatsTest < Wurk::Test::UnitCase
   end
 
   def test_workers_size_sums_busy_across_identities
-    register_identity!('busy' => '4')
+    # Serialize against ProcessSetTest's `DEL processes` test — without
+    # this, our identity can be wiped between SADD and SMEMBERS, leaving
+    # workers_size at 0.
+    Wurk::Test::PROCESSES_MUTEX.synchronize do
+      register_identity!('busy' => '4')
 
-    assert_operator Wurk::Stats.new.workers_size, :>=, 4
+      assert_operator Wurk::Stats.new.workers_size, :>=, 4
+    end
   end
 
   def test_workers_size_ignores_missing_busy_field


### PR DESCRIPTION
## Summary

Closes the Sidekiq Pro parity PR group on the `feat/batch-implementation` branch.

- **Batches** — `Wurk::Batch`, `Status`, `BatchSet`, atomic BATCH_PUSH Lua, callbacks, invalidation, death handler.
- **Reliable client** — in-process ring buffer drains on next push; per-process, in-memory.
- **Queue pause/resume** — `paused` SET, fetcher skips paused queues, in-flight jobs untouched.
- **`expires_in`** — server middleware drops expired jobs cleanly (counts as batch success), no preemption mid-perform.
- **Statsd / DogStatsd** — `Wurk::Metrics::Statsd` server middleware: `sidekiq.jobs.count/success/failure/perform/perform_dist`, per-job `options` proc + `dd_rate`, lazy post-fork client via `config.dogstatsd = -> { ... }`.
- **Fast Lua API** — `Queue#delete_job(jid)`, `Queue#delete_by_class(klass)`, `SortedSet#scan { |entry| }` yielding `SortedEntry` on arity-1 blocks.
- **Poison pill** — `super_fetch:recovered:<jid>` INCR with 72h TTL, ≥3 → dead set + `jobs.poison` + `on_poison` callback receives `{jid:, klass:, count:, queue:}`.

## Test plan

- [x] 1090 minitest assertions pass (`bin/rake test`)
- [x] rubocop clean on all new files
- [x] No mutation of Redis key schema or job JSON format
- [x] Statsd no-op when no client configured (existing callers don't crash)
- [x] Lua scripts SHA1-stable (parity tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full batch system with lifecycle callbacks, nested batches, status/querying and discovery.
  * Fast API: remove jobs by ID or class; faster sorted-set iteration.
  * Reliable client push with in-process buffering during Redis outages.
  * Queue pause/unpause controls; job expiry skipping; poison-pill detection.
  * DogStatsD/StatsD metrics middleware.

* **Bug Fixes**
  * Fetcher now excludes paused queues when retrieving work.

* **Chores**
  * README requirements, compatibility alias for BatchSet, expanded test coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/developerz-ai/wurk/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->