### PR TITLE
feat: reliable_push opt-in `:raise` overflow + background drainer (closes #19)

### DIFF
--- a/lib/wurk/client/buffered.rb
+++ b/lib/wurk/client/buffered.rb
@@ -14,6 +14,26 @@ module Wurk
       DEFAULT_BUFFER_CAP = 1_000
       DRAINING_KEY = :wurk_reliable_push_draining
 
+      # Overflow modes. `:drop_oldest` is the spec default (Sidekiq Pro §5
+      # ring buffer). `:raise` lets callers decide what to do on backpressure
+      # — Wurk extension surfaced for issue #19's "over-cap pushes raise so
+      # callers can decide" requirement.
+      OVERFLOW_MODES        = %i[drop_oldest raise].freeze
+      DEFAULT_OVERFLOW_MODE = :drop_oldest
+
+      # Raised by `enbuffer` when the cap would be exceeded under
+      # `overflow_mode == :raise`. Inherits from RuntimeError so callers
+      # can rescue narrowly. The payload that triggered the overflow rides
+      # along so the caller can persist/log/forward it.
+      class Overflow < RuntimeError
+        attr_reader :payload
+
+        def initialize(payload)
+          @payload = payload
+          super("reliable_push buffer is full (cap=#{Buffered.buffer_cap})")
+        end
+      end
+
       # Eagerly initialized: `||=` inside an accessor is not atomic — two
       # threads racing first-touch could end up holding distinct Mutex
       # instances and lose all synchronization on the shared buffer.
@@ -53,21 +73,45 @@ module Wurk
           buffer_mutex.synchronize { buffer.size }
         end
 
+        def overflow_mode
+          @overflow_mode ||= DEFAULT_OVERFLOW_MODE
+        end
+
+        def overflow_mode=(mode)
+          mode = mode.to_sym
+          raise ArgumentError, "overflow_mode must be one of #{OVERFLOW_MODES.inspect}" unless OVERFLOW_MODES.include?(mode)
+
+          @overflow_mode = mode
+        end
+
         def reset!
           buffer_mutex.synchronize do
             @buffer = []
             @buffer_cap = nil
+            @overflow_mode = nil
           end
         end
 
-        # Append payloads to the ring; oldest evicted when over cap.
+        # Append payloads to the buffer. Behavior on cap exhaustion depends
+        # on `overflow_mode`:
+        #   * :drop_oldest (default, spec) — ring buffer, oldest evicted.
+        #   * :raise                       — Overflow raised, buffer left
+        #                                    unchanged for already-appended
+        #                                    siblings in the same call; the
+        #                                    offending payload is attached
+        #                                    to the exception.
         # Drops batched payloads — caller is expected to re-raise for those.
         def enbuffer(payloads)
           cap = buffer_cap
+          mode = overflow_mode
           buffer_mutex.synchronize do
             payloads.each do |p|
+              if buffer.size >= cap
+                raise Overflow, p if mode == :raise
+
+                buffer.shift # :drop_oldest
+              end
               buffer << p
-              buffer.shift while buffer.size > cap
             end
           end
         end
@@ -95,6 +139,31 @@ module Wurk
           @buffer ||= []
         end
 
+        # Start a background drain thread that wakes every `interval`
+        # seconds and tries to flush the buffer. Idempotent — replaces
+        # any prior drainer with one at the new interval. Issue #19
+        # requirement: "Background drain thread flushes on reconnect" —
+        # handles the case where push activity stops mid-outage so the
+        # passive (drain-on-next-push) path never fires.
+        def start_drainer!(interval: Drainer::DEFAULT_INTERVAL)
+          INSTALL_MUTEX.synchronize do
+            @drainer&.stop
+            @drainer = Drainer.new(interval: interval)
+            @drainer.start
+          end
+        end
+
+        def stop_drainer!
+          INSTALL_MUTEX.synchronize do
+            @drainer&.stop
+            @drainer = nil
+          end
+        end
+
+        def drainer_running?
+          INSTALL_MUTEX.synchronize { @drainer&.running? == true }
+        end
+
         private
 
         def install_mutex
@@ -120,6 +189,73 @@ module Wurk
           false
         ensure
           Thread.current[DRAINING_KEY] = false
+        end
+      end
+
+      # Background drain thread. Wakes every `interval` seconds and tries
+      # `Buffered.drain!` against a fresh Wurk::Client. drain! already
+      # short-circuits on the first ConnectionError, so a still-down Redis
+      # just leaves the buffer alone for this tick — no exponential
+      # backoff or explicit "reconnect detection" needed; the inner
+      # connection retry already lives inside `client.raw_push`.
+      class Drainer
+        DEFAULT_INTERVAL = 2.0
+        STOP_JOIN_TIMEOUT = 5.0
+
+        def initialize(interval: DEFAULT_INTERVAL, client_factory: -> { Wurk::Client.new })
+          raise ArgumentError, 'interval must be a positive Numeric' unless interval.is_a?(Numeric) && interval.positive?
+
+          @interval = interval
+          @client_factory = client_factory
+          @done = false
+          @thread = nil
+          @wake = ConditionVariable.new
+          @lock = Mutex.new
+        end
+
+        def start
+          @lock.synchronize do
+            return if @thread&.alive?
+
+            @done = false
+            @thread = Thread.new { run }
+            @thread.name = 'wurk-reliable_push-drainer'
+          end
+        end
+
+        def stop
+          @lock.synchronize do
+            @done = true
+            @wake.broadcast
+          end
+          @thread&.join(STOP_JOIN_TIMEOUT)
+          @thread = nil
+        end
+
+        def running?
+          @thread&.alive? == true
+        end
+
+        private
+
+        def run
+          until @done
+            wait_interval
+            break if @done
+
+            begin
+              Buffered.drain!(@client_factory.call)
+            rescue StandardError
+              # Swallow — next tick retries. Don't let a transient blow up
+              # the daemon thread.
+            end
+          end
+        end
+
+        # Mutex+ConditionVariable lets `stop` wake the thread immediately
+        # instead of waiting up to `interval` seconds for sleep to return.
+        def wait_interval
+          @lock.synchronize { @wake.wait(@lock, @interval) unless @done }
         end
       end
 
@@ -169,6 +305,35 @@ module Wurk
 
       def reliable_push_buffer=(value)
         Buffered.buffer_cap = value
+      end
+
+      def reliable_push_overflow
+        Buffered.overflow_mode
+      end
+
+      def reliable_push_overflow=(mode)
+        Buffered.overflow_mode = mode
+      end
+
+      # Start an opt-in background drainer thread. Implicitly enables
+      # reliable_push! so callers don't have to chain the two. Idempotent;
+      # calling again replaces the thread with one at the new interval.
+      # Spec for reliable_push (sidekiq-pro.md §5) only requires drain on
+      # next push — this is a Wurk extension for issue #19's "Background
+      # drain thread flushes on reconnect" so producer-stopped-mid-outage
+      # buffers don't sit idle until next push.
+      def reliable_push_drainer(interval: Buffered::Drainer::DEFAULT_INTERVAL)
+        Buffered.install!
+        Buffered.start_drainer!(interval: interval)
+        true
+      end
+
+      def reliable_push_drainer_stop!
+        Buffered.stop_drainer!
+      end
+
+      def reliable_push_drainer_running?
+        Buffered.drainer_running?
       end
     end
   end

--- a/lib/wurk/client/buffered.rb
+++ b/lib/wurk/client/buffered.rb
@@ -131,6 +131,9 @@ module Wurk
 
         private
 
+        # Capture the pool from the provided client and set it as the default
+        # factory for the drainer. Ensures buffered jobs are drained to the
+        # same pool they were pushed to, unless explicitly overridden.
         def capture_pool_from_client(client)
           return unless client && !buffer_client_factory
 

--- a/lib/wurk/client/buffered.rb
+++ b/lib/wurk/client/buffered.rb
@@ -79,7 +79,9 @@ module Wurk
 
         def overflow_mode=(mode)
           mode = mode.to_sym
-          raise ArgumentError, "overflow_mode must be one of #{OVERFLOW_MODES.inspect}" unless OVERFLOW_MODES.include?(mode)
+          unless OVERFLOW_MODES.include?(mode)
+            raise ArgumentError, "overflow_mode must be one of #{OVERFLOW_MODES.inspect}"
+          end
 
           @overflow_mode = mode
         end
@@ -145,10 +147,11 @@ module Wurk
         # requirement: "Background drain thread flushes on reconnect" —
         # handles the case where push activity stops mid-outage so the
         # passive (drain-on-next-push) path never fires.
-        def start_drainer!(interval: Drainer::DEFAULT_INTERVAL)
+        def start_drainer!(interval: Drainer::DEFAULT_INTERVAL, client_factory: nil)
           INSTALL_MUTEX.synchronize do
             @drainer&.stop
-            @drainer = Drainer.new(interval: interval)
+            factory = client_factory || -> { Wurk::Client.new }
+            @drainer = Drainer.new(interval: interval, client_factory: factory)
             @drainer.start
           end
         end
@@ -203,7 +206,9 @@ module Wurk
         STOP_JOIN_TIMEOUT = 5.0
 
         def initialize(interval: DEFAULT_INTERVAL, client_factory: -> { Wurk::Client.new })
-          raise ArgumentError, 'interval must be a positive Numeric' unless interval.is_a?(Numeric) && interval.positive?
+          unless interval.is_a?(Numeric) && interval.positive?
+            raise ArgumentError, 'interval must be a positive Numeric'
+          end
 
           @interval = interval
           @client_factory = client_factory
@@ -218,8 +223,10 @@ module Wurk
             return if @thread&.alive?
 
             @done = false
-            @thread = Thread.new { run }
-            @thread.name = 'wurk-reliable_push-drainer'
+            @thread = Thread.new do
+              Thread.current.name = 'wurk-reliable_push-drainer'
+              run
+            end
           end
         end
 

--- a/lib/wurk/client/buffered.rb
+++ b/lib/wurk/client/buffered.rb
@@ -41,6 +41,8 @@ module Wurk
       BUFFER_MUTEX  = Mutex.new
 
       class << self
+        attr_accessor :buffer_client_factory
+
         # Idempotent. Prepends the wrapper module into Wurk::Client so push /
         # push_bulk drain the buffer before each call and raw_push catches
         # connection errors. Safe to call from multiple threads.
@@ -78,7 +80,12 @@ module Wurk
         end
 
         def overflow_mode=(mode)
-          mode = mode.to_sym
+          begin
+            mode = mode.to_sym
+          rescue NoMethodError, TypeError
+            raise ArgumentError, "overflow_mode must be one of #{OVERFLOW_MODES.inspect}"
+          end
+
           unless OVERFLOW_MODES.include?(mode)
             raise ArgumentError, "overflow_mode must be one of #{OVERFLOW_MODES.inspect}"
           end
@@ -91,6 +98,7 @@ module Wurk
             @buffer = []
             @buffer_cap = nil
             @overflow_mode = nil
+            @buffer_client_factory = nil
           end
         end
 
@@ -103,7 +111,10 @@ module Wurk
         #                                    offending payload is attached
         #                                    to the exception.
         # Drops batched payloads — caller is expected to re-raise for those.
-        def enbuffer(payloads)
+        # If client is provided, captures its pool for drainer to use by default.
+        def enbuffer(payloads, client: nil)
+          capture_pool_from_client(client)
+
           cap = buffer_cap
           mode = overflow_mode
           buffer_mutex.synchronize do
@@ -117,6 +128,17 @@ module Wurk
             end
           end
         end
+
+        private
+
+        def capture_pool_from_client(client)
+          return unless client && !buffer_client_factory
+
+          pool = client.instance_variable_get(:@pool)
+          self.buffer_client_factory = -> { Wurk::Client.new(pool: pool) }
+        end
+
+        public
 
         # Drain payloads through `raw_push` on the given client. Stops on
         # the first ConnectionError, preserving order at the head of the
@@ -150,7 +172,7 @@ module Wurk
         def start_drainer!(interval: Drainer::DEFAULT_INTERVAL, client_factory: nil)
           INSTALL_MUTEX.synchronize do
             @drainer&.stop
-            factory = client_factory || -> { Wurk::Client.new }
+            factory = client_factory || buffer_client_factory || -> { Wurk::Client.new }
             @drainer = Drainer.new(interval: interval, client_factory: factory)
             @drainer.start
           end
@@ -287,7 +309,7 @@ module Wurk
           raise if Thread.current[Buffered::DRAINING_KEY]
 
           bidless, batched = payloads.partition { |p| !p['bid'] }
-          Buffered.enbuffer(bidless) if bidless.any?
+          Buffered.enbuffer(bidless, client: self) if bidless.any?
           raise unless batched.empty?
         end
       end

--- a/test/unit/client_buffered_test.rb
+++ b/test/unit/client_buffered_test.rb
@@ -33,6 +33,7 @@ class ClientBufferedTest < Wurk::Test::UnitCase
   end
 
   def teardown
+    Wurk::Client.reliable_push_drainer_stop!
     Wurk::Client::Buffered.reset!
     @pool.with do |conn|
       conn.call('DEL', "queue:#{@queue}")
@@ -184,6 +185,108 @@ class ClientBufferedTest < Wurk::Test::UnitCase
     assert_equal [[1], [2], [3]], Wurk::Client::Buffered.buffer.map { |p| p['args'] } # rubocop:disable Lint/AmbiguousBlockAssociation
   end
 
+  # --- overflow mode (issue #19, opt-in raise on cap) --------------------
+
+  def test_overflow_mode_default_is_drop_oldest
+    assert_equal :drop_oldest, Wurk::Client::Buffered.overflow_mode
+    assert_equal :drop_oldest, Wurk::Client.reliable_push_overflow
+  end
+
+  def test_overflow_mode_setter_accepts_known_modes
+    Wurk::Client.reliable_push_overflow = :raise
+
+    assert_equal :raise, Wurk::Client.reliable_push_overflow
+
+    Wurk::Client.reliable_push_overflow = 'drop_oldest'
+
+    assert_equal :drop_oldest, Wurk::Client.reliable_push_overflow
+  end
+
+  def test_overflow_mode_setter_rejects_unknown
+    assert_raises(ArgumentError) { Wurk::Client.reliable_push_overflow = :explode }
+  end
+
+  def test_overflow_raise_raises_when_cap_reached
+    Wurk::Client.reliable_push_buffer = 2
+    Wurk::Client.reliable_push_overflow = :raise
+    failing = build_client(failing_pool)
+
+    failing.push(base_item('args' => ['first']))
+    failing.push(base_item('args' => ['second']))
+
+    err = assert_raises(Wurk::Client::Buffered::Overflow) { failing.push(base_item('args' => ['third'])) }
+
+    assert_equal ['third'], err.payload['args']
+    assert_equal 2, Wurk::Client::Buffered.buffer_size, 'buffer untouched by overflow payload'
+  end
+
+  def test_overflow_raise_preserves_oldest_when_cap_reached
+    Wurk::Client.reliable_push_buffer = 1
+    Wurk::Client.reliable_push_overflow = :raise
+    failing = build_client(failing_pool)
+
+    failing.push(base_item('args' => ['keep']))
+    assert_raises(Wurk::Client::Buffered::Overflow) { failing.push(base_item('args' => ['reject'])) }
+
+    assert_equal [['keep']], Wurk::Client::Buffered.buffer.map { |p| p['args'] } # rubocop:disable Lint/AmbiguousBlockAssociation
+  end
+
+  # --- background drainer (issue #19) ------------------------------------
+
+  def test_reliable_push_drainer_starts_thread
+    Wurk::Client.reliable_push_drainer(interval: 0.05)
+
+    assert_predicate Wurk::Client, :reliable_push_drainer_running?
+  end
+
+  def test_reliable_push_drainer_idempotent_restart
+    Wurk::Client.reliable_push_drainer(interval: 0.05)
+    first = Wurk::Client::Buffered.instance_variable_get(:@drainer)
+    Wurk::Client.reliable_push_drainer(interval: 0.1)
+    second = Wurk::Client::Buffered.instance_variable_get(:@drainer)
+
+    refute_same first, second
+    assert_predicate Wurk::Client, :reliable_push_drainer_running?
+  end
+
+  def test_reliable_push_drainer_stop
+    Wurk::Client.reliable_push_drainer(interval: 0.05)
+    Wurk::Client.reliable_push_drainer_stop!
+
+    refute_predicate Wurk::Client, :reliable_push_drainer_running?
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def test_drainer_drains_buffer_against_recovering_pool
+    pool = togglable_pool
+    failing_client = build_client(pool.failing_facade)
+    failing_client.push(base_item('args' => ['a']))
+    failing_client.push(base_item('args' => ['b']))
+
+    assert_equal 2, Wurk::Client::Buffered.buffer_size
+
+    # Background drainer points at the real Redis pool — once it ticks,
+    # both queued payloads should land in the live queue.
+    Wurk::Client::Buffered.start_drainer!(interval: 0.02)
+    Wurk::Client::Buffered.instance_variable_get(:@drainer).instance_variable_set(
+      :@client_factory, -> { Wurk::Client.new(pool: @pool) }
+    )
+
+    deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + 3.0
+    until Wurk::Client::Buffered.buffer_size.zero? || ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) > deadline
+      sleep 0.02
+    end
+
+    assert_equal 0, Wurk::Client::Buffered.buffer_size, "drainer did not flush buffer within 3s"
+    assert_equal [['a'], ['b']], queued_args.reverse
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  def test_drainer_rejects_non_positive_interval
+    assert_raises(ArgumentError) { Wurk::Client::Buffered::Drainer.new(interval: 0) }
+    assert_raises(ArgumentError) { Wurk::Client::Buffered::Drainer.new(interval: -1) }
+  end
+
   private
 
   # Statsd singletons are process-global — serialize against every other test
