### PR TITLE
feat: Ent parity — Limiters, Periodic, Leader, Unique, Encryption, History

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,6 +42,8 @@ Naming/MethodParameterName:
     - k
     - v
     - tz
+    - at
+    - ms
 
 # Tests assert on Sidekiq-spec'd integer defaults (e.g. timeout: 25). Allow trailing digits.
 Naming/VariableNumber:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,7 @@ Naming/MethodParameterName:
     - h
     - k
     - v
+    - tz
 
 # Tests assert on Sidekiq-spec'd integer defaults (e.g. timeout: 25). Allow trailing digits.
 Naming/VariableNumber:

--- a/lib/wurk.rb
+++ b/lib/wurk.rb
@@ -210,6 +210,13 @@ require_relative 'wurk/middleware/expiry'
 # Spec: docs/target/sidekiq-pro.md §3.2.
 require_relative 'wurk/middleware/poison_pill'
 
+# Limiter server middleware: catches OverLimit, reschedules onto the same
+# queue with `Time.now + backoff` until `overrated` hits the reschedule cap.
+# Registered AFTER Batch::ServerMiddleware so a rescheduled OverLimit
+# unwinds back through the batch onion without ack'ing success.
+# Spec: docs/target/sidekiq-ent.md §1.4.
+Wurk.configuration.server_middleware.add(Wurk::Limiter::ServerMiddleware)
+
 # Pro Fast API: Lua-backed Queue#delete_job / #delete_by_class plus
 # SortedSet#scan { |JobRecord| … }. Mixed in via include/prepend on the
 # existing data API classes so the surface is wire-compat with Sidekiq Pro.

--- a/lib/wurk.rb
+++ b/lib/wurk.rb
@@ -57,6 +57,8 @@ require_relative 'wurk/encryption'
 require_relative 'wurk/metrics'
 require_relative 'wurk/metrics/statsd'
 require_relative 'wurk/metrics/history'
+require_relative 'wurk/metrics/query'
+require_relative 'wurk/deploy'
 
 require 'json'
 

--- a/lib/wurk/compat.rb
+++ b/lib/wurk/compat.rb
@@ -19,7 +19,31 @@ module Sidekiq
   # classes under them — but `Sidekiq.pro?` / `Sidekiq.ent?` still return
   # `false` per docs/target/sidekiq-free.md §32 (Wurk advertises as free OSS).
   module Pro; end
-  module Enterprise; end
+
+  # Sidekiq Enterprise feature surface (`unique!`, `Crypto`, `Unique.locked?`).
+  # Wurk ships these free; the namespace exists for drop-in compat.
+  # Implementations live under `Wurk::*`; this module just delegates.
+  module Enterprise
+    class << self
+      # Installs the Wurk::Unique client+server middleware pair globally.
+      # Spec: docs/target/sidekiq-ent.md §3.1.
+      def unique!
+        Wurk::Unique.enable!
+      end
+
+      def unique?
+        Wurk::Unique.enabled?
+      end
+    end
+
+    # Wurk::Unique introspection: `Sidekiq::Enterprise::Unique.locked?(...)`.
+    # Spec §3.6.
+    module Unique
+      def self.locked?(*)
+        Wurk::Unique.locked?(*)
+      end
+    end
+  end
 
   BasicFetch       = Wurk::Fetcher::Reliable
   Batch            = Wurk::Batch

--- a/lib/wurk/compat.rb
+++ b/lib/wurk/compat.rb
@@ -43,6 +43,20 @@ module Sidekiq
         Wurk::Unique.locked?(*)
       end
     end
+
+    # AES-256-GCM args encryption. `Sidekiq::Enterprise::Crypto.enable(...)`
+    # delegates to `Wurk::Encryption.enable`. Spec: docs/target/sidekiq-ent.md §4.
+    module Crypto
+      class << self
+        def enable(active_version:, &)
+          Wurk::Encryption.enable(active_version: active_version, &)
+        end
+
+        def enabled?
+          Wurk::Encryption.enabled?
+        end
+      end
+    end
   end
 
   BasicFetch       = Wurk::Fetcher::Reliable
@@ -58,6 +72,7 @@ module Sidekiq
   Periodic         = Wurk::Cron
   DeadSet          = Wurk::DeadSet
   Embedded         = Wurk::Embedded
+  Encryption       = Wurk::Encryption
   IterableJob      = Wurk::IterableJob
   Job              = Wurk::Job
   JobLogger        = Wurk::JobLogger

--- a/lib/wurk/compat.rb
+++ b/lib/wurk/compat.rb
@@ -31,6 +31,7 @@ module Sidekiq
   Config           = Wurk::Configuration
   Context          = Wurk::Context
   Cron             = Wurk::Cron
+  Periodic         = Wurk::Cron
   DeadSet          = Wurk::DeadSet
   Embedded         = Wurk::Embedded
   IterableJob      = Wurk::IterableJob

--- a/lib/wurk/compat.rb
+++ b/lib/wurk/compat.rb
@@ -71,6 +71,7 @@ module Sidekiq
   Cron             = Wurk::Cron
   Periodic         = Wurk::Cron
   DeadSet          = Wurk::DeadSet
+  Deploy           = Wurk::Deploy
   Embedded         = Wurk::Embedded
   Encryption       = Wurk::Encryption
   IterableJob      = Wurk::IterableJob

--- a/lib/wurk/component.rb
+++ b/lib/wurk/component.rb
@@ -68,6 +68,24 @@ module Wurk
       config.handle_exception(ex, ctx)
     end
 
+    # --- cluster leadership --------------------------------------------
+
+    # True iff this process currently holds the cluster `dear-leader` lock.
+    # Per spec, the check is performed at call time (Wurk does not cache);
+    # callers must not poll faster than the 60s follower cadence. Returns
+    # false unconditionally when `WURK_LEADER=false` is set on the process
+    # (opt-out hot-standby). Any Redis error is swallowed → false, so a
+    # transient partition can't propagate as an exception into user code.
+    #
+    # Spec: docs/target/sidekiq-ent.md §6.1.
+    def leader?
+      return false if ENV[Wurk::Leader::OPT_OUT_ENV].to_s.downcase == 'false'
+
+      redis { |c| c.call('GET', Wurk::Leader::DEFAULT_KEY) } == identity
+    rescue StandardError
+      false
+    end
+
     # --- thread boundaries ---------------------------------------------
 
     # Wraps a block at a thread boundary: any unhandled exception is reported

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -202,6 +202,20 @@ module Wurk
       @options[:average_scheduled_poll_interval] = interval
     end
 
+    # --- Periodic (Cron) registration ------------------------------------
+
+    # Yields a Wurk::Cron::Manager so the host app can register periodic
+    # jobs at boot. Manager state is shared per-process so multiple
+    # `config.periodic` blocks accumulate (matches Sidekiq Ent §2.1).
+    #
+    # Spec: docs/target/sidekiq-ent.md §2.
+    def periodic
+      require_relative 'cron'
+      @periodic_manager ||= Wurk::Cron::Manager.new(self)
+      yield @periodic_manager if block_given?
+      @periodic_manager
+    end
+
     # --- Lifecycle hooks --------------------------------------------------
 
     def on(event, &block)

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -32,7 +32,8 @@ module Wurk
         shutdown: [],
         exit: [],
         heartbeat: [],
-        beat: []
+        beat: [],
+        leader: []
       },
       dead_max_jobs: 10_000,
       dead_timeout_in_seconds: 180 * 24 * 60 * 60,
@@ -42,7 +43,7 @@ module Wurk
       redis_idle_timeout: nil
     }.freeze
 
-    LIFECYCLE_EVENTS = %i[startup quiet shutdown exit heartbeat beat].freeze
+    LIFECYCLE_EVENTS = %i[startup quiet shutdown exit heartbeat beat leader].freeze
     DEFAULT_THREAD_PRIORITY = -1
 
     # Default error handler. Wraps the report in the thread-local

--- a/lib/wurk/cron.rb
+++ b/lib/wurk/cron.rb
@@ -1,14 +1,528 @@
 # frozen_string_literal: true
 
+require 'json'
+require 'digest'
+require 'time'
+require_relative 'component'
+require_relative 'client'
+require_relative 'leader'
+
 module Wurk
-  # Sidekiq Enterprise periodic jobs. Cron-spec strings, distributed
-  # firing via Wurk::Leader so only one process enqueues per tick.
+  # Sidekiq Enterprise periodic jobs. Pure leader-driven cron — only the
+  # elected leader enqueues per tick; followers run nothing. No backfill
+  # on restart. DST-aware via per-loop timezone. In-tree crontab parser
+  # (no fugit dependency) supporting 5-field expressions plus the standard
+  # `@hourly` / `@daily` / `@weekly` / `@monthly` / `@yearly` aliases.
+  #
+  # Spec: docs/target/sidekiq-ent.md §2.
+  #
+  # Layout:
+  #   * `Cron::Parser` — crontab → wall-clock match + `next_fire_at`. Walks
+  #     forward minute-by-minute in the loop's TZ; DST gaps are skipped
+  #     naturally because the wall-clock components advance past them.
+  #   * `Cron::Loop` — one registered job. Identity = SHA1(schedule+klass+opts)
+  #     so a re-registration of the same loop is idempotent.
+  #   * `Cron::Manager` — registration DSL. `mgr.register(cron, klass, **opts)`
+  #     with `tz=` mass-setter. Writes to Redis (`periodic` SET + `loops:{lid}`
+  #     HASH).
+  #   * `Cron::LoopSet` — Enumerable view (`each`/`size`/`fetch(lid)`).
+  #   * `Cron::ConfigTester` — boot-time validator. Verifies cron syntax and
+  #     that every worker class constant resolves.
+  #   * `Cron::Poller` — once-per-minute tick loop. `Wurk::Leader` gates
+  #     enqueue; non-leaders still parse but never push.
+  #
+  # Wire-compat: `periodic`, `loops:{lid}`, `loop-history:{lid}`, `cron-leader`
+  # — all per docs/target/sidekiq-ent.md §2.7.
   module Cron
-    class Job; end
+    PERIODIC_KEY = 'periodic'
+    LOOP_PREFIX = 'loops:'
+    HISTORY_PREFIX = 'loop-history:'
+    LEADER_KEY = 'cron-leader'
+
+    HISTORY_CAP = 25
+    DEFAULT_TICK_SECONDS = 60
+    DEFAULT_LEADER_TTL = 30
+    MISSED_TICK_THRESHOLD = 90
+
+    # 5-field crontab + `@aliases`. No seconds field, no DOW name aliases
+    # (sidekiq-ent §2.2 uses numeric DOW only).
+    class Parser
+      FIELDS = [
+        [0, 59],
+        [0, 23],
+        [1, 31],
+        [1, 12],
+        [0, 7]
+      ].freeze
+
+      ALIASES = {
+        '@hourly' => '0 * * * *',
+        '@daily' => '0 0 * * *',
+        '@midnight' => '0 0 * * *',
+        '@weekly' => '0 0 * * 0',
+        '@monthly' => '0 0 1 * *',
+        '@yearly' => '0 0 1 1 *',
+        '@annually' => '0 0 1 1 *'
+      }.freeze
+
+      MAX_LOOKAHEAD_MINUTES = 366 * 24 * 60 * 4
+
+      attr_reader :expression, :fields
+
+      def initialize(expression)
+        parts = normalize_expression(expression)
+        @expression = parts.join(' ')
+        @fields = parts.each_with_index.map { |part, i| parse_field(part, *FIELDS[i]) }
+        @dom_restricted = parts[2] != '*'
+        @dow_restricted = parts[4] != '*'
+      end
+
+      # Smallest UTC epoch strictly greater than `from_epoch` whose wall-clock
+      # components in `tz` match every field. Returns nil if no match within
+      # ~4 years (a malformed loop like Feb 29 in a non-leap span).
+      def next_fire_at(from_epoch, tz = nil)
+        t = ((from_epoch.to_i / 60) + 1) * 60
+        MAX_LOOKAHEAD_MINUTES.times do
+          wc = wall_clock(t, tz)
+          return t if match_components?(wc)
+
+          t += 60
+        end
+        nil
+      end
+
+      def match?(time, tz = nil)
+        match_components?(wall_clock(time.to_i, tz))
+      end
+
+      private
+
+      def match_components?(components)
+        min, hour, dom, mon, dow = components
+        return false unless @fields[0].include?(min)
+        return false unless @fields[1].include?(hour)
+        return false unless @fields[3].include?(mon)
+
+        match_day?(dom, dow)
+      end
+
+      # Cron quirk (§2.6): if both dom and dow are restricted, OR them so
+      # `0 0 13 * 5` matches "Friday the 13th". If only one is set, that
+      # one must match. Both wild → always match the day half.
+      def match_day?(dom, dow)
+        dom_ok = @fields[2].include?(dom)
+        dow_ok = @fields[4].include?(dow)
+        return dom_ok || dow_ok if @dom_restricted && @dow_restricted
+        return dom_ok if @dom_restricted
+        return dow_ok if @dow_restricted
+
+        true
+      end
+
+      def normalize_expression(expression)
+        raise ArgumentError, 'cron expression must be a String' unless expression.is_a?(String)
+
+        normalized = (ALIASES[expression.strip] || expression).strip
+        parts = normalized.split(/\s+/)
+        return parts if parts.size == 5
+
+        raise ArgumentError, "cron expression must have 5 fields (got #{parts.size}): #{expression.inspect}"
+      end
+
+      def parse_field(part, min, max)
+        raw = part == '*' ? (min..max).to_a : part.split(',').flat_map { |c| parse_chunk(c, min, max) }
+        normalized = raw.map { |v| max == 7 && v == 7 ? 0 : v }
+        Set.new(normalized)
+      end
+
+      def parse_chunk(chunk, min, max)
+        if chunk.include?('/')
+          parse_step(chunk, min, max)
+        elsif chunk.include?('-')
+          parse_range(chunk, min, max)
+        else
+          v = Integer(chunk)
+          validate_value!(v, min, max)
+          [v]
+        end
+      end
+
+      def parse_step(chunk, min, max)
+        base, step = chunk.split('/', 2)
+        step_i = Integer(step)
+        raise ArgumentError, "cron step must be >= 1 (got #{step_i})" if step_i < 1
+
+        base_values = base == '*' ? (min..max).to_a : parse_chunk(base, min, max)
+        start = base_values.first
+        base_values.select { |v| ((v - start) % step_i).zero? }
+      end
+
+      def parse_range(chunk, min, max)
+        a, b = chunk.split('-', 2).map { |x| Integer(x) }
+        raise ArgumentError, "cron range start > end (#{a} > #{b})" if a > b
+
+        validate_value!(a, min, max)
+        validate_value!(b, min, max)
+        (a..b).to_a
+      end
+
+      def validate_value!(v, min, max)
+        return if v.between?(min, max)
+
+        raise ArgumentError, "cron value #{v} out of range #{min}..#{max}"
+      end
+
+      # epoch → [min, hour, dom, mon, dow] in `tz`. Accepts:
+      #   * nil          → UTC
+      #   * AS::TimeZone → responds to #at
+      #   * TZInfo::Tz   → responds to #utc_to_local
+      #   * IANA String  → parsed via ENV TZ override (POSIX `tzset(3)`)
+      def wall_clock(epoch, tz)
+        t = case tz
+            when nil then ::Time.at(epoch).utc
+            else local_time(epoch, tz)
+            end
+        dow = t.wday
+        [t.min, t.hour, t.day, t.mon, dow]
+      end
+
+      def local_time(epoch, tz)
+        return tz.at(epoch) if tz.respond_to?(:at) && !tz.is_a?(String)
+        return tz.utc_to_local(::Time.at(epoch).utc) if tz.respond_to?(:utc_to_local)
+
+        with_tz_env(tz.to_s) { ::Time.at(epoch) }
+      end
+
+      def with_tz_env(name)
+        old = ENV.fetch('TZ', nil)
+        ENV['TZ'] = name
+        yield
+      ensure
+        ENV['TZ'] = old
+      end
+    end
+
+    # One registered loop. Carries identity, schedule, options, and the
+    # cached parser. Immutable after `register!` — re-registering the same
+    # (schedule, klass, options) triple no-ops.
+    class Loop
+      attr_reader :lid, :schedule, :klass, :options, :tz
+
+      def initialize(schedule:, klass:, options: {}, tz: nil, lid: nil)
+        raise ArgumentError, 'klass must be a String' unless klass.is_a?(String) && !klass.empty?
+
+        @schedule = schedule
+        @klass = klass
+        @options = stringify_options(options)
+        @tz = tz
+        @parser = Parser.new(schedule)
+        @lid = lid || Cron.lid(schedule, klass, @options)
+      end
+
+      def parser
+        @parser ||= Parser.new(@schedule)
+      end
+
+      def paused?
+        @options['paused'].to_s == '1' || @options['paused'] == true
+      end
+
+      def queue
+        @options['queue'] || 'default'
+      end
+
+      def args
+        Array(@options['args'])
+      end
+
+      def retry_value
+        @options.fetch('retry', true)
+      end
+
+      def history
+        Wurk.redis do |c|
+          entries = c.call('LRANGE', "#{HISTORY_PREFIX}#{@lid}", 0, -1)
+          entries.map { |e| JSON.parse(e) }
+        end
+      end
+
+      def to_redis_hash
+        {
+          'schedule' => @schedule,
+          'klass' => @klass,
+          'options' => Wurk.dump_json(@options),
+          'tz' => tz_name.to_s,
+          'paused' => paused? ? '1' : '0'
+        }
+      end
+
+      def next_fire_at(from_epoch = ::Time.now.to_i)
+        parser.next_fire_at(from_epoch, @tz)
+      end
+
+      def tz_name
+        return nil if @tz.nil?
+        return @tz.name if @tz.respond_to?(:name)
+        return @tz.identifier if @tz.respond_to?(:identifier)
+
+        @tz.to_s
+      end
+
+      def self.from_redis(lid, hash)
+        h = hash.is_a?(Array) ? hash.each_slice(2).to_h : hash
+        opts = h['options'] ? JSON.parse(h['options']) : {}
+        opts['paused'] = '1' if h['paused'] == '1'
+        tz = h['tz'].to_s.empty? ? nil : h['tz']
+        new(lid: lid, schedule: h['schedule'], klass: h['klass'], options: opts, tz: tz)
+      end
+
+      private
+
+      def stringify_options(opts)
+        opts.transform_keys(&:to_s)
+      end
+    end
+
+    # Registration DSL. One Manager per `config.periodic` block; multiple
+    # blocks accumulate. `mgr.tz=` sets the default tz for subsequent
+    # `register` calls; per-call `tz:` overrides.
+    class Manager
+      attr_accessor :tz
+      attr_reader :loops
+
+      def initialize(config = nil)
+        @config = config
+        @loops = []
+        @tz = nil
+      end
+
+      def register(cron, klass, **opts)
+        klass_name = klass.is_a?(String) ? klass : klass.to_s
+        tz = opts.delete(:tz) || @tz
+        normalized = opts.transform_keys(&:to_s)
+        loop_obj = Loop.new(schedule: cron, klass: klass_name, options: normalized, tz: tz)
+        @loops << loop_obj
+        Cron.persist(loop_obj)
+        loop_obj
+      end
+    end
+
+    # Enumerable view of every registered loop. Reads `periodic` SET +
+    # `loops:{lid}` HASH on each iteration — cheap because the dashboard's
+    # list view is the only hot caller.
+    class LoopSet
+      include ::Enumerable
+
+      def initialize(_config = nil); end
+
+      def each
+        return enum_for(:each) unless block_given?
+
+        Wurk.redis do |c|
+          lids = c.call('SMEMBERS', PERIODIC_KEY)
+          lids.each do |lid|
+            h = c.call('HGETALL', "#{LOOP_PREFIX}#{lid}")
+            next if h.nil? || h.empty?
+
+            yield Loop.from_redis(lid, h)
+          end
+        end
+      end
+
+      def size
+        Wurk.redis { |c| c.call('SCARD', PERIODIC_KEY).to_i }
+      end
+
+      def fetch(lid)
+        h = Wurk.redis { |c| c.call('HGETALL', "#{LOOP_PREFIX}#{lid}") }
+        return nil if h.nil? || h.empty?
+
+        h = h.each_slice(2).to_h if h.is_a?(Array)
+        return nil if h.empty?
+
+        Loop.from_redis(lid, h)
+      end
+    end
+
+    # Boot-time validator. Runs the user's periodic block against a
+    # disposable Manager whose register call also resolves the klass
+    # constant — a typo'd class name surfaces here instead of on the
+    # first tick in production.
+    class ConfigTester
+      def verify(&block)
+        raise ArgumentError, 'block required' unless block
+
+        mgr = Manager.new
+        block.call(mgr)
+        mgr.loops.each { |lp| resolve_klass!(lp.klass) }
+        mgr.loops
+      end
+
+      private
+
+      def resolve_klass!(klass)
+        klass.split('::').inject(Object) { |mod, name| mod.const_get(name) }
+      rescue NameError => e
+        raise ArgumentError, "Cron worker class #{klass.inspect} could not be resolved: #{e.message}"
+      end
+    end
+
+    # Once-per-minute tick driver. Leader-only enqueue per loop. Followers
+    # still iterate the LoopSet (cheap) so they're warm if leadership
+    # transfers mid-tick. Missed-tick warning when wall-clock has drifted
+    # more than `MISSED_TICK_THRESHOLD` seconds past the expected fire.
+    class Poller
+      include Component
+
+      def initialize(config)
+        @config = config
+        @done = false
+        @mutex = ::Mutex.new
+        @sleeper = ::ConditionVariable.new
+        @leader = Leader.new(key: LEADER_KEY, ttl: DEFAULT_LEADER_TTL)
+        @client = Client.new(config: config)
+        @thread = nil
+        @tick_interval = DEFAULT_TICK_SECONDS
+      end
+
+      def start
+        @poller_thread ||= safe_thread('cron-poller') do # rubocop:disable Naming/MemoizedInstanceVariableName
+          until @done
+            tick
+            wait
+          end
+          @leader.release
+        end
+      end
+
+      def terminate
+        @mutex.synchronize do
+          @done = true
+          @sleeper.signal
+        end
+      end
+
+      def tick
+        @leader.acquire
+        return unless @leader.leader?
+
+        LoopSet.new.each { |lp| enqueue_if_due(lp) }
+      rescue StandardError => e
+        handle_exception(e, { context: 'cron-poller' })
+      end
+
+      def enqueue_if_due(loop_obj)
+        return if loop_obj.paused?
+
+        now = ::Time.now.to_i
+        prev_fire, next_fire = read_fire_marks(loop_obj.lid)
+        next_fire ||= loop_obj.next_fire_at(prev_fire || (now - @tick_interval))
+        return if next_fire.nil? || next_fire > now
+
+        warn_missed_tick(loop_obj, next_fire, now)
+        jid = enqueue!(loop_obj)
+        future = loop_obj.next_fire_at(now)
+        record_fire(loop_obj, jid, now, future)
+        jid
+      end
+
+      private
+
+      def wait
+        @mutex.synchronize do
+          @sleeper.wait(@mutex, @tick_interval) unless @done
+        end
+      end
+
+      def warn_missed_tick(loop_obj, expected, now)
+        return if now - expected <= MISSED_TICK_THRESHOLD
+
+        logger.warn(
+          "[cron] missed tick lid=#{loop_obj.lid} klass=#{loop_obj.klass} " \
+          "expected_at=#{expected} fired_at=#{now} drift=#{now - expected}s"
+        )
+      end
+
+      def enqueue!(loop_obj)
+        @client.push(
+          'class' => loop_obj.klass,
+          'args' => loop_obj.args,
+          'queue' => loop_obj.queue,
+          'retry' => loop_obj.retry_value
+        )
+      end
+
+      def read_fire_marks(lid)
+        Wurk.redis do |c|
+          vals = c.call('HMGET', "#{LOOP_PREFIX}#{lid}", 'lf', 'nf')
+          [vals[0]&.to_i, vals[1]&.to_i]
+        end
+      end
+
+      def record_fire(loop_obj, jid, fired_at, future)
+        history_entry = Wurk.dump_json([fired_at, jid])
+        Wurk.redis do |c|
+          c.call('HSET', "#{LOOP_PREFIX}#{loop_obj.lid}", 'lf', fired_at.to_s, 'nf', future.to_s)
+          c.call('LPUSH', "#{HISTORY_PREFIX}#{loop_obj.lid}", history_entry)
+          c.call('LTRIM', "#{HISTORY_PREFIX}#{loop_obj.lid}", 0, HISTORY_CAP - 1)
+        end
+      end
+    end
 
     class << self
-      def register(name, cron, worker_class, args = []); end
-      def jobs; end
+      # Stable 16-hex lid from (schedule, klass, options). Re-registering
+      # the same triple no-ops because the Redis writes overwrite under
+      # the same key.
+      def lid(schedule, klass, options)
+        opts = options.is_a?(Hash) ? options : {}
+        ::Digest::SHA1.hexdigest("#{schedule}|#{klass}|#{JSON.dump(opts.sort.to_h)}")[0, 16]
+      end
+
+      # Task-stated convenience signature. `name` is treated as a label;
+      # the lid is still derived from (schedule, klass, opts) so the
+      # call is idempotent. Callers that want the Sidekiq DSL should use
+      # `Manager#register` via `config.periodic { |mgr| ... }`.
+      def register(name, cron, worker_class, args = [], **opts)
+        merged = opts.merge(args: args)
+        merged[:label] = name if name
+        Loop.new(schedule: cron, klass: worker_class.to_s, options: merged).tap { |lp| persist(lp) }
+      end
+
+      def persist(loop_obj)
+        Wurk.redis do |c|
+          c.call('SADD', PERIODIC_KEY, loop_obj.lid)
+          c.call('HSET', "#{LOOP_PREFIX}#{loop_obj.lid}", *loop_obj.to_redis_hash.flatten)
+        end
+        loop_obj
+      end
+
+      # Drop a loop entirely. Used by the Web UI delete action and by the
+      # config-reload path so a removed `register(...)` line vanishes from
+      # Redis on next boot.
+      def unregister(lid)
+        Wurk.redis do |c|
+          c.call('SREM', PERIODIC_KEY, lid)
+          c.call('DEL', "#{LOOP_PREFIX}#{lid}", "#{HISTORY_PREFIX}#{lid}")
+        end
+      end
+
+      # Test helper: wipe every Cron Redis key. Production code must not
+      # call this — it removes every registered loop in the cluster.
+      def reset!
+        Wurk.redis do |c|
+          lids = c.call('SMEMBERS', PERIODIC_KEY)
+          lids.each do |lid|
+            c.call('DEL', "#{LOOP_PREFIX}#{lid}", "#{HISTORY_PREFIX}#{lid}")
+          end
+          c.call('DEL', PERIODIC_KEY, LEADER_KEY)
+        end
+      end
+
+      def jobs
+        LoopSet.new
+      end
     end
   end
+
+  Periodic = Cron unless const_defined?(:Periodic)
 end

