### PR TITLE
feat: expired job counter — stats + dashboard for `expires_in` (closes #20)

### DIFF
--- a/app/controllers/wurk/api/serializers.rb
+++ b/app/controllers/wurk/api/serializers.rb
@@ -13,6 +13,7 @@ module Wurk
         {
           processed: stats.processed,
           failed: stats.failed,
+          expired: stats.expired,
           scheduled_size: stats.scheduled_size,
           retry_size: stats.retry_size,
           dead_size: stats.dead_size,

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef } from 'react';
 export interface StatsSnapshot {
   processed: number;
   failed: number;
+  expired: number;
   busy: number;
   enqueued: number;
   retries: number;

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -15,6 +15,7 @@
   "dashboard": {
     "processed": "Verarbeitet",
     "failed": "Fehlgeschlagen",
+    "expired": "Abgelaufen",
     "busy": "Beschäftigt",
     "enqueued": "In Warteschlange",
     "retries": "Wiederholungen",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -15,6 +15,7 @@
   "dashboard": {
     "processed": "Processed",
     "failed": "Failed",
+    "expired": "Expired",
     "busy": "Busy",
     "enqueued": "Enqueued",
     "retries": "Retries",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -15,6 +15,7 @@
   "dashboard": {
     "processed": "Procesados",
     "failed": "Fallidos",
+    "expired": "Caducados",
     "busy": "Ocupados",
     "enqueued": "En cola",
     "retries": "Reintentos",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -15,6 +15,7 @@
   "dashboard": {
     "processed": "Traités",
     "failed": "Échoués",
+    "expired": "Expirés",
     "busy": "Occupés",
     "enqueued": "En file",
     "retries": "Relances",

--- a/frontend/src/i18n/ja.json
+++ b/frontend/src/i18n/ja.json
@@ -15,6 +15,7 @@
   "dashboard": {
     "processed": "処理済み",
     "failed": "失敗",
+    "expired": "期限切れ",
     "busy": "実行中",
     "enqueued": "キュー中",
     "retries": "リトライ",

--- a/frontend/src/i18n/pt-BR.json
+++ b/frontend/src/i18n/pt-BR.json
@@ -15,6 +15,7 @@
   "dashboard": {
     "processed": "Processados",
     "failed": "Falhos",
+    "expired": "Expirados",
     "busy": "Ocupados",
     "enqueued": "Na fila",
     "retries": "Tentativas",

--- a/frontend/src/i18n/zh-CN.json
+++ b/frontend/src/i18n/zh-CN.json
@@ -15,6 +15,7 @@
   "dashboard": {
     "processed": "已处理",
     "failed": "失败",
+    "expired": "已过期",
     "busy": "繁忙",
     "enqueued": "排队中",
     "retries": "重试",

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -8,6 +8,7 @@ import { relativeTime } from '../utils';
 interface StatsData {
   processed: number;
   failed: number;
+  expired: number;
   busy: number;
   enqueued: number;
   retries: number;
@@ -56,6 +57,7 @@ export default function Dashboard({ sse }: DashboardProps) {
   const cards = [
     { key: 'processed', label: t('dashboard.processed'), value: stats.processed, color: 'var(--success)' },
     { key: 'failed', label: t('dashboard.failed'), value: stats.failed, color: 'var(--danger)' },
+    { key: 'expired', label: t('dashboard.expired'), value: stats.expired, color: 'var(--text-muted)' },
     { key: 'busy', label: t('dashboard.busy'), value: stats.busy, color: 'var(--warning)' },
     { key: 'enqueued', label: t('dashboard.enqueued'), value: stats.enqueued },
     { key: 'retries', label: t('dashboard.retries'), value: stats.retries, color: 'var(--warning)' },

--- a/lib/wurk/keys.rb
+++ b/lib/wurk/keys.rb
@@ -32,8 +32,14 @@ module Wurk
     # Global processed counter; per-day variants append `:YYYY-MM-DD`.
     STAT_PROCESSED = 'stat:processed'
 
-    # TTL applied to per-day `stat:processed:*` / `stat:failed:*` strings.
-    # 5 years, in seconds. Matches Sidekiq::Launcher::STATS_TTL.
+    # Global expired counter — subset of processed: jobs the Expiry server
+    # middleware dropped before `perform` because `expiry` had already
+    # elapsed. Per-day variants append `:YYYY-MM-DD`. Spec: sidekiq-pro.md §7.
+    STAT_EXPIRED = 'stat:expired'
+
+    # TTL applied to per-day `stat:processed:*` / `stat:failed:*` /
+    # `stat:expired:*` strings. 5 years, in seconds. Matches
+    # Sidekiq::Launcher::STATS_TTL.
     STATS_TTL = 5 * 365 * 24 * 60 * 60
 
     # Build a queue list key from a queue name. Centralizing the concat keeps

--- a/lib/wurk/launcher.rb
+++ b/lib/wurk/launcher.rb
@@ -18,17 +18,17 @@ module Wurk
   #   * `stop`             — graceful drain inside `config[:timeout]`.
   #   * `heartbeat`        — one-shot beat (also driven by the heartbeat thread).
   #
-  # `flush_stats` rolls per-process Processor counters (PROCESSED / FAILURE)
-  # into the global + per-day Redis strings every beat. Per-day keys carry
-  # `STATS_TTL` so old days expire automatically.
+  # `flush_stats` rolls per-process Processor counters (PROCESSED / FAILURE
+  # / EXPIRED) into the global + per-day Redis strings every beat. Per-day
+  # keys carry `STATS_TTL` so old days expire automatically.
   #
   # Spec: docs/target/sidekiq-free.md §12 (Sidekiq::Launcher).
   class Launcher
     include Component
 
     # 5 years, in seconds. Per-day `stat:processed:YYYY-MM-DD` /
-    # `stat:failed:YYYY-MM-DD` strings carry this TTL so they roll off
-    # without manual cleanup.
+    # `stat:failed:YYYY-MM-DD` / `stat:expired:YYYY-MM-DD` strings carry
+    # this TTL so they roll off without manual cleanup.
     STATS_TTL = 5 * 365 * 24 * 60 * 60
 
     # Re-exported for test/third-party callers that read it off Launcher
@@ -99,14 +99,15 @@ module Wurk
     end
 
     # Rolls in-process Processor counters into Redis. Pipelined so a single
-    # round trip covers all six writes. Skips when both counters are zero
-    # to avoid touching keys we have nothing to add to.
+    # round trip covers all writes. Skips when all counters are zero to
+    # avoid touching keys we have nothing to add to.
     def flush_stats
       processed = Processor::PROCESSED.reset
       failed = Processor::FAILURE.reset
-      return if processed.zero? && failed.zero?
+      expired = Processor::EXPIRED.reset
+      return if processed.zero? && failed.zero? && expired.zero?
 
-      write_stats(processed, failed)
+      write_stats(processed, failed, expired)
     rescue StandardError => e
       # Replay-safety: counters were reset above, so a Redis blip would
       # otherwise drop stats. We log and accept — the per-job at-least-once
@@ -120,16 +121,25 @@ module Wurk
 
     private
 
-    def write_stats(processed, failed)
+    def write_stats(processed, failed, expired)
       day = Time.now.utc.strftime('%F')
       @config.redis do |conn|
         conn.pipelined do |pipe|
-          pipe.call('INCRBY', Keys::STAT_PROCESSED, processed)
-          pipe.call('INCRBY', "#{Keys::STAT_PROCESSED}:#{day}", processed)
-          pipe.call('EXPIRE', "#{Keys::STAT_PROCESSED}:#{day}", STATS_TTL)
-          pipe.call('INCRBY', 'stat:failed', failed)
-          pipe.call('INCRBY', "stat:failed:#{day}", failed)
-          pipe.call('EXPIRE', "stat:failed:#{day}", STATS_TTL)
+          if processed.positive?
+            pipe.call('INCRBY', Keys::STAT_PROCESSED, processed)
+            pipe.call('INCRBY', "#{Keys::STAT_PROCESSED}:#{day}", processed)
+            pipe.call('EXPIRE', "#{Keys::STAT_PROCESSED}:#{day}", STATS_TTL)
+          end
+          if failed.positive?
+            pipe.call('INCRBY', 'stat:failed', failed)
+            pipe.call('INCRBY', "stat:failed:#{day}", failed)
+            pipe.call('EXPIRE', "stat:failed:#{day}", STATS_TTL)
+          end
+          if expired.positive?
+            pipe.call('INCRBY', Keys::STAT_EXPIRED, expired)
+            pipe.call('INCRBY', "#{Keys::STAT_EXPIRED}:#{day}", expired)
+            pipe.call('EXPIRE', "#{Keys::STAT_EXPIRED}:#{day}", STATS_TTL)
+          end
         end
       end
     end

--- a/lib/wurk/launcher.rb
+++ b/lib/wurk/launcher.rb
@@ -125,23 +125,19 @@ module Wurk
       day = Time.now.utc.strftime('%F')
       @config.redis do |conn|
         conn.pipelined do |pipe|
-          if processed.positive?
-            pipe.call('INCRBY', Keys::STAT_PROCESSED, processed)
-            pipe.call('INCRBY', "#{Keys::STAT_PROCESSED}:#{day}", processed)
-            pipe.call('EXPIRE', "#{Keys::STAT_PROCESSED}:#{day}", STATS_TTL)
-          end
-          if failed.positive?
-            pipe.call('INCRBY', 'stat:failed', failed)
-            pipe.call('INCRBY', "stat:failed:#{day}", failed)
-            pipe.call('EXPIRE', "stat:failed:#{day}", STATS_TTL)
-          end
-          if expired.positive?
-            pipe.call('INCRBY', Keys::STAT_EXPIRED, expired)
-            pipe.call('INCRBY', "#{Keys::STAT_EXPIRED}:#{day}", expired)
-            pipe.call('EXPIRE', "#{Keys::STAT_EXPIRED}:#{day}", STATS_TTL)
-          end
+          incr_stat_key(pipe, Keys::STAT_PROCESSED, processed, day)
+          incr_stat_key(pipe, 'stat:failed', failed, day)
+          incr_stat_key(pipe, Keys::STAT_EXPIRED, expired, day)
         end
       end
+    end
+
+    def incr_stat_key(pipe, key, value, day)
+      return unless value.positive?
+
+      pipe.call('INCRBY', key, value)
+      pipe.call('INCRBY', "#{key}:#{day}", value)
+      pipe.call('EXPIRE', "#{key}:#{day}", STATS_TTL)
     end
 
     # Pipelined identity write via Heartbeat, then dispatch any signals

--- a/lib/wurk/middleware/expiry.rb
+++ b/lib/wurk/middleware/expiry.rb
@@ -2,6 +2,7 @@
 
 require_relative '../middleware'
 require_relative '../metrics/statsd'
+require_relative '../processor'
 
 module Wurk
   module Middleware
@@ -11,6 +12,9 @@ module Wurk
     # longer preempts — long-running jobs that started in time finish.
     #
     # The skip path:
+    #   * bumps Wurk::Processor::EXPIRED so the heartbeat flushes
+    #     `stat:expired` + `stat:expired:YYYY-MM-DD` to Redis, surfacing the
+    #     count in Wurk::Stats and the dashboard
     #   * emits `jobs.expired` via Wurk::Metrics::Statsd (no-op when no client
     #     is configured)
     #   * returns without yielding — no exception, so JobRetry treats it as a
@@ -18,6 +22,10 @@ module Wurk
     #   * counts as a batch success: because this middleware is registered
     #     AFTER `Wurk::Batch::ServerMiddleware`, returning unwinds back through
     #     batch's `yield`, and batch's `ack_success` still runs on the way out
+    #
+    # The expired job is *also* counted toward PROCESSED — Processor#stats's
+    # ensure block always increments PROCESSED, so EXPIRED is an additive
+    # subset (executed = processed - failed - expired). Matches Sidekiq Pro.
     #
     # Spec: docs/target/sidekiq-pro.md §7.
     class Expiry
@@ -28,6 +36,7 @@ module Wurk
         return yield unless expiry
 
         if ::Time.now.to_f > expiry.to_f
+          Wurk::Processor::EXPIRED.incr
           Wurk::Metrics::Statsd.increment('jobs.expired', tags: ["class:#{job['class']}"])
           return
         end

--- a/lib/wurk/processor.rb
+++ b/lib/wurk/processor.rb
@@ -130,6 +130,7 @@ module Wurk
 
     PROCESSED  = Counter.new
     FAILURE    = Counter.new
+    EXPIRED    = Counter.new
     WORK_STATE = SharedWorkState.new
 
     private

--- a/lib/wurk/stats.rb
+++ b/lib/wurk/stats.rb
@@ -23,6 +23,7 @@ module Wurk
 
     def processed       = @stats.fetch(:processed)
     def failed          = @stats.fetch(:failed)
+    def expired         = @stats.fetch(:expired)
     def scheduled_size  = @stats.fetch(:scheduled_size)
     def retry_size      = @stats.fetch(:retry_size)
     def dead_size       = @stats.fetch(:dead_size)
@@ -85,11 +86,11 @@ module Wurk
       compute_latency(payload, now_ms)
     end
 
-    # Resets the named global counters. With no args, clears `processed`
-    # and `failed`. SET … 0 (not DEL — keeps the key around so reads stay
-    # `Integer` not `nil`).
+    # Resets the named global counters. With no args, clears `processed`,
+    # `failed`, and `expired`. SET … 0 (not DEL — keeps the key around so
+    # reads stay `Integer` not `nil`).
     def reset(*stats)
-      all      = %w[failed processed]
+      all      = %w[failed processed expired]
       to_clear = stats.empty? ? all : all & stats.flatten.map(&:to_s)
       Wurk.redis do |conn|
         conn.pipelined do |pipe|
@@ -105,12 +106,13 @@ module Wurk
     FAST_QUERIES = [
       ['GET',   'stat:processed'],
       ['GET',   'stat:failed'],
+      ['GET',   Keys::STAT_EXPIRED],
       ['ZCARD', Keys::SCHEDULE],
       ['ZCARD', Keys::RETRY],
       ['ZCARD', Keys::DEAD],
       ['SCARD', Keys::PROCESSES]
     ].freeze
-    FAST_KEYS = %i[processed failed scheduled_size retry_size dead_size processes_size].freeze
+    FAST_KEYS = %i[processed failed expired scheduled_size retry_size dead_size processes_size].freeze
     private_constant :FAST_QUERIES, :FAST_KEYS
 
     def fetch_stats_fast!
@@ -147,9 +149,10 @@ module Wurk
       0.0
     end
 
-    # Per-day historical processed/failed counts. Reads
-    # `stat:processed:YYYY-MM-DD` and `stat:failed:YYYY-MM-DD` strings;
-    # missing days return 0. Range 1..1825 (5 years) mirrors upstream.
+    # Per-day historical processed/failed/expired counts. Reads
+    # `stat:processed:YYYY-MM-DD`, `stat:failed:YYYY-MM-DD`, and
+    # `stat:expired:YYYY-MM-DD` strings; missing days return 0. Range
+    # 1..1825 (5 years) mirrors upstream.
     class History
       MAX_DAYS = 1_825
 
@@ -163,6 +166,7 @@ module Wurk
 
       def processed = date_stat_hash('processed')
       def failed    = date_stat_hash('failed')
+      def expired   = date_stat_hash('expired')
 
       private
 

--- a/test/engine/api_endpoints_test.rb
+++ b/test/engine/api_endpoints_test.rb
@@ -31,7 +31,7 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
   end
 
   STATS_KEYS = %i[
-    processed failed scheduled_size retry_size dead_size
+    processed failed expired scheduled_size retry_size dead_size
     processes_size enqueued default_queue_latency
   ].freeze
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,6 +44,12 @@ module Wurk
     # the reader see 0 instead of the identity it just registered.
     PROCESSES_MUTEX = Mutex.new
 
+    # Suite-wide mutex for tests that read/write the in-process
+    # `Wurk::Processor::{PROCESSED, FAILURE, EXPIRED}` counters and then
+    # assert on their value. Without it, the LauncherTest flush_stats
+    # tests and MiddlewareExpiryTest's EXPIRED.incr would race.
+    PROCESSOR_COUNTER_MUTEX = Mutex.new
+
     # Base class for non-engine tests.
     class UnitCase < ::Minitest::Test
       include RedisNamespace

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -34,8 +34,10 @@ class LauncherTest < Wurk::Test::UnitCase
       c.call('UNLINK',
              "stat:processed-#{@ns}",
              "stat:failed-#{@ns}",
+             "stat:expired-#{@ns}",
              "stat:processed:#{day}-#{@ns}",
-             "stat:failed:#{day}-#{@ns}")
+             "stat:failed:#{day}-#{@ns}",
+             "stat:expired:#{day}-#{@ns}")
     end
   ensure
     super
@@ -212,54 +214,81 @@ class LauncherTest < Wurk::Test::UnitCase
   # --- flush_stats -----------------------------------------------------
 
   def test_flush_stats_noops_when_counters_zero
-    launcher = Wurk::Launcher.new(@config)
-    Wurk::Processor::PROCESSED.reset
-    Wurk::Processor::FAILURE.reset
-    write_called = false
-    launcher.define_singleton_method(:write_stats) { |_p, _f| write_called = true }
+    Wurk::Test::PROCESSOR_COUNTER_MUTEX.synchronize do
+      launcher = Wurk::Launcher.new(@config)
+      reset_counters
+      write_called = false
+      launcher.define_singleton_method(:write_stats) { |_p, _f, _e| write_called = true }
 
-    launcher.flush_stats
+      launcher.flush_stats
 
-    refute write_called, 'write_stats must not run when both counters are zero'
+      refute write_called, 'write_stats must not run when all counters are zero'
+    end
   end
 
   def test_flush_stats_increments_global_counters
-    launcher = Wurk::Launcher.new(@config)
-    reset_counters
-    Wurk::Processor::PROCESSED.incr(3)
-    Wurk::Processor::FAILURE.incr(1)
-    received = nil
-    launcher.define_singleton_method(:write_stats) { |p, f| received = [p, f] }
+    Wurk::Test::PROCESSOR_COUNTER_MUTEX.synchronize do
+      launcher = Wurk::Launcher.new(@config)
+      reset_counters
+      Wurk::Processor::PROCESSED.incr(3)
+      Wurk::Processor::FAILURE.incr(1)
+      Wurk::Processor::EXPIRED.incr(2)
+      received = nil
+      launcher.define_singleton_method(:write_stats) { |p, f, e| received = [p, f, e] }
 
-    launcher.flush_stats
+      launcher.flush_stats
 
-    assert_equal [3, 1], received
+      assert_equal [3, 1, 2], received
+    end
+  end
+
+  def test_flush_stats_fires_write_stats_when_only_expired_is_nonzero
+    Wurk::Test::PROCESSOR_COUNTER_MUTEX.synchronize do
+      launcher = Wurk::Launcher.new(@config)
+      reset_counters
+      Wurk::Processor::EXPIRED.incr(1)
+      received = nil
+      launcher.define_singleton_method(:write_stats) { |p, f, e| received = [p, f, e] }
+
+      launcher.flush_stats
+
+      assert_equal [0, 0, 1], received
+    end
   end
 
   def test_flush_stats_sets_ttl_on_per_day_keys
-    launcher = Wurk::Launcher.new(@config)
-    reset_counters
-    Wurk::Processor::PROCESSED.incr(1)
-    Wurk::Processor::FAILURE.incr(1)
+    Wurk::Test::PROCESSOR_COUNTER_MUTEX.synchronize do
+      launcher = Wurk::Launcher.new(@config)
+      reset_counters
+      Wurk::Processor::PROCESSED.incr(1)
+      Wurk::Processor::FAILURE.incr(1)
+      Wurk::Processor::EXPIRED.incr(1)
 
-    launcher.flush_stats
+      launcher.flush_stats
 
-    day = Time.now.utc.strftime('%F')
-    ttl_p, ttl_f = read_daily_ttls(day)
+      day = Time.now.utc.strftime('%F')
+      ttl_p, ttl_f, ttl_e = read_daily_ttls(day)
 
-    assert_operator ttl_p, :>, 0
-    assert_operator ttl_f, :>, 0
+      assert_operator ttl_p, :>, 0
+      assert_operator ttl_f, :>, 0
+      assert_operator ttl_e, :>, 0
+    end
   end
 
   def test_flush_stats_resets_in_process_counters
-    launcher = Wurk::Launcher.new(@config)
-    Wurk::Processor::PROCESSED.incr(5)
-    Wurk::Processor::FAILURE.incr(2)
+    Wurk::Test::PROCESSOR_COUNTER_MUTEX.synchronize do
+      launcher = Wurk::Launcher.new(@config)
+      reset_counters
+      Wurk::Processor::PROCESSED.incr(5)
+      Wurk::Processor::FAILURE.incr(2)
+      Wurk::Processor::EXPIRED.incr(3)
 
-    launcher.flush_stats
+      launcher.flush_stats
 
-    assert_equal 0, Wurk::Processor::PROCESSED.reset
-    assert_equal 0, Wurk::Processor::FAILURE.reset
+      assert_equal 0, Wurk::Processor::PROCESSED.reset
+      assert_equal 0, Wurk::Processor::FAILURE.reset
+      assert_equal 0, Wurk::Processor::EXPIRED.reset
+    end
   end
 
   # --- heartbeat -------------------------------------------------------
@@ -455,11 +484,16 @@ class LauncherTest < Wurk::Test::UnitCase
   def reset_counters
     Wurk::Processor::PROCESSED.reset
     Wurk::Processor::FAILURE.reset
+    Wurk::Processor::EXPIRED.reset
   end
 
   def read_daily_ttls(day)
     @pool.with do |c|
-      [c.call('TTL', "#{Wurk::Keys::STAT_PROCESSED}:#{day}").to_i, c.call('TTL', "stat:failed:#{day}").to_i]
+      [
+        c.call('TTL', "#{Wurk::Keys::STAT_PROCESSED}:#{day}").to_i,
+        c.call('TTL', "stat:failed:#{day}").to_i,
+        c.call('TTL', "#{Wurk::Keys::STAT_EXPIRED}:#{day}").to_i
+      ]
     end
   end
 

--- a/test/unit/middleware_expiry_test.rb
+++ b/test/unit/middleware_expiry_test.rb
@@ -158,6 +158,28 @@ class MiddlewareExpiryTest < Wurk::Test::UnitCase
     end
   end
 
+  # The EXPIRED counter is a process-global singleton. Serialize against
+  # LauncherTest's flush_stats tests which also reset/incr it.
+  def test_skip_bumps_processor_expired_counter
+    Wurk::Test::PROCESSOR_COUNTER_MUTEX.synchronize do
+      Wurk::Processor::EXPIRED.reset
+      past = ::Time.now.to_f - 60
+      build_middleware.call(nil, { 'class' => 'X', 'expiry' => past }, 'q') { flunk 'must not yield' }
+
+      assert_equal 1, Wurk::Processor::EXPIRED.reset
+    end
+  end
+
+  def test_does_not_bump_expired_counter_on_yield
+    Wurk::Test::PROCESSOR_COUNTER_MUTEX.synchronize do
+      Wurk::Processor::EXPIRED.reset
+      future = ::Time.now.to_f + 60
+      build_middleware.call(nil, { 'class' => 'X', 'expiry' => future }, 'q') { :ok }
+
+      assert_equal 0, Wurk::Processor::EXPIRED.reset
+    end
+  end
+
   def test_expiry_at_exactly_now_does_not_skip
     # Strict `>` per spec §7: equal timestamps aren't expired yet.
     # Minitest 6 dropped `Time.stub`; hand-rolled override pins Time.now

--- a/test/unit/middleware_expiry_test.rb
+++ b/test/unit/middleware_expiry_test.rb
@@ -164,6 +164,7 @@ class MiddlewareExpiryTest < Wurk::Test::UnitCase
     Wurk::Test::PROCESSOR_COUNTER_MUTEX.synchronize do
       Wurk::Processor::EXPIRED.reset
       past = ::Time.now.to_f - 60
+
       build_middleware.call(nil, { 'class' => 'X', 'expiry' => past }, 'q') { flunk 'must not yield' }
 
       assert_equal 1, Wurk::Processor::EXPIRED.reset

--- a/test/unit/stats_test.rb
+++ b/test/unit/stats_test.rb
@@ -356,12 +356,13 @@ class StatsTest < Wurk::Test::UnitCase
   end
 
   def test_history_expired_returns_hash_keyed_by_date_string
-    today = Date.today.strftime('%Y-%m-%d')
-    @pool.with { |c| c.call('SET', "stat:expired:#{today}", 7) }
+    date = Date.new(2000, 1, 1) + (object_id % 10_000)
+    day = date.strftime('%Y-%m-%d')
+    @pool.with { |c| c.call('SET', "stat:expired:#{day}", 7) }
     begin
-      assert_equal 7, Wurk::Stats::History.new(3).expired[today]
+      assert_equal 7, Wurk::Stats::History.new(1, date).expired[day]
     ensure
-      @pool.with { |c| c.call('DEL', "stat:expired:#{today}") }
+      @pool.with { |c| c.call('DEL', "stat:expired:#{day}") }
     end
   end
 

--- a/test/unit/stats_test.rb
+++ b/test/unit/stats_test.rb
@@ -38,6 +38,7 @@ class StatsTest < Wurk::Test::UnitCase
     COUNTER_MUTEX.synchronize do
       @processed_before = @pool.with { |c| c.call('GET', 'stat:processed') }
       @failed_before    = @pool.with { |c| c.call('GET', 'stat:failed') }
+      @expired_before   = @pool.with { |c| c.call('GET', 'stat:expired') }
     end
   end
 
@@ -55,6 +56,7 @@ class StatsTest < Wurk::Test::UnitCase
       COUNTER_MUTEX.synchronize do
         restore_counter(conn, 'stat:processed', @processed_before)
         restore_counter(conn, 'stat:failed',    @failed_before)
+        restore_counter(conn, 'stat:expired',   @expired_before)
       end
     end
   ensure
@@ -82,6 +84,19 @@ class StatsTest < Wurk::Test::UnitCase
       @pool.with { |c| c.call('INCRBY', 'stat:failed', 3) }
 
       assert_operator Wurk::Stats.new.failed, :>=, base + 3
+    end
+  end
+
+  def test_expired_returns_integer
+    assert_kind_of Integer, Wurk::Stats.new.expired
+  end
+
+  def test_expired_reflects_redis_value
+    COUNTER_MUTEX.synchronize do
+      base = Wurk::Stats.new.expired
+      @pool.with { |c| c.call('INCRBY', 'stat:expired', 5) }
+
+      assert_operator Wurk::Stats.new.expired, :>=, base + 5
     end
   end
 
@@ -239,11 +254,12 @@ class StatsTest < Wurk::Test::UnitCase
 
   # --- reset -------------------------------------------------------------
 
-  def test_reset_clears_both_counters_by_default
+  def test_reset_clears_all_counters_by_default
     COUNTER_MUTEX.synchronize do
       @pool.with do |c|
         c.call('SET', 'stat:processed', 999)
         c.call('SET', 'stat:failed', 999)
+        c.call('SET', 'stat:expired', 999)
       end
       Wurk::Stats.new.reset
 
@@ -251,6 +267,22 @@ class StatsTest < Wurk::Test::UnitCase
 
       assert_equal 0, snap.processed
       assert_equal 0, snap.failed
+      assert_equal 0, snap.expired
+    end
+  end
+
+  def test_reset_with_expired_clears_only_expired
+    COUNTER_MUTEX.synchronize do
+      @pool.with do |c|
+        c.call('SET', 'stat:processed', 30)
+        c.call('SET', 'stat:expired', 90)
+      end
+      Wurk::Stats.new.reset('expired')
+
+      snap = Wurk::Stats.new
+
+      assert_equal 0, snap.expired
+      assert_operator snap.processed, :>=, 30
     end
   end
 
@@ -320,6 +352,16 @@ class StatsTest < Wurk::Test::UnitCase
       assert_equal 4, Wurk::Stats::History.new(3).failed[today]
     ensure
       @pool.with { |c| c.call('DEL', "stat:failed:#{today}") }
+    end
+  end
+
+  def test_history_expired_returns_hash_keyed_by_date_string
+    today = Date.today.strftime('%Y-%m-%d')
+    @pool.with { |c| c.call('SET', "stat:expired:#{today}", 7) }
+    begin
+      assert_equal 7, Wurk::Stats::History.new(3).expired[today]
+    ensure
+      @pool.with { |c| c.call('DEL', "stat:expired:#{today}") }
     end
   end
 


### PR DESCRIPTION
## Summary
Closes the third scope bullet of #20 ("counter for expired jobs surfaced in stats + dashboard"). The client-side stamping and server-side skip already shipped in #9; this PR adds the visibility layer.

- `Wurk::Processor::EXPIRED` atomic in-process counter, bumped by the Expiry middleware on skip. Additive subset of `PROCESSED` (executed = processed − failed − expired), matching Sidekiq Pro.
- `Launcher.flush_stats` writes `stat:expired` + `stat:expired:YYYY-MM-DD` (5y TTL) alongside processed/failed.
- `Wurk::Stats#expired`, `Stats::History#expired`, `Stats#reset` defaults include expired.
- `stats_payload` JSON exposes `expired`; SPA renders an Expired tile and SSE streams it. i18n added for all 7 shipped locales.

## Test plan
- [x] `bin/rake test` — 1446 runs, 0 failures locally.
- [x] End-to-end Redis repro: enqueue with `expires_in: -5` → middleware skips → counter increments → flush writes global + per-day with TTL → `Stats#expired` reads it → `/wurk/api/stats` exposes it.
- [x] Frontend `tsc -b` clean.
- [x] CI green (gate via claudetm).
- [x] CodeRabbit comments resolved (gate via claudetm).

## Notes (separate follow-up issues being filed)
Three pre-existing bugs surfaced during local QA, all unrelated to this PR — each gets its own issue:
1. `exe/wurk` standalone runner — fetcher nil because only `Swarm::ChildBoot#apply_slot_to_config` wires it.
2. Railtie's `Wurk.configuration.topology` — undefined on Configuration, after-initialize errors silently and the swarm never forks from a Rails host.
3. Engine's `Rack::Static` mount — `urls: ['/wurk-assets']` + `root: vendor/assets/dashboard` mismatch (Rack doesn't strip the URL prefix), so dashboard assets 404 in any mounted host.

Closes #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard shows a new "Expired" metric counting jobs that expired before processing; metric is tracked and exposed in the stats API.

* **Internationalization**
  * Added "Expired" translations for English, Spanish, French, German, Japanese, Portuguese (Brazil), and Simplified Chinese.

* **Tests**
  * Expanded tests to cover the expired metric, its counters, reset/TTL behavior, and middleware interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/developerz-ai/wurk/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->