@@ -219,6 +322,26 @@ class ClientBufferedTest < Wurk::Test::UnitCase
       blk.call(FailingConn.new)
     end
     pool
+  end
+
+  # A togglable pool wrapper for the drainer integration test. Exposes
+  # `failing_facade` for the producer (raises ConnectionError) and the
+  # real pool stays untouched for the drainer to recover into.
+  def togglable_pool
+    real_pool = @pool
+    TogglablePoolPair.new(real_pool)
+  end
+
+  class TogglablePoolPair
+    def initialize(real_pool)
+      @real_pool = real_pool
+    end
+
+    def failing_facade
+      facade = Object.new
+      facade.define_singleton_method(:with) { |&blk| blk.call(FailingConn.new) }
+      facade
+    end
   end
 
   def queued_payloads

--- a/test/unit/client_outage_test.rb
+++ b/test/unit/client_outage_test.rb
@@ -38,7 +38,7 @@ class ClientOutageTest < Wurk::Test::UnitCase
     super
   end
 
-  # rubocop:disable Metrics/AbcSize, Minitest/MultipleAssertions
+  # rubocop:disable Metrics/AbcSize
   def test_producer_through_redis_outage_preserves_all_jobs_in_order
     pool   = TogglablePool.new(@real_pool)
     client = Wurk::Client.new(pool: pool)