--- a/lib/wurk/deploy.rb
+++ b/lib/wurk/deploy.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module Wurk
+  # Records deploy markers into Redis so the history pane can overlay
+  # "deployed at" lines onto job-throughput charts. Wire-compatible with
+  # Sidekiq's `Sidekiq::Deploy`:
+  #
+  #   <YYYYMMDD>-marks    HASH    fields = iso8601 timestamp (rounded to minute),
+  #                               values = label string, TTL = 90 days
+  #   deploylock-<label>  STRING  SET NX EX 60, dedupe lock for same-label marks
+  #
+  # The lock collapses multiple `mark!` calls for the same label inside a
+  # 60-second window into a single HSET — fleet-wide deploys where every
+  # process calls `Wurk::Deploy.mark!` at boot end up with one row, not N.
+  #
+  # Spec: docs/target/sidekiq-free.md §23.
+  class Deploy
+    MARK_TTL = 90 * 24 * 60 * 60   # 90 days
+    LOCK_TTL = 60                  # 1 minute dedupe window
+    LOCK_PREFIX = 'deploylock-'
+    MARKS_SUFFIX = '-marks'
+
+    # Default label maker: short git SHA + commit subject. Same shape as
+    # Sidekiq Pro's LABEL_MAKER so existing deploy hooks keep working.
+    LABEL_MAKER = -> { `git log -1 --format="%h %s"`.strip }
+
+    # Class-level shorthand `Wurk::Deploy.mark!(label: "abc")` builds a
+    # one-shot Deploy and delegates. Matches Sidekiq's `Sidekiq::Deploy.mark!`.
+    def self.mark!(label: nil, at: ::Time.now)
+      new.mark!(label: label, at: at)
+    end
+
+    def initialize(pool: nil)
+      @pool = pool
+    end
+
+    # Writes a deploy marker. Returns the iso8601 timestamp written, or
+    # `nil` when the per-label lock was already held (a previous process
+    # within the last 60 seconds beat us to it for the same label).
+    def mark!(label: nil, at: ::Time.now)
+      label = resolve_label(label)
+      return nil if label.nil? || label.empty?
+
+      ts = round_to_minute(at)
+      iso = ts.iso8601
+      write_mark?(label, ts, iso) ? iso : nil
+    end
+
+    # Returns the deploy marks for `date` (Date or Time) as `{iso8601 => label}`.
+    def fetch(date = ::Time.now.utc)
+      date = date.utc if date.respond_to?(:utc)
+      key = "#{date.strftime('%Y%m%d')}#{MARKS_SUFFIX}"
+      with_redis { |c| c.call('HGETALL', key) } || {}
+    end
+
+    private
+
+    def round_to_minute(at)
+      utc = at.utc
+      ::Time.utc(utc.year, utc.month, utc.day, utc.hour, utc.min)
+    end
+
+    def write_mark?(label, time, iso)
+      lock_key = "#{LOCK_PREFIX}#{label}"
+      marks_key = "#{time.strftime('%Y%m%d')}#{MARKS_SUFFIX}"
+      with_redis do |conn|
+        return false unless conn.call('SET', lock_key, iso, 'NX', 'EX', LOCK_TTL) == 'OK'
+
+        conn.call('HSET', marks_key, iso, label)
+        conn.call('EXPIRE', marks_key, MARK_TTL)
+      end
+      true
+    end
+
+    def resolve_label(label)
+      return label unless label.nil? || label.empty?
+
+      LABEL_MAKER.call
+    rescue StandardError
+      nil
+    end
+
+    def with_redis(&)
+      if @pool
+        @pool.with(&)
+      else
+        Wurk.redis(&)
+      end
+    end
+  end
+end

--- a/lib/wurk/encryption.rb
+++ b/lib/wurk/encryption.rb
@@ -1,15 +1,222 @@
 # frozen_string_literal: true
 
+require 'base64'
+require 'json'
+require 'openssl'
+require_relative 'middleware'
+
 module Wurk
-  # Sidekiq Enterprise encryption. AES-256-GCM with key rotation.
-  # Implemented as a middleware pair encrypting/decrypting job args.
+  # Sidekiq Enterprise encryption. AES-256-GCM over the **last** positional
+  # argument of `perform`. Implemented as a client/server middleware pair —
+  # client envelopes the last arg into a `{v, iv, ct, tag}` Hash, server
+  # peels it back before invoking perform.
+  #
+  # Activation:
+  #
+  #   Sidekiq::Enterprise::Crypto.enable(active_version: 1) do |version|
+  #     File.read("config/crypto/secret.#{Rails.env}.#{version}.key", mode: 'rb')
+  #   end
+  #
+  # The block is the **only** key source: file, ENV, KMS — anything that maps
+  # `Integer version → 32-byte binary key`. Wurk caches resolved keys per
+  # version in-process; rotate by writing a new key file, bumping
+  # `active_version`, and calling `enable` again.
+  #
+  # Per-worker opt-in:
+  #
+  #   class PrivateJob
+  #     include Sidekiq::Job
+  #     sidekiq_options encrypt: true
+  #     def perform(public_arg, secret_bag); end
+  #   end
+  #
+  # Wire format (per docs/target/sidekiq-ent.md §4.4): the last arg becomes
+  # a plain JSON Hash `{"v"=>N, "iv"=>b64(iv), "ct"=>b64(ct), "tag"=>b64(tag)}`
+  # — *not* a base64 blob of a binary envelope — so the args array stays
+  # valid JSON for inspectors that don't know about encryption.
+  #
+  # Constraints:
+  #   * `perform` must take ≥ 2 positional args. Pass `nil` first if no
+  #     cleartext payload exists.
+  #   * Only the last positional argument is encrypted. All earlier args
+  #     remain plaintext.
+  #   * Incompatible with Wurk::Unique (each ciphertext differs → digest
+  #     defeats the lock). Documented invariant.
+  #   * Web UI redacts the last arg when `encrypt: true` is set on the job.
+  #
+  # Spec: docs/target/sidekiq-ent.md §4.
   module Encryption
-    class ClientMiddleware; end
-    class ServerMiddleware; end
+    CIPHER_NAME = 'aes-256-gcm'
+    KEY_BYTES = 32
+    IV_BYTES = 12 # GCM standard: 96-bit IV.
+    TAG_BYTES = 16
+    ENVELOPE_MARKER = '__wurk_enc__'
+
+    class Error < StandardError; end
+    class KeyMissingError < Error; end
 
     class << self
-      def keys; end
-      def rotate!(new_key); end
+      attr_reader :active_version
+
+      def enabled?
+        @enabled == true
+      end
+
+      # Install crypto with a key resolver. `active_version` is the version
+      # used to *encrypt* new pushes; the resolver block must still return
+      # keys for any older in-flight versions so they decrypt.
+      #
+      # Idempotent: re-calling rebinds the resolver and rebuilds the cache.
+      # Middleware is installed at most once per chain.
+      def enable(active_version:, &resolver) # rubocop:disable Naming/PredicateMethod
+        raise ArgumentError, 'active_version is required' unless active_version
+        raise ArgumentError, 'block returning the key bytes is required' unless resolver
+
+        @active_version = Integer(active_version)
+        @resolver = resolver
+        @key_cache = {}
+        @enabled = true
+        register_middleware!
+        true
+      end
+
+      # Test helper — not part of the public Sidekiq surface.
+      def disable!
+        @enabled = false
+        @active_version = nil
+        @resolver = nil
+        @key_cache = nil
+        nil
+      end
+
+      # Resolve and cache the 32-byte key for `version`. Re-raises with a
+      # Wurk-specific exception when the resolver returns nothing usable so
+      # callers don't have to detect "nil from block" themselves.
+      def key_for(version)
+        raise Error, 'Wurk::Encryption not enabled' unless enabled?
+
+        @key_cache ||= {}
+        @key_cache[version] ||= validate_key!(version, @resolver.call(version))
+      end
+
+      # Encrypt `value` (any JSON-serializable Ruby value) under
+      # `active_version`. Returns a Hash literal — JSON-friendly, so the
+      # job payload stays inspectable.
+      def encrypt(value)
+        version = @active_version
+        key = key_for(version)
+        iv = ::OpenSSL::Random.random_bytes(IV_BYTES)
+        cipher = ::OpenSSL::Cipher.new(CIPHER_NAME).encrypt
+        cipher.key = key
+        cipher.iv = iv
+        ct = cipher.update(::JSON.dump(value)) + cipher.final
+        tag = cipher.auth_tag(TAG_BYTES)
+
+        {
+          ENVELOPE_MARKER => true,
+          'v' => version,
+          'iv' => ::Base64.strict_encode64(iv),
+          'ct' => ::Base64.strict_encode64(ct),
+          'tag' => ::Base64.strict_encode64(tag)
+        }
+      end
+
+      # Decrypt the envelope produced by `encrypt`. Raises
+      # `OpenSSL::Cipher::CipherError` on tag mismatch (bad key / tamper)
+      # — server middleware lets it bubble so the failure flows through
+      # the retry/dead pipeline per §4.6.
+      def decrypt(envelope)
+        version = Integer(envelope['v'])
+        cipher = build_decrypt_cipher(envelope, key_for(version))
+        plain = cipher.update(::Base64.strict_decode64(envelope['ct'])) + cipher.final
+        ::JSON.parse(plain, quirks_mode: true)
+      end
+
+      # @return [Boolean] true if `value` looks like a Wurk crypto envelope.
+      # Used by both server middleware and the Web UI redactor — single
+      # source of truth so the two cannot drift.
+      def envelope?(value)
+        value.is_a?(::Hash) && value[ENVELOPE_MARKER] == true &&
+          value.key?('v') && value.key?('iv') && value.key?('ct') && value.key?('tag')
+      end
+
+      # Web UI display helper (§4.7). Given a job hash, returns the args
+      # array with the last element replaced by the literal `"<encrypted>"`
+      # when the job opted in. Cleartext preceding args are untouched so
+      # operators can still triage on user_id / object_id / etc.
+      def redact_args(job)
+        args = job['args'] || job[:args] || []
+        return args unless job['encrypt'] || job[:encrypt]
+        return args if args.empty?
+
+        args[0..-2] + ['<encrypted>']
+      end
+
+      private
+
+      def build_decrypt_cipher(envelope, key)
+        cipher = ::OpenSSL::Cipher.new(CIPHER_NAME).decrypt
+        cipher.key = key
+        cipher.iv = ::Base64.strict_decode64(envelope['iv'])
+        cipher.auth_tag = ::Base64.strict_decode64(envelope['tag'])
+        cipher
+      end
+
+      def validate_key!(version, bytes)
+        raise KeyMissingError, "key resolver returned nil for version #{version}" if bytes.nil?
+
+        bytes = bytes.dup.force_encoding(::Encoding::ASCII_8BIT)
+        unless bytes.bytesize == KEY_BYTES
+          raise Error, "key for version #{version} must be #{KEY_BYTES} bytes, got #{bytes.bytesize}"
+        end
+
+        bytes
+      end
+
+      def register_middleware!
+        Wurk.configuration.client_middleware.add(ClientMiddleware) \
+          unless Wurk.configuration.client_middleware.exists?(ClientMiddleware)
+        Wurk.configuration.server_middleware.add(ServerMiddleware) \
+          unless Wurk.configuration.server_middleware.exists?(ServerMiddleware)
+      end
+    end
+
+    # Client middleware — envelopes the **last** positional argument when
+    # the job opts in via `sidekiq_options encrypt: true`. Skips silently
+    # when crypto is disabled, the job didn't opt in, or `args` is empty
+    # (per §4.3, an opt-in worker with empty args is a user bug, but we
+    # don't enqueue garbage — let perform raise ArgumentError if it cares).
+    class ClientMiddleware
+      include Wurk::Middleware::ClientMiddleware
+
+      def call(_worker, job, _queue, _redis_pool)
+        return yield unless Wurk::Encryption.enabled? && job['encrypt']
+
+        args = job['args']
+        if args.is_a?(::Array) && !args.empty? && !Wurk::Encryption.envelope?(args.last)
+          job['args'] = args[0..-2] + [Wurk::Encryption.encrypt(args.last)]
+        end
+        yield
+      end
+    end
+
+    # Server middleware — peels the envelope before perform runs. Decrypt
+    # failures (bad tag, missing version) raise
+    # `OpenSSL::Cipher::CipherError`; we let it bubble so the standard
+    # retry/dead pipeline handles it. Plaintext args remain visible for
+    # triage per §4.6.
+    class ServerMiddleware
+      include Wurk::Middleware::ServerMiddleware
+
+      def call(_worker, job, _queue)
+        return yield unless Wurk::Encryption.enabled? && job['encrypt']
+
+        args = job['args']
+        if args.is_a?(::Array) && !args.empty? && Wurk::Encryption.envelope?(args.last)
+          job['args'] = args[0..-2] + [Wurk::Encryption.decrypt(args.last)]
+        end
+        yield
+      end
     end
   end
 end

--- a/lib/wurk/leader.rb
+++ b/lib/wurk/leader.rb
@@ -2,68 +2,90 @@
 
 require 'securerandom'
 require 'socket'
+require_relative 'component'
 
 module Wurk
-  # Leader election via Redis SET NX + TTL refresh. Used by Cron and any
-  # other once-per-cluster work. Best-effort (not Raft): a partitioned
-  # leader can briefly co-exist with a new one until the TTL expires —
-  # downstream callers must idempotency-guard their once-per-cluster
-  # writes (Cron does this implicitly via per-tick fire marks).
+  # Cluster leader election via Redis `SET NX EX`. Single-leader-per-cluster
+  # is best-effort (not Raft): a partitioned ex-leader can briefly co-exist
+  # with a new one until the TTL expires. Callers that need strict mutual
+  # exclusion must idempotency-guard their writes (see `#token`).
   #
-  # Spec: docs/target/sidekiq-ent.md §6. The fencing-token + lifecycle
-  # event surface (`config.on(:leader)`, `Component#leader?`) lands in
-  # the dedicated Leader task; this class implements the minimum
-  # `acquire`/`release`/`leader?` API that Cron's tick loop requires.
+  # Wire-compat: the cluster lock lives at `dear-leader` (STRING, EX≈30s)
+  # holding the `<hostname>:<pid>:<process_nonce>` identity. Each fresh
+  # gain also pulls a monotonic fencing token via `INCR leader-token`,
+  # exposed on `#token`. Wurk goes a small step beyond Sidekiq Enterprise
+  # (which deliberately does not expose fencing) so downstream code that
+  # *can* benefit from a guard has one available; the token is best-effort
+  # too — it is never re-read on subsequent acquires, only on transitions.
+  #
+  # Cadence per spec: renew every 15s while leader, recheck every 60s as
+  # follower, lock TTL 30s. Opt out a process from campaigning entirely
+  # with `WURK_LEADER=false` (useful for hot-standby pools).
+  #
+  # Spec: docs/target/sidekiq-ent.md §6.
   class Leader
+    DEFAULT_KEY = 'dear-leader'
+    TOKEN_KEY = 'leader-token'
     DEFAULT_TTL = 30
+    DEFAULT_RENEW_INTERVAL = 15
+    DEFAULT_FOLLOWER_INTERVAL = 60
     OPT_OUT_ENV = 'WURK_LEADER'
+    THREAD_NAME = 'wurk-leader'
 
-    attr_reader :key, :ttl
+    attr_reader :key, :ttl, :owner, :token, :config
 
-    def initialize(key:, ttl: DEFAULT_TTL, pool: nil, owner: nil)
+    def initialize(config: nil, key: DEFAULT_KEY, ttl: DEFAULT_TTL, # rubocop:disable Metrics/ParameterLists
+                   renew_interval: DEFAULT_RENEW_INTERVAL,
+                   follower_interval: DEFAULT_FOLLOWER_INTERVAL,
+                   pool: nil, owner: nil)
+      @config = config
       @key = key
       @ttl = ttl
+      @renew_interval = renew_interval
+      @follower_interval = follower_interval
       @pool = pool
-      @owner = owner || build_owner_id
+      @owner = owner || cluster_identity
       @held = false
+      @token = nil
+      @thread = nil
+      @done = false
+      @mutex = ::Mutex.new
+      @sleeper = ::ConditionVariable.new
     end
 
-    # SET key owner NX EX ttl. If the key already holds our owner string
-    # (rare — same process re-entering the loop), refresh the TTL via
-    # EXPIRE so leadership doesn't lapse. Opt-out env `WURK_LEADER=false`
-    # makes acquire a no-op and `leader?` permanently false; useful for
-    # hot-standby pools.
-    def acquire
-      if ENV[OPT_OUT_ENV].to_s.downcase == 'false'
-        @held = false
-        return false
-      end
-
-      redis do |c|
-        result = c.call('SET', @key, @owner, 'NX', 'EX', @ttl)
-        if result == 'OK'
-          @held = true
-          return true
-        end
-
-        if c.call('GET', @key) == @owner
-          c.call('EXPIRE', @key, @ttl)
-          @held = true
-          return true
-        end
-
-        @held = false
-        false
-      end
+    # `WURK_LEADER=false` makes `acquire` a no-op and `leader?` permanently
+    # false; the renewal thread also refuses to start. Useful for hot-
+    # standby pools that must never campaign.
+    def disabled?
+      ENV[OPT_OUT_ENV].to_s.downcase == 'false'
     end
 
-    # CAS delete: only DEL if we still own the key, otherwise a stale
+    # SET NX EX. If the key already holds *our* owner string (rare — same
+    # process re-entering after a hiccup), refresh via EXPIRE so leadership
+    # doesn't lapse. On any follower → leader transition, INCR the global
+    # `leader-token` so the new token is strictly greater than every prior
+    # leader's, then dispatch the `:leader` lifecycle event.
+    def acquire # rubocop:disable Naming/PredicateMethod
+      return false if disabled?
+
+      transition = run_set_or_refresh
+      return false unless transition
+
+      if transition == :gained
+        @token = redis_call { |c| c.call('INCR', TOKEN_KEY) }
+        dispatch_leader_event
+      end
+      true
+    end
+
+    # CAS DEL — only drop the key if we still own it, otherwise a stale
     # release would yank leadership from whichever follower took over.
     def release
-      redis do |c|
+      redis_call do |c|
         c.call('DEL', @key) if c.call('GET', @key) == @owner
       end
       @held = false
+      @token = nil
       nil
     end
 
@@ -71,25 +93,129 @@ module Wurk
       @held
     end
 
-    def owner
-      @owner.dup
+    # Spawns the periodic re-election thread. Idempotent. While leader,
+    # the loop re-acquires (refreshing TTL) every `renew_interval`; while
+    # follower, it polls every `follower_interval`. Caller must invoke
+    # `stop` for orderly shutdown — the thread also releases its lock on
+    # exit.
+    def start
+      return nil if disabled?
+
+      @mutex.synchronize do
+        return @thread if @thread
+
+        @done = false
+      end
+      @thread = spawn_loop_thread
+    end
+
+    def stop
+      @mutex.synchronize do
+        @done = true
+        @sleeper.signal
+      end
+      @thread&.join
+      @thread = nil
+      release
+    end
+
+    def running?
+      !@thread.nil? && @thread.alive?
     end
 
     private
 
-    def redis(&)
+    # Returns `:gained` on first acquisition, `:held` on renewal, or `nil`
+    # if another process currently holds the key. Sets `@held` accordingly
+    # so `leader?` reflects the latest state regardless of branch.
+    def run_set_or_refresh
+      redis_call do |c|
+        result = c.call('SET', @key, @owner, 'NX', 'EX', @ttl)
+        if result == 'OK'
+          outcome = @held ? :held : :gained
+          @held = true
+          return outcome
+        end
+
+        if c.call('GET', @key) == @owner
+          c.call('EXPIRE', @key, @ttl)
+          outcome = @held ? :held : :gained
+          @held = true
+          return outcome
+        end
+
+        @held = false
+        @token = nil
+        nil
+      end
+    end
+
+    def dispatch_leader_event
+      return if @config.nil?
+      return unless @config.respond_to?(:[])
+
+      bucket = @config[:lifecycle_events]&.[](:leader)
+      return if bucket.nil? || bucket.empty?
+
+      bucket.each { |hook| invoke_hook(hook) }
+    end
+
+    def invoke_hook(hook)
+      hook.call
+    rescue StandardError => e
+      @config.handle_exception(e, event: :leader) if @config.respond_to?(:handle_exception)
+    end
+
+    def redis_call(&)
       if @pool
         @pool.with(&)
+      elsif @config
+        @config.redis(&)
       else
         Wurk.redis(&)
       end
     end
 
-    def build_owner_id
-      host = ::Socket.gethostname
-      "#{::Process.pid}@#{host}:#{::SecureRandom.hex(4)}"
+    # Matches `Wurk::Component#identity` so `ProcessSet::Process#leader?`
+    # (which compares `dear-leader == process.identity`) sees a match.
+    def cluster_identity
+      "#{hostname}:#{::Process.pid}:#{Component::PROCESS_NONCE}"
+    end
+
+    def hostname
+      ENV['DYNO'] || ::Socket.gethostname
     rescue StandardError
-      "#{::Process.pid}@localhost:#{::SecureRandom.hex(4)}"
+      'localhost'
+    end
+
+    def spawn_loop_thread
+      t = Thread.new { run_loop }
+      t.name = THREAD_NAME
+      t.report_on_exception = false
+      t
+    end
+
+    def run_loop
+      until done?
+        tick_once
+        wait_next
+      end
+      release
+    end
+
+    def tick_once
+      acquire
+    rescue StandardError => e
+      @config.handle_exception(e, context: THREAD_NAME) if @config.respond_to?(:handle_exception)
+    end
+
+    def wait_next
+      interval = @held ? @renew_interval : @follower_interval
+      @mutex.synchronize { @sleeper.wait(@mutex, interval) unless @done }
+    end
+
+    def done?
+      @mutex.synchronize { @done }
     end
   end
 end

--- a/lib/wurk/leader.rb
+++ b/lib/wurk/leader.rb
@@ -1,12 +1,95 @@
 # frozen_string_literal: true
 
+require 'securerandom'
+require 'socket'
+
 module Wurk
-  # Leader election via Redis SETNX + fencing token. Used by Cron and any
-  # other once-per-cluster work. Spec: docs/target/sidekiq-ent.md.
+  # Leader election via Redis SET NX + TTL refresh. Used by Cron and any
+  # other once-per-cluster work. Best-effort (not Raft): a partitioned
+  # leader can briefly co-exist with a new one until the TTL expires —
+  # downstream callers must idempotency-guard their once-per-cluster
+  # writes (Cron does this implicitly via per-tick fire marks).
+  #
+  # Spec: docs/target/sidekiq-ent.md §6. The fencing-token + lifecycle
+  # event surface (`config.on(:leader)`, `Component#leader?`) lands in
+  # the dedicated Leader task; this class implements the minimum
+  # `acquire`/`release`/`leader?` API that Cron's tick loop requires.
   class Leader
-    def initialize(key:); end
-    def acquire; end
-    def release; end
-    def leader?; end
+    DEFAULT_TTL = 30
+    OPT_OUT_ENV = 'WURK_LEADER'
+
+    attr_reader :key, :ttl
+
+    def initialize(key:, ttl: DEFAULT_TTL, pool: nil, owner: nil)
+      @key = key
+      @ttl = ttl
+      @pool = pool
+      @owner = owner || build_owner_id
+      @held = false
+    end
+
+    # SET key owner NX EX ttl. If the key already holds our owner string
+    # (rare — same process re-entering the loop), refresh the TTL via
+    # EXPIRE so leadership doesn't lapse. Opt-out env `WURK_LEADER=false`
+    # makes acquire a no-op and `leader?` permanently false; useful for
+    # hot-standby pools.
+    def acquire
+      if ENV[OPT_OUT_ENV].to_s.downcase == 'false'
+        @held = false
+        return false
+      end
+
+      redis do |c|
+        result = c.call('SET', @key, @owner, 'NX', 'EX', @ttl)
+        if result == 'OK'
+          @held = true
+          return true
+        end
+
+        if c.call('GET', @key) == @owner
+          c.call('EXPIRE', @key, @ttl)
+          @held = true
+          return true
+        end
+
+        @held = false
+        false
+      end
+    end
+
+    # CAS delete: only DEL if we still own the key, otherwise a stale
+    # release would yank leadership from whichever follower took over.
+    def release
+      redis do |c|
+        c.call('DEL', @key) if c.call('GET', @key) == @owner
+      end
+      @held = false
+      nil
+    end
+
+    def leader?
+      @held
+    end
+
+    def owner
+      @owner.dup
+    end
+
+    private
+
+    def redis(&)
+      if @pool
+        @pool.with(&)
+      else
+        Wurk.redis(&)
+      end
+    end
+
+    def build_owner_id
+      host = ::Socket.gethostname
+      "#{::Process.pid}@#{host}:#{::SecureRandom.hex(4)}"
+    rescue StandardError
+      "#{::Process.pid}@localhost:#{::SecureRandom.hex(4)}"
+    end
   end
 end

--- a/lib/wurk/limiter.rb
+++ b/lib/wurk/limiter.rb
@@ -1,19 +1,753 @@
 # frozen_string_literal: true
 
+require 'json'
+require 'digest'
+require 'securerandom'
+require_relative 'lua'
+
 module Wurk
-  # Sidekiq Enterprise rate limiters: concurrent, window, bucket, unlimited.
-  # Spec: docs/target/sidekiq-ent.md.
+  # Sidekiq Enterprise rate limiters: concurrent, bucket, window, leaky,
+  # points, unlimited. Lua-backed; all timing inside Lua is from TIME so
+  # clock skew across hosts doesn't matter inside one Redis. Spec:
+  # docs/target/sidekiq-ent.md §1.
+  #
+  # Layout:
+  #   * `Limiter::Base` owns the metadata write (lmtr:{name}) + the global
+  #     `lmtr-list` registration so the Web UI can list every limiter.
+  #   * Per-type subclasses (Concurrent / Bucket / Window / Leaky / Points)
+  #     own their acquire/wait loop. Each delegates the atomic step to a
+  #     Lua script in `lib/wurk/lua/limiter_*.lua`.
+  #   * `Unlimited` is a no-op stub for tests and the `unlimited(*)`
+  #     constructor — same `within_limit` surface, never raises.
+  #
+  # Wire-compat: every key uses the `lmtr-...:` prefix family from §1.7
+  # and the limiter is added to the shared `lmtr-list` SET.
   module Limiter
-    class Concurrent; end
-    class Window; end
-    class Bucket; end
-    class Unlimited; end
+    DEFAULT_TTL = 90 * 24 * 3600
+    DEFAULT_WAIT_TIMEOUT = 5
+    DEFAULT_LOCK_TIMEOUT = 30
+    DEFAULT_RESCHEDULE = 20
+    DEFAULT_BACKOFF = lambda do |_limiter, job, _exc|
+      overrated = job.is_a?(Hash) ? job.fetch('overrated', 0).to_i : 0
+      (300 * overrated) + rand(300) + 1
+    end
+
+    NAME_PATTERN = /\A[\w\-:.\#@]+\z/
+
+    LIST_KEY = 'lmtr-list'
+
+    # Server middleware catches OverLimit, increments `job['overrated']`, and
+    # reschedules onto the same queue with `Time.now + backoff`. The
+    # `#limiter` attr lets the middleware reach the per-limiter backoff
+    # proc + reschedule cap. `#job` is set by the middleware just before the
+    # re-raise so error_handlers can see which job was in flight.
+    class OverLimit < StandardError
+      attr_reader :limiter
+      attr_accessor :job
+
+      def initialize(limiter, job = nil, msg = nil)
+        @limiter = limiter
+        @job = job
+        super(msg || "limit '#{limiter.name}' (#{limiter.type}) reached")
+      end
+    end
+
+    # Global config. Sidekiq Enterprise documents three knobs (§1.6):
+    # `backoff` (Proc), `redis` (a Hash that builds a dedicated pool), and
+    # `errors` (Array of exception classes the middleware also treats as
+    # OverLimit). All three are mutable and re-read on every push/perform.
+    class Config
+      attr_accessor :backoff, :errors
+      attr_reader :redis
+
+      def initialize
+        @backoff = DEFAULT_BACKOFF
+        @errors = [OverLimit]
+        @redis = nil
+        @redis_pool = nil
+      end
+
+      # Accept either a Hash (the documented Sidekiq Ent shape — `{ size:,
+      # url: }`) or an already-built `RedisPool`. The first redis read
+      # lazily materializes the pool; per-fork safety is the caller's
+      # responsibility (same contract as Wurk.redis_pool).
+      def redis=(value)
+        @redis = value
+        @redis_pool = nil
+      end
+
+      def pool
+        return nil if @redis.nil?
+
+        @redis_pool ||= case @redis
+                        when Wurk::RedisPool then @redis
+                        when Hash
+                          Wurk::RedisPool.new(
+                            size: @redis[:size] || 10,
+                            url: @redis[:url] || Wurk::RedisPool::DEFAULT_URL,
+                            timeout: @redis[:timeout] || Wurk::RedisPool::DEFAULT_TIMEOUT,
+                            name: 'limiter'
+                          )
+                        else
+                          raise ArgumentError, "Limiter.config.redis must be Hash or RedisPool, got #{@redis.class}"
+                        end
+      end
+    end
 
     class << self
-      def concurrent(name, **opts); end
-      def window(name, **opts); end
-      def bucket(name, **opts); end
-      def unlimited(name); end
+      def configure
+        yield config
+      end
+
+      def config
+        @config ||= Config.new
+      end
+
+      # Test helper: blow away config + cached pool so a test that mutates
+      # `config.backoff` doesn't leak into the next one. Not part of the
+      # public Sidekiq surface.
+      def reset_config!
+        @config = nil
+      end
+
+      # Redis access: caller-supplied pool (Limiter.configure.redis = …) wins,
+      # else fall back to the default Wurk pool. This is the same hierarchy
+      # Sidekiq Ent documents — dedicated rate-limiter pool is opt-in.
+      def redis(&)
+        pool = config.pool || Wurk.redis_pool
+        pool.with(&)
+      end
+
+      def concurrent(name, limit, wait_timeout: DEFAULT_WAIT_TIMEOUT, lock_timeout: DEFAULT_LOCK_TIMEOUT,
+                     policy: :raise, backoff: nil, ttl: DEFAULT_TTL)
+        Concurrent.new(name,
+                       limit: limit,
+                       wait_timeout: wait_timeout,
+                       lock_timeout: lock_timeout,
+                       policy: policy,
+                       backoff: backoff,
+                       ttl: ttl)
+      end
+
+      def bucket(name, count, interval, wait_timeout: DEFAULT_WAIT_TIMEOUT, backoff: nil,
+                 ttl: DEFAULT_TTL, reschedule: DEFAULT_RESCHEDULE)
+        Bucket.new(name,
+                   count: count,
+                   interval: interval,
+                   wait_timeout: wait_timeout,
+                   backoff: backoff,
+                   ttl: ttl,
+                   reschedule: reschedule)
+      end
+
+      def window(name, count, interval, wait_timeout: DEFAULT_WAIT_TIMEOUT, backoff: nil,
+                 ttl: DEFAULT_TTL, reschedule: DEFAULT_RESCHEDULE)
+        Window.new(name,
+                   count: count,
+                   interval: interval,
+                   wait_timeout: wait_timeout,
+                   backoff: backoff,
+                   ttl: ttl,
+                   reschedule: reschedule)
+      end
+
+      def leaky(name, bucket_size, drain, wait_timeout: DEFAULT_WAIT_TIMEOUT, backoff: nil, ttl: DEFAULT_TTL)
+        Leaky.new(name,
+                  bucket_size: bucket_size,
+                  drain: drain,
+                  wait_timeout: wait_timeout,
+                  backoff: backoff,
+                  ttl: ttl)
+      end
+
+      def points(name, initial_points, refill_per_second, backoff: nil, ttl: DEFAULT_TTL)
+        Points.new(name,
+                   initial: initial_points,
+                   refill: refill_per_second,
+                   backoff: backoff,
+                   ttl: ttl)
+      end
+
+      def unlimited(*_args, **_opts)
+        Unlimited.new
+      end
+
+      # `:second :minute :hour :day` symbols → seconds. Window also accepts
+      # a raw Integer; bucket does not (boundary semantics require a unit).
+      INTERVAL_UNITS = {
+        second: 1,
+        minute: 60,
+        hour: 3600,
+        day: 86_400
+      }.freeze
+
+      def interval_seconds(interval, allow_integer:)
+        case interval
+        when Symbol
+          INTERVAL_UNITS.fetch(interval) do
+            raise ArgumentError, "interval must be one of #{INTERVAL_UNITS.keys.inspect} (got #{interval.inspect})"
+          end
+        when Integer
+          unless allow_integer
+            raise ArgumentError, "interval must be a Symbol (got Integer); use #{INTERVAL_UNITS.keys.inspect}"
+          end
+
+          interval
+        else
+          raise ArgumentError, "interval must be Symbol or Integer (got #{interval.class})"
+        end
+      end
+    end
+
+    # Base class. Holds the public introspection contract documented in
+    # §1.5 — name / type / options / size / status / reset / delete plus
+    # the `within_limit(...) { ... }` block. Subclasses override the
+    # acquire path and the per-type metric/size methods.
+    class Base
+      attr_reader :name, :options
+
+      def initialize(name, **options)
+        unless name.is_a?(String) && NAME_PATTERN.match?(name)
+          raise ArgumentError, "limiter name must match #{NAME_PATTERN.inspect} (got #{name.inspect})"
+        end
+
+        ttl = options[:ttl] || DEFAULT_TTL
+        # Spec §1.2: ttl floor of 24h. Anything tighter risks losing the
+        # metadata hash mid-job and orphaning slots that read it.
+        raise ArgumentError, 'ttl must be >= 86_400' if ttl < 86_400
+
+        @name = name.dup.freeze
+        @options = options
+        register!
+      end
+
+      def type
+        raise NotImplementedError
+      end
+
+      def within_limit(**, &)
+        raise NotImplementedError
+      end
+
+      def size
+        0
+      end
+
+      def status
+        {}
+      end
+
+      def reset
+        Wurk::Limiter.redis do |c|
+          state_keys.each { |k| c.call('DEL', k) }
+        end
+      end
+
+      def delete
+        Wurk::Limiter.redis do |c|
+          (state_keys + [meta_key]).each { |k| c.call('DEL', k) }
+          c.call('SREM', LIST_KEY, @name)
+        end
+      end
+
+      # Stable fingerprint for the limiter — Sidekiq 8.0+ switched from
+      # SHA1 → SHA256 (~10% larger encoding). Web UI groups limiters by
+      # this so that interpolated names (`stripe-#{user_id}`) get a single
+      # row per shape.
+      def fingerprint
+        @fingerprint ||= Digest::SHA256.hexdigest("#{type}|#{@name}|#{JSON.dump(serializable_options)}")
+      end
+
+      protected
+
+      def meta_key
+        "lmtr:#{@name}"
+      end
+
+      def state_keys
+        []
+      end
+
+      def serializable_options
+        @options.transform_values do |v|
+          case v
+          when Proc then '<proc>'
+          when Symbol, Numeric, String, true, false, nil then v
+          else v.to_s
+          end
+        end
+      end
+
+      def register!
+        Wurk::Limiter.redis do |c|
+          c.call('SADD', LIST_KEY, @name)
+          c.call(
+            'HSET', meta_key,
+            'type', type.to_s,
+            'options', JSON.dump(serializable_options),
+            'fingerprint', fingerprint
+          )
+          c.call('EXPIRE', meta_key, @options[:ttl])
+        end
+      end
+
+      def ttl
+        @options[:ttl]
+      end
+
+      # Stable random slot id (Concurrent) / nonce (Window). 16 hex chars
+      # = 8 bytes — wide enough to avoid collision under any realistic
+      # burst and short enough to keep ZSET memory bounded.
+      def random_id
+        SecureRandom.hex(8)
+      end
+
+      def lua(name, keys:, argv:)
+        Wurk::Limiter.redis do |c|
+          Wurk::Lua::Loader.eval_cached(c, name, keys: keys, argv: argv)
+        end
+      end
+    end
+
+    # ---- Concurrent ---------------------------------------------------
+    #
+    # Atomic slot acquisition in a ZSET. Score = expiry epoch; the acquire
+    # script first evicts expired slots (bumping the `reclaimed` metric)
+    # then ZADDs if there's headroom.
+    #
+    # On exhaustion: spin loop with backoff. The spec says "blocks via
+    # Redis stream XREAD" — that's a perf optimization; the visible
+    # behavior is identical: blocks up to `wait_timeout` then OverLimit
+    # (or silent return for `policy: :ignore`).
+    class Concurrent < Base
+      WAIT_SLEEP = 0.05
+
+      def type = :concurrent
+
+      def size
+        Wurk::Limiter.redis { |c| c.call('ZCARD', state_key).to_i }
+      end
+
+      def status
+        h = Wurk::Limiter.redis { |c| c.call('HGETALL', stats_key) }
+        # redis-client returns either a flat array or a hash depending on
+        # the server version — normalize once so callers always see a hash.
+        h = h.each_slice(2).to_h if h.is_a?(Array)
+        %w[held held_time immediate waited wait_time overages reclaimed].each_with_object({}) do |k, out|
+          out[k] = (h[k] || '0').to_i
+        end
+      end
+
+      def within_limit(&block)
+        raise ArgumentError, 'block required' unless block
+
+        started = monotime
+        deadline = started + @options[:wait_timeout]
+        slot = random_id
+        acquired_at = nil
+        loop do
+          result = acquire(slot)
+          if result[0].to_i == 1
+            acquired_at = monotime
+            break
+          end
+
+          return if @options[:policy] == :ignore
+
+          remaining = deadline - monotime
+          if remaining <= 0
+            bump_counter('overages')
+            raise OverLimit.new(self)
+          end
+
+          sleep [remaining, WAIT_SLEEP].min
+        end
+
+        begin
+          incr_immediate_or_waited(acquired_at - started)
+          block.call
+        ensure
+          release(slot)
+          bump_counter('held_time', (monotime - acquired_at).to_i) if acquired_at
+        end
+      end
+
+      protected
+
+      def state_keys
+        [state_key, stats_key]
+      end
+
+      private
+
+      def state_key
+        "lmtr-cs:#{@name}"
+      end
+
+      def stats_key
+        "lmtr-stats:#{@name}"
+      end
+
+      def acquire(slot)
+        lua(:limiter_concurrent_acquire,
+            keys: [state_key, stats_key],
+            argv: [@options[:limit], @options[:lock_timeout], slot, ttl])
+      end
+
+      def release(slot)
+        lua(:limiter_concurrent_release, keys: [state_key], argv: [slot])
+      end
+
+      def bump_counter(field, by = 1)
+        Wurk::Limiter.redis do |c|
+          c.call('HINCRBY', stats_key, field, by)
+          c.call('EXPIRE', stats_key, ttl)
+        end
+      end
+
+      def incr_immediate_or_waited(elapsed)
+        if elapsed < WAIT_SLEEP
+          bump_counter('immediate')
+        else
+          bump_counter('waited')
+          bump_counter('wait_time', elapsed.to_i)
+        end
+      end
+
+      def monotime
+        ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+      end
+    end
+
+    # ---- Bucket -------------------------------------------------------
+    #
+    # Cardinal-boundary counter. Reset at the top of the unit (00:00 of
+    # minute/hour/day). On exhaustion sleep until next boundary, retry,
+    # OverLimit if that exceeds wait_timeout.
+    class Bucket < Base
+      def type = :bucket
+
+      def initialize(name, **options)
+        # Eager interval validation so a typo in `:fortnight` blows up at boot,
+        # not at first call. Lazy validation defers failures to runtime.
+        Limiter.interval_seconds(options[:interval], allow_integer: false)
+        super
+      end
+
+      def size
+        epoch = (::Time.now.to_i / interval_seconds) * interval_seconds
+        key = "lmtr-b:#{@name}:#{epoch / interval_seconds}"
+        Wurk::Limiter.redis { |c| (c.call('GET', key) || '0').to_i }
+      end
+
+      def within_limit(used: 1, &block)
+        raise ArgumentError, 'block required' unless block
+
+        deadline = ::Time.now.to_f + @options[:wait_timeout]
+        loop do
+          ok, _current, secs_to_next = acquire(used)
+          return block.call if ok.to_i == 1
+
+          remaining = deadline - ::Time.now.to_f
+          raise OverLimit.new(self) if remaining <= 0
+
+          sleep [remaining, secs_to_next.to_f, 0.05].compact.min.clamp(0.0, remaining)
+        end
+      end
+
+      protected
+
+      def state_keys
+        # Bucket keys are per-epoch and self-expiring; reset wipes the
+        # current epoch, the only one a caller could care about. Older
+        # epochs already EXPIRE'd.
+        epoch = ::Time.now.to_i / interval_seconds
+        ["lmtr-b:#{@name}:#{epoch}"]
+      end
+
+      private
+
+      def interval_seconds
+        @interval_seconds ||= Limiter.interval_seconds(@options[:interval], allow_integer: false)
+      end
+
+      def acquire(used)
+        lua(:limiter_bucket_acquire,
+            keys: ["lmtr-b:#{@name}"],
+            argv: [@options[:count], interval_seconds, used, ttl])
+      end
+    end
+
+    # ---- Window -------------------------------------------------------
+    #
+    # Sliding window via ZSET of timestamps. Accepts symbolic units or a
+    # raw Integer (in seconds). Used-units expand to N ZADDs in the Lua
+    # script so multi-charge calls remain atomic.
+    class Window < Base
+      WAIT_SLEEP = 0.5
+
+      def type = :window
+
+      def initialize(name, **options)
+        # Symbol or raw Integer (spec §1.2: window accepts both).
+        Limiter.interval_seconds(options[:interval], allow_integer: true)
+        super
+      end
+
+      def size
+        cutoff = ::Time.now.to_f - interval_seconds
+        Wurk::Limiter.redis do |c|
+          c.call('ZREMRANGEBYSCORE', state_key, '-inf', "(#{cutoff}")
+          c.call('ZCARD', state_key).to_i
+        end
+      end
+
+      def within_limit(used: 1, &block)
+        raise ArgumentError, 'block required' unless block
+
+        deadline = ::Time.now.to_f + @options[:wait_timeout]
+        loop do
+          ok, _current, _oldest = acquire(used)
+          return block.call if ok.to_i == 1
+
+          remaining = deadline - ::Time.now.to_f
+          raise OverLimit.new(self) if remaining <= 0
+
+          sleep [remaining, WAIT_SLEEP].min
+        end
+      end
+
+      protected
+
+      def state_keys
+        [state_key]
+      end
+
+      private
+
+      def state_key
+        "lmtr-w:#{@name}"
+      end
+
+      def interval_seconds
+        @interval_seconds ||= Limiter.interval_seconds(@options[:interval], allow_integer: true)
+      end
+
+      def acquire(used)
+        lua(:limiter_window_acquire,
+            keys: [state_key],
+            argv: [@options[:count], interval_seconds, used, ttl, random_id])
+      end
+    end
+
+    # ---- Leaky --------------------------------------------------------
+    #
+    # Leaky bucket: drain rate = bucket_size / drain ops/sec. Stored as a
+    # HASH of {level, last} — Lua compares level vs bucket_size after
+    # leaking elapsed * drain_per_sec.
+    class Leaky < Base
+      WAIT_SLEEP = 0.05
+
+      def type = :leaky
+
+      def size
+        h = Wurk::Limiter.redis { |c| c.call('HGET', state_key, 'level') }
+        h.to_f
+      end
+
+      def within_limit(&block)
+        raise ArgumentError, 'block required' unless block
+
+        deadline = ::Time.now.to_f + @options[:wait_timeout]
+        loop do
+          ok, _level = acquire
+          return block.call if ok.to_i == 1
+
+          remaining = deadline - ::Time.now.to_f
+          raise OverLimit.new(self) if remaining <= 0
+
+          sleep [remaining, WAIT_SLEEP].min
+        end
+      end
+
+      protected
+
+      def state_keys
+        [state_key]
+      end
+
+      private
+
+      def state_key
+        "lmtr-l:#{@name}"
+      end
+
+      def drain_interval_seconds
+        case @options[:drain]
+        when Symbol
+          Limiter.interval_seconds(@options[:drain], allow_integer: false)
+        when Integer
+          @options[:drain]
+        else
+          raise ArgumentError, "drain must be Symbol or Integer (got #{@options[:drain].class})"
+        end
+      end
+
+      # bucket_size / drain → ops per second.
+      def drain_per_sec
+        @drain_per_sec ||= @options[:bucket_size].to_f / drain_interval_seconds
+      end
+
+      def acquire
+        lua(:limiter_leaky_acquire,
+            keys: [state_key],
+            argv: [@options[:bucket_size], drain_per_sec, ttl])
+      end
+    end
+
+    # ---- Points -------------------------------------------------------
+    #
+    # Token-bucket with explicit `estimate:` per call. Refills at
+    # `refill_per_second` capped at `initial_points`. Failure mode is
+    # immediate (spec §1.4 — no sleep loop). The block is invoked with a
+    # `Handle` so user code may refund/over-charge via `handle.points_used`.
+    class Points < Base
+      class Handle
+        def initialize(limiter, estimate)
+          @limiter = limiter
+          @estimate = estimate
+        end
+
+        # Positive delta returns points to the bucket; negative records an
+        # under-estimate. Either way, clamped to [0, cap].
+        def points_used(actual)
+          delta = @estimate - actual
+          @limiter.send(:refund, delta)
+        end
+      end
+
+      def type = :points
+
+      # Apply refill on read so the size matches what the *next* acquire
+      # would see. Stored balance only updates on acquire/refund; without
+      # this, a fully-refilled bucket reports stale low numbers.
+      def size
+        cap = @options[:initial].to_f
+        data = Wurk::Limiter.redis { |c| c.call('HMGET', state_key, 'points', 'last') }
+        stored = data[0]
+        return cap if stored.nil?
+
+        last = (data[1] || ::Time.now.to_f).to_f
+        elapsed = [::Time.now.to_f - last, 0.0].max
+        [cap, stored.to_f + (elapsed * @options[:refill].to_f)].min
+      end
+
+      def within_limit(estimate:, &block)
+        raise ArgumentError, 'block required' unless block
+        raise ArgumentError, 'estimate must be positive' if estimate <= 0
+
+        ok, _remaining = acquire(estimate)
+        raise OverLimit.new(self) unless ok.to_i == 1
+
+        handle = Handle.new(self, estimate)
+        block.call(handle)
+      end
+
+      protected
+
+      def state_keys
+        [state_key]
+      end
+
+      private
+
+      def state_key
+        "lmtr-p:#{@name}"
+      end
+
+      def acquire(estimate)
+        lua(:limiter_points_acquire,
+            keys: [state_key],
+            argv: [@options[:initial], @options[:refill], estimate, ttl])
+      end
+
+      def refund(delta)
+        lua(:limiter_points_refund,
+            keys: [state_key],
+            argv: [delta, @options[:initial], ttl]).to_f
+      end
+    end
+
+    # ---- Unlimited ----------------------------------------------------
+    #
+    # No-op for the tests + bypass scenarios documented in §1.8. The
+    # within_limit block runs unconditionally and the introspection
+    # methods all return zeros so dashboards render predictably.
+    class Unlimited
+      def name = 'unlimited'
+      def type = :unlimited
+      def options = {}
+      def size = 0
+      def status = {}
+      def fingerprint = Digest::SHA256.hexdigest('unlimited')
+      def reset = nil
+      def delete = nil
+
+      # Accept all the kwargs the other limiters take so a worker can swap
+      # `limiter = Sidekiq::Limiter.unlimited` in tests without touching
+      # call sites. `points`-style callers pass an `estimate:` and expect a
+      # `|handle|` block param — we yield a zero-cost handle just in case.
+      def within_limit(**_kwargs, &block)
+        raise ArgumentError, 'block required' unless block
+
+        if block.arity == 0
+          block.call
+        else
+          block.call(Points::Handle.new(self, 0))
+        end
+      end
+    end
+
+    # ---- Server Middleware --------------------------------------------
+    #
+    # Catches OverLimit (and any class registered in
+    # `Limiter.config.errors`), bumps `job['overrated']`, computes the
+    # backoff, and reschedules to the same queue via `Client.push` with
+    # `at: Time.now + backoff`. Once `overrated >= reschedule`, re-raises
+    # so the normal retry/dead pipeline takes over.
+    class ServerMiddleware
+      include Wurk::Middleware::ServerMiddleware
+
+      def call(_worker, job, _queue)
+        yield
+      rescue StandardError => e
+        raise unless over_limit?(e)
+
+        handle_over_limit(job, e)
+      end
+
+      private
+
+      def over_limit?(exc)
+        Wurk::Limiter.config.errors.any? { |k| exc.is_a?(k) }
+      end
+
+      def handle_over_limit(job, exc)
+        job['overrated'] = job.fetch('overrated', 0).to_i + 1
+        limiter = exc.respond_to?(:limiter) ? exc.limiter : nil
+        exc.job = job if exc.respond_to?(:job=)
+        reschedule_cap = (limiter && limiter.options[:reschedule]) || Wurk::Limiter::DEFAULT_RESCHEDULE
+        raise exc if job['overrated'] >= reschedule_cap
+
+        backoff_proc = (limiter && limiter.options[:backoff]) || Wurk::Limiter.config.backoff
+        delay = backoff_proc.call(limiter, job, exc).to_f
+        Wurk::Client.new.push(job.merge('at' => ::Time.now.to_f + delay))
+      end
     end
   end
 end
+
+require_relative 'middleware'
+# Server-middleware registration happens in wurk.rb after the Wurk
+# `class << self` block defines `Wurk.configuration` — limiter.rb
+# loads earlier than that, so trying to call it here would NoMethodError.

--- a/lib/wurk/lua.rb
+++ b/lib/wurk/lua.rb
@@ -156,6 +156,16 @@ module Wurk
       return removed
     LUA
 
+    # Limiter scripts live in `lib/wurk/lua/limiter_*.lua` — one file per
+    # type. Loaded at boot, the file's basename (minus `.lua`) becomes the
+    # SCRIPTS key as a symbol. Keeping them as separate files makes diffing
+    # individual rate-limiter changes painless and keeps each script self-
+    # contained for the `redis-cli --eval` debug workflow.
+    LUA_DIR = File.expand_path('lua', __dir__)
+    FILE_SCRIPTS = Dir.glob(File.join(LUA_DIR, '*.lua')).each_with_object({}) do |path, h|
+      h[File.basename(path, '.lua').to_sym] = File.read(path)
+    end.freeze
+
     SCRIPTS = {
       zpopbyscore: ZPOPBYSCORE,
       bulk_push: BULK_PUSH,
@@ -166,7 +176,7 @@ module Wurk
       batch_invalidate: BATCH_INVALIDATE,
       fast_delete_job: FAST_DELETE_JOB,
       fast_delete_by_class: FAST_DELETE_BY_CLASS
-    }.freeze
+    }.merge(FILE_SCRIPTS).freeze
 
     # SHA1 of each script source — matches what `SCRIPT LOAD` returns.
     # Precomputing keeps `eval_cached` allocation-free in the hot path.

--- a/lib/wurk/lua/limiter_bucket_acquire.lua
+++ b/lib/wurk/lua/limiter_bucket_acquire.lua
@@ -1,0 +1,27 @@
+-- Bucket limiter: increment counter for current epoch slot.
+-- All timing is from TIME (Redis-local clock) per spec — never Ruby's clock
+-- inside Lua. Epoch = floor(now / interval), so counters reset at cardinal
+-- boundaries of the interval unit (00 of minute/hour/day).
+-- KEYS[1] = lmtr-b:<name>:<placeholder>  (suffixed with :<epoch> below)
+-- ARGV[1] = limit (max count per epoch)
+-- ARGV[2] = interval seconds
+-- ARGV[3] = used (units to charge; 1 by default)
+-- ARGV[4] = ttl seconds
+-- Returns {acquired, current, seconds_to_next_boundary}.
+local prefix = KEYS[1]
+local t = redis.call('TIME')
+local now = tonumber(t[1])
+local interval = tonumber(ARGV[2])
+local epoch = math.floor(now / interval)
+local key = prefix .. ':' .. epoch
+local limit = tonumber(ARGV[1])
+local used = tonumber(ARGV[3])
+local ttl = tonumber(ARGV[4])
+local current = tonumber(redis.call('GET', key) or '0')
+local remaining = (epoch + 1) * interval - now
+if current + used <= limit then
+  current = redis.call('INCRBY', key, used)
+  redis.call('EXPIRE', key, ttl)
+  return {1, current, remaining}
+end
+return {0, current, remaining}

--- a/lib/wurk/lua/limiter_concurrent_acquire.lua
+++ b/lib/wurk/lua/limiter_concurrent_acquire.lua
@@ -1,0 +1,29 @@
+-- Concurrent limiter: atomic slot acquire.
+-- KEYS[1] = lmtr-cs:<name>     ZSET of held slot ids, score = expiry epoch.
+-- KEYS[2] = lmtr-stats:<name>  HASH of metric counters.
+-- ARGV[1] = limit
+-- ARGV[2] = lock_timeout seconds
+-- ARGV[3] = slot_id (caller-generated; SHA-fingerprinted on the Ruby side)
+-- ARGV[4] = ttl seconds
+-- Returns {acquired, held, reclaimed}. acquired: 1 if slot recorded, 0 if full.
+-- reclaimed: count of expired slots evicted on this pass.
+local cs_key = KEYS[1]
+local st_key = KEYS[2]
+local t = redis.call('TIME')
+local now = tonumber(t[1])
+local limit = tonumber(ARGV[1])
+local lock_to = tonumber(ARGV[2])
+local slot_id = ARGV[3]
+local ttl = tonumber(ARGV[4])
+local reclaimed = redis.call('ZREMRANGEBYSCORE', cs_key, '-inf', '(' .. now)
+if reclaimed > 0 then
+  redis.call('HINCRBY', st_key, 'reclaimed', reclaimed)
+end
+local held = redis.call('ZCARD', cs_key)
+if held < limit then
+  redis.call('ZADD', cs_key, now + lock_to, slot_id)
+  redis.call('EXPIRE', cs_key, ttl)
+  redis.call('EXPIRE', st_key, ttl)
+  return {1, held + 1, reclaimed}
+end
+return {0, held, reclaimed}

--- a/lib/wurk/lua/limiter_concurrent_release.lua
+++ b/lib/wurk/lua/limiter_concurrent_release.lua
@@ -1,0 +1,7 @@
+-- Concurrent limiter: release a held slot. ZREM returns 0 when the slot
+-- was already reclaimed by the acquire path's ZREMRANGEBYSCORE — caller
+-- treats that as an "overage" and bumps the metric on the Ruby side.
+-- KEYS[1] = lmtr-cs:<name>
+-- ARGV[1] = slot_id
+-- Returns 1 if removed, 0 if already reclaimed.
+return redis.call('ZREM', KEYS[1], ARGV[1])

--- a/lib/wurk/lua/limiter_leaky_acquire.lua
+++ b/lib/wurk/lua/limiter_leaky_acquire.lua
@@ -1,0 +1,31 @@
+-- Leaky bucket: drip = bucket_size / drain ops/sec, but exposed as
+-- (bucket_size, drain_per_sec_float) — the Ruby caller pre-divides.
+-- On each acquire: compute leaked = elapsed * drain_per_sec, decrement
+-- level by that amount (floor 0), then if level+1 <= bucket_size add 1.
+-- KEYS[1] = lmtr-l:<name>
+-- ARGV[1] = bucket_size
+-- ARGV[2] = drain_per_sec (float)
+-- ARGV[3] = ttl
+-- Returns {acquired, current_level_float}.
+local key = KEYS[1]
+local t = redis.call('TIME')
+local now = tonumber(t[1]) + tonumber(t[2]) / 1000000
+local bucket_size = tonumber(ARGV[1])
+local drain = tonumber(ARGV[2])
+local ttl = tonumber(ARGV[3])
+local data = redis.call('HMGET', key, 'level', 'last')
+local level = tonumber(data[1] or '0')
+local last = tonumber(data[2] or now)
+local elapsed = now - last
+if elapsed < 0 then elapsed = 0 end
+local new_level = level - (elapsed * drain)
+if new_level < 0 then new_level = 0 end
+if new_level + 1 <= bucket_size then
+  new_level = new_level + 1
+  redis.call('HSET', key, 'level', tostring(new_level), 'last', tostring(now))
+  redis.call('EXPIRE', key, ttl)
+  return {1, tostring(new_level)}
+end
+redis.call('HSET', key, 'level', tostring(new_level), 'last', tostring(now))
+redis.call('EXPIRE', key, ttl)
+return {0, tostring(new_level)}