@@ -60,7 +60,7 @@ class ClientOutageTest < Wurk::Test::UnitCase
 
     assert_equal %w[1 2 3 4 5], tags
   end
-  # rubocop:enable Metrics/AbcSize, Minitest/MultipleAssertions
+  # rubocop:enable Metrics/AbcSize
 
   # The producer-stops case the background drainer exists for — without it,
   # the passive drain-on-next-push path never fires.
@@ -74,11 +74,9 @@ class ClientOutageTest < Wurk::Test::UnitCase
 
     assert_equal 3, Wurk::Client::Buffered.buffer_size
 
-    Wurk::Client::Buffered.start_drainer!(interval: 0.02)
-    # Drainer's default factory uses the global config pool; redirect to
-    # @real_pool so recovery lands in the queue we assert on.
-    Wurk::Client::Buffered.instance_variable_get(:@drainer).instance_variable_set(
-      :@client_factory, -> { Wurk::Client.new(pool: @real_pool) }
+    Wurk::Client::Buffered.start_drainer!(
+      interval: 0.02,
+      client_factory: -> { Wurk::Client.new(pool: @real_pool) }
     )
     pool.recover!
 

--- a/test/unit/client_outage_test.rb
+++ b/test/unit/client_outage_test.rb
@@ -3,20 +3,15 @@
 require_relative '../test_helper'
 require 'json'
 
-# Issue #19 DoD: "Kill Redis for 10s while a producer pushes → no exceptions;
-# on Redis return, all jobs land in correct queue in order."
-#
-# Simulates a real outage by routing the producer's pushes through a togglable
-# pool that swaps between a `FailingConn` (raises RedisClient::ConnectionError
-# on every pipelined call, mimicking a dead socket) and the live Redis pool.
-# We do NOT bring down the real Redis — that would race every other parallel
-# test sharing the instance.
+# Issue #19 DoD coverage. The togglable pool stands in for the real outage
+# because `redis-cli SHUTDOWN` / `DEBUG SLEEP` would race every parallel
+# sibling against the shared test Redis. Drain + LRANGE assertions still
+# round-trip through the live server.
 class ClientOutageTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  # Wurk::Client::Buffered installs InstanceMethods globally; tests that
-  # toggle activation or mutate the singleton buffer/drainer must serialize
-  # within this class.
+  # Buffered installs InstanceMethods globally; serialize within this class
+  # so the singleton buffer/drainer state can't race sibling tests.
   MUTEX = Mutex.new
 
   def run(*args, &)
@@ -43,28 +38,19 @@ class ClientOutageTest < Wurk::Test::UnitCase
     super
   end
 
-  # The DoD scenario. A producer pushes 5 jobs total: 1 before the outage,
-  # 3 during, 1 after. Buffered catches the middle 3; the next post-outage
-  # push drains them oldest-first then enqueues #5. End state: 5 jobs in
-  # the queue in original push order.
   # rubocop:disable Metrics/AbcSize, Minitest/MultipleAssertions
   def test_producer_through_redis_outage_preserves_all_jobs_in_order
     pool   = TogglablePool.new(@real_pool)
     client = Wurk::Client.new(pool: pool)
 
-    # Push #1 — pool is healthy, lands in Redis directly.
     client.push(item(tag: '1'))
 
     pool.fail!
-
-    # Push #2..#4 during the outage — buffered, no exceptions raised.
     %w[2 3 4].each { |t| client.push(item(tag: t)) }
 
     assert_equal 3, Wurk::Client::Buffered.buffer_size, 'all 3 outage pushes must buffer'
 
     pool.recover!
-
-    # Push #5 — drains 2,3,4 then pushes 5.
     client.push(item(tag: '5'))
 
     assert_equal 0, Wurk::Client::Buffered.buffer_size
@@ -76,9 +62,8 @@ class ClientOutageTest < Wurk::Test::UnitCase
   end
   # rubocop:enable Metrics/AbcSize, Minitest/MultipleAssertions
 
-  # The producer-stops-mid-outage case the background drainer exists for.
-  # No further pushes happen after the buffered batch, so the passive
-  # drain-on-next-push path would never fire; the drainer thread must.
+  # The producer-stops case the background drainer exists for — without it,
+  # the passive drain-on-next-push path never fires.
   # rubocop:disable Metrics/AbcSize
   def test_background_drainer_flushes_when_pool_recovers_without_new_push
     pool = TogglablePool.new(@real_pool)
@@ -90,8 +75,8 @@ class ClientOutageTest < Wurk::Test::UnitCase
     assert_equal 3, Wurk::Client::Buffered.buffer_size
 
     Wurk::Client::Buffered.start_drainer!(interval: 0.02)
-    # Point the drainer at the live pool (its built-in factory uses the
-    # global config pool; we want it to recover *into* @real_pool).
+    # Drainer's default factory uses the global config pool; redirect to
+    # @real_pool so recovery lands in the queue we assert on.
     Wurk::Client::Buffered.instance_variable_get(:@drainer).instance_variable_set(
       :@client_factory, -> { Wurk::Client.new(pool: @real_pool) }
     )
@@ -117,10 +102,6 @@ class ClientOutageTest < Wurk::Test::UnitCase
     { 'class' => @class_name, 'args' => [tag], 'queue' => @queue }
   end
 
-  # Toggles between healthy (delegates to the real pool) and failing
-  # (yields a connection whose `call` raises ConnectionError on every
-  # invocation). Thread-safe — `fail!` / `recover!` only flip an atomic
-  # flag read in `with`.
   class TogglablePool
     def initialize(real_pool)
       @real_pool = real_pool
@@ -145,7 +126,6 @@ class ClientOutageTest < Wurk::Test::UnitCase
     end
   end
 
-  # Mimics a dead socket. Raises on every pipelined call.
   class FailingConn
     def pipelined
       yield self

--- a/test/unit/client_outage_test.rb
+++ b/test/unit/client_outage_test.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'json'
+
+# Issue #19 DoD: "Kill Redis for 10s while a producer pushes → no exceptions;
+# on Redis return, all jobs land in correct queue in order."
+#
+# Simulates a real outage by routing the producer's pushes through a togglable
+# pool that swaps between a `FailingConn` (raises RedisClient::ConnectionError
+# on every pipelined call, mimicking a dead socket) and the live Redis pool.
+# We do NOT bring down the real Redis — that would race every other parallel
+# test sharing the instance.
+class ClientOutageTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  # Wurk::Client::Buffered installs InstanceMethods globally; tests that
+  # toggle activation or mutate the singleton buffer/drainer must serialize
+  # within this class.
+  MUTEX = Mutex.new
+
+  def run(*args, &)
+    MUTEX.synchronize { super }
+  end
+
+  def setup
+    super
+    @real_pool  = Wurk.configuration.redis_pool
+    @class_name = "OutageJob@#{Process.pid}-#{object_id}"
+    @queue      = "outage-q-#{Process.pid}-#{object_id}"
+    Wurk::Client.reliable_push!
+    Wurk::Client::Buffered.reset!
+  end
+
+  def teardown
+    Wurk::Client.reliable_push_drainer_stop!
+    Wurk::Client::Buffered.reset!
+    @real_pool.with do |c|
+      c.call('DEL', "queue:#{@queue}")
+      c.call('SREM', 'queues', @queue)
+    end
+  ensure
+    super
+  end
+
+  # The DoD scenario. A producer pushes 5 jobs total: 1 before the outage,
+  # 3 during, 1 after. Buffered catches the middle 3; the next post-outage
+  # push drains them oldest-first then enqueues #5. End state: 5 jobs in
+  # the queue in original push order.
+  # rubocop:disable Metrics/AbcSize, Minitest/MultipleAssertions
+  def test_producer_through_redis_outage_preserves_all_jobs_in_order
+    pool   = TogglablePool.new(@real_pool)
+    client = Wurk::Client.new(pool: pool)
+
+    # Push #1 — pool is healthy, lands in Redis directly.
+    client.push(item(tag: '1'))
+
+    pool.fail!
+
+    # Push #2..#4 during the outage — buffered, no exceptions raised.
+    %w[2 3 4].each { |t| client.push(item(tag: t)) }
+
+    assert_equal 3, Wurk::Client::Buffered.buffer_size, 'all 3 outage pushes must buffer'
+
+    pool.recover!
+
+    # Push #5 — drains 2,3,4 then pushes 5.
+    client.push(item(tag: '5'))
+
+    assert_equal 0, Wurk::Client::Buffered.buffer_size
+
+    queued = @real_pool.with { |c| c.call('LRANGE', "queue:#{@queue}", 0, -1) }
+    tags = queued.map { |s| JSON.parse(s)['args'].first }.reverse
+
+    assert_equal %w[1 2 3 4 5], tags
+  end
+  # rubocop:enable Metrics/AbcSize, Minitest/MultipleAssertions
+
+  # The producer-stops-mid-outage case the background drainer exists for.
+  # No further pushes happen after the buffered batch, so the passive
+  # drain-on-next-push path would never fire; the drainer thread must.
+  # rubocop:disable Metrics/AbcSize
+  def test_background_drainer_flushes_when_pool_recovers_without_new_push
+    pool = TogglablePool.new(@real_pool)
+    client = Wurk::Client.new(pool: pool)
+
+    pool.fail!
+    %w[a b c].each { |t| client.push(item(tag: t)) }
+
+    assert_equal 3, Wurk::Client::Buffered.buffer_size
+
+    Wurk::Client::Buffered.start_drainer!(interval: 0.02)
+    # Point the drainer at the live pool (its built-in factory uses the
+    # global config pool; we want it to recover *into* @real_pool).
+    Wurk::Client::Buffered.instance_variable_get(:@drainer).instance_variable_set(
+      :@client_factory, -> { Wurk::Client.new(pool: @real_pool) }
+    )
+    pool.recover!
+
+    deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + 3.0
+    until Wurk::Client::Buffered.buffer_size.zero? || ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) > deadline
+      sleep 0.02
+    end
+
+    assert_equal 0, Wurk::Client::Buffered.buffer_size, 'background drainer did not flush within 3s'
+
+    queued = @real_pool.with { |c| c.call('LRANGE', "queue:#{@queue}", 0, -1) }
+    tags = queued.map { |s| JSON.parse(s)['args'].first }.reverse
+
+    assert_equal %w[a b c], tags
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  private
+
+  def item(tag:)
+    { 'class' => @class_name, 'args' => [tag], 'queue' => @queue }
+  end
+
+  # Toggles between healthy (delegates to the real pool) and failing
+  # (yields a connection whose `call` raises ConnectionError on every
+  # invocation). Thread-safe — `fail!` / `recover!` only flip an atomic
+  # flag read in `with`.
+  class TogglablePool
+    def initialize(real_pool)
+      @real_pool = real_pool
+      @failing = false
+      @mutex = Mutex.new
+    end
+
+    def fail!
+      @mutex.synchronize { @failing = true }
+    end
+
+    def recover!
+      @mutex.synchronize { @failing = false }
+    end
+
+    def with(&)
+      if @mutex.synchronize { @failing }
+        yield FailingConn.new
+      else
+        @real_pool.with(&)
+      end
+    end
+  end
+
+  # Mimics a dead socket. Raises on every pipelined call.
+  class FailingConn
+    def pipelined
+      yield self
+    end
+
+    def call(*)
+      raise RedisClient::ConnectionError, 'simulated outage'
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Re-lands the client outage-buffer work after the PR #38 → #39 revert. Closes #19.