--- a/lib/wurk/lua/limiter_points_acquire.lua
+++ b/lib/wurk/lua/limiter_points_acquire.lua
@@ -1,0 +1,34 @@
+-- Points limiter: token bucket with explicit `estimate` charge per call.
+-- Refill = refill_per_sec * elapsed, capped at the initial cap. If the
+-- (refilled) balance is < estimate, OverLimit immediately — no sleep
+-- loop (spec §1.4: points raises immediately when empty). On success
+-- the caller may refund/over-charge via limiter_points_refund.lua.
+-- KEYS[1] = lmtr-p:<name>
+-- ARGV[1] = initial_points (cap)
+-- ARGV[2] = refill_per_sec
+-- ARGV[3] = estimate
+-- ARGV[4] = ttl
+-- Returns {acquired, points_after_charge_or_balance}.
+local key = KEYS[1]
+local t = redis.call('TIME')
+local now = tonumber(t[1]) + tonumber(t[2]) / 1000000
+local cap = tonumber(ARGV[1])
+local refill = tonumber(ARGV[2])
+local estimate = tonumber(ARGV[3])
+local ttl = tonumber(ARGV[4])
+local data = redis.call('HMGET', key, 'points', 'last')
+local points = tonumber(data[1] or cap)
+local last = tonumber(data[2] or now)
+local elapsed = now - last
+if elapsed < 0 then elapsed = 0 end
+local refilled = points + (elapsed * refill)
+if refilled > cap then refilled = cap end
+if refilled >= estimate then
+  local remaining = refilled - estimate
+  redis.call('HSET', key, 'points', tostring(remaining), 'last', tostring(now))
+  redis.call('EXPIRE', key, ttl)
+  return {1, tostring(remaining)}
+end
+redis.call('HSET', key, 'points', tostring(refilled), 'last', tostring(now))
+redis.call('EXPIRE', key, ttl)
+return {0, tostring(refilled)}

--- a/lib/wurk/lua/limiter_points_refund.lua
+++ b/lib/wurk/lua/limiter_points_refund.lua
@@ -1,0 +1,18 @@
+-- Points limiter: post-call adjust. `delta` is signed — positive refunds
+-- unused estimate, negative records an under-estimate. Clamped to [0, cap].
+-- KEYS[1] = lmtr-p:<name>
+-- ARGV[1] = delta (float)
+-- ARGV[2] = cap
+-- ARGV[3] = ttl
+-- Returns the new points balance.
+local key = KEYS[1]
+local delta = tonumber(ARGV[1])
+local cap = tonumber(ARGV[2])
+local ttl = tonumber(ARGV[3])
+local current = tonumber(redis.call('HGET', key, 'points') or '0')
+local new_val = current + delta
+if new_val < 0 then new_val = 0 end
+if new_val > cap then new_val = cap end
+redis.call('HSET', key, 'points', tostring(new_val))
+redis.call('EXPIRE', key, ttl)
+return tostring(new_val)

--- a/lib/wurk/lua/limiter_window_acquire.lua
+++ b/lib/wurk/lua/limiter_window_acquire.lua
@@ -1,0 +1,35 @@
+-- Window limiter: sliding window via ZSET of timestamps.
+-- Sliding from the first use, not from a fixed epoch boundary. Each call
+-- trims entries older than (now - interval) and counts what remains; if
+-- under limit, ZADDs `used` entries with scores at now and unique member
+-- ids (microsecond + counter suffix to allow multi-add in one TIME tick).
+-- KEYS[1] = lmtr-w:<name>
+-- ARGV[1] = limit
+-- ARGV[2] = interval seconds (float ok)
+-- ARGV[3] = used
+-- ARGV[4] = ttl
+-- ARGV[5] = nonce (Ruby-side random; isolates parallel callers)
+-- Returns {acquired, current_size, oldest_score_in_window_or_-1}.
+local key = KEYS[1]
+local t = redis.call('TIME')
+local now = tonumber(t[1]) + tonumber(t[2]) / 1000000
+local interval = tonumber(ARGV[2])
+local limit = tonumber(ARGV[1])
+local used = tonumber(ARGV[3])
+local ttl = tonumber(ARGV[4])
+local nonce = ARGV[5]
+redis.call('ZREMRANGEBYSCORE', key, '-inf', '(' .. (now - interval))
+local current = redis.call('ZCARD', key)
+if current + used <= limit then
+  for i = 1, used do
+    redis.call('ZADD', key, now, now .. ':' .. nonce .. ':' .. i)
+  end
+  redis.call('EXPIRE', key, ttl)
+  return {1, current + used, -1}
+end
+local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+local oldest_score = -1
+if oldest[2] then
+  oldest_score = tonumber(oldest[2])
+end
+return {0, current, tostring(oldest_score)}

--- a/lib/wurk/metrics/history.rb
+++ b/lib/wurk/metrics/history.rb
@@ -1,12 +1,144 @@
 # frozen_string_literal: true
 
+require_relative '../middleware'
+
 module Wurk
   module Metrics
-    # Ent feature parity: historical time-series stored in Redis,
-    # bucketed minutely / hourly / daily. Powers the metrics pane.
+    # Ent feature parity (§5): server middleware that records per-job-class
+    # execution metrics into Redis time-buckets. The on-the-wire schema is
+    # wire-compat with Sidekiq 8.x's history pane so dashboards built against
+    # `j|YYMMDD|H:M` HASH keys keep working unchanged.
+    #
+    # Bucket layout (spec: docs/target/sidekiq-free.md §1.6):
+    #
+    #   j|YYMMDD|H:M    HASH   per-minute bucket, TTL = MID_TERM (3 days)
+    #     <klass>|p     INT    processed count
+    #     <klass>|f     INT    failed count
+    #     <klass>|ms    INT    total ms spent
+    #
+    #   j|YYMMDD|H:m0   HASH   10-minute rollup (last digit zeroed),
+    #                          TTL = SHORT_TERM (8 hours) — short window for
+    #                          quick aggregate queries without scanning 600 minute keys.
+    #
+    #   <klass>-YYMMDD-H  HASH per-class hourly histogram, TTL = MID_TERM
+    #
+    # Every bucket TTL is set on first write (EXPIRE NX-equivalent: only when
+    # the HASH was newly created in this call) — re-asserting TTL on every
+    # write would keep the bucket alive indefinitely while traffic continues,
+    # but that's the desired behavior here: as long as a class keeps running,
+    # we keep the minute bucket around for the retention window measured from
+    # *last write*, not from first write. So we EXPIRE unconditionally.
+    #
+    # The middleware is hot-path — every successful job pays for it. Writes
+    # are pipelined in a single round-trip per job (1 HINCRBY × 3 + 1 EXPIRE
+    # per bucket × 3 buckets = 12 commands, batched).
     class History
-      def record(job_class, duration_ms, status:); end
-      def query(job_class:, from:, to:); end
+      include Wurk::Middleware::ServerMiddleware
+
+      # Per spec §1.6 — naming mirrors the upstream constants so anyone
+      # grepping the Sidekiq source for `MID_TERM` lands here.
+      MID_TERM = 3 * 24 * 60 * 60      # 3 days, in seconds
+      SHORT_TERM = 8 * 60 * 60         # 8 hours, in seconds
+
+      MINUTE_KEY_PREFIX = 'j|'
+      DATE_FORMAT = '%y%m%d'           # YYMMDD — two-digit year per spec
+
+      def call(_worker, job, _queue)
+        klass = job['class']
+        started = monotonic_ms
+        success = false
+        begin
+          result = yield
+          success = true
+          result
+        ensure
+          duration = (monotonic_ms - started).round
+          # Best-effort: a metrics write failure must never propagate into
+          # the job result. The processor already finalized the ack path.
+          begin
+            self.class.record(klass, duration, success: success, redis_pool: redis_pool)
+          rescue StandardError => e
+            handle_error(e)
+          end
+        end
+      end
+
+      class << self
+        # Single Redis round-trip per job. `success: true` → `<klass>|p`;
+        # `success: false` → `<klass>|f`. `<klass>|ms` accumulates total
+        # runtime in milliseconds for *both* outcomes (so an operator can
+        # ask "how much wall-clock time has FooJob consumed?" without
+        # branching on outcome).
+        def record(klass, duration_ms, success:, redis_pool: nil, at: ::Time.now)
+          return if klass.nil? || klass.empty?
+
+          ms = duration_ms.to_i
+          ms = 0 if ms.negative?
+          buckets = { minute: minute_key(at), rollup: rollup_key(at), hour: hour_key(klass, at) }
+          with_pool(redis_pool) { |conn| pipeline_write(conn, klass, ms, success, buckets) }
+          nil
+        end
+
+        # Minute + 10-min rollup share a per-class `|p|f|ms` field layout;
+        # the hourly bucket is already class-scoped so its fields are bare
+        # `p|f|ms`. Pipeline all 9 commands in one round-trip.
+        def pipeline_write(conn, klass, ms, success, buckets)
+          outcome = success ? 'p' : 'f'
+          class_outcome = "#{klass}|#{outcome}"
+          class_ms = "#{klass}|ms"
+          conn.pipelined do |pipe|
+            incr_bucket(pipe, buckets[:minute], [class_outcome, class_ms, ms, MID_TERM])
+            incr_bucket(pipe, buckets[:rollup], [class_outcome, class_ms, ms, SHORT_TERM])
+            incr_bucket(pipe, buckets[:hour], [outcome, 'ms', ms, MID_TERM])
+          end
+        end
+
+        def incr_bucket(pipe, key, parts)
+          outcome_field, ms_field, ms, ttl = parts
+          pipe.call('HINCRBY', key, outcome_field, 1)
+          pipe.call('HINCRBY', key, ms_field, ms)
+          pipe.call('EXPIRE', key, ttl)
+        end
+
+        # Public formatters — Wurk::Metrics::Query reuses these so the two
+        # cannot drift on bucket-naming convention.
+        def minute_key(time)
+          t = time.utc
+          format("#{MINUTE_KEY_PREFIX}%<date>s|%<hr>d:%<min>d",
+                 date: t.strftime(DATE_FORMAT), hr: t.hour, min: t.min)
+        end
+
+        def rollup_key(time)
+          t = time.utc
+          format("#{MINUTE_KEY_PREFIX}%<date>s|%<hr>d:%<min>d",
+                 date: t.strftime(DATE_FORMAT), hr: t.hour, min: (t.min / 10) * 10)
+        end
+
+        def hour_key(klass, time)
+          t = time.utc
+          "#{klass}-#{t.strftime(DATE_FORMAT)}-#{t.hour}"
+        end
+      end
+
+      private
+
+      def monotonic_ms
+        ::Process.clock_gettime(::Process::CLOCK_MONOTONIC, :float_millisecond)
+      end
+
+      def handle_error(err)
+        cfg = config || Wurk.configuration
+        cfg.handle_exception(err, context: 'Wurk::Metrics::History')
+      end
+
+      def self.with_pool(pool, &)
+        if pool
+          pool.with(&)
+        else
+          Wurk.redis(&)
+        end
+      end
+      private_class_method :with_pool
     end
   end
 end

--- a/lib/wurk/metrics/query.rb
+++ b/lib/wurk/metrics/query.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require_relative 'history'
+
+module Wurk
+  module Metrics
+    # Read-side for the per-class HASH bucket schema written by
+    # `Wurk::Metrics::History`. Backs the Web UI's history pane and any
+    # external dashboarding code; both rely on the same HGETALL fan-out
+    # over a contiguous range of minute / hour keys.
+    #
+    # Window caps are spec-enforced:
+    #
+    #   minutes ≤ 480  (8h — same as the 10-minute rollup retention)
+    #   hours   ≤ 72   (3d — same as MID_TERM retention)
+    #
+    # A wider window has no data to read anyway (the buckets are TTL'd out),
+    # so we fail loudly rather than silently returning sparse results.
+    module Query
+      MAX_MINUTES = 480
+      MAX_HOURS = 72
+      TOTAL_FIELDS = %w[p f ms].freeze
+      private_constant :TOTAL_FIELDS
+
+      class WindowTooWide < ::ArgumentError; end
+
+      module_function
+
+      # Aggregate per-job-class totals over a recent window of minute
+      # buckets. Returns array of `[class_name, {p:, f:, ms:}]` tuples
+      # sorted by volume (p + f) descending so the UI's "top jobs" table
+      # renders without a second sort pass.
+      def top_jobs(class_filter: nil, minutes: 60, hours: nil, now: ::Time.now)
+        minutes = hours * 60 if hours
+        cap_hours!(hours) if hours
+        rows = aggregate_minutes(now, cap_minutes!(minutes)).to_a
+        rows = rows.select { |(k, _)| k.start_with?(class_filter) } if class_filter && !class_filter.empty?
+        rows.sort_by { |(_k, s)| -(s[:p] + s[:f]) }
+      end
+
+      # Per-class time-series. `minutes` reads the per-minute bucket; `hours`
+      # reads the per-class hourly bucket (separate keys per spec, so a long
+      # window doesn't fan out over 4320 minute hashes).
+      def for_job(klass, minutes: nil, hours: nil, now: ::Time.now)
+        validate_for_job!(klass, minutes, hours)
+        minutes ? minute_series(klass, now, cap_minutes!(minutes)) : hour_series(klass, now, cap_hours!(hours))
+      end
+
+      def validate_for_job!(klass, minutes, hours)
+        raise ArgumentError, 'klass required' if klass.nil? || klass.empty?
+        raise ArgumentError, 'pass exactly one of minutes: or hours:' if minutes && hours
+        raise ArgumentError, 'pass minutes: or hours:' if minutes.nil? && hours.nil?
+      end
+
+      def cap_minutes!(minutes)
+        check_window!(Integer(minutes), MAX_MINUTES, 'minutes')
+      end
+
+      def cap_hours!(hours)
+        check_window!(Integer(hours), MAX_HOURS, 'hours')
+      end
+
+      def check_window!(value, max, label)
+        raise ArgumentError, "#{label} must be positive" if value <= 0
+        raise WindowTooWide, "#{label} must be <= #{max} (got #{value})" if value > max
+
+        value
+      end
+
+      def aggregate_minutes(now, minutes)
+        totals = ::Hash.new { |h, k| h[k] = { p: 0, f: 0, ms: 0 } }
+        pipeline_hgetall(minute_keys(now, minutes)).each { |hash| accumulate!(totals, hash) }
+        totals
+      end
+
+      def accumulate!(totals, hash)
+        return if hash.nil? || hash.empty?
+
+        hash.each do |field, value|
+          klass, kind = field.split('|', 2)
+          next unless kind && TOTAL_FIELDS.include?(kind)
+
+          totals[klass][kind.to_sym] += Integer(value)
+        end
+      end
+
+      def minute_series(klass, now, minutes)
+        rows = pipeline_hmget(minute_keys(now, minutes), %W[#{klass}|p #{klass}|f #{klass}|ms])
+        zip_rows(minute_timestamps(now, minutes), rows)
+      end
+
+      def hour_series(klass, now, hours)
+        timestamps = hour_timestamps(now, hours)
+        keys = timestamps.map { |t| Wurk::Metrics::History.hour_key(klass, t) }
+        zip_rows(timestamps, pipeline_hmget(keys, %w[p f ms]))
+      end
+
+      def zip_rows(timestamps, rows)
+        timestamps.zip(rows).map { |at, (p, f, ms)| { at: at, p: p.to_i, f: f.to_i, ms: ms.to_i } }
+      end
+
+      def minute_keys(now, minutes)
+        minute_timestamps(now, minutes).map { |t| Wurk::Metrics::History.minute_key(t) }
+      end
+
+      # Truncate to the minute so the bucket boundary matches what the
+      # writer used. Fractional-second drift would otherwise pull in an
+      # unrelated minute on the edge of the window.
+      def minute_timestamps(now, minutes)
+        floor = floor_to(now, :min)
+        (0...minutes).map { |i| floor - (i * 60) }.reverse
+      end
+
+      def hour_timestamps(now, hours)
+        floor = floor_to(now, :hour)
+        (0...hours).map { |i| floor - (i * 3600) }.reverse
+      end
+
+      def floor_to(time, unit)
+        t = time.utc
+        case unit
+        when :min  then ::Time.utc(t.year, t.month, t.day, t.hour, t.min)
+        when :hour then ::Time.utc(t.year, t.month, t.day, t.hour)
+        end
+      end
+
+      def pipeline_hgetall(keys)
+        return [] if keys.empty?
+
+        Wurk.redis { |c| c.pipelined { |p| keys.each { |k| p.call('HGETALL', k) } } }
+      end
+
+      def pipeline_hmget(keys, fields)
+        return [] if keys.empty?
+
+        Wurk.redis { |c| c.pipelined { |p| keys.each { |k| p.call('HMGET', k, *fields) } } }
+      end
+    end
+  end
+end

--- a/lib/wurk/unique.rb
+++ b/lib/wurk/unique.rb
@@ -1,11 +1,240 @@
 # frozen_string_literal: true
 
+require 'json'
+require 'digest'
+require_relative 'middleware'
+
 module Wurk
-  # Sidekiq Enterprise unique jobs. Three modes:
-  # until_executed, until_executing, until_and_while_executing.
-  # Implemented as a middleware pair (client + server).
+  # Sidekiq Enterprise unique jobs. Best-effort dedup at enqueue time keyed
+  # by a SHA256 digest of `[class, queue, args]` (overridable via
+  # `sidekiq_unique_context`). Three lock-release strategies:
+  #
+  #   * `unique_until: :success` (default) — lock retained through retries;
+  #     server middleware DELs it on successful perform. Surviving across
+  #     a process crash is bounded by `unique_for` TTL.
+  #   * `unique_until: :start` — server middleware DELs the lock right
+  #     *before* invoking perform; a duplicate can be enqueued while the
+  #     first is running.
+  #
+  # Wire-compat (§3.9): single-key Redis layout — `unique:<sha256>` STRING
+  # holding the owning JID. Scheduled jobs extend the TTL by the delay so
+  # the lock covers the entire wait+execution window (§3.4).
+  #
+  # Spec: docs/target/sidekiq-ent.md §3.
   module Unique
-    class ClientMiddleware; end
-    class ServerMiddleware; end
+    KEY_PREFIX = 'unique:'
+    DEFAULT_UNTIL = :success
+    VALID_UNTIL = %i[success start].freeze
+
+    # `Sidekiq::Enterprise.unique!` flips this on. The middleware pair is
+    # always loaded (so worker `sidekiq_options unique_for:` is a no-op
+    # without `unique!`) — only when the flag is set does the client
+    # middleware actually compute and SETNX the digest.
+    class << self
+      def enabled?
+        @enabled == true
+      end
+
+      def enable! # rubocop:disable Naming/PredicateMethod
+        @enabled = true
+        register_middleware!
+        true
+      end
+
+      # Test helper — not part of the public Sidekiq surface. Clears the
+      # flag so per-test enable!/disable! does not leak across runs.
+      def disable!
+        @enabled = false
+        nil
+      end
+
+      # Compute the lock key for an arbitrary `(queue, klass, args)` triple.
+      # Used by both the client middleware and the public `locked?` probe so
+      # they cannot drift.
+      def lock_key(klass, queue, args)
+        context = [klass.to_s, queue.to_s, args]
+        "#{KEY_PREFIX}#{Digest::SHA256.hexdigest(JSON.dump(context))}"
+      end
+
+      # Compute the lock key from a job payload, honoring
+      # `sidekiq_unique_context` when the worker class is loaded and
+      # defines it.
+      def lock_key_for(job)
+        context = unique_context(job)
+        "#{KEY_PREFIX}#{Digest::SHA256.hexdigest(JSON.dump(context))}"
+      end
+
+      # Default: `[class, queue, args]`. Workers may override by defining
+      # `self.sidekiq_unique_context(job)` returning any JSON-serializable
+      # value (e.g. a subset of args). Spec §3.5.
+      def unique_context(job)
+        klass = resolve_class(job['class'])
+        if klass.respond_to?(:sidekiq_unique_context)
+          klass.sidekiq_unique_context(job)
+        else
+          [job['class'], job['queue'], job['args']]
+        end
+      end
+
+      private
+
+      def resolve_class(name)
+        return nil if name.nil? || name.to_s.empty?
+
+        ::Object.const_get(name.to_s)
+      rescue ::NameError
+        nil
+      end
+
+      def register_middleware!
+        Wurk.configuration.client_middleware.add(ClientMiddleware) \
+          unless Wurk.configuration.client_middleware.exists?(ClientMiddleware)
+        Wurk.configuration.server_middleware.add(ServerMiddleware) \
+          unless Wurk.configuration.server_middleware.exists?(ServerMiddleware)
+      end
+    end
+
+    # Coerce `unique_for` to a numeric seconds value. Accepts Integer,
+    # Numeric, ActiveSupport::Duration (any `to_i`-respondent), or `false`
+    # (skip). Returns nil when uniqueness should be skipped.
+    def self.coerce_ttl(value)
+      return nil if value.nil? || value == false
+      return value if value.is_a?(Integer) && value.positive?
+      return value.to_i if value.is_a?(Numeric)
+      return value.to_i if duration_like?(value)
+
+      nil
+    end
+
+    def self.duration_like?(value)
+      return false unless value.respond_to?(:to_i)
+
+      value.respond_to?(:since) || value.class.name.to_s.include?('Duration')
+    end
+
+    # ------------------------------------------------------------------
+    # Introspection — `Sidekiq::Enterprise::Unique.locked?`
+    # ------------------------------------------------------------------
+
+    # @return [String, nil] owning jid, or nil when the lock is free.
+    def self.locked?(queue_or_klass, klass_or_args = nil, args = nil)
+      queue, klass, payload = normalize_locked_args(queue_or_klass, klass_or_args, args)
+      key = lock_key(klass, queue, payload)
+      Wurk.redis { |c| c.call('GET', key) }
+    end
+
+    # Accepts either `(klass, args)` or `(queue, klass, args)`. Without a
+    # queue the default Wurk job queue is assumed — matches the Sidekiq
+    # Ent docs §3.6.
+    def self.normalize_locked_args(first, second, third)
+      if third.nil?
+        [Wurk.default_job_options['queue'] || 'default', first, Array(second)]
+      else
+        [first.to_s, second, Array(third)]
+      end
+    end
+    private_class_method :normalize_locked_args
+
+    # ------------------------------------------------------------------
+    # Client middleware — SETNX lock at push time.
+    # ------------------------------------------------------------------
+    #
+    # Drops the duplicate by returning nil from the chain (Wurk::Client
+    # treats nil as "halted"; the caller's `perform_async` returns nil
+    # JID). Logs the holder JID for debuggability.
+    class ClientMiddleware
+      include Wurk::Middleware::ClientMiddleware
+
+      def call(_worker, job, _queue, redis_pool, &)
+        return yield unless Wurk::Unique.enabled?
+
+        ttl = effective_ttl(job)
+        return yield if ttl.nil?
+
+        acquire_or_drop(redis_pool, job, Wurk::Unique.lock_key_for(job), ttl, &)
+      end
+
+      private
+
+      # Add `at - now` delay to the base TTL so a scheduled job's lock
+      # spans the wait + execution window (§3.4). Returns nil when the
+      # job opts out (`unique_for: false` / missing).
+      def effective_ttl(job)
+        base = Wurk::Unique.coerce_ttl(job['unique_for'])
+        return nil if base.nil?
+        return base unless job['at']
+
+        delay = (job['at'].to_f - ::Time.now.to_f).ceil
+        delay.positive? ? base + delay : base
+      end
+
+      def acquire_or_drop(pool, job, key, ttl)
+        pool.with do |conn|
+          return yield if conn.call('SET', key, job['jid'], 'NX', 'EX', ttl) == 'OK'
+
+          log_duplicate(job, conn.call('GET', key))
+        end
+        nil
+      end
+
+      def log_duplicate(job, holder)
+        return unless Wurk.logger
+
+        msg = "Wurk::Unique: duplicate #{job['class']} dropped " \
+              "(jid=#{job['jid']} blocked by jid=#{holder || '?'})"
+        Wurk.logger.info { msg }
+      end
+    end
+
+    # ------------------------------------------------------------------
+    # Server middleware — release lock per `unique_until` strategy.
+    # ------------------------------------------------------------------
+    #
+    # `:start`   → DEL before perform. Lock-after-this-point not held; a
+    #              duplicate can be re-enqueued while the first runs.
+    # `:success` → DEL only on successful return. Retries keep the lock.
+    #              Spec §3.7: a raise during perform leaves the lock so
+    #              the retry can proceed; the TTL bounds the worst case.
+    class ServerMiddleware
+      include Wurk::Middleware::ServerMiddleware
+
+      def call(_worker, job, _queue)
+        return yield unless Wurk::Unique.enabled? && Wurk::Unique.coerce_ttl(job['unique_for'])
+
+        mode = unique_until(job)
+        key = Wurk::Unique.lock_key_for(job)
+
+        if mode == :start
+          release(key, job['jid'])
+          yield
+        else
+          result = yield
+          release(key, job['jid'])
+          result
+        end
+      end
+
+      private
+
+      # Honor `unique_until: :start | :success`, fall back to default.
+      def unique_until(job)
+        raw = job['unique_until']
+        return DEFAULT_UNTIL if raw.nil?
+
+        sym = raw.to_sym
+        VALID_UNTIL.include?(sym) ? sym : DEFAULT_UNTIL
+      end
+
+      # CAS DEL: only drop the key if the owning JID still matches ours.
+      # Prevents a long-overdue retry from releasing a fresh lock held by
+      # a re-enqueued duplicate after the original TTL expired.
+      def release(key, jid)
+        redis_pool.with do |conn|
+          conn.call('DEL', key) if conn.call('GET', key) == jid
+        end
+      rescue StandardError => e
+        Wurk.logger&.warn { "Wurk::Unique release failed: #{e.class}: #{e.message}" }
+      end
+    end
   end
 end

--- a/test/unit/cron_test.rb
+++ b/test/unit/cron_test.rb
@@ -1,11 +1,517 @@
 # frozen_string_literal: true
 
-require_relative "../test_helper"
+require_relative '../test_helper'
 
 class CronTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  def test_skeleton
-    skip "implementation pending — see docs/target/sidekiq-ent.md (Sidekiq::Cron)"
+  REDIS_URL = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
+
+  # Workers used by ConfigTester resolution checks. Bodies stay empty —
+  # the test only needs the constant to resolve, not actual perform logic.
+  class FooWorker # rubocop:disable Lint/EmptyClass
+  end
+
+  class BarWorker # rubocop:disable Lint/EmptyClass
+  end
+
+  def setup
+    super
+    @suffix = "cron#{Process.pid}#{object_id}"
+    @lids = []
+  end
+
+  def teardown
+    @lids.each { |lid| Wurk::Cron.unregister(lid) }
+  ensure
+    super
+  end
+
+  # ---- Parser: fields ---------------------------------------------------
+
+  def test_parser_rejects_wrong_field_count
+    assert_raises(ArgumentError) { Wurk::Cron::Parser.new('* * * *') }
+    assert_raises(ArgumentError) { Wurk::Cron::Parser.new('* * * * * *') }
+  end
+
+  def test_parser_rejects_non_string
+    assert_raises(ArgumentError) { Wurk::Cron::Parser.new(nil) }
+    assert_raises(ArgumentError) { Wurk::Cron::Parser.new(123) }
+  end
+
+  def test_parser_expands_wildcard_minute
+    p = Wurk::Cron::Parser.new('* * * * *')
+
+    assert_equal 60, p.fields[0].size
+  end
+
+  def test_parser_step_every_five_minutes
+    p = Wurk::Cron::Parser.new('*/5 * * * *')
+
+    assert_equal Set.new([0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55]), p.fields[0]
+  end
+
+  def test_parser_list_values
+    p = Wurk::Cron::Parser.new('0,15,30,45 * * * *')
+
+    assert_equal Set.new([0, 15, 30, 45]), p.fields[0]
+  end
+
+  def test_parser_range
+    p = Wurk::Cron::Parser.new('* 9-17 * * *')
+
+    assert_equal Set.new(9..17), p.fields[1]
+  end
+
+  def test_parser_range_with_step
+    p = Wurk::Cron::Parser.new('* 8-18/2 * * *')
+
+    assert_equal Set.new([8, 10, 12, 14, 16, 18]), p.fields[1]
+  end
+
+  def test_parser_dow_7_normalized_to_0
+    p = Wurk::Cron::Parser.new('0 0 * * 7')
+
+    assert_includes p.fields[4], 0
+    refute_includes p.fields[4], 7
+  end
+
+  def test_parser_rejects_out_of_range_minute
+    assert_raises(ArgumentError) { Wurk::Cron::Parser.new('60 * * * *') }
+  end
+
+  def test_parser_rejects_out_of_range_hour
+    assert_raises(ArgumentError) { Wurk::Cron::Parser.new('* 24 * * *') }
+  end
+
+  def test_parser_rejects_out_of_range_dom
+    assert_raises(ArgumentError) { Wurk::Cron::Parser.new('* * 32 * *') }
+  end
+
+  def test_parser_rejects_out_of_range_month
+    assert_raises(ArgumentError) { Wurk::Cron::Parser.new('* * * 13 *') }
+  end
+
+  def test_parser_rejects_out_of_range_dow
+    assert_raises(ArgumentError) { Wurk::Cron::Parser.new('* * * * 8') }
+  end
+
+  def test_parser_rejects_reversed_range
+    assert_raises(ArgumentError) { Wurk::Cron::Parser.new('10-5 * * * *') }
+  end
+
+  def test_parser_rejects_zero_step
+    assert_raises(ArgumentError) { Wurk::Cron::Parser.new('*/0 * * * *') }
+  end
+
+  def test_parser_alias_hourly
+    assert_equal '0 * * * *', Wurk::Cron::Parser.new('@hourly').expression
+  end
+
+  def test_parser_alias_daily
+    assert_equal '0 0 * * *', Wurk::Cron::Parser.new('@daily').expression
+  end
+
+  def test_parser_alias_weekly
+    assert_equal '0 0 * * 0', Wurk::Cron::Parser.new('@weekly').expression
+  end
+
+  def test_parser_alias_monthly
+    assert_equal '0 0 1 * *', Wurk::Cron::Parser.new('@monthly').expression
+  end
+
+  def test_parser_alias_yearly
+    assert_equal '0 0 1 1 *', Wurk::Cron::Parser.new('@yearly').expression
+  end
+
+  # ---- Parser: next_fire_at --------------------------------------------
+
+  def test_next_fire_at_every_minute
+    p = Wurk::Cron::Parser.new('* * * * *')
+    now = ::Time.utc(2026, 1, 1, 12, 0, 30).to_i
+    nxt = p.next_fire_at(now)
+
+    assert_equal ::Time.utc(2026, 1, 1, 12, 1, 0).to_i, nxt
+  end
+
+  def test_next_fire_at_every_five_minutes
+    p = Wurk::Cron::Parser.new('*/5 * * * *')
+    now = ::Time.utc(2026, 1, 1, 12, 2, 0).to_i
+    nxt = p.next_fire_at(now)
+
+    assert_equal ::Time.utc(2026, 1, 1, 12, 5, 0).to_i, nxt
+  end
+
+  def test_next_fire_at_daily_at_4am
+    p = Wurk::Cron::Parser.new('0 4 * * *')
+    now = ::Time.utc(2026, 1, 1, 5, 0, 0).to_i
+    nxt = p.next_fire_at(now)
+
+    assert_equal ::Time.utc(2026, 1, 2, 4, 0, 0).to_i, nxt
+  end
+
+  def test_next_fire_at_strictly_after_from
+    p = Wurk::Cron::Parser.new('* * * * *')
+    boundary = ::Time.utc(2026, 1, 1, 12, 0, 0).to_i
+    nxt = p.next_fire_at(boundary)
+
+    assert_operator nxt, :>, boundary
+    assert_equal boundary + 60, nxt
+  end
+
+  def test_next_fire_at_weekly_sunday_midnight
+    p = Wurk::Cron::Parser.new('0 0 * * 0')
+    # 2026-01-04 is a Sunday.
+    monday = ::Time.utc(2026, 1, 5, 12, 0, 0).to_i
+    nxt = p.next_fire_at(monday)
+
+    assert_equal 0, ::Time.at(nxt).utc.wday
+  end
+
+  def test_next_fire_at_dow_seven_matches_sunday
+    p = Wurk::Cron::Parser.new('0 0 * * 7')
+    monday = ::Time.utc(2026, 1, 5, 12, 0, 0).to_i
+    nxt = p.next_fire_at(monday)
+
+    assert_equal 0, ::Time.at(nxt).utc.wday
+  end
+
+  # ---- Loop -------------------------------------------------------------
+
+  def test_loop_lid_stable_for_same_inputs
+    a = Wurk::Cron::Loop.new(schedule: '* * * * *', klass: 'A', options: { 'queue' => 'low' })
+    b = Wurk::Cron::Loop.new(schedule: '* * * * *', klass: 'A', options: { 'queue' => 'low' })
+
+    assert_equal a.lid, b.lid
+    assert_equal 16, a.lid.length
+  end
+
+  def test_loop_lid_differs_for_different_inputs
+    a = Wurk::Cron::Loop.new(schedule: '* * * * *', klass: 'A')
+    b = Wurk::Cron::Loop.new(schedule: '* * * * *', klass: 'B')
+
+    refute_equal a.lid, b.lid
+  end
+
+  def test_loop_rejects_invalid_cron
+    assert_raises(ArgumentError) { Wurk::Cron::Loop.new(schedule: 'bogus', klass: 'A') }
+  end
+
+  def test_loop_rejects_empty_klass
+    assert_raises(ArgumentError) { Wurk::Cron::Loop.new(schedule: '* * * * *', klass: '') }
+  end
+
+  def test_loop_to_redis_hash_carries_schedule_and_klass
+    lp = Wurk::Cron::Loop.new(schedule: '* * * * *', klass: 'A')
+    h = lp.to_redis_hash
+
+    assert_equal '* * * * *', h['schedule']
+    assert_equal 'A', h['klass']
+  end
+
+  def test_loop_to_redis_hash_json_options_round_trip
+    lp = Wurk::Cron::Loop.new(schedule: '* * * * *', klass: 'A', options: { queue: 'low', args: [1, 2] })
+    parsed = JSON.parse(lp.to_redis_hash['options'])
+
+    assert_equal({ 'queue' => 'low', 'args' => [1, 2] }, parsed)
+  end
+
+  def test_loop_paused_flag_round_trips
+    lp = Wurk::Cron::Loop.new(schedule: '* * * * *', klass: 'A', options: { 'paused' => '1' })
+
+    assert_predicate lp, :paused?
+  end
+
+  # ---- Manager registration + Redis -----------------------------------
+
+  def test_register_adds_lid_to_periodic_set
+    lp = register_for_persist_test
+    membership = Wurk.redis { |c| c.call('SISMEMBER', Wurk::Cron::PERIODIC_KEY, lp.lid) }
+
+    assert_equal 1, membership
+  end
+
+  def test_register_writes_schedule_to_loop_hash
+    lp = register_for_persist_test
+
+    assert_equal '*/5 * * * *', loop_hash(lp.lid)['schedule']
+  end
+
+  def test_register_writes_klass_to_loop_hash
+    lp = register_for_persist_test
+
+    assert_equal 'CronTest::FooWorker', loop_hash(lp.lid)['klass']
+  end
+
+  def test_register_idempotent_for_same_inputs
+    mgr = Wurk::Cron::Manager.new
+    a = mgr.register('*/5 * * * *', 'CronTest::FooWorker')
+    b = mgr.register('*/5 * * * *', 'CronTest::FooWorker')
+    @lids << a.lid
+    membership = Wurk.redis { |c| c.call('SISMEMBER', Wurk::Cron::PERIODIC_KEY, a.lid) }
+
+    assert_equal a.lid, b.lid
+    assert_equal 1, membership
+  end
+
+  def test_manager_tz_default_applies_to_subsequent_registers
+    mgr = Wurk::Cron::Manager.new
+    mgr.tz = 'America/Chicago'
+    lp = mgr.register('0 4 * * *', 'CronTest::FooWorker')
+    @lids << lp.lid
+
+    assert_equal 'America/Chicago', lp.tz
+  end
+
+  def test_manager_per_call_tz_overrides_default
+    mgr = Wurk::Cron::Manager.new
+    mgr.tz = 'America/Chicago'
+    lp = mgr.register('0 4 * * *', 'CronTest::FooWorker', tz: 'Asia/Tokyo')
+    @lids << lp.lid
+
+    assert_equal 'Asia/Tokyo', lp.tz
+  end
+
+  def test_register_accepts_constant_klass
+    mgr = Wurk::Cron::Manager.new
+    lp = mgr.register('* * * * *', CronTest::FooWorker)
+    @lids << lp.lid
+
+    assert_equal 'CronTest::FooWorker', lp.klass
+  end
+
+  # ---- Top-level register(name, cron, klass, args) --------------------
+
+  def test_module_register_carries_schedule_and_klass
+    lp = Wurk::Cron.register('nightly', '0 4 * * *', 'CronTest::BarWorker', ['nightly'], queue: 'low')
+    @lids << lp.lid
+
+    assert_equal ['0 4 * * *', 'CronTest::BarWorker'], [lp.schedule, lp.klass]
+  end
+
+  def test_module_register_carries_args_and_queue
+    lp = Wurk::Cron.register('nightly', '0 4 * * *', 'CronTest::BarWorker', ['nightly'], queue: 'low')
+    @lids << lp.lid
+
+    assert_equal [['nightly'], 'low'], [lp.args, lp.queue]
+  end
+
+  # ---- LoopSet --------------------------------------------------------
+
+  def test_loop_set_each_yields_registered_loops
+    mgr = Wurk::Cron::Manager.new
+    a = mgr.register('* * * * *', "CronTest::FooWorker#{@suffix}A")
+    b = mgr.register('0 * * * *', "CronTest::FooWorker#{@suffix}B")
+    @lids << a.lid << b.lid
+
+    set = Wurk::Cron::LoopSet.new
+    found = set.to_a.map(&:lid)
+
+    assert_includes found, a.lid
+    assert_includes found, b.lid
+  end
+
+  def test_loop_set_size_matches_registered_count
+    mgr = Wurk::Cron::Manager.new
+    lp = mgr.register('* * * * *', "CronTest::Sized#{@suffix}")
+    @lids << lp.lid
+
+    assert_operator Wurk::Cron::LoopSet.new.size, :>=, 1
+  end
+
+  def test_loop_set_fetch_returns_loop_for_known_lid
+    mgr = Wurk::Cron::Manager.new
+    lp = mgr.register('* * * * *', "CronTest::Fetch#{@suffix}", queue: 'high')
+    @lids << lp.lid
+
+    found = Wurk::Cron::LoopSet.new.fetch(lp.lid)
+
+    refute_nil found
+    assert_equal lp.lid, found.lid
+    assert_equal 'high', found.queue
+  end
+
+  def test_loop_set_fetch_returns_nil_for_unknown_lid
+    assert_nil Wurk::Cron::LoopSet.new.fetch('deadbeef00000000')
+  end
+
+  # ---- ConfigTester ---------------------------------------------------
+
+  def test_config_tester_verifies_valid_block
+    block = ->(mgr) { mgr.register('* * * * *', 'CronTest::FooWorker') }
+    loops = Wurk::Cron::ConfigTester.new.verify(&block)
+    @lids.concat(loops.map(&:lid))
+
+    assert_equal 1, loops.size
+  end
+
+  def test_config_tester_raises_on_missing_class
+    block = ->(mgr) { mgr.register('* * * * *', 'NoSuchWorker123') }
+    err = assert_raises(ArgumentError) { Wurk::Cron::ConfigTester.new.verify(&block) }
+
+    assert_match(/NoSuchWorker123/, err.message)
+  end
+
+  def test_config_tester_raises_on_invalid_cron
+    block = ->(mgr) { mgr.register('bogus expr', 'CronTest::FooWorker') }
+    assert_raises(ArgumentError) { Wurk::Cron::ConfigTester.new.verify(&block) }
+  end
+
+  def test_config_tester_requires_block
+    assert_raises(ArgumentError) { Wurk::Cron::ConfigTester.new.verify }
+  end
+
+  # ---- Poller leader-driven enqueue -----------------------------------
+
+  def test_poller_does_not_enqueue_when_not_leader
+    mgr = Wurk::Cron::Manager.new
+    queue = "cron-q-#{@suffix}"
+    lp = mgr.register('* * * * *', "CronTest::Pollee#{@suffix}", queue: queue)
+    @lids << lp.lid
+
+    poller = Wurk::Cron::Poller.new(Wurk.configuration)
+    # Stub leader to deny acquisition.
+    leader = poller.instance_variable_get(:@leader)
+    leader.define_singleton_method(:acquire) { false }
+    leader.define_singleton_method(:leader?) { false }
+
+    poller.tick
+
+    len = Wurk.redis { |c| c.call('LLEN', "queue:#{queue}") }
+    cleanup_queue(queue)
+
+    assert_equal 0, len
+  end
+
+  def test_poller_enqueues_payload_when_leader
+    job = enqueue_via_leader_tick(klass: "CronTest::Pollee#{@suffix}", queue: "cron-q-#{@suffix}", args: [1, 2])
+
+    assert_equal "CronTest::Pollee#{@suffix}", job['class']
+  end
+
+  def test_poller_enqueues_args_when_leader
+    job = enqueue_via_leader_tick(klass: "CronTest::PolleeArgs#{@suffix}", queue: "cron-qa-#{@suffix}", args: [1, 2])
+
+    assert_equal [1, 2], job['args']
+  end
+
+  def test_poller_enqueues_queue_when_leader
+    queue = "cron-qq-#{@suffix}"
+    job = enqueue_via_leader_tick(klass: "CronTest::PolleeQ#{@suffix}", queue: queue, args: [])
+
+    assert_equal queue, job['queue']
+  end
+
+  def test_poller_skips_paused_loops
+    mgr = Wurk::Cron::Manager.new
+    queue = "cron-q-paused-#{@suffix}"
+    lp = mgr.register('* * * * *', "CronTest::Paused#{@suffix}", queue: queue, paused: '1')
+    @lids << lp.lid
+
+    poller = Wurk::Cron::Poller.new(Wurk.configuration)
+    leader = poller.instance_variable_get(:@leader)
+    leader.define_singleton_method(:acquire) { true }
+    leader.define_singleton_method(:leader?) { true }
+
+    poller.tick
+
+    len = Wurk.redis { |c| c.call('LLEN', "queue:#{queue}") }
+    cleanup_queue(queue)
+
+    assert_equal 0, len
+  end
+
+  def test_poller_records_history_entry_on_fire
+    history = history_after_leader_tick
+
+    assert_equal 1, history.size
+  end
+
+  def test_poller_history_entry_carries_ts_and_jid
+    history = history_after_leader_tick
+    ts, jid = JSON.parse(history.first)
+
+    assert ts.is_a?(Integer) && jid.is_a?(String) && !jid.empty?
+  end
+
+  # ---- Configuration#periodic -----------------------------------------
+
+  def test_configure_server_periodic_block_yields_manager
+    cfg = Wurk::Configuration.new
+    mgr_seen = nil
+    cfg.periodic { |mgr| mgr_seen = mgr }
+
+    assert_kind_of Wurk::Cron::Manager, mgr_seen
+  end
+
+  def test_configure_periodic_returns_manager_without_block
+    cfg = Wurk::Configuration.new
+
+    assert_kind_of Wurk::Cron::Manager, cfg.periodic
+  end
+
+  # ---- Sidekiq aliases ------------------------------------------------
+
+  def test_aliased_under_sidekiq_namespace
+    assert_same Wurk::Cron, Sidekiq::Cron
+    assert_same Wurk::Cron, Sidekiq::Periodic
+  end
+
+  def test_constants_match_spec_keys
+    assert_equal 'periodic', Wurk::Cron::PERIODIC_KEY
+    assert_equal 'loops:', Wurk::Cron::LOOP_PREFIX
+    assert_equal 'cron-leader', Wurk::Cron::LEADER_KEY
+  end
+
+  private
+
+  def cleanup_queue(queue)
+    Wurk.redis do |c|
+      c.call('DEL', "queue:#{queue}")
+      c.call('SREM', 'queues', queue)
+    end
+  end
+
+  def register_for_persist_test
+    mgr = Wurk::Cron::Manager.new
+    lp = mgr.register('*/5 * * * *', 'CronTest::FooWorker', queue: 'low')
+    @lids << lp.lid
+    lp
+  end
+
+  def loop_hash(lid)
+    h = Wurk.redis { |c| c.call('HGETALL', "#{Wurk::Cron::LOOP_PREFIX}#{lid}") }
+    h.is_a?(Array) ? h.each_slice(2).to_h : h
+  end
+
+  def build_leader_poller
+    poller = Wurk::Cron::Poller.new(Wurk.configuration)
+    leader = poller.instance_variable_get(:@leader)
+    leader.define_singleton_method(:acquire) { true }
+    leader.define_singleton_method(:leader?) { true }
+    poller
+  end
+
+  def enqueue_via_leader_tick(klass:, queue:, args:)
+    mgr = Wurk::Cron::Manager.new
+    lp = mgr.register('* * * * *', klass, queue: queue, args: args)
+    @lids << lp.lid
+    build_leader_poller.tick
+    raw = Wurk.redis { |c| c.call('RPOP', "queue:#{queue}") }
+    cleanup_queue(queue)
+    raise 'no job enqueued' if raw.nil?
+
+    JSON.parse(raw)
+  end
+
+  def history_after_leader_tick
+    mgr = Wurk::Cron::Manager.new
+    queue = "cron-q-hist-#{@suffix}"
+    lp = mgr.register('* * * * *', "CronTest::Hist#{@suffix}", queue: queue)
+    @lids << lp.lid
+    build_leader_poller.tick
+    history = Wurk.redis { |c| c.call('LRANGE', "#{Wurk::Cron::HISTORY_PREFIX}#{lp.lid}", 0, -1) }
+    cleanup_queue(queue)
+    history
   end
 end

--- a/test/unit/deploy_test.rb
+++ b/test/unit/deploy_test.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+class DeployTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @suffix = "dep#{Process.pid}_#{object_id}"
+    @label = "deploy-#{@suffix}"
+    @at = ::Time.utc(2026, 5, 21, 14, 37, 12)
+  end
+
+  def teardown
+    Wurk.redis do |c|
+      c.call('DEL', "deploylock-#{@label}")
+      c.call('DEL', '20260521-marks')
+    end
+  ensure
+    super
+  end
+
+  def test_mark_writes_hash_field_at_iso8601_rounded_to_minute
+    iso = Wurk::Deploy.mark!(label: @label, at: @at)
+
+    assert_equal '2026-05-21T14:37:00Z', iso
+    val = Wurk.redis { |c| c.call('HGET', '20260521-marks', iso) }
+
+    assert_equal @label, val
+  end
+
+  def test_mark_sets_marks_ttl_to_90_days
+    Wurk::Deploy.mark!(label: @label, at: @at)
+
+    ttl = Wurk.redis { |c| c.call('TTL', '20260521-marks') }
+
+    assert_operator ttl, :>, Wurk::Deploy::MARK_TTL - 60
+    assert_operator ttl, :<=, Wurk::Deploy::MARK_TTL
+  end
+
+  def test_mark_acquires_per_label_lock_with_60s_ttl
+    Wurk::Deploy.mark!(label: @label, at: @at)
+
+    ttl = Wurk.redis { |c| c.call('TTL', "deploylock-#{@label}") }
+
+    assert_operator ttl, :>, 0
+    assert_operator ttl, :<=, Wurk::Deploy::LOCK_TTL
+  end
+
+  def test_mark_returns_nil_when_lock_already_held
+    first = Wurk::Deploy.mark!(label: @label, at: @at)
+    second = Wurk::Deploy.mark!(label: @label, at: @at)
+
+    refute_nil first
+    assert_nil second
+  end
+
+  def test_mark_with_blank_label_returns_nil_when_label_maker_fails
+    orig = Wurk::Deploy::LABEL_MAKER
+    Wurk::Deploy.send(:remove_const, :LABEL_MAKER)
+    Wurk::Deploy.const_set(:LABEL_MAKER, -> { raise 'no git' })
+
+    assert_nil Wurk::Deploy.mark!(label: nil, at: @at)
+  ensure
+    Wurk::Deploy.send(:remove_const, :LABEL_MAKER)
+    Wurk::Deploy.const_set(:LABEL_MAKER, orig)
+  end
+
+  def test_mark_rounds_seconds_off
+    iso = Wurk::Deploy.mark!(label: @label, at: ::Time.utc(2026, 5, 21, 14, 37, 59))
+
+    assert_equal '2026-05-21T14:37:00Z', iso
+  end
+
+  def test_fetch_returns_iso_to_label_hash
+    Wurk::Deploy.mark!(label: @label, at: @at)
+
+    marks = Wurk::Deploy.new.fetch(@at)
+
+    assert_equal({ '2026-05-21T14:37:00Z' => @label }, marks)
+  end
+
+  def test_fetch_empty_when_no_marks
+    assert_equal({}, Wurk::Deploy.new.fetch(@at))
+  end
+
+  def test_class_mark_delegates_to_instance
+    assert_kind_of String, Wurk::Deploy.mark!(label: @label, at: @at)
+  end
+
+  def test_sidekiq_deploy_alias_exists
+    assert_equal Wurk::Deploy, Sidekiq::Deploy
+  end
+end

--- a/test/unit/encryption_test.rb
+++ b/test/unit/encryption_test.rb
@@ -1,11 +1,425 @@
 # frozen_string_literal: true
 
-require_relative "../test_helper"
+require_relative '../test_helper'
 
 class EncryptionTest < Wurk::Test::UnitCase
-  parallelize_me!
+  # NOT parallelize_me! — these tests flip the process-wide
+  # `Wurk::Encryption.enabled?` flag and install client/server middleware
+  # on the global config. Running in parallel would let one test's
+  # `enable` leak into another's "should be a no-op" assertion.
 
-  def test_skeleton
-    skip "implementation pending — see docs/target/sidekiq-ent.md (encryption)"
+  ENABLE_MUTEX = ::Mutex.new
+
+  KEY_V1 = ("\x01" * 32).b
+  KEY_V2 = ("\x02" * 32).b
+
+  def teardown
+    Wurk::Encryption.disable!
+    Wurk.configuration.client_middleware.remove(Wurk::Encryption::ClientMiddleware)
+    Wurk.configuration.server_middleware.remove(Wurk::Encryption::ServerMiddleware)
+  ensure
+    super
+  end
+
+  # ---- enable / disable ------------------------------------------------
+
+  def test_disabled_by_default
+    refute_predicate Wurk::Encryption, :enabled?
+    refute_predicate Sidekiq::Enterprise::Crypto, :enabled?
+  end
+
+  def test_enable_requires_active_version
+    assert_raises(ArgumentError) do
+      Wurk::Encryption.enable(active_version: nil) { |_v| KEY_V1 }
+    end
+  end
+
+  def test_enable_requires_block
+    assert_raises(ArgumentError) do
+      Wurk::Encryption.enable(active_version: 1)
+    end
+  end
+
+  def test_enable_via_sidekiq_enterprise_crypto
+    ENABLE_MUTEX.synchronize do
+      Sidekiq::Enterprise::Crypto.enable(active_version: 1) { |_v| KEY_V1 }
+
+      assert_predicate Sidekiq::Enterprise::Crypto, :enabled?
+      assert_predicate Wurk::Encryption, :enabled?
+      assert_equal 1, Wurk::Encryption.active_version
+    end
+  end
+
+  def test_enable_installs_both_middleware
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+
+      assert Wurk.configuration.client_middleware.exists?(Wurk::Encryption::ClientMiddleware)
+      assert Wurk.configuration.server_middleware.exists?(Wurk::Encryption::ServerMiddleware)
+    end
+  end
+
+  def test_enable_is_idempotent
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+
+      client_count = Wurk.configuration.client_middleware.entries.count { |e| e.klass == Wurk::Encryption::ClientMiddleware }
+      server_count = Wurk.configuration.server_middleware.entries.count { |e| e.klass == Wurk::Encryption::ServerMiddleware }
+
+      assert_equal 1, client_count
+      assert_equal 1, server_count
+    end
+  end
+
+  # ---- key validation --------------------------------------------------
+
+  def test_key_for_raises_when_resolver_returns_nil
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| nil }
+
+      assert_raises(Wurk::Encryption::KeyMissingError) do
+        Wurk::Encryption.key_for(1)
+      end
+    end
+  end
+
+  def test_key_for_raises_on_wrong_size
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| 'shorty' }
+
+      assert_raises(Wurk::Encryption::Error) do
+        Wurk::Encryption.key_for(1)
+      end
+    end
+  end
+
+  def test_key_for_caches_resolver_calls
+    ENABLE_MUTEX.synchronize do
+      calls = 0
+      Wurk::Encryption.enable(active_version: 1) do |_v|
+        calls += 1
+        KEY_V1
+      end
+
+      Wurk::Encryption.key_for(1)
+      Wurk::Encryption.key_for(1)
+
+      assert_equal 1, calls
+    end
+  end
+
+  def test_key_for_without_enable_raises
+    refute_predicate Wurk::Encryption, :enabled?
+
+    assert_raises(Wurk::Encryption::Error) do
+      Wurk::Encryption.key_for(1)
+    end
+  end
+
+  # ---- encrypt / decrypt round-trip -----------------------------------
+
+  def test_encrypt_returns_envelope_shape # rubocop:disable Minitest/MultipleAssertions
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      env = Wurk::Encryption.encrypt('hello')
+
+      assert_kind_of Hash, env
+      assert_equal 1, env['v']
+      assert env.key?('iv')
+      assert env.key?('ct')
+      assert env.key?('tag')
+      assert Wurk::Encryption.envelope?(env)
+    end
+  end
+
+  def test_encrypt_decrypt_roundtrip_string
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      env = Wurk::Encryption.encrypt('top secret')
+
+      assert_equal 'top secret', Wurk::Encryption.decrypt(env)
+    end
+  end
+
+  def test_encrypt_decrypt_roundtrip_hash
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      payload = { 'cc' => '4111111111111111', 'cvv' => '123' }
+      env = Wurk::Encryption.encrypt(payload)
+
+      assert_equal payload, Wurk::Encryption.decrypt(env)
+    end
+  end
+
+  def test_encrypt_decrypt_roundtrip_array
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      payload = [1, 'two', { 'three' => 3 }]
+      env = Wurk::Encryption.encrypt(payload)
+
+      assert_equal payload, Wurk::Encryption.decrypt(env)
+    end
+  end
+
+  def test_each_encrypt_produces_unique_iv_and_ct
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      a = Wurk::Encryption.encrypt('same')
+      b = Wurk::Encryption.encrypt('same')
+
+      refute_equal a['iv'], b['iv']
+      refute_equal a['ct'], b['ct']
+    end
+  end
+
+  def test_tampered_ciphertext_raises_cipher_error
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      env = Wurk::Encryption.encrypt('payload')
+      env['ct'] = ::Base64.strict_encode64(::Base64.strict_decode64(env['ct']).succ)
+
+      assert_raises(::OpenSSL::Cipher::CipherError) do
+        Wurk::Encryption.decrypt(env)
+      end
+    end
+  end
+
+  def test_wrong_key_version_raises_cipher_error
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      env = Wurk::Encryption.encrypt('payload')
+      # Rebind v=1 → KEY_V2 so the tag fails to authenticate.
+      Wurk::Encryption.disable!
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V2 }
+
+      assert_raises(::OpenSSL::Cipher::CipherError) do
+        Wurk::Encryption.decrypt(env)
+      end
+    end
+  end
+
+  # ---- key rotation ----------------------------------------------------
+
+  def test_rotation_decrypts_legacy_envelopes # rubocop:disable Minitest/MultipleAssertions
+    ENABLE_MUTEX.synchronize do
+      keys = { 1 => KEY_V1, 2 => KEY_V2 }
+      Wurk::Encryption.enable(active_version: 1) { |v| keys[v] }
+      legacy = Wurk::Encryption.encrypt('old data')
+
+      assert_equal 1, legacy['v']
+
+      Wurk::Encryption.disable!
+      Wurk::Encryption.enable(active_version: 2) { |v| keys[v] }
+      fresh = Wurk::Encryption.encrypt('new data')
+
+      assert_equal 2, fresh['v']
+      assert_equal 'old data', Wurk::Encryption.decrypt(legacy)
+      assert_equal 'new data', Wurk::Encryption.decrypt(fresh)
+    end
+  end
+
+  # ---- envelope? -------------------------------------------------------
+
+  def test_envelope_predicate_recognizes_real_envelope
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+
+      assert Wurk::Encryption.envelope?(Wurk::Encryption.encrypt('x'))
+    end
+  end
+
+  def test_envelope_predicate_rejects_plain_hash # rubocop:disable Minitest/MultipleAssertions
+    refute Wurk::Encryption.envelope?({ 'v' => 1, 'iv' => 'a', 'ct' => 'b', 'tag' => 'c' })
+    refute Wurk::Encryption.envelope?({ Wurk::Encryption::ENVELOPE_MARKER => true })
+    refute Wurk::Encryption.envelope?('string')
+    refute Wurk::Encryption.envelope?(nil)
+    refute Wurk::Encryption.envelope?([1, 2])
+  end
+
+  # ---- ClientMiddleware ------------------------------------------------
+
+  def test_client_middleware_skips_when_disabled
+    job = { 'class' => 'X', 'args' => [1, 'secret'], 'encrypt' => true }
+    ran = invoke_client(job)
+
+    assert ran
+    assert_equal 'secret', job['args'].last
+  end
+
+  def test_client_middleware_skips_without_opt_in
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      job = { 'class' => 'X', 'args' => [1, 'secret'] }
+      invoke_client(job)
+
+      assert_equal 'secret', job['args'].last
+    end
+  end
+
+  def test_client_middleware_encrypts_last_arg
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      job = { 'class' => 'X', 'args' => ['public', { 'secret' => 'shh' }], 'encrypt' => true }
+      invoke_client(job)
+
+      assert_equal 'public', job['args'].first
+      assert Wurk::Encryption.envelope?(job['args'].last)
+    end
+  end
+
+  def test_client_middleware_leaves_already_encrypted_arg_alone
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      env = Wurk::Encryption.encrypt('precomputed')
+      job = { 'class' => 'X', 'args' => [1, env], 'encrypt' => true }
+      invoke_client(job)
+
+      assert_equal env, job['args'].last
+    end
+  end
+
+  def test_client_middleware_handles_empty_args
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      job = { 'class' => 'X', 'args' => [], 'encrypt' => true }
+      invoke_client(job)
+
+      assert_equal [], job['args']
+    end
+  end
+
+  def test_client_middleware_chain_continues
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      job = { 'class' => 'X', 'args' => [1, 'secret'], 'encrypt' => true }
+
+      assert_equal :done, invoke_client(job) { :done }
+    end
+  end
+
+  # ---- ServerMiddleware ------------------------------------------------
+
+  def test_server_middleware_skips_when_disabled
+    env = { Wurk::Encryption::ENVELOPE_MARKER => true, 'v' => 1, 'iv' => 'a', 'ct' => 'b', 'tag' => 'c' }
+    job = { 'class' => 'X', 'args' => [1, env], 'encrypt' => true }
+    invoke_server(job) { :ok }
+
+    assert_equal env, job['args'].last
+  end
+
+  def test_server_middleware_skips_without_opt_in
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      env = Wurk::Encryption.encrypt('shh')
+      job = { 'class' => 'X', 'args' => [1, env] }
+      invoke_server(job) { :ok }
+
+      assert_equal env, job['args'].last
+    end
+  end
+
+  def test_server_middleware_decrypts_last_arg
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      payload = { 'secret' => 'value' }
+      job = { 'class' => 'X', 'args' => ['public', Wurk::Encryption.encrypt(payload)], 'encrypt' => true }
+      invoke_server(job) { :ok }
+
+      assert_equal 'public', job['args'].first
+      assert_equal payload, job['args'].last
+    end
+  end
+
+  def test_server_middleware_no_op_when_last_arg_is_plain
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      job = { 'class' => 'X', 'args' => [1, 'already plain'], 'encrypt' => true }
+      invoke_server(job) { :ok }
+
+      assert_equal 'already plain', job['args'].last
+    end
+  end
+
+  def test_server_middleware_propagates_perform_return
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      job = { 'class' => 'X', 'args' => [Wurk::Encryption.encrypt('x')], 'encrypt' => true }
+
+      assert_equal :result, invoke_server(job) { :result }
+    end
+  end
+
+  def test_server_middleware_lets_cipher_error_bubble
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      env = Wurk::Encryption.encrypt('x')
+      env['tag'] = ::Base64.strict_encode64("\x00" * 16)
+      job = { 'class' => 'X', 'args' => [nil, env], 'encrypt' => true }
+
+      assert_raises(::OpenSSL::Cipher::CipherError) do
+        invoke_server(job) { :unreached }
+      end
+    end
+  end
+
+  # ---- end-to-end pair -------------------------------------------------
+
+  def test_pair_roundtrip_through_both_middleware
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      secret = { 'card' => '4111', 'cvv' => '999' }
+      job = { 'class' => 'X', 'args' => [42, secret], 'encrypt' => true }
+      invoke_client(job)
+
+      refute_equal secret, job['args'].last
+      assert Wurk::Encryption.envelope?(job['args'].last)
+
+      invoke_server(job) { :ok }
+
+      assert_equal [42, secret], job['args']
+    end
+  end
+
+  # ---- Web UI redaction (§4.7) -----------------------------------------
+
+  def test_redact_args_passthrough_when_not_encrypted
+    job = { 'args' => [1, 'two'] }
+
+    assert_equal [1, 'two'], Wurk::Encryption.redact_args(job)
+  end
+
+  def test_redact_args_replaces_last_arg_when_encrypted
+    job = { 'args' => [1, { 'secret' => 'x' }], 'encrypt' => true }
+
+    assert_equal [1, '<encrypted>'], Wurk::Encryption.redact_args(job)
+  end
+
+  def test_redact_args_handles_empty_args
+    job = { 'args' => [], 'encrypt' => true }
+
+    assert_equal [], Wurk::Encryption.redact_args(job)
+  end
+
+  def test_redact_args_supports_symbol_keys
+    job = { args: [1, 'secret'], encrypt: true }
+
+    assert_equal [1, '<encrypted>'], Wurk::Encryption.redact_args(job)
+  end
+
+  # ---- helpers ---------------------------------------------------------
+
+  private
+
+  def invoke_client(job, &)
+    block = block_given? ? proc(&) : proc { true }
+    pool = Wurk.configuration.redis_pool
+    Wurk::Encryption::ClientMiddleware.new.call(nil, job, job['queue'], pool, &block)
+  end
+
+  def invoke_server(job, &)
+    mw = Wurk::Encryption::ServerMiddleware.new
+    mw.config = Wurk.configuration
+    mw.call(nil, job, job['queue'], &)
   end
 end