The buffered client already shipped the Sidekiq Pro §5 spec (ring buffer, drain on next push, batched-payload bypass). This PR adds the two issue extensions on top, both opt-in so the spec-compat default is unchanged.

- **\`Wurk::Client.reliable_push_overflow = :raise\`** — when the cap is reached, \`enbuffer\` raises \`Wurk::Client::Buffered::Overflow\` with the offending payload attached on the exception. Default stays \`:drop_oldest\` (spec).
- **\`Wurk::Client.reliable_push_drainer(interval:)\`** — opt-in background thread that periodically attempts to flush the buffer. Handles the *producer-stops-mid-outage* case where the passive drain-on-next-push path would never fire.

## What's different vs the reverted PR #38
- CodeRabbit's \"trim comments that restate code\" finding is **already applied** on this branch (commit \`61853f4\`).
- No \`--auto-merge\`. Claudetm runs with \`--no-auto-merge\`; merge stays the user's click.

## Test plan
- [x] \`bin/rake test\` — 1451 / 0 failures
- [x] \`bin/rake test:parity\` — 16 / 0 failures
- [x] \`bin/rake test:ecosystem\` — all suites passed
- [x] Behavioral driver (\`/tmp/outage_drive.rb\`) verified locally — all 3 scenarios (DoD, background drainer, \`:raise\` overflow) pass
- [x] CI green (gate via claudetm)
- [x] CodeRabbit clean + every thread addressed (gate via claudetm)

## DoD verification
Per issue #19: *\"Kill Redis for 10s while a producer pushes → no exceptions; on Redis return, all jobs land in correct queue in order.\"* Covered end-to-end by \`test_producer_through_redis_outage_preserves_all_jobs_in_order\` (real Redis through a togglable pool) and verified manually with the driver script.

Closes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable overflow handling for the reliable push buffer: drop oldest (default) or raise an Overflow (includes offending payload); reset clears configuration.
  * Optional background drainer thread to periodically flush buffered jobs, with interval validation, responsive stop, and error resilience. Starting the drainer enables reliable-push behavior tied to the originating client.

* **Tests**
  * Unit and integration tests covering overflow semantics, drainer lifecycle/validation, and buffering behavior during simulated Redis outages; tests ensure drainer teardown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/developerz-ai/wurk/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->