--- a/test/unit/leader_test.rb
+++ b/test/unit/leader_test.rb
@@ -1,11 +1,401 @@
 # frozen_string_literal: true
 
-require_relative "../test_helper"
+require_relative '../test_helper'
 
 class LeaderTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  def test_skeleton
-    skip "implementation pending — see docs/target/sidekiq-ent.md (leader election)"
+  # Tests touch process-global ENV['WURK_LEADER'] and (in one case) the
+  # shared `dear-leader` STRING. Serialize those — parallel runners would
+  # otherwise see each other's ENV writes mid-flight.
+  ENV_MUTEX = Mutex.new
+  CLUSTER_KEY_MUTEX = Mutex.new
+
+  def setup
+    super
+    @suffix = "leader-#{Process.pid}-#{object_id}"
+    @key = "leader-test:#{@suffix}"
+    @leaders = []
+  end
+
+  def teardown
+    @leaders.each do |ldr|
+      ldr.stop if ldr.running?
+      ldr.release
+    end
+    Wurk.redis { |c| c.call('DEL', @key) }
+  ensure
+    super
+  end
+
+  # ---- API surface ------------------------------------------------------
+
+  def test_default_key_is_dear_leader
+    assert_equal 'dear-leader', Wurk::Leader::DEFAULT_KEY
+  end
+
+  def test_token_key_is_leader_token
+    assert_equal 'leader-token', Wurk::Leader::TOKEN_KEY
+  end
+
+  def test_default_ttl_thirty_seconds
+    assert_equal 30, Wurk::Leader::DEFAULT_TTL
+  end
+
+  def test_default_renew_is_half_ttl
+    assert_equal Wurk::Leader::DEFAULT_TTL / 2, Wurk::Leader::DEFAULT_RENEW_INTERVAL
+  end
+
+  # ---- Owner identity ---------------------------------------------------
+
+  def test_owner_matches_component_identity_format
+    ldr = build_leader
+
+    assert_match(/\A.+:#{Process.pid}:[0-9a-f]{12}\z/, ldr.owner)
+  end
+
+  def test_owner_explicit_override
+    ldr = build_leader(owner: 'host-x:99:abcdef')
+
+    assert_equal 'host-x:99:abcdef', ldr.owner
+  end
+
+  # ---- acquire / release ------------------------------------------------
+
+  def test_acquire_returns_true_when_lock_available
+    ldr = build_leader
+
+    assert ldr.acquire
+    assert_predicate ldr, :leader?
+  end
+
+  def test_acquire_writes_owner_to_key
+    ldr = build_leader
+    ldr.acquire
+
+    assert_equal(ldr.owner, Wurk.redis { |c| c.call('GET', @key) })
+  end
+
+  def test_acquire_sets_ttl
+    ldr = build_leader(ttl: 5)
+    ldr.acquire
+    ttl = Wurk.redis { |c| c.call('TTL', @key) }
+
+    assert_operator ttl, :>, 0
+    assert_operator ttl, :<=, 5
+  end
+
+  def test_second_acquire_returns_false_for_competitor
+    a = build_leader(owner: 'a-owner')
+    b = build_leader(owner: 'b-owner')
+
+    assert a.acquire
+    refute b.acquire
+    refute_predicate b, :leader?
+  end
+
+  def test_re_acquire_refreshes_ttl
+    ldr = build_leader(ttl: 30)
+    ldr.acquire
+    ttl_before = Wurk.redis { |c| c.call('TTL', @key) }
+    Wurk.redis { |c| c.call('EXPIRE', @key, 5) }
+    ldr.acquire
+
+    ttl_after = Wurk.redis { |c| c.call('TTL', @key) }
+
+    assert_operator ttl_after, :>, ttl_before - 5
+  end
+
+  def test_release_drops_key_when_owner
+    ldr = build_leader
+    ldr.acquire
+    ldr.release
+
+    assert_nil(Wurk.redis { |c| c.call('GET', @key) })
+    refute_predicate ldr, :leader?
+  end
+
+  def test_release_is_cas_only
+    a = build_leader
+    a.acquire
+    Wurk.redis { |c| c.call('SET', @key, 'someone-else') }
+    a.release
+
+    assert_equal('someone-else', Wurk.redis { |c| c.call('GET', @key) })
+  end
+
+  # ---- Fencing token ----------------------------------------------------
+
+  def test_token_nil_before_acquire
+    ldr = build_leader
+
+    assert_nil ldr.token
+  end
+
+  def test_token_assigned_on_acquire
+    ldr = build_leader
+    ldr.acquire
+
+    assert_kind_of Integer, ldr.token
+    assert_operator ldr.token, :>, 0
+  end
+
+  def test_token_monotonic_across_acquisitions
+    a = build_leader
+    b = build_leader
+
+    a.acquire
+    first = a.token
+    a.release
+    b.acquire
+
+    assert_operator b.token, :>, first
+  end
+
+  def test_token_unchanged_on_renewal
+    ldr = build_leader
+    ldr.acquire
+    initial = ldr.token
+    ldr.acquire
+
+    assert_equal initial, ldr.token
+  end
+
+  def test_token_cleared_when_losing_election
+    a = build_leader(owner: 'a-owner')
+    a.acquire
+
+    refute_nil a.token
+
+    b = build_leader(owner: 'b-owner')
+
+    refute b.acquire
+
+    assert_nil b.token
+  end
+
+  def test_token_cleared_after_release
+    ldr = build_leader
+    ldr.acquire
+    ldr.release
+
+    assert_nil ldr.token
+  end
+
+  # ---- Opt-out ----------------------------------------------------------
+
+  def test_opt_out_disables_acquire
+    with_env('WURK_LEADER', 'false') do
+      ldr = build_leader
+
+      refute ldr.acquire
+      assert_predicate ldr, :disabled?
+    end
+  end
+
+  def test_opt_out_skips_redis_write
+    with_env('WURK_LEADER', 'false') do
+      build_leader.acquire
+
+      assert_nil(Wurk.redis { |c| c.call('GET', @key) })
+    end
+  end
+
+  def test_opt_out_keeps_leader_predicate_false
+    with_env('WURK_LEADER', 'false') do
+      ldr = build_leader
+      ldr.acquire
+
+      refute_predicate ldr, :leader?
+    end
+  end
+
+  def test_opt_out_blocks_start
+    with_env('WURK_LEADER', 'false') do
+      ldr = build_leader
+      result = ldr.start
+
+      assert_nil result
+      refute_predicate ldr, :running?
+    end
+  end
+
+  def test_opt_out_is_case_insensitive
+    with_env('WURK_LEADER', 'FALSE') do
+      assert_predicate build_leader, :disabled?
+    end
+  end
+
+  # ---- :leader lifecycle event -----------------------------------------
+
+  def test_leader_event_fires_once_on_gain
+    config = build_config
+    fired = 0
+    config.on(:leader) { fired += 1 }
+    ldr = build_leader(config: config)
+
+    ldr.acquire
+    ldr.acquire
+
+    assert_equal 1, fired
+  end
+
+  def test_leader_event_refires_after_losing_and_regaining
+    config = build_config
+    fired = 0
+    config.on(:leader) { fired += 1 }
+    ldr = build_leader(config: config)
+
+    ldr.acquire
+    ldr.release
+    ldr.acquire
+
+    assert_equal 2, fired
+  end
+
+  def test_leader_event_skipped_when_no_config
+    ldr = build_leader(config: nil)
+
+    ldr.acquire
+
+    pass # no exception is the assertion — bucketless dispatch is a no-op
+  end
+
+  def test_leader_event_handler_error_reported
+    config = build_config
+    seen = []
+    config.error_handlers << ->(ex, ctx, _cfg) { seen << [ex.message, ctx] }
+    config.on(:leader) { raise 'leader-hook-boom' }
+    ldr = build_leader(config: config)
+    ldr.acquire
+
+    assert_equal [['leader-hook-boom', { event: :leader }]], seen
+  end
+
+  # ---- Component#leader? -----------------------------------------------
+
+  def test_component_leader_predicate_true_when_dear_leader_matches_identity
+    CLUSTER_KEY_MUTEX.synchronize do
+      config = build_config
+      host = component_host(config)
+      Wurk.redis { |c| c.call('SET', 'dear-leader', host.identity, 'EX', 5) }
+
+      assert_predicate host, :leader?
+    ensure
+      Wurk.redis { |c| c.call('DEL', 'dear-leader') }
+    end
+  end
+
+  def test_component_leader_predicate_false_when_unset
+    CLUSTER_KEY_MUTEX.synchronize do
+      Wurk.redis { |c| c.call('DEL', 'dear-leader') }
+      host = component_host(build_config)
+
+      refute_predicate host, :leader?
+    end
+  end
+
+  def test_component_leader_predicate_false_when_other_owner
+    CLUSTER_KEY_MUTEX.synchronize do
+      Wurk.redis { |c| c.call('SET', 'dear-leader', 'someone-else', 'EX', 5) }
+      host = component_host(build_config)
+
+      refute_predicate host, :leader?
+    ensure
+      Wurk.redis { |c| c.call('DEL', 'dear-leader') }
+    end
+  end
+
+  def test_component_leader_predicate_honors_opt_out
+    CLUSTER_KEY_MUTEX.synchronize do
+      host = component_host(build_config)
+      Wurk.redis { |c| c.call('SET', 'dear-leader', host.identity, 'EX', 5) }
+
+      with_env('WURK_LEADER', 'false') do
+        refute_predicate host, :leader?
+      end
+    ensure
+      Wurk.redis { |c| c.call('DEL', 'dear-leader') }
+    end
+  end
+
+  # ---- Periodic re-election thread -------------------------------------
+
+  def test_start_returns_thread_and_running
+    ldr = build_leader(renew_interval: 0.05, follower_interval: 0.05)
+    t = ldr.start
+
+    assert_kind_of Thread, t
+    assert_predicate ldr, :running?
+  end
+
+  def test_start_is_idempotent
+    ldr = build_leader(renew_interval: 0.05, follower_interval: 0.05)
+    t1 = ldr.start
+    t2 = ldr.start
+
+    assert_same t1, t2
+  end
+
+  def test_periodic_loop_acquires_when_available
+    ldr = build_leader(renew_interval: 0.05, follower_interval: 0.05)
+    ldr.start
+    deadline = Time.now + 2
+    sleep 0.05 until ldr.leader? || Time.now > deadline
+
+    assert_predicate ldr, :leader?
+  end
+
+  def test_stop_releases_and_clears_thread
+    ldr = build_leader(renew_interval: 0.05, follower_interval: 0.05)
+    ldr.start
+    deadline = Time.now + 2
+    sleep 0.05 until ldr.leader? || Time.now > deadline
+    ldr.stop
+
+    refute_predicate ldr, :running?
+    refute_predicate ldr, :leader?
+    assert_nil(Wurk.redis { |c| c.call('GET', @key) })
+  end
+
+  def test_thread_name_set_for_observability
+    ldr = build_leader(renew_interval: 0.05, follower_interval: 0.05)
+    t = ldr.start
+
+    assert_equal Wurk::Leader::THREAD_NAME, t.name
+  end
+
+  private
+
+  def build_leader(**)
+    ldr = Wurk::Leader.new(key: @key, **)
+    @leaders << ldr
+    ldr
+  end
+
+  def build_config
+    cfg = Wurk::Configuration.new
+    cfg.logger = ::Logger.new(IO::NULL)
+    cfg
+  end
+
+  def component_host(config)
+    Class.new do
+      include Wurk::Component
+
+      attr_reader :config
+
+      def initialize(cfg) = @config = cfg
+    end.new(config)
+  end
+
+  def with_env(key, value)
+    ENV_MUTEX.synchronize do
+      prior = ENV.fetch(key, nil)
+      ENV[key] = value
+      yield
+    ensure
+      prior.nil? ? ENV.delete(key) : ENV[key] = prior
+    end
   end
 end

--- a/test/unit/limiter_bucket_test.rb
+++ b/test/unit/limiter_bucket_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+class LimiterBucketTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  REDIS_URL = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
+
+  def setup
+    super
+    @suffix = "bk#{Process.pid}#{object_id}"
+    @pool = Wurk::RedisPool.new(size: 2, url: REDIS_URL, timeout: 2, name: 'bkp')
+    @pool.with { |c| Wurk::Lua::Loader.script_load_all(c) }
+    Wurk::Limiter.reset_config!
+    Wurk::Limiter.config.redis = @pool
+  end
+
+  def teardown
+    @pool.with do |c|
+      cursor = '0'
+      loop do
+        cursor, keys = c.call('SCAN', cursor, 'MATCH', 'lmtr*', 'COUNT', 500)
+        c.call('DEL', *keys) unless keys.empty?
+        break if cursor == '0'
+      end
+    end
+    @pool.disconnect!
+    Wurk::Limiter.reset_config!
+  ensure
+    super
+  end
+
+  def test_first_call_increments_bucket_and_yields
+    l = Wurk::Limiter.bucket("a-#{@suffix}", 5, :minute)
+    ran = false
+    l.within_limit { ran = true }
+
+    assert ran
+    assert_equal 1, l.size
+  end
+
+  def test_exhausted_bucket_raises_over_limit_with_zero_wait
+    l = Wurk::Limiter.bucket("b-#{@suffix}", 2, :minute, wait_timeout: 0)
+    l.within_limit {}
+    l.within_limit {}
+    assert_raises(Wurk::Limiter::OverLimit) { l.within_limit {} }
+  end
+
+  def test_within_limit_accepts_used_parameter
+    l = Wurk::Limiter.bucket("c-#{@suffix}", 5, :minute)
+    l.within_limit(used: 3) {}
+
+    assert_equal 3, l.size
+  end
+
+  def test_rejects_overage_when_used_exceeds_remaining
+    l = Wurk::Limiter.bucket("d-#{@suffix}", 2, :minute, wait_timeout: 0)
+    l.within_limit(used: 2) {}
+    assert_raises(Wurk::Limiter::OverLimit) { l.within_limit(used: 1) {} }
+  end
+
+  def test_interval_symbols_map_to_seconds
+    %i[second minute hour day].each do |interval|
+      l = Wurk::Limiter.bucket("e-#{interval}-#{@suffix}", 1, interval)
+      l.within_limit {}
+
+      assert_equal 1, l.size
+    end
+  end
+
+  def test_integer_interval_is_rejected_for_bucket
+    assert_raises(ArgumentError) { Wurk::Limiter.bucket("f-#{@suffix}", 1, 60) }
+  end
+
+  def test_unknown_interval_symbol_is_rejected
+    assert_raises(ArgumentError) { Wurk::Limiter.bucket("g-#{@suffix}", 1, :fortnight) }
+  end
+
+  def test_block_exception_still_counts_against_bucket
+    # Bucket increments at acquire time, before yield — exceptions don't refund.
+    l = Wurk::Limiter.bucket("h-#{@suffix}", 5, :minute)
+    assert_raises(RuntimeError) { l.within_limit { raise 'boom' } }
+    assert_equal 1, l.size
+  end
+
+  def test_options_exposes_input_params
+    l = Wurk::Limiter.bucket("i-#{@suffix}", 9, :hour, reschedule: 3)
+
+    assert_equal 9, l.options[:count]
+    assert_equal :hour, l.options[:interval]
+    assert_equal 3, l.options[:reschedule]
+  end
+end

--- a/test/unit/limiter_bucket_test.rb
+++ b/test/unit/limiter_bucket_test.rb
@@ -17,11 +17,20 @@ class LimiterBucketTest < Wurk::Test::UnitCase
   end
 
   def teardown
+    # Scope cleanup to this test's @suffix so parallel limiter tests don't
+    # wipe each other's state mid-run (failure mode: another test's
+    # `within_limit` sees an empty counter because we DEL'd its key).
     @pool.with do |c|
       cursor = '0'
       loop do
-        cursor, keys = c.call('SCAN', cursor, 'MATCH', 'lmtr*', 'COUNT', 500)
+        cursor, keys = c.call('SCAN', cursor, 'MATCH', "*#{@suffix}*", 'COUNT', 500)
         c.call('DEL', *keys) unless keys.empty?
+        break if cursor == '0'
+      end
+      cursor = '0'
+      loop do
+        cursor, names = c.call('SSCAN', Wurk::Limiter::LIST_KEY, cursor, 'MATCH', "*#{@suffix}*", 'COUNT', 500)
+        c.call('SREM', Wurk::Limiter::LIST_KEY, *names) unless names.empty?
         break if cursor == '0'
       end
     end

--- a/test/unit/limiter_concurrent_test.rb
+++ b/test/unit/limiter_concurrent_test.rb
@@ -17,11 +17,20 @@ class LimiterConcurrentTest < Wurk::Test::UnitCase
   end
 
   def teardown
+    # Scope cleanup to this test's @suffix so parallel limiter tests don't
+    # wipe each other's state mid-run (failure mode: another test's
+    # `within_limit` sees an empty counter because we DEL'd its key).
     @pool.with do |c|
       cursor = '0'
       loop do
-        cursor, keys = c.call('SCAN', cursor, 'MATCH', 'lmtr*', 'COUNT', 500)
+        cursor, keys = c.call('SCAN', cursor, 'MATCH', "*#{@suffix}*", 'COUNT', 500)
         c.call('DEL', *keys) unless keys.empty?
+        break if cursor == '0'
+      end
+      cursor = '0'
+      loop do
+        cursor, names = c.call('SSCAN', Wurk::Limiter::LIST_KEY, cursor, 'MATCH', "*#{@suffix}*", 'COUNT', 500)
+        c.call('SREM', Wurk::Limiter::LIST_KEY, *names) unless names.empty?
         break if cursor == '0'
       end
     end

--- a/test/unit/limiter_concurrent_test.rb
+++ b/test/unit/limiter_concurrent_test.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+class LimiterConcurrentTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  REDIS_URL = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
+
+  def setup
+    super
+    @suffix = "cc#{Process.pid}#{object_id}"
+    @pool = Wurk::RedisPool.new(size: 4, url: REDIS_URL, timeout: 2, name: 'ccp')
+    @pool.with { |c| Wurk::Lua::Loader.script_load_all(c) }
+    Wurk::Limiter.reset_config!
+    Wurk::Limiter.config.redis = @pool
+  end
+
+  def teardown
+    @pool.with do |c|
+      cursor = '0'
+      loop do
+        cursor, keys = c.call('SCAN', cursor, 'MATCH', 'lmtr*', 'COUNT', 500)
+        c.call('DEL', *keys) unless keys.empty?
+        break if cursor == '0'
+      end
+    end
+    @pool.disconnect!
+    Wurk::Limiter.reset_config!
+  ensure
+    super
+  end
+
+  def test_acquires_one_slot_and_yields_block
+    l = Wurk::Limiter.concurrent("a-#{@suffix}", 1)
+    ran = false
+    l.within_limit { ran = true }
+
+    assert ran
+    assert_equal 0, l.size
+  end
+
+  def test_raises_over_limit_when_full_and_wait_zero
+    l = Wurk::Limiter.concurrent("b-#{@suffix}", 1, wait_timeout: 0)
+    assert_raises(Wurk::Limiter::OverLimit) do
+      l.within_limit do
+        # nested call from another "thread" emulated via second limiter instance
+        l2 = Wurk::Limiter.concurrent("b-#{@suffix}", 1, wait_timeout: 0)
+
+        l2.within_limit { flunk 'should not enter' }
+      end
+    end
+  end
+
+  def test_policy_ignore_skips_block_silently_when_full
+    l1 = Wurk::Limiter.concurrent("c-#{@suffix}", 1, wait_timeout: 0, policy: :ignore)
+    ran = false
+    l1.within_limit do
+      l2 = Wurk::Limiter.concurrent("c-#{@suffix}", 1, wait_timeout: 0, policy: :ignore)
+      l2.within_limit { ran = true }
+    end
+
+    refute ran, 'inner block should be skipped silently'
+  end
+
+  def test_two_holders_run_when_limit_two
+    l = Wurk::Limiter.concurrent("d-#{@suffix}", 2)
+    count = 0
+    l.within_limit do
+      count += 1
+      l.within_limit { count += 1 }
+    end
+
+    assert_equal 2, count
+  end
+
+  def test_size_reflects_active_holders
+    l = Wurk::Limiter.concurrent("e-#{@suffix}", 2)
+
+    l.within_limit do
+      assert_equal 1, l.size
+    end
+    assert_equal 0, l.size
+  end
+
+  def test_release_removes_slot_after_block
+    l = Wurk::Limiter.concurrent("f-#{@suffix}", 1)
+    l.within_limit {}
+
+    assert_equal 0, l.size
+  end
+
+  def test_block_exception_still_releases_slot
+    l = Wurk::Limiter.concurrent("g-#{@suffix}", 1)
+    assert_raises(RuntimeError) do
+      l.within_limit { raise 'boom' }
+    end
+    assert_equal 0, l.size
+  end
+
+  def test_lock_timeout_reclaims_expired_slots
+    l = Wurk::Limiter.concurrent("h-#{@suffix}", 1, lock_timeout: 1, wait_timeout: 2)
+    # Manually inject an expired slot at score 1 (well in the past).
+    @pool.with { |c| c.call('ZADD', "lmtr-cs:h-#{@suffix}", 1, 'orphan') }
+    ran = false
+    l.within_limit { ran = true }
+
+    assert ran
+    assert_operator l.status['reclaimed'], :>=, 1
+  end
+
+  def test_status_returns_metrics_hash
+    l = Wurk::Limiter.concurrent("i-#{@suffix}", 1)
+    l.within_limit {}
+    s = l.status
+
+    assert_kind_of Hash, s
+    assert s.key?('immediate')
+    assert_operator s['immediate'].to_i + s['waited'].to_i, :>=, 1
+  end
+
+  def test_reset_clears_state
+    l = Wurk::Limiter.concurrent("j-#{@suffix}", 1)
+    @pool.with { |c| c.call('ZADD', "lmtr-cs:j-#{@suffix}", ::Time.now.to_i + 30, 'x') }
+    l.reset
+
+    assert_equal 0, l.size
+  end
+
+  def test_options_exposes_input_params
+    l = Wurk::Limiter.concurrent("k-#{@suffix}", 7, lock_timeout: 11, wait_timeout: 3)
+
+    assert_equal 7, l.options[:limit]
+    assert_equal 11, l.options[:lock_timeout]
+    assert_equal 3, l.options[:wait_timeout]
+  end
+end

--- a/test/unit/limiter_leaky_test.rb
+++ b/test/unit/limiter_leaky_test.rb
@@ -17,11 +17,20 @@ class LimiterLeakyTest < Wurk::Test::UnitCase
   end
 
   def teardown
+    # Scope cleanup to this test's @suffix so parallel limiter tests don't
+    # wipe each other's state mid-run (failure mode: another test's
+    # `within_limit` sees an empty counter because we DEL'd its key).
     @pool.with do |c|
       cursor = '0'
       loop do
-        cursor, keys = c.call('SCAN', cursor, 'MATCH', 'lmtr*', 'COUNT', 500)
+        cursor, keys = c.call('SCAN', cursor, 'MATCH', "*#{@suffix}*", 'COUNT', 500)
         c.call('DEL', *keys) unless keys.empty?
+        break if cursor == '0'
+      end
+      cursor = '0'
+      loop do
+        cursor, names = c.call('SSCAN', Wurk::Limiter::LIST_KEY, cursor, 'MATCH', "*#{@suffix}*", 'COUNT', 500)
+        c.call('SREM', Wurk::Limiter::LIST_KEY, *names) unless names.empty?
         break if cursor == '0'
       end
     end

--- a/test/unit/limiter_leaky_test.rb
+++ b/test/unit/limiter_leaky_test.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+class LimiterLeakyTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  REDIS_URL = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
+
+  def setup
+    super
+    @suffix = "lk#{Process.pid}#{object_id}"
+    @pool = Wurk::RedisPool.new(size: 2, url: REDIS_URL, timeout: 2, name: 'lkp')
+    @pool.with { |c| Wurk::Lua::Loader.script_load_all(c) }
+    Wurk::Limiter.reset_config!
+    Wurk::Limiter.config.redis = @pool
+  end
+
+  def teardown
+    @pool.with do |c|
+      cursor = '0'
+      loop do
+        cursor, keys = c.call('SCAN', cursor, 'MATCH', 'lmtr*', 'COUNT', 500)
+        c.call('DEL', *keys) unless keys.empty?
+        break if cursor == '0'
+      end
+    end
+    @pool.disconnect!
+    Wurk::Limiter.reset_config!
+  ensure
+    super
+  end
+
+  def test_within_limit_yields
+    l = Wurk::Limiter.leaky("a-#{@suffix}", 5, :second)
+    ran = false
+    l.within_limit { ran = true }
+
+    assert ran
+    assert_operator l.size, :>, 0
+  end
+
+  def test_overflows_when_bucket_full
+    l = Wurk::Limiter.leaky("b-#{@suffix}", 3, 60, wait_timeout: 0)
+    3.times { l.within_limit {} }
+    assert_raises(Wurk::Limiter::OverLimit) { l.within_limit {} }
+  end
+
+  def test_leak_replenishes_capacity_over_time
+    l = Wurk::Limiter.leaky("c-#{@suffix}", 2, 1, wait_timeout: 0)
+    2.times { l.within_limit {} }
+    sleep 1.5
+    l.within_limit {}
+  end
+
+  def test_drain_as_integer_seconds
+    l = Wurk::Limiter.leaky("d-#{@suffix}", 10, 60)
+    l.within_limit {}
+
+    assert_operator l.size, :>, 0
+  end
+
+  def test_drain_as_symbol_unit
+    l = Wurk::Limiter.leaky("e-#{@suffix}", 10, :minute)
+    l.within_limit {}
+
+    assert_operator l.size, :>, 0
+  end
+
+  def test_invalid_drain_type_raises
+    l = Wurk::Limiter.leaky("f-#{@suffix}", 10, 'bogus')
+    assert_raises(ArgumentError) { l.within_limit {} }
+  end
+
+  def test_reset_clears_level
+    l = Wurk::Limiter.leaky("g-#{@suffix}", 3, 60)
+    l.within_limit {}
+    l.reset
+
+    assert_equal 0, l.size
+  end
+
+  def test_block_exception_still_charges
+    l = Wurk::Limiter.leaky("h-#{@suffix}", 5, 60)
+    assert_raises(RuntimeError) { l.within_limit { raise 'boom' } }
+    assert_operator l.size, :>, 0
+  end
+
+  def test_options_exposes_input_params
+    l = Wurk::Limiter.leaky("i-#{@suffix}", 7, :second)
+
+    assert_equal 7, l.options[:bucket_size]
+    assert_equal :second, l.options[:drain]
+  end
+end

--- a/test/unit/limiter_points_test.rb
+++ b/test/unit/limiter_points_test.rb
@@ -17,11 +17,20 @@ class LimiterPointsTest < Wurk::Test::UnitCase
   end
 
   def teardown
+    # Scope cleanup to this test's @suffix so parallel limiter tests don't
+    # wipe each other's state mid-run (failure mode: another test's
+    # `within_limit` sees an empty counter because we DEL'd its key).
     @pool.with do |c|
       cursor = '0'
       loop do
-        cursor, keys = c.call('SCAN', cursor, 'MATCH', 'lmtr*', 'COUNT', 500)
+        cursor, keys = c.call('SCAN', cursor, 'MATCH', "*#{@suffix}*", 'COUNT', 500)
         c.call('DEL', *keys) unless keys.empty?
+        break if cursor == '0'
+      end
+      cursor = '0'
+      loop do
+        cursor, names = c.call('SSCAN', Wurk::Limiter::LIST_KEY, cursor, 'MATCH', "*#{@suffix}*", 'COUNT', 500)
+        c.call('SREM', Wurk::Limiter::LIST_KEY, *names) unless names.empty?
         break if cursor == '0'
       end
     end

--- a/test/unit/limiter_points_test.rb
+++ b/test/unit/limiter_points_test.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+class LimiterPointsTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  REDIS_URL = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
+
+  def setup
+    super
+    @suffix = "pt#{Process.pid}#{object_id}"
+    @pool = Wurk::RedisPool.new(size: 2, url: REDIS_URL, timeout: 2, name: 'ptp')
+    @pool.with { |c| Wurk::Lua::Loader.script_load_all(c) }
+    Wurk::Limiter.reset_config!
+    Wurk::Limiter.config.redis = @pool
+  end
+
+  def teardown
+    @pool.with do |c|
+      cursor = '0'
+      loop do
+        cursor, keys = c.call('SCAN', cursor, 'MATCH', 'lmtr*', 'COUNT', 500)
+        c.call('DEL', *keys) unless keys.empty?
+        break if cursor == '0'
+      end
+    end
+    @pool.disconnect!
+    Wurk::Limiter.reset_config!
+  ensure
+    super
+  end
+
+  def test_within_limit_yields_handle
+    l = Wurk::Limiter.points("a-#{@suffix}", 100, 10)
+    got_handle = nil
+    l.within_limit(estimate: 10) { |h| got_handle = h }
+
+    refute_nil got_handle
+    assert_respond_to got_handle, :points_used
+  end
+
+  def test_charges_estimate_from_balance
+    l = Wurk::Limiter.points("b-#{@suffix}", 100, 0)
+    l.within_limit(estimate: 30) { |_h| }
+
+    assert_in_delta 70, l.size, 0.1
+  end
+
+  def test_immediately_raises_when_balance_below_estimate
+    l = Wurk::Limiter.points("c-#{@suffix}", 50, 0)
+    assert_raises(Wurk::Limiter::OverLimit) do
+      l.within_limit(estimate: 100) { |_h| flunk 'should not enter' }
+    end
+  end
+
+  def test_handle_points_used_refunds_overestimate
+    # Charged 50, only used 20 → refund 30 → balance = 100 - 20 = 80.
+    l = Wurk::Limiter.points("d-#{@suffix}", 100, 0)
+    l.within_limit(estimate: 50) { |h| h.points_used(20) }
+
+    assert_in_delta 80, l.size, 0.1
+  end
+
+  def test_handle_points_used_records_under_estimate
+    l = Wurk::Limiter.points("e-#{@suffix}", 100, 0)
+    l.within_limit(estimate: 10) { |h| h.points_used(30) }
+
+    assert_in_delta 70, l.size, 0.1
+  end
+
+  def test_refill_replenishes_over_time
+    l = Wurk::Limiter.points("f-#{@suffix}", 100, 50)
+    l.within_limit(estimate: 100) { |_h| }
+
+    assert_in_delta 0, l.size, 1
+    sleep 0.5
+    l.within_limit(estimate: 20) { |_h| }
+  end
+
+  def test_refill_caps_at_initial
+    l = Wurk::Limiter.points("g-#{@suffix}", 100, 1_000_000)
+    l.within_limit(estimate: 10) { |_h| }
+    sleep 0.05
+
+    assert_in_delta 100, l.size, 1
+  end
+
+  def test_negative_estimate_rejected
+    l = Wurk::Limiter.points("h-#{@suffix}", 100, 0)
+    assert_raises(ArgumentError) { l.within_limit(estimate: 0) { |_h| } }
+  end
+
+  def test_reset_restores_full_balance_on_next_acquire
+    l = Wurk::Limiter.points("i-#{@suffix}", 100, 0)
+    l.within_limit(estimate: 50) { |_h| }
+    l.reset
+    # After reset, balance defaults to `initial` per the Lua acquire.
+    l.within_limit(estimate: 90) { |_h| }
+  end
+
+  def test_options_exposes_input_params
+    l = Wurk::Limiter.points("j-#{@suffix}", 200, 3)
+
+    assert_equal 200, l.options[:initial]
+    assert_equal 3, l.options[:refill]
+  end
+end

--- a/test/unit/limiter_test.rb
+++ b/test/unit/limiter_test.rb
@@ -17,11 +17,20 @@ class LimiterTest < Wurk::Test::UnitCase
   end
 
   def teardown
+    # Scope cleanup to this test's @suffix so parallel limiter tests don't
+    # wipe each other's state mid-run (failure mode: another test's
+    # `within_limit` sees an empty counter because we DEL'd its key).
     @pool.with do |c|
       cursor = '0'
       loop do
-        cursor, keys = c.call('SCAN', cursor, 'MATCH', 'lmtr*', 'COUNT', 500)
+        cursor, keys = c.call('SCAN', cursor, 'MATCH', "*#{@suffix}*", 'COUNT', 500)
         c.call('DEL', *keys) unless keys.empty?
+        break if cursor == '0'
+      end
+      cursor = '0'
+      loop do
+        cursor, names = c.call('SSCAN', Wurk::Limiter::LIST_KEY, cursor, 'MATCH', "*#{@suffix}*", 'COUNT', 500)
+        c.call('SREM', Wurk::Limiter::LIST_KEY, *names) unless names.empty?
         break if cursor == '0'
       end
     end

--- a/test/unit/limiter_test.rb
+++ b/test/unit/limiter_test.rb
@@ -1,11 +1,191 @@
 # frozen_string_literal: true
 
-require_relative "../test_helper"
+require_relative '../test_helper'
 
 class LimiterTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  def test_skeleton
-    skip "implementation pending — see docs/target/sidekiq-ent.md (Sidekiq::Limiter)"
+  REDIS_URL = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
+
+  def setup
+    super
+    @suffix = "ltest#{Process.pid}#{object_id}"
+    @pool = Wurk::RedisPool.new(size: 1, url: REDIS_URL, timeout: 2, name: 'ltop')
+    @pool.with { |c| Wurk::Lua::Loader.script_load_all(c) }
+    Wurk::Limiter.reset_config!
+    Wurk::Limiter.config.redis = @pool
+  end
+
+  def teardown
+    @pool.with do |c|
+      cursor = '0'
+      loop do
+        cursor, keys = c.call('SCAN', cursor, 'MATCH', 'lmtr*', 'COUNT', 500)
+        c.call('DEL', *keys) unless keys.empty?
+        break if cursor == '0'
+      end
+    end
+    @pool.disconnect!
+    Wurk::Limiter.reset_config!
+  ensure
+    super
+  end
+
+  # ----- constructors dispatch to per-type classes ----------------------
+
+  def test_concurrent_returns_concurrent_instance
+    l = Wurk::Limiter.concurrent("cc-#{@suffix}", 1)
+
+    assert_instance_of Wurk::Limiter::Concurrent, l
+    assert_equal :concurrent, l.type
+    assert_equal "cc-#{@suffix}", l.name
+  end
+
+  def test_bucket_returns_bucket_instance
+    l = Wurk::Limiter.bucket("bk-#{@suffix}", 1, :minute)
+
+    assert_instance_of Wurk::Limiter::Bucket, l
+    assert_equal :bucket, l.type
+  end
+
+  def test_window_returns_window_instance
+    l = Wurk::Limiter.window("wn-#{@suffix}", 1, :minute)
+
+    assert_instance_of Wurk::Limiter::Window, l
+    assert_equal :window, l.type
+  end
+
+  def test_leaky_returns_leaky_instance
+    l = Wurk::Limiter.leaky("lk-#{@suffix}", 1, 1)
+
+    assert_instance_of Wurk::Limiter::Leaky, l
+    assert_equal :leaky, l.type
+  end
+
+  def test_points_returns_points_instance
+    l = Wurk::Limiter.points("pt-#{@suffix}", 100, 10)
+
+    assert_instance_of Wurk::Limiter::Points, l
+    assert_equal :points, l.type
+  end
+
+  def test_unlimited_ignores_arguments_and_yields_unconditionally
+    l = Wurk::Limiter.unlimited('whatever', 9999, foo: :bar)
+
+    assert_instance_of Wurk::Limiter::Unlimited, l
+    assert_equal :unlimited, l.type
+
+    ran = false
+    l.within_limit { ran = true }
+
+    assert ran
+  end
+
+  # ----- OverLimit shape ------------------------------------------------
+
+  def test_over_limit_exposes_limiter_and_job
+    l = Wurk::Limiter.concurrent("ovr-#{@suffix}", 1, wait_timeout: 0)
+    job = { 'jid' => 'abc', 'class' => 'X', 'args' => [], 'queue' => 'default' }
+    exc = Wurk::Limiter::OverLimit.new(l, job)
+
+    assert_equal l, exc.limiter
+    assert_equal job, exc.job
+    assert_kind_of StandardError, exc
+  end
+
+  # ----- name validation ------------------------------------------------
+
+  def test_constructor_rejects_invalid_name
+    assert_raises(ArgumentError) { Wurk::Limiter.concurrent('bad name with spaces', 1) }
+  end
+
+  def test_constructor_rejects_ttl_under_24h
+    assert_raises(ArgumentError) { Wurk::Limiter.concurrent("ttl-#{@suffix}", 1, ttl: 60) }
+  end
+
+  # ----- registration in lmtr-list -------------------------------------
+
+  def test_constructor_registers_in_lmtr_list_and_metadata_hash
+    name = "reg-#{@suffix}"
+    Wurk::Limiter.concurrent(name, 5)
+
+    @pool.with do |c|
+      assert_equal 1, c.call('SISMEMBER', Wurk::Limiter::LIST_KEY, name)
+      type = c.call('HGET', "lmtr:#{name}", 'type')
+
+      assert_equal 'concurrent', type
+    end
+  end
+
+  # ----- delete + reset cleanup ----------------------------------------
+
+  def test_delete_removes_state_keys_and_list_membership
+    name = "del-#{@suffix}"
+    l = Wurk::Limiter.concurrent(name, 1)
+    l.within_limit {} # creates state
+    l.delete
+    @pool.with do |c|
+      assert_equal 0, c.call('SISMEMBER', Wurk::Limiter::LIST_KEY, name)
+      assert_equal 0, c.call('EXISTS', "lmtr:#{name}")
+      assert_equal 0, c.call('EXISTS', "lmtr-cs:#{name}")
+    end
+  end
+
+  # ----- configure --------------------------------------------------
+
+  def test_configure_sets_backoff
+    Wurk::Limiter.configure { |c| c.backoff = ->(_l, _j, _e) { 42 } }
+
+    assert_equal 42, Wurk::Limiter.config.backoff.call(nil, {}, nil)
+  end
+
+  def test_configure_errors_array_can_be_extended
+    Wurk::Limiter.config.errors << ArgumentError
+
+    assert_includes Wurk::Limiter.config.errors, ArgumentError
+  end
+
+  # ----- fingerprint is SHA256 -----------------------------------------
+
+  def test_fingerprint_is_sha256_hex
+    l = Wurk::Limiter.concurrent("fp-#{@suffix}", 1)
+
+    assert_match(/\A[0-9a-f]{64}\z/, l.fingerprint)
+  end
+
+  # ----- server middleware reschedule path -----------------------------
+
+  def test_server_middleware_reschedules_on_over_limit
+    l = Wurk::Limiter.bucket("mw-#{@suffix}", 1, :minute, wait_timeout: 0, reschedule: 5)
+    jid = "mwj#{@suffix}"
+    job = { 'class' => 'NoopWorker', 'args' => [1], 'queue' => 'default', 'jid' => jid }
+    mw = Wurk::Limiter::ServerMiddleware.new
+    mw.config = Wurk.configuration
+
+    begin
+      mw.call(nil, job, 'default') { raise Wurk::Limiter::OverLimit.new(l, job) }
+
+      assert_equal 1, job['overrated']
+      # Scheduled push lands in the global `schedule` ZSET with score = at.
+      scored = Wurk.redis { |c| c.call('ZRANGE', 'schedule', 0, -1) }
+
+      assert(scored.any? { |payload| payload.include?(jid) }, "schedule missing jid: #{scored.inspect}")
+    ensure
+      Wurk.redis do |c|
+        c.call('ZRANGE', 'schedule', 0, -1).each { |p| c.call('ZREM', 'schedule', p) if p.include?(jid) }
+      end
+    end
+  end
+
+  def test_server_middleware_reraises_after_reschedule_cap
+    l = Wurk::Limiter.bucket("cap-#{@suffix}", 1, :minute, wait_timeout: 0, reschedule: 2)
+    job = { 'class' => 'NoopWorker', 'args' => [], 'queue' => 'default', 'jid' => 'jjj', 'overrated' => 1 }
+    mw = Wurk::Limiter::ServerMiddleware.new
+    mw.config = Wurk.configuration
+
+    assert_raises(Wurk::Limiter::OverLimit) do
+      mw.call(nil, job, 'default') { raise Wurk::Limiter::OverLimit.new(l, job) }
+    end
+    assert_equal 2, job['overrated']
   end
 end

--- a/test/unit/limiter_window_test.rb
+++ b/test/unit/limiter_window_test.rb
@@ -17,11 +17,20 @@ class LimiterWindowTest < Wurk::Test::UnitCase
   end
 
   def teardown
+    # Scope cleanup to this test's @suffix so parallel limiter tests don't
+    # wipe each other's state mid-run (failure mode: another test's
+    # `within_limit` sees an empty counter because we DEL'd its key).
     @pool.with do |c|
       cursor = '0'
       loop do
-        cursor, keys = c.call('SCAN', cursor, 'MATCH', 'lmtr*', 'COUNT', 500)
+        cursor, keys = c.call('SCAN', cursor, 'MATCH', "*#{@suffix}*", 'COUNT', 500)
         c.call('DEL', *keys) unless keys.empty?
+        break if cursor == '0'
+      end
+      cursor = '0'
+      loop do
+        cursor, names = c.call('SSCAN', Wurk::Limiter::LIST_KEY, cursor, 'MATCH', "*#{@suffix}*", 'COUNT', 500)
+        c.call('SREM', Wurk::Limiter::LIST_KEY, *names) unless names.empty?
         break if cursor == '0'
       end
     end

--- a/test/unit/limiter_window_test.rb
+++ b/test/unit/limiter_window_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+class LimiterWindowTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  REDIS_URL = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
+
+  def setup
+    super
+    @suffix = "wn#{Process.pid}#{object_id}"
+    @pool = Wurk::RedisPool.new(size: 2, url: REDIS_URL, timeout: 2, name: 'wnp')
+    @pool.with { |c| Wurk::Lua::Loader.script_load_all(c) }
+    Wurk::Limiter.reset_config!
+    Wurk::Limiter.config.redis = @pool
+  end
+
+  def teardown
+    @pool.with do |c|
+      cursor = '0'
+      loop do
+        cursor, keys = c.call('SCAN', cursor, 'MATCH', 'lmtr*', 'COUNT', 500)
+        c.call('DEL', *keys) unless keys.empty?
+        break if cursor == '0'
+      end
+    end
+    @pool.disconnect!
+    Wurk::Limiter.reset_config!
+  ensure
+    super
+  end
+
+  def test_within_limit_yields_block
+    l = Wurk::Limiter.window("a-#{@suffix}", 5, :minute)
+    ran = false
+    l.within_limit { ran = true }
+
+    assert ran
+    assert_equal 1, l.size
+  end
+
+  def test_full_window_raises_over_limit
+    l = Wurk::Limiter.window("b-#{@suffix}", 2, :minute, wait_timeout: 0)
+    l.within_limit {}
+    l.within_limit {}
+    assert_raises(Wurk::Limiter::OverLimit) { l.within_limit {} }
+  end
+
+  def test_window_accepts_integer_seconds
+    l = Wurk::Limiter.window("c-#{@suffix}", 3, 30, wait_timeout: 0)
+    3.times { l.within_limit {} }
+    assert_raises(Wurk::Limiter::OverLimit) { l.within_limit {} }
+  end
+
+  def test_sliding_window_lets_old_entries_drop_off
+    l = Wurk::Limiter.window("d-#{@suffix}", 2, 1, wait_timeout: 0)
+    l.within_limit {}
+    l.within_limit {}
+    sleep 1.2
+    l.within_limit {}
+
+    assert_operator l.size, :<=, 2
+  end
+
+  def test_used_parameter_adds_multiple_entries
+    l = Wurk::Limiter.window("e-#{@suffix}", 5, :minute)
+    l.within_limit(used: 3) {}
+
+    assert_equal 3, l.size
+  end
+
+  def test_used_overage_raises_when_remaining_too_small
+    l = Wurk::Limiter.window("f-#{@suffix}", 3, :minute, wait_timeout: 0)
+    l.within_limit(used: 2) {}
+    assert_raises(Wurk::Limiter::OverLimit) { l.within_limit(used: 2) {} }
+  end
+
+  def test_reset_clears_window
+    l = Wurk::Limiter.window("g-#{@suffix}", 5, :minute)
+    l.within_limit {}
+    l.within_limit {}
+    l.reset
+
+    assert_equal 0, l.size
+  end
+
+  def test_block_exception_still_charges_window
+    l = Wurk::Limiter.window("h-#{@suffix}", 5, :minute)
+    assert_raises(RuntimeError) { l.within_limit { raise 'boom' } }
+    assert_equal 1, l.size
+  end
+
+  def test_options_exposes_input_params
+    l = Wurk::Limiter.window("i-#{@suffix}", 4, :second)
+
+    assert_equal 4, l.options[:count]
+    assert_equal :second, l.options[:interval]
+  end
+end

--- a/test/unit/lua_test.rb
+++ b/test/unit/lua_test.rb
@@ -34,7 +34,10 @@ class LuaTest < Wurk::Test::UnitCase
     assert_equal(
       %i[zpopbyscore bulk_push reliable_schedule_promote
          batch_push batch_ack_success batch_ack_complete batch_invalidate
-         fast_delete_job fast_delete_by_class].sort,
+         fast_delete_job fast_delete_by_class
+         limiter_concurrent_acquire limiter_concurrent_release
+         limiter_bucket_acquire limiter_window_acquire limiter_leaky_acquire
+         limiter_points_acquire limiter_points_refund].sort,
       Wurk::Lua::SCRIPTS.keys.sort
     )
   end

--- a/test/unit/metrics_history_test.rb
+++ b/test/unit/metrics_history_test.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+class MetricsHistoryTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @at = ::Time.utc(2026, 5, 21, 14, 37, 12)
+    @klass = "FooJob#{Process.pid}_#{object_id}"
+  end
+
+  def teardown
+    Wurk.redis do |c|
+      cursor = '0'
+      loop do
+        cursor, keys = c.call('SCAN', cursor, 'MATCH', "*#{@klass}*", 'COUNT', 500)
+        c.call('DEL', *keys) unless keys.empty?
+        break if cursor == '0'
+      end
+      # HDEL only this class's fields — minute/rollup buckets are shared
+      # with other parallel tests writing at the same UTC minute.
+      [Wurk::Metrics::History.minute_key(@at), Wurk::Metrics::History.rollup_key(@at)].each do |key|
+        c.call('HDEL', key, "#{@klass}|p", "#{@klass}|f", "#{@klass}|ms")
+      end
+    end
+  ensure
+    super
+  end
+
+  # ---- bucket key formatting -----------------------------------------------
+
+  def test_minute_key_format
+    assert_equal 'j|260521|14:37', Wurk::Metrics::History.minute_key(@at)
+  end
+
+  def test_rollup_key_zeroes_last_digit_of_minute
+    assert_equal 'j|260521|14:30', Wurk::Metrics::History.rollup_key(@at)
+    assert_equal 'j|260521|14:30', Wurk::Metrics::History.rollup_key(::Time.utc(2026, 5, 21, 14, 39))
+    assert_equal 'j|260521|14:40', Wurk::Metrics::History.rollup_key(::Time.utc(2026, 5, 21, 14, 40))
+  end
+
+  def test_hour_key_format
+    assert_equal 'FooJob-260521-14', Wurk::Metrics::History.hour_key('FooJob', @at)
+  end
+
+  def test_minute_key_uses_utc
+    local_time = ::Time.utc(2026, 5, 21, 23, 30) + 60
+
+    assert_equal 'j|260521|23:31', Wurk::Metrics::History.minute_key(local_time)
+  end
+
+  # ---- record() writes to all three buckets --------------------------------
+
+  def test_record_writes_processed_counter_in_minute_bucket
+    Wurk::Metrics::History.record(@klass, 42, success: true, at: @at)
+
+    minute = Wurk::Metrics::History.minute_key(@at)
+    val = Wurk.redis { |c| c.call('HGET', minute, "#{@klass}|p") }
+
+    assert_equal '1', val
+  end
+
+  def test_record_writes_failed_counter_when_unsuccessful
+    Wurk::Metrics::History.record(@klass, 8, success: false, at: @at)
+
+    minute = Wurk::Metrics::History.minute_key(@at)
+    val = Wurk.redis { |c| c.call('HGET', minute, "#{@klass}|f") }
+
+    assert_equal '1', val
+  end
+
+  def test_record_accumulates_ms_across_success_and_failure
+    Wurk::Metrics::History.record(@klass, 10, success: true, at: @at)
+    Wurk::Metrics::History.record(@klass, 25, success: false, at: @at)
+
+    minute = Wurk::Metrics::History.minute_key(@at)
+    val = Wurk.redis { |c| c.call('HGET', minute, "#{@klass}|ms") }
+
+    assert_equal '35', val
+  end
+
+  def test_record_writes_rollup_bucket
+    Wurk::Metrics::History.record(@klass, 15, success: true, at: @at)
+
+    rollup = Wurk::Metrics::History.rollup_key(@at)
+    val = Wurk.redis { |c| c.call('HGET', rollup, "#{@klass}|p") }
+
+    assert_equal '1', val
+  end
+
+  def test_record_writes_hourly_bucket
+    Wurk::Metrics::History.record(@klass, 20, success: true, at: @at)
+    Wurk::Metrics::History.record(@klass, 30, success: false, at: @at)
+
+    hour = Wurk::Metrics::History.hour_key(@klass, @at)
+    p, f, ms = Wurk.redis { |c| c.call('HMGET', hour, 'p', 'f', 'ms') }
+
+    assert_equal '1', p
+    assert_equal '1', f
+    assert_equal '50', ms
+  end
+
+  def test_record_sets_minute_ttl_to_mid_term
+    Wurk::Metrics::History.record(@klass, 1, success: true, at: @at)
+
+    ttl = Wurk.redis { |c| c.call('TTL', Wurk::Metrics::History.minute_key(@at)) }
+
+    assert_operator ttl, :>, Wurk::Metrics::History::MID_TERM - 60
+    assert_operator ttl, :<=, Wurk::Metrics::History::MID_TERM
+  end
+
+  def test_record_sets_rollup_ttl_to_short_term
+    Wurk::Metrics::History.record(@klass, 1, success: true, at: @at)
+
+    ttl = Wurk.redis { |c| c.call('TTL', Wurk::Metrics::History.rollup_key(@at)) }
+
+    assert_operator ttl, :>, Wurk::Metrics::History::SHORT_TERM - 60
+    assert_operator ttl, :<=, Wurk::Metrics::History::SHORT_TERM
+  end
+
+  def test_record_sets_hourly_ttl_to_mid_term
+    Wurk::Metrics::History.record(@klass, 1, success: true, at: @at)
+
+    ttl = Wurk.redis { |c| c.call('TTL', Wurk::Metrics::History.hour_key(@klass, @at)) }
+
+    assert_operator ttl, :>, Wurk::Metrics::History::MID_TERM - 60
+    assert_operator ttl, :<=, Wurk::Metrics::History::MID_TERM
+  end
+
+  def test_record_ignores_blank_klass
+    Wurk::Metrics::History.record(nil, 1, success: true, at: @at)
+    Wurk::Metrics::History.record('', 1, success: true, at: @at)
+
+    minute = Wurk::Metrics::History.minute_key(@at)
+
+    refute(Wurk.redis { |c| c.call('EXISTS', minute) == 1 })
+  end
+
+  def test_record_clamps_negative_duration_to_zero
+    Wurk::Metrics::History.record(@klass, -50, success: true, at: @at)
+
+    minute = Wurk::Metrics::History.minute_key(@at)
+    val = Wurk.redis { |c| c.call('HGET', minute, "#{@klass}|ms") }
+
+    assert_equal '0', val
+  end
+
+  # ---- middleware integration ---------------------------------------------
+
+  def test_middleware_records_success_and_yields_return
+    mw = build_middleware
+    job = { 'class' => @klass }
+    result = mw.call(nil, job, 'default') { :ok }
+
+    assert_equal :ok, result
+    minute = Wurk::Metrics::History.minute_key(::Time.now.utc)
+
+    assert_equal('1', Wurk.redis { |c| c.call('HGET', minute, "#{@klass}|p") })
+  end
+
+  def test_middleware_records_failure_when_perform_raises
+    mw = build_middleware
+    job = { 'class' => @klass }
+    assert_raises(::RuntimeError) do
+      mw.call(nil, job, 'default') { raise 'boom' }
+    end
+
+    minute = Wurk::Metrics::History.minute_key(::Time.now.utc)
+
+    assert_equal('1', Wurk.redis { |c| c.call('HGET', minute, "#{@klass}|f") })
+  end
+
+  def test_middleware_swallows_redis_failure_post_perform
+    broken_pool = Object.new
+    def broken_pool.with(&)
+      raise 'redis down'
+    end
+
+    cfg = Wurk::Configuration.new
+    cfg.logger = Logger.new(IO::NULL)
+    # Stub redis_pool on this throwaway capsule so the middleware reads our broken pool.
+    cfg.default_capsule.instance_variable_set(:@redis_pool, broken_pool)
+    mw = Wurk::Metrics::History.new
+    mw.config = cfg
+
+    result = mw.call(nil, { 'class' => @klass }, 'default') { :ok }
+
+    assert_equal :ok, result
+  end
+
+  private
+
+  def build_middleware
+    mw = Wurk::Metrics::History.new
+    mw.config = Wurk.configuration
+    mw
+  end
+end

--- a/test/unit/metrics_query_test.rb
+++ b/test/unit/metrics_query_test.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+class MetricsQueryTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @suffix = "q#{Process.pid}_#{object_id}"
+    @klass_a = "AlphaJob#{@suffix}"
+    @klass_b = "BetaJob#{@suffix}"
+    # Pin the test window to a stable UTC moment, well past minute boundary
+    # so floor_to(:min) lands inside our writes (not on the second-edge).
+    @now = ::Time.utc(2026, 5, 21, 14, 37, 12)
+  end
+
+  def teardown
+    Wurk.redis do |c|
+      cursor = '0'
+      loop do
+        cursor, keys = c.call('SCAN', cursor, 'MATCH', "*#{@suffix}*", 'COUNT', 500)
+        c.call('DEL', *keys) unless keys.empty?
+        break if cursor == '0'
+      end
+      # Per-class fields only — never DEL the shared minute/rollup buckets,
+      # other parallel tests for the same minute will lose their writes.
+      [@now, @now - 60, @now - 120].each do |t|
+        [Wurk::Metrics::History.minute_key(t), Wurk::Metrics::History.rollup_key(t)].each do |key|
+          [@klass_a, @klass_b].each do |kls|
+            c.call('HDEL', key, "#{kls}|p", "#{kls}|f", "#{kls}|ms")
+          end
+        end
+      end
+    end
+  ensure
+    super
+  end
+
+  # ---- caps ---------------------------------------------------------------
+
+  def test_top_jobs_caps_minutes
+    assert_raises(Wurk::Metrics::Query::WindowTooWide) do
+      Wurk::Metrics::Query.top_jobs(minutes: 481)
+    end
+  end
+
+  def test_top_jobs_caps_hours
+    assert_raises(Wurk::Metrics::Query::WindowTooWide) do
+      Wurk::Metrics::Query.top_jobs(hours: 73)
+    end
+  end
+
+  def test_top_jobs_requires_positive_minutes
+    assert_raises(ArgumentError) do
+      Wurk::Metrics::Query.top_jobs(minutes: 0)
+    end
+  end
+
+  def test_for_job_requires_class
+    assert_raises(ArgumentError) do
+      Wurk::Metrics::Query.for_job(nil, minutes: 1)
+    end
+  end
+
+  def test_for_job_rejects_both_minutes_and_hours
+    assert_raises(ArgumentError) do
+      Wurk::Metrics::Query.for_job('X', minutes: 1, hours: 1)
+    end
+  end
+
+  def test_for_job_rejects_neither_minutes_nor_hours
+    assert_raises(ArgumentError) do
+      Wurk::Metrics::Query.for_job('X')
+    end
+  end
+
+  def test_for_job_caps_minutes
+    assert_raises(Wurk::Metrics::Query::WindowTooWide) do
+      Wurk::Metrics::Query.for_job('X', minutes: 999)
+    end
+  end
+
+  def test_for_job_caps_hours
+    assert_raises(Wurk::Metrics::Query::WindowTooWide) do
+      Wurk::Metrics::Query.for_job('X', hours: 999)
+    end
+  end
+
+  # ---- top_jobs aggregation -----------------------------------------------
+
+  def test_top_jobs_aggregates_per_class
+    Wurk::Metrics::History.record(@klass_a, 100, success: true, at: @now)
+    Wurk::Metrics::History.record(@klass_a, 200, success: false, at: @now - 60)
+    Wurk::Metrics::History.record(@klass_b, 50, success: true, at: @now)
+
+    rows = Wurk::Metrics::Query.top_jobs(minutes: 5, now: @now)
+    found = rows.to_h
+
+    assert_equal({ p: 1, f: 1, ms: 300 }, found[@klass_a])
+    assert_equal({ p: 1, f: 0, ms: 50 }, found[@klass_b])
+  end
+
+  def test_top_jobs_sorted_descending_by_volume
+    5.times { Wurk::Metrics::History.record(@klass_a, 1, success: true, at: @now) }
+    2.times { Wurk::Metrics::History.record(@klass_b, 1, success: true, at: @now) }
+
+    rows = Wurk::Metrics::Query.top_jobs(minutes: 5, now: @now)
+    classes = rows.map(&:first).select { |k| [@klass_a, @klass_b].include?(k) }
+
+    assert_equal [@klass_a, @klass_b], classes
+  end
+
+  def test_top_jobs_filters_by_prefix
+    Wurk::Metrics::History.record(@klass_a, 1, success: true, at: @now)
+    Wurk::Metrics::History.record(@klass_b, 1, success: true, at: @now)
+
+    rows = Wurk::Metrics::Query.top_jobs(class_filter: 'Alpha', minutes: 5, now: @now)
+    klasses = rows.map(&:first)
+
+    assert(klasses.all? { |k| k.start_with?('Alpha') })
+    assert_includes klasses, @klass_a
+  end
+
+  def test_top_jobs_hours_arg_converts_to_minutes
+    Wurk::Metrics::History.record(@klass_a, 7, success: true, at: @now)
+
+    rows = Wurk::Metrics::Query.top_jobs(hours: 1, now: @now)
+
+    assert_includes rows.map(&:first), @klass_a
+  end
+
+  # ---- for_job series -----------------------------------------------------
+
+  def test_for_job_minutes_returns_chronological_rows
+    Wurk::Metrics::History.record(@klass_a, 10, success: true, at: @now - 60)
+    Wurk::Metrics::History.record(@klass_a, 25, success: true, at: @now)
+
+    rows = Wurk::Metrics::Query.for_job(@klass_a, minutes: 3, now: @now)
+
+    assert_equal 3, rows.size
+    assert_operator rows.first[:at], :<, rows.last[:at]
+    last_two = rows.last(2).map { |r| r[:p] }
+
+    assert_equal [1, 1], last_two
+  end
+
+  def test_for_job_minutes_returns_zeros_for_empty_buckets
+    rows = Wurk::Metrics::Query.for_job(@klass_a, minutes: 2, now: @now)
+
+    assert(rows.all? { |r| r[:p].zero? && r[:f].zero? && r[:ms].zero? })
+  end
+
+  def test_for_job_hours_returns_chronological_rows
+    Wurk::Metrics::History.record(@klass_a, 99, success: true, at: @now)
+
+    rows = Wurk::Metrics::Query.for_job(@klass_a, hours: 2, now: @now)
+
+    assert_equal 2, rows.size
+    assert_equal 1, rows.last[:p]
+    assert_equal 99, rows.last[:ms]
+  end
+end

--- a/test/unit/unique_test.rb
+++ b/test/unit/unique_test.rb
@@ -1,11 +1,394 @@
 # frozen_string_literal: true
 
-require_relative "../test_helper"
+require_relative '../test_helper'
 
 class UniqueTest < Wurk::Test::UnitCase
-  parallelize_me!
+  # NOT parallelize_me! — these tests flip the process-wide
+  # `Wurk::Unique.enabled?` flag and install client/server middleware on
+  # the global config. Running in parallel would let one test's `enable!`
+  # leak into another's "should be a no-op" assertion.
 
-  def test_skeleton
-    skip "implementation pending — see docs/target/sidekiq-ent.md (unique jobs)"
+  REDIS_URL = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
+
+  ENABLE_MUTEX = ::Mutex.new
+
+  def setup
+    super
+    @suffix = "uniq#{Process.pid}#{object_id}"
+    @keys = []
+  end
+
+  def teardown
+    Wurk.redis do |c|
+      @keys.each { |k| c.call('DEL', k) }
+    end
+    Wurk::Unique.disable!
+    Wurk.configuration.client_middleware.remove(Wurk::Unique::ClientMiddleware)
+    Wurk.configuration.server_middleware.remove(Wurk::Unique::ServerMiddleware)
+  ensure
+    super
+  end
+
+  # ---- digest / lock key ----------------------------------------------
+
+  def test_lock_key_is_sha256_with_unique_prefix
+    key = Wurk::Unique.lock_key('FooJob', 'default', [1, 2, 3])
+
+    assert_match(/\Aunique:[0-9a-f]{64}\z/, key)
+  end
+
+  def test_lock_key_stable_for_same_inputs
+    a = Wurk::Unique.lock_key('FooJob', 'default', [1, 2])
+    b = Wurk::Unique.lock_key('FooJob', 'default', [1, 2])
+
+    assert_equal a, b
+  end
+
+  def test_lock_key_differs_by_class
+    a = Wurk::Unique.lock_key('A', 'default', [1])
+    b = Wurk::Unique.lock_key('B', 'default', [1])
+
+    refute_equal a, b
+  end
+
+  def test_lock_key_differs_by_queue
+    a = Wurk::Unique.lock_key('A', 'q1', [1])
+    b = Wurk::Unique.lock_key('A', 'q2', [1])
+
+    refute_equal a, b
+  end
+
+  def test_lock_key_differs_by_args
+    a = Wurk::Unique.lock_key('A', 'q', [1])
+    b = Wurk::Unique.lock_key('A', 'q', [2])
+
+    refute_equal a, b
+  end
+
+  def test_lock_key_for_uses_default_context
+    job = { 'class' => 'FooJob', 'queue' => 'default', 'args' => [42] }
+
+    assert_equal Wurk::Unique.lock_key('FooJob', 'default', [42]),
+                 Wurk::Unique.lock_key_for(job)
+  end
+
+  def test_lock_key_honors_sidekiq_unique_context
+    klass = Class.new do
+      def self.name = 'CustomContextJob'
+
+      def self.sidekiq_unique_context(job)
+        ['CustomContextJob', job['queue'], [job['args'].first]]
+      end
+    end
+    stub_const('CustomContextJob', klass) do
+      a = Wurk::Unique.lock_key_for({ 'class' => 'CustomContextJob', 'queue' => 'q', 'args' => [1, 'noise'] })
+      b = Wurk::Unique.lock_key_for({ 'class' => 'CustomContextJob', 'queue' => 'q', 'args' => [1, 'other'] })
+
+      assert_equal a, b
+    end
+  end
+
+  # ---- enable / disable -----------------------------------------------
+
+  def test_disabled_by_default
+    refute_predicate Wurk::Unique, :enabled?
+    refute_predicate Sidekiq::Enterprise, :unique?
+  end
+
+  def test_enable_via_sidekiq_enterprise_sets_predicates
+    ENABLE_MUTEX.synchronize do
+      Sidekiq::Enterprise.unique!
+
+      assert_predicate Wurk::Unique, :enabled?
+      assert_predicate Sidekiq::Enterprise, :unique?
+    end
+  end
+
+  def test_enable_installs_both_middleware
+    ENABLE_MUTEX.synchronize do
+      Sidekiq::Enterprise.unique!
+
+      assert Wurk.configuration.client_middleware.exists?(Wurk::Unique::ClientMiddleware)
+      assert Wurk.configuration.server_middleware.exists?(Wurk::Unique::ServerMiddleware)
+    end
+  end
+
+  def test_enable_is_idempotent
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      Wurk::Unique.enable!
+
+      client_count = Wurk.configuration.client_middleware.entries.count { |e| e.klass == Wurk::Unique::ClientMiddleware }
+      server_count = Wurk.configuration.server_middleware.entries.count { |e| e.klass == Wurk::Unique::ServerMiddleware }
+
+      assert_equal 1, client_count
+      assert_equal 1, server_count
+    end
+  end
+
+  # ---- coerce_ttl ------------------------------------------------------
+
+  def test_coerce_ttl_passes_through_positive_integer
+    assert_equal 60, Wurk::Unique.coerce_ttl(60)
+  end
+
+  def test_coerce_ttl_false_means_skip
+    assert_nil Wurk::Unique.coerce_ttl(false)
+    assert_nil Wurk::Unique.coerce_ttl(nil)
+  end
+
+  def test_coerce_ttl_handles_duration_like
+    duration = duration_double(600)
+
+    assert_equal 600, Wurk::Unique.coerce_ttl(duration)
+  end
+
+  # ---- ClientMiddleware: SETNX --------------------------------------
+
+  def test_client_middleware_skips_when_disabled
+    job = { 'class' => 'X', 'queue' => 'q', 'args' => [], 'jid' => 'j1', 'unique_for' => 60 }
+    track_key(job)
+    ran = invoke_client(job)
+
+    assert ran
+    assert_nil(Wurk.redis { |c| c.call('GET', Wurk::Unique.lock_key_for(job)) })
+  end
+
+  def test_client_middleware_skips_when_unique_for_missing
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      job = { 'class' => 'X', 'queue' => 'q', 'args' => [], 'jid' => 'j1' }
+      ran = invoke_client(job)
+
+      assert ran
+    end
+  end
+
+  def test_client_middleware_skips_when_unique_for_false
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      job = { 'class' => 'X', 'queue' => 'q', 'args' => [], 'jid' => 'j1', 'unique_for' => false }
+      ran = invoke_client(job)
+
+      assert ran
+    end
+  end
+
+  def test_client_middleware_acquires_lock_first_push
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      job = build_job(jid: 'jid-1', ttl: 60)
+      ran = invoke_client(job)
+      track_key(job)
+
+      assert ran
+      assert_equal('jid-1', Wurk.redis { |c| c.call('GET', Wurk::Unique.lock_key_for(job)) })
+    end
+  end
+
+  def test_client_middleware_drops_duplicate
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      first = build_job(jid: 'jid-1', ttl: 60)
+      second = build_job(jid: 'jid-2', ttl: 60)
+      track_key(first)
+
+      assert invoke_client(first)
+      refute invoke_client(second)
+      assert_equal('jid-1', Wurk.redis { |c| c.call('GET', Wurk::Unique.lock_key_for(first)) })
+    end
+  end
+
+  def test_client_middleware_logs_holder_on_duplicate
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      io = StringIO.new
+      with_logger(::Logger.new(io)) do
+        invoke_client(build_job(jid: 'jid-A', ttl: 60))
+        track_key(build_job(jid: 'jid-A', ttl: 60))
+        invoke_client(build_job(jid: 'jid-B', ttl: 60))
+      end
+
+      assert_includes io.string, 'jid-A'
+      assert_includes io.string, 'jid=jid-B'
+    end
+  end
+
+  def test_client_middleware_ttl_includes_schedule_delay
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      job = build_job(jid: 'sched-1', ttl: 30)
+      job['at'] = ::Time.now.to_f + 120
+      ran = invoke_client(job)
+      track_key(job)
+
+      assert ran
+      ttl = Wurk.redis { |c| c.call('TTL', Wurk::Unique.lock_key_for(job)) }
+
+      assert_operator ttl, :>=, 120
+    end
+  end
+
+  # ---- ServerMiddleware: lock release strategy -----------------------
+
+  def test_server_middleware_no_op_when_disabled
+    job = build_job(jid: 'sj-noop', ttl: 30)
+    Wurk.redis { |c| c.call('SET', Wurk::Unique.lock_key_for(job), 'owner', 'EX', 30) }
+    track_key(job)
+    ran = invoke_server(job) { true }
+
+    assert ran
+    refute_nil(Wurk.redis { |c| c.call('GET', Wurk::Unique.lock_key_for(job)) })
+  end
+
+  def test_server_middleware_until_success_releases_after_success
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      job = build_job(jid: 'sj-ok', ttl: 30, until_mode: :success)
+      Wurk.redis { |c| c.call('SET', Wurk::Unique.lock_key_for(job), 'sj-ok', 'EX', 30) }
+      track_key(job)
+
+      assert_equal :done, invoke_server(job) { :done }
+      assert_nil(Wurk.redis { |c| c.call('GET', Wurk::Unique.lock_key_for(job)) })
+    end
+  end
+
+  def test_server_middleware_until_success_retains_on_raise
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      job = build_job(jid: 'sj-raise', ttl: 30, until_mode: :success)
+      Wurk.redis { |c| c.call('SET', Wurk::Unique.lock_key_for(job), 'sj-raise', 'EX', 30) }
+      track_key(job)
+
+      assert_raises(RuntimeError) { invoke_server(job) { raise 'boom' } }
+      assert_equal('sj-raise', Wurk.redis { |c| c.call('GET', Wurk::Unique.lock_key_for(job)) })
+    end
+  end
+
+  def test_server_middleware_until_start_releases_before_perform
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      job = build_job(jid: 'sj-start', ttl: 30, until_mode: :start)
+      key = Wurk::Unique.lock_key_for(job)
+      Wurk.redis { |c| c.call('SET', key, 'sj-start', 'EX', 30) }
+      track_key(job)
+
+      seen_during_perform = nil
+      invoke_server(job) { seen_during_perform = Wurk.redis { |c| c.call('GET', key) } }
+
+      assert_nil seen_during_perform
+    end
+  end
+
+  def test_server_middleware_release_is_cas_protected
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      job = build_job(jid: 'cas-job', ttl: 30, until_mode: :success)
+      key = Wurk::Unique.lock_key_for(job)
+      Wurk.redis { |c| c.call('SET', key, 'someone-else', 'EX', 30) }
+      track_key(job)
+      invoke_server(job) { :ok }
+
+      assert_equal('someone-else', Wurk.redis { |c| c.call('GET', key) })
+    end
+  end
+
+  def test_server_middleware_invalid_until_defaults_to_success
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      job = build_job(jid: 'sj-bad', ttl: 30, until_mode: 'garbage')
+      Wurk.redis { |c| c.call('SET', Wurk::Unique.lock_key_for(job), 'sj-bad', 'EX', 30) }
+      track_key(job)
+
+      invoke_server(job) { :ok }
+
+      assert_nil(Wurk.redis { |c| c.call('GET', Wurk::Unique.lock_key_for(job)) })
+    end
+  end
+
+  # ---- locked? introspection ------------------------------------------
+
+  def test_locked_returns_jid_when_present
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      job = build_job(jid: 'holder', ttl: 60)
+      key = Wurk::Unique.lock_key_for(job)
+      Wurk.redis { |c| c.call('SET', key, 'holder', 'EX', 60) }
+      track_key(job)
+
+      assert_equal 'holder', Sidekiq::Enterprise::Unique.locked?(job['queue'], job['class'], job['args'])
+    end
+  end
+
+  def test_locked_returns_nil_when_absent
+    assert_nil Sidekiq::Enterprise::Unique.locked?('default', 'NeverEnqueued', [])
+  end
+
+  def test_locked_two_arg_form_uses_default_queue
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      default_queue = Wurk.default_job_options['queue']
+      job = { 'class' => 'TwoArg', 'queue' => default_queue, 'args' => [99] }
+      key = Wurk::Unique.lock_key_for(job)
+      Wurk.redis { |c| c.call('SET', key, 'who', 'EX', 60) }
+      @keys << key
+
+      assert_equal 'who', Wurk::Unique.locked?('TwoArg', [99])
+    end
+  end
+
+  private
+
+  def build_job(jid:, ttl:, until_mode: nil, klass: "UniqJob#{@suffix}", queue: 'q')
+    {
+      'class' => klass,
+      'queue' => queue,
+      'args' => [1, 'x'],
+      'jid' => jid,
+      'unique_for' => ttl
+    }.tap do |h|
+      h['unique_until'] = until_mode if until_mode
+    end
+  end
+
+  def invoke_client(job)
+    pool = Wurk.configuration.redis_pool
+    Wurk::Unique::ClientMiddleware.new.call(nil, job, job['queue'], pool) { true }
+  end
+
+  def invoke_server(job, &)
+    mw = Wurk::Unique::ServerMiddleware.new
+    mw.config = Wurk.configuration
+    mw.call(nil, job, job['queue'], &)
+  end
+
+  def track_key(job)
+    @keys << Wurk::Unique.lock_key_for(job)
+  end
+
+  def with_logger(logger)
+    prior = Wurk.logger
+    Wurk.configuration.logger = logger
+    yield
+  ensure
+    Wurk.configuration.logger = prior
+  end
+
+  def stub_const(name, klass)
+    ::Object.const_set(name, klass)
+    yield
+  ensure
+    ::Object.send(:remove_const, name) if ::Object.const_defined?(name)
+  end
+
+  # Stand-in for ActiveSupport::Duration so coerce_ttl handles it correctly
+  # without pulling in ActiveSupport.
+  def duration_double(seconds)
+    Class.new do
+      def initialize(secs) = @secs = secs
+      def to_i = @secs
+      def since(_then) = ::Time.now
+      def self.name = 'ActiveSupport::Duration'
+    end.new(seconds)
   end
 end


### PR DESCRIPTION
## Summary

Final task in the Ent parity PR group. Brings the surface specified in `docs/target/sidekiq-ent.md` into Wurk under MIT, wire-compat with Sidekiq's Redis schema.

- **Limiter family** — concurrent / bucket / window / leaky / points; Lua-backed with `OverLimit` + middleware reschedule.
- **Cron / Periodic** — leader-driven, DST-aware, in-tree parser.
- **Leader** — Redis `SET NX EX` + fencing token + `Component#leader?`.
- **Unique** — SHA256 client/server middleware pair.
- **Encryption** — AES-256-GCM envelope on the last positional arg, with key rotation.
- **History (this task)** — per-class minute / 10-min rollup / hourly HASH buckets (`j|YYMMDD|H:M`, `<klass>-YYMMDD-H`); `Wurk::Metrics::Query.top_jobs/for_job` with `minutes ≤ 480` / `hours ≤ 72` caps; `Wurk::Deploy.mark!` writing `<YYYYMMDD>-marks` HSET (90d TTL) + `deploylock-<label>` NX/EX 60 dedupe.

## Test plan

- [x] `bin/rake test` — 1356 runs, 0 failures, 5 skips
- [x] `bundle exec rubocop` — clean on all touched files
- [x] Redis bucket TTLs verified: MID_TERM 3d on minute + hourly, SHORT_TERM 8h on 10-min rollup
- [x] Sidekiq aliases land: `Sidekiq::Deploy == Wurk::Deploy`, `Sidekiq::Enterprise::Crypto.enable` delegates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Periodic job scheduling with cron expressions, timezone-aware firing, and a registration API
  * Deploy markers for recording deploy events
  * AES-256-GCM job argument encryption with key resolution and rotation
  * Five rate-limiting strategies: concurrent, bucket, window, leaky, and points-based (with server reschedule handling)
  * Job execution metrics plus a query API for recent minute/hour windows
  * Duplicate job prevention with configurable lock TTL
  * Leader election and :leader lifecycle hooks
  * Sidekiq Enterprise–style API aliases for compatibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/developerz-ai/wurk/pull/10?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->