### PR TITLE
feat: liveness HTTP endpoint for k8s probes (closes #23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,53 @@ Anything implemented here MUST match `docs/target/sidekiq-{free,pro,ent}.md` exa
 
 ---
 
+## 🩺 Kubernetes probes
+
+Opt in to a thin HTTP listener for liveness/readiness probes:
+
+```ruby
+Wurk.configure_server do |config|
+  config.health_check(port: 7433)
+end
+```
+
+Endpoints (off by default; only start when `health_check` is configured):
+
+| Path     | Meaning                                                                 |
+|----------|-------------------------------------------------------------------------|
+| `/live`  | 200 while the Launcher is running. 503 once `stop` / `quiet` is called. |
+| `/ready` | 200 only when Redis is reachable **and** the heartbeat fired within the last 30s (configurable). 503 otherwise. |
+
+Example k8s `Deployment` spec:
+
+```yaml
+spec:
+  template:
+    spec:
+      containers:
+        - name: wurk
+          image: myorg/myapp:latest
+          ports:
+            - containerPort: 7433
+              name: health
+          livenessProbe:
+            httpGet:
+              path: /live
+              port: health
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: health
+            periodSeconds: 5
+            failureThreshold: 2
+```
+
+Knobs: `health_check(port:, bind: '0.0.0.0', ready_window: 30)`. In swarm mode only the first child to call `start` binds the port; the rest log a warning and skip — drive your supervisor topology accordingly.
+
+---
+
 ## 🤝 Migration
 
 ```diff

--- a/lib/wurk.rb
+++ b/lib/wurk.rb
@@ -209,6 +209,11 @@ require_relative 'wurk/batch/death_handler'
 # Spec: docs/target/sidekiq-pro.md §7.
 require_relative 'wurk/middleware/expiry'
 
+# Health probe HTTP server — opt-in via `config.health_check(port:)`. Loaded
+# at top level so the constants resolve in Launcher#build_health_server even
+# in standalone (no-Rails) boot.
+require_relative 'wurk/health'
+
 # Poison-pill detection — orphan recovery counter + dead set on threshold.
 # Spec: docs/target/sidekiq-pro.md §3.2.
 require_relative 'wurk/middleware/poison_pill'

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -229,7 +229,15 @@ module Wurk
     # Spec: docs/target/sidekiq-ent.md §7.1.2.
     def health_check(port:, bind: '0.0.0.0', ready_window: 30)
       guard_frozen!
-      @options[:health_check_options] = { port: port.to_i, bind: bind.to_s, ready_window: ready_window.to_i }
+      p = Integer(port)
+      rw = Integer(ready_window)
+      raise ArgumentError, 'port must be between 0 and 65535' unless (0..65535).cover?(p)
+      raise ArgumentError, 'ready_window must be > 0' unless rw.positive?
+
+      b = bind.to_s
+      raise ArgumentError, 'bind must be a non-empty string' if b.empty?
+
+      @options[:health_check_options] = { port: p, bind: b, ready_window: rw }
     end
 
     # --- Lifecycle hooks --------------------------------------------------

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -217,6 +217,21 @@ module Wurk
       @periodic_manager
     end
 
+    # --- K8s liveness/readiness probes -----------------------------------
+
+    # Opt-in thin HTTP listener inside the worker process for k8s probes.
+    # When called, the Launcher will start a TCP server on `port` bound to
+    # `bind` exposing `GET /live` (200 while not stopping) and `GET /ready`
+    # (200 only when Redis is reachable AND heartbeat fired within
+    # `ready_window` seconds).
+    #
+    # Off by default — call this in a `configure_server` block to enable.
+    # Spec: docs/target/sidekiq-ent.md §7.1.2.
+    def health_check(port:, bind: '0.0.0.0', ready_window: 30)
+      guard_frozen!
+      @options[:health_check_options] = { port: port.to_i, bind: bind.to_s, ready_window: ready_window.to_i }
+    end
+
     # --- Lifecycle hooks --------------------------------------------------
 
     def on(event, &block)

--- a/lib/wurk/health.rb
+++ b/lib/wurk/health.rb
@@ -85,21 +85,28 @@ module Wurk
             handle(client) if client
           rescue ::IO::WaitReadable
             next
+          rescue ::StandardError => e
+            logger&.error { "Wurk::Health accept: #{e.class}: #{e.message}" }
+            next
           end
         end
       rescue ::IOError, ::Errno::EBADF
         # Server was closed during shutdown — expected.
-      rescue ::StandardError => e
-        logger&.error { "Wurk::Health accept loop: #{e.class}: #{e.message}" }
       end
 
       def handle(client)
+        return unless ::IO.select([client], nil, nil, 1.0)
         request_line = client.gets("\r\n")
         return if request_line.nil?
 
         method, path, = request_line.strip.split(' ', 3)
         # Drain remaining headers; ignore the body (probes don't send one).
-        while (line = client.gets("\r\n")) && line != "\r\n"
+        # Wait for readability before each gets so a stalled client can't
+        # block the single accept thread mid-headers.
+        loop do
+          break unless ::IO.select([client], nil, nil, 1.0)
+          line = client.gets("\r\n")
+          break if line.nil? || line == "\r\n"
         end
 
         body, status = response_for(method, path)

--- a/lib/wurk/health.rb
+++ b/lib/wurk/health.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+require 'socket'
+require 'json'
+
+module Wurk
+  # Thin HTTP listener for k8s liveness/readiness probes. Optional, off by
+  # default — opt in with `config.health_check(port: 7433)`.
+  #
+  # Endpoints:
+  #   * GET /live  → 200 while the Launcher is running (not in quiet/stop).
+  #   * GET /ready → 200 only when Redis is reachable AND the heartbeat has
+  #                  fired within `ready_window` seconds. 503 otherwise.
+  # Anything else returns 404 JSON.
+  #
+  # The server uses a raw TCPServer and one accept thread. No Rack, no
+  # dependencies — it lives inside every worker process where Rails may or
+  # may not exist (standalone CLI, Embedded, swarm child). Bound to a
+  # dedicated port so it does not collide with the host application's HTTP.
+  #
+  # Spec: docs/target/sidekiq-ent.md §7.1.2 (`config.health_check`).
+  module Health
+    DEFAULT_PORT          = 7433
+    DEFAULT_BIND          = '0.0.0.0'
+    DEFAULT_READY_WINDOW  = 30
+
+    # The HTTP listener. Owns one TCPServer + one accept thread. Idempotent
+    # start/stop; safe to call from Launcher#run / Launcher#stop.
+    class Server
+      ACCEPT_TIMEOUT = 0.2
+
+      attr_reader :port, :bind
+
+      def initialize(launcher, port: DEFAULT_PORT, bind: DEFAULT_BIND, ready_window: DEFAULT_READY_WINDOW)
+        @launcher     = launcher
+        @config       = launcher.instance_variable_get(:@config)
+        @port         = port
+        @bind         = bind
+        @ready_window = ready_window
+        @server       = nil
+        @thread       = nil
+        @done         = false
+      end
+
+      def start
+        @server = ::TCPServer.new(@bind, @port)
+        # Capture the OS-assigned port when caller passed 0 (test pattern,
+        # also lets the kernel pick a free port at boot).
+        @port = @server.addr[1]
+        @done = false
+        @thread = ::Thread.new { run }
+        @thread.name = 'wurk-health'
+        self
+      rescue ::Errno::EADDRINUSE => e
+        # Swarm children all try to bind the same port — only the first wins.
+        # Don't crash the worker; just log and skip.
+        logger&.warn { "Wurk::Health: port #{@port} in use; health server NOT started (#{e.message})" }
+        @server = nil
+        @thread = nil
+        self
+      end
+
+      def stop
+        @done = true
+        srv = @server
+        @server = nil
+        srv&.close
+        @thread&.join(2)
+        @thread = nil
+      end
+
+      def running?
+        @thread&.alive? == true
+      end
+
+      private
+
+      def run
+        until @done
+          ready = ::IO.select([@server], nil, nil, ACCEPT_TIMEOUT)
+          next unless ready
+
+          begin
+            client, _addr = @server.accept_nonblock(exception: false)
+            handle(client) if client
+          rescue ::IO::WaitReadable
+            next
+          end
+        end
+      rescue ::IOError, ::Errno::EBADF
+        # Server was closed during shutdown — expected.
+      rescue ::StandardError => e
+        logger&.error { "Wurk::Health accept loop: #{e.class}: #{e.message}" }
+      end
+
+      def handle(client)
+        request_line = client.gets("\r\n")
+        return if request_line.nil?
+
+        method, path, = request_line.strip.split(' ', 3)
+        # Drain remaining headers; ignore the body (probes don't send one).
+        while (line = client.gets("\r\n")) && line != "\r\n"
+        end
+
+        body, status = response_for(method, path)
+        write_response(client, status, body)
+      rescue ::StandardError => e
+        logger&.error { "Wurk::Health request: #{e.class}: #{e.message}" }
+      ensure
+        client&.close
+      end
+
+      def response_for(method, path)
+        return [json('error', message: 'method not allowed'), 405] unless method == 'GET'
+
+        case path
+        when '/live'  then live_response
+        when '/ready' then ready_response
+        else [json('error', message: 'not found', path: path), 404]
+        end
+      end
+
+      def live_response
+        if @launcher.stopping?
+          [json('down', check: 'live', reason: 'stopping'), 503]
+        else
+          [json('ok', check: 'live'), 200]
+        end
+      end
+
+      def ready_response
+        redis_ok = ping_redis
+        beat_fresh = heartbeat_fresh?
+
+        if redis_ok && beat_fresh
+          [json('ok', check: 'ready'), 200]
+        else
+          reason = !redis_ok ? 'redis unreachable' : 'heartbeat stale'
+          [json('down', check: 'ready', reason: reason), 503]
+        end
+      end
+
+      def ping_redis
+        @config.redis { |conn| conn.call('PING') } == 'PONG'
+      rescue ::StandardError
+        false
+      end
+
+      def heartbeat_fresh?
+        hb = @launcher.instance_variable_get(:@heartbeat)
+        return false unless hb&.respond_to?(:last_beat_at)
+
+        last = hb.last_beat_at
+        return false if last.nil?
+
+        (::Time.now.to_f - last) < @ready_window
+      end
+
+      def json(status, **extra)
+        ::JSON.generate({ status: status }.merge(extra))
+      end
+
+      def write_response(client, status, body)
+        reason = case status
+                 when 200 then 'OK'
+                 when 404 then 'Not Found'
+                 when 405 then 'Method Not Allowed'
+                 when 503 then 'Service Unavailable'
+                 else 'Status'
+                 end
+
+        client.write(
+          "HTTP/1.1 #{status} #{reason}\r\n" \
+          "Content-Type: application/json\r\n" \
+          "Content-Length: #{body.bytesize}\r\n" \
+          "Connection: close\r\n\r\n" \
+          "#{body}"
+        )
+      end
+
+      def logger
+        @config&.logger
+      end
+    end
+  end
+end

--- a/lib/wurk/heartbeat.rb
+++ b/lib/wurk/heartbeat.rb
@@ -37,7 +37,7 @@ module Wurk
     BEAT_PAUSE = 10
     TTL_SECONDS = 60
 
-    attr_reader :identity, :rtt_us
+    attr_reader :identity, :rtt_us, :last_beat_at
 
     # `quiet:` is a callable so Launcher can keep ownership of its `@done`
     # flag without an awkward setter contract. `info_overrides:` lets the
@@ -58,6 +58,7 @@ module Wurk
     # `:heartbeat` so partition recovery is observable.
     def beat!
       sigs, @rtt_us = pipelined_beat
+      @last_beat_at = Time.now.to_f
       if @first_heartbeat
         @first_heartbeat = false
         fire_event(:heartbeat)

--- a/lib/wurk/launcher.rb
+++ b/lib/wurk/launcher.rb
@@ -4,6 +4,7 @@ require_relative 'component'
 require_relative 'manager'
 require_relative 'processor'
 require_relative 'heartbeat'
+require_relative 'health'
 require_relative 'keys'
 
 module Wurk
@@ -46,6 +47,7 @@ module Wurk
       @started_at = nil
       @heartbeat = nil
       @heartbeat_thread = nil
+      @health_server = build_health_server
     end
 
     # Boot order matters:
@@ -54,12 +56,15 @@ module Wurk
     #      sees the process the moment it can pick up jobs.
     #   3. start the poller (scheduler).
     #   4. start the managers (which start their processors).
+    #   5. start the health probe server LAST so the listener doesn't
+    #      accept k8s probes until the rest of the launcher is up.
     def run(async_beat: true)
       @started_at = Time.now.to_f
       @config.freeze!
       @heartbeat_thread = safe_thread('heartbeat', &method(:start_heartbeat)) if async_beat
       @poller&.start
       @managers.each(&:start)
+      @health_server&.start
     end
 
     # Idempotent. Flips `stopping?` true, halts fetching across every
@@ -164,10 +169,13 @@ module Wurk
 
     # Erase the live-process footprint. flush_stats first so we don't drop
     # the final batch of counters; then Heartbeat#stop! removes us from the
-    # `processes` SET and UNLINK-s the identity + work hashes.
+    # `processes` SET and UNLINK-s the identity + work hashes. The probe
+    # server is closed alongside so kubelet stops getting 200s after the
+    # process is no longer healthy.
     def clear_heartbeat
       flush_stats
       @heartbeat&.stop!
+      @health_server&.stop
     end
 
     # Heartbeat thread loop. `safe_thread` already wraps exceptions; we
@@ -196,6 +204,21 @@ module Wurk
       return nil unless defined?(Wurk::Scheduled::Poller)
 
       Wurk::Scheduled::Poller.new(@config)
+    end
+
+    # Returns a Health::Server when `config.health_check(...)` has set
+    # `:health_check_options`; nil otherwise. Off by default — the listener
+    # is opt-in to keep the worker's port surface minimal.
+    def build_health_server
+      opts = @config[:health_check_options]
+      return nil unless opts
+
+      Health::Server.new(
+        self,
+        port:         opts.fetch(:port, Health::DEFAULT_PORT),
+        bind:         opts.fetch(:bind, Health::DEFAULT_BIND),
+        ready_window: opts.fetch(:ready_window, Health::DEFAULT_READY_WINDOW)
+      )
     end
   end
 end

--- a/test/integration/liveness_probe_test.rb
+++ b/test/integration/liveness_probe_test.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'socket'
+require 'json'
+
+# Issue #23 DoD: "Manual test: kill Redis → /ready returns 503, /live stays
+# 200." This exercises the full Launcher → Heartbeat → Health::Server wiring
+# end-to-end against real TCP and real Redis. The Redis-down scenario uses a
+# togglable pool wrapper (same pattern as client_outage_test) so we don't
+# disrupt sibling tests by SHUTDOWN-ing the shared instance.
+class LivenessProbeTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  POLL_TIMEOUT = 3.0
+  POLL_INTERVAL = 0.05
+
+  def setup
+    super
+    @ns = "lp-#{Process.pid}-#{object_id}"
+    @config = Wurk::Configuration.new
+    @config.logger = ::Logger.new(IO::NULL)
+    @config[:tag] = @ns
+    cap = @config.default_capsule
+    cap.queues = ['default']
+    cap.concurrency = 1
+    cap.fetcher = Wurk::Fetcher::Reliable.new(cap)
+    # Materialize lazy ivars before Launcher.run freezes the capsule —
+    # otherwise Heartbeat#beat! and the health server's Redis ping hit
+    # FrozenError on first call. Mirrors Swarm::ChildBoot#apply_slot_to_config.
+    cap.redis_pool
+    cap.local_redis_pool
+    cap.client_middleware
+    cap.server_middleware
+    # Bind on 127.0.0.1:0 so each test gets a unique OS-assigned port.
+    @config.health_check(port: 0, bind: '127.0.0.1', ready_window: 5)
+    @launcher = nil
+  end
+
+  def teardown
+    if @launcher
+      @launcher.instance_variable_set(:@done, true)
+      @launcher.instance_variable_get(:@health_server)&.stop
+      @launcher.instance_variable_get(:@heartbeat)&.stop! rescue nil
+    end
+  ensure
+    super
+  end
+
+  def test_live_returns_200_when_launcher_running
+    boot_launcher
+
+    body = probe('/live')
+
+    assert_equal 200, body[:status_code]
+    assert_equal 'ok', body[:json]['status']
+  end
+
+  def test_ready_returns_200_once_first_heartbeat_fires
+    boot_launcher
+    @launcher.heartbeat # one synchronous beat so heartbeat_fresh? passes
+
+    body = probe('/ready')
+
+    assert_equal 200, body[:status_code]
+    assert_equal 'ok', body[:json]['status']
+  end
+
+  # Verifies the issue DoD: kill Redis (here: short-circuit beats so
+  # heartbeat goes stale within the launcher's view) → /ready returns 503,
+  # /live stays 200. The full "Redis socket actually unreachable" branch is
+  # covered by the unit test (HealthTest#test_ready_returns_503_when_redis_unreachable)
+  # because a hard pool swap on a frozen Launcher fights Configuration's
+  # freeze invariant by design.
+  def test_ready_returns_503_when_heartbeat_goes_stale_but_live_stays_200
+    boot_launcher
+    @launcher.heartbeat # one fresh beat
+    hb = @launcher.instance_variable_get(:@heartbeat)
+    # Rewind last_beat_at past the ready window so /ready treats it as stale.
+    hb.instance_variable_set(:@last_beat_at, ::Time.now.to_f - 60)
+
+    ready = probe('/ready')
+
+    assert_equal 503, ready[:status_code]
+    assert_equal 'heartbeat stale', ready[:json]['reason']
+
+    live = probe('/live')
+
+    assert_equal 200, live[:status_code], '/live must stay 200 while only the heartbeat is stale'
+  end
+
+  def test_live_returns_503_after_stop
+    boot_launcher
+    # Trigger stopping? without invoking the full stop pipeline (which would
+    # also tear down the health server before we can probe it).
+    @launcher.instance_variable_set(:@done, true)
+
+    body = probe('/live')
+
+    assert_equal 503, body[:status_code]
+    assert_equal 'stopping', body[:json]['reason']
+  end
+
+  private
+
+  def boot_launcher
+    @launcher = Wurk::Launcher.new(@config)
+    @launcher.run(async_beat: false)
+    wait_for_probe_listener
+    @launcher
+  end
+
+  # Health::Server starts in a thread; busy-wait until its port answers.
+  def wait_for_probe_listener
+    deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + POLL_TIMEOUT
+    while ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) < deadline
+      return if listener_ready?
+
+      sleep POLL_INTERVAL
+    end
+    flunk 'Health::Server did not start within poll timeout'
+  end
+
+  def listener_ready?
+    server = @launcher.instance_variable_get(:@health_server)
+    server&.running? == true && server.port.positive?
+  end
+
+  def probe(path)
+    server = @launcher.instance_variable_get(:@health_server)
+    raw = ::TCPSocket.open('127.0.0.1', server.port) do |s|
+      s.write("GET #{path} HTTP/1.1\r\nHost: localhost\r\n\r\n")
+      s.read
+    end
+    head, body = raw.split("\r\n\r\n", 2)
+    {
+      status_code: head.lines.first.split(' ', 3)[1].to_i,
+      json: ::JSON.parse(body)
+    }
+  end
+
+end

--- a/test/integration/liveness_probe_test.rb
+++ b/test/integration/liveness_probe_test.rb
@@ -17,7 +17,7 @@ class LivenessProbeTest < Wurk::Test::UnitCase
 
   def setup
     super
-    @ns = "lp-#{Process.pid}-#{object_id}"
+    @ns = "lp:#{Process.pid}:#{object_id}"
     @config = Wurk::Configuration.new
     @config.logger = ::Logger.new(IO::NULL)
     @config[:tag] = @ns
@@ -123,7 +123,12 @@ class LivenessProbeTest < Wurk::Test::UnitCase
 
   def listener_ready?
     server = @launcher.instance_variable_get(:@health_server)
-    server&.running? == true && server.port.positive?
+    return false unless server&.running? == true && server.port.positive?
+
+    ::TCPSocket.open('127.0.0.1', server.port, &:close)
+    true
+  rescue Errno::ECONNREFUSED, IOError
+    false
   end
 
   def probe(path)

--- a/test/unit/health_test.rb
+++ b/test/unit/health_test.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'socket'
+require 'json'
+
+# Drives Wurk::Health::Server against a stub Launcher. Real TCP sockets,
+# loopback only, port 0 so each test gets a fresh OS-assigned port — no
+# parallel-test collision.
+class HealthTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  class FakeRedisConn
+    def initialize(response: 'PONG', raise_with: nil)
+      @response = response
+      @raise_with = raise_with
+    end
+
+    def call(*)
+      raise @raise_with if @raise_with
+
+      @response
+    end
+  end
+
+  class FakeConfig
+    attr_reader :logger
+
+    def initialize(redis_conn: FakeRedisConn.new)
+      @logger = ::Logger.new(IO::NULL)
+      @redis_conn = redis_conn
+    end
+
+    def redis
+      yield @redis_conn
+    end
+  end
+
+  class FakeHeartbeat
+    attr_reader :last_beat_at
+
+    def initialize(last_beat_at: nil)
+      @last_beat_at = last_beat_at
+    end
+  end
+
+  class FakeLauncher
+    def initialize(config:, heartbeat: nil, stopping: false)
+      @config = config
+      @heartbeat = heartbeat
+      @stopping = stopping
+    end
+
+    def stopping?
+      @stopping
+    end
+  end
+
+  def teardown
+    @server&.stop
+  ensure
+    super
+  end
+
+  # --- /live --------------------------------------------------------------
+
+  def test_live_returns_200_when_launcher_running
+    launcher = FakeLauncher.new(config: FakeConfig.new)
+    body = get(launcher, '/live')
+
+    assert_equal 200, body[:status_code]
+    assert_equal 'ok', body[:json]['status']
+    assert_equal 'live', body[:json]['check']
+  end
+
+  def test_live_returns_503_when_launcher_stopping
+    launcher = FakeLauncher.new(config: FakeConfig.new, stopping: true)
+    body = get(launcher, '/live')
+
+    assert_equal 503, body[:status_code]
+    assert_equal 'down', body[:json]['status']
+    assert_equal 'stopping', body[:json]['reason']
+  end
+
+  # --- /ready -------------------------------------------------------------
+
+  def test_ready_returns_200_when_redis_up_and_heartbeat_fresh
+    launcher = FakeLauncher.new(
+      config: FakeConfig.new,
+      heartbeat: FakeHeartbeat.new(last_beat_at: ::Time.now.to_f)
+    )
+    body = get(launcher, '/ready')
+
+    assert_equal 200, body[:status_code]
+    assert_equal 'ok', body[:json]['status']
+  end
+
+  def test_ready_returns_503_when_redis_unreachable
+    failing = FakeRedisConn.new(raise_with: RedisClient::ConnectionError.new('down'))
+    launcher = FakeLauncher.new(
+      config: FakeConfig.new(redis_conn: failing),
+      heartbeat: FakeHeartbeat.new(last_beat_at: ::Time.now.to_f)
+    )
+    body = get(launcher, '/ready')
+
+    assert_equal 503, body[:status_code]
+    assert_equal 'redis unreachable', body[:json]['reason']
+  end
+
+  def test_ready_returns_503_when_heartbeat_never_fired
+    launcher = FakeLauncher.new(
+      config: FakeConfig.new,
+      heartbeat: FakeHeartbeat.new(last_beat_at: nil)
+    )
+    body = get(launcher, '/ready')
+
+    assert_equal 503, body[:status_code]
+    assert_equal 'heartbeat stale', body[:json]['reason']
+  end
+
+  def test_ready_returns_503_when_heartbeat_stale
+    launcher = FakeLauncher.new(
+      config: FakeConfig.new,
+      heartbeat: FakeHeartbeat.new(last_beat_at: ::Time.now.to_f - 60)
+    )
+    body = get(launcher, '/ready', ready_window: 30)
+
+    assert_equal 503, body[:status_code]
+    assert_equal 'heartbeat stale', body[:json]['reason']
+  end
+
+  # --- other paths --------------------------------------------------------
+
+  def test_unknown_path_returns_404_json
+    launcher = FakeLauncher.new(config: FakeConfig.new)
+    body = get(launcher, '/something')
+
+    assert_equal 404, body[:status_code]
+    assert_equal 'error', body[:json]['status']
+    assert_equal '/something', body[:json]['path']
+  end
+
+  def test_non_get_returns_405
+    launcher = FakeLauncher.new(config: FakeConfig.new)
+    body = request(launcher, "POST /live HTTP/1.1\r\nHost: x\r\n\r\n")
+
+    assert_equal 405, body[:status_code]
+  end
+
+  # --- lifecycle ----------------------------------------------------------
+
+  def test_start_idempotency_via_address_in_use
+    launcher = FakeLauncher.new(config: FakeConfig.new)
+    @server = build_server(launcher)
+    @server.start
+    port = @server.port
+
+    # Second server on the same explicit port must not raise — logs and skips.
+    second = Wurk::Health::Server.new(launcher, port: port, bind: '127.0.0.1')
+    second.start
+
+    refute_predicate second, :running?, 'second bind on busy port must skip cleanly'
+  end
+
+  def test_stop_terminates_thread_and_unbinds
+    launcher = FakeLauncher.new(config: FakeConfig.new)
+    @server = build_server(launcher)
+    @server.start
+
+    assert_predicate @server, :running?
+
+    @server.stop
+
+    refute_predicate @server, :running?
+  end
+
+  private
+
+  # Builds a server bound on 127.0.0.1:0 (OS-assigned port) so parallel
+  # tests can't collide on a fixed port.
+  def build_server(launcher, ready_window: 30)
+    Wurk::Health::Server.new(launcher, port: 0, bind: '127.0.0.1', ready_window: ready_window)
+  end
+
+  # Fires a single HTTP GET against a freshly-started server and parses
+  # the response into { status_code:, json: }. Server is stored on @server
+  # so teardown can shut it down even on test failure.
+  def get(launcher, path, ready_window: 30)
+    request(launcher, "GET #{path} HTTP/1.1\r\nHost: localhost\r\n\r\n", ready_window: ready_window)
+  end
+
+  def request(launcher, raw, ready_window: 30)
+    @server = build_server(launcher, ready_window: ready_window)
+    @server.start
+    raw_response = ::TCPSocket.open('127.0.0.1', @server.port) do |s|
+      s.write(raw)
+      s.read
+    end
+    parse_response(raw_response)
+  end
+
+  def parse_response(raw)
+    head, body = raw.split("\r\n\r\n", 2)
+    status_code = head.lines.first.split(' ', 3)[1].to_i
+    { status_code: status_code, json: ::JSON.parse(body) }
+  end
+end


### PR DESCRIPTION
## Summary
Opt-in thin HTTP listener inside the worker process for k8s liveness/readiness probes — matches Sidekiq Ent 7.1.2's `config.health_check` API. Off by default.

- **`Wurk::Health::Server`** — raw `TCPServer` + one accept thread; no Rack, no new dependencies. Lives inside every worker process whether Rails is loaded or not (standalone CLI, Embedded, swarm child).
- **`Configuration#health_check(port:, bind:, ready_window:)`** — opt-in knob. The Launcher builds + starts the listener last during `run`, tears it down during `clear_heartbeat` so kubelet stops getting 200s *before* the rest of the worker dies.
- **`Heartbeat#last_beat_at`** — records wall-clock time of each successful beat; `/ready` reads it to gate on heartbeat freshness.
- **README**: k8s `Deployment` example with `livenessProbe` + `readinessProbe`.

### Endpoints
| Path | Behavior |
|---|---|
| `GET /live` | 200 while `stopping?` is false. 503 with reason=`stopping` after `quiet`/`stop`. |
| `GET /ready` | 200 only when Redis `PING` succeeds **AND** heartbeat fired within `ready_window` (default 30s). 503 with reason=`redis unreachable` or `heartbeat stale` otherwise. |

## Test plan
- [x] `bin/rake test` — 1472 / 0 failures (incl. 10 new unit + 4 new integration tests)
- [x] `bin/rake test:parity` — 16 / 0 failures
- [x] `bin/rake test:ecosystem` — all suites passed
- [x] Behavioral driver verified locally — all 4 stages (no heartbeat, fresh heartbeat, stale heartbeat, stopping) produce expected statuses
- [x] Real Redis kill repro: `redis-cli SHUTDOWN NOSAVE` → `/ready: 503` + `/live: 200`; restart Redis → both back to 200
- [x] CI green (gate via claudetm)
- [x] CodeRabbit clean + every thread addressed (gate via claudetm)

## How to test in prod

1. Add to your `Wurk.configure_server` block and redeploy:
   ```ruby
   Wurk.configure_server do |config|
     config.health_check(port: 7433)
   end
   ```
   Then expose the port on the container (e.g. `containerPort: 7433`).

2. From a sidecar / another pod with `curl`:
   ```bash
   curl -s -o /dev/null -w "%{http_code}" http://<pod-ip>:7433/live    # → 200
   curl -s -o /dev/null -w "%{http_code}" http://<pod-ip>:7433/ready   # → 200
   ```

3. Pause Redis briefly to verify `/ready` correctly drains traffic without restarting the pod:
   ```bash
   kubectl exec redis-0 -- redis-cli DEBUG SLEEP 15
   ```
   While that's running:
   ```bash
   curl -s -o /dev/null -w "%{http_code}" http://<pod-ip>:7433/ready   # → 503
   curl -s -o /dev/null -w "%{http_code}" http://<pod-ip>:7433/live    # → still 200
   ```
   Kubelet stops sending traffic but doesn't bounce the pod. Once Redis recovers, both flip back to 200.

4. Wire up the probes in your `Deployment` — the README has a copy-paste YAML snippet.

## DoD verification
Per issue #23: *"Kill Redis → `/ready` returns 503, `/live` stays 200."* Covered by `LivenessProbeTest#test_ready_returns_503_when_heartbeat_goes_stale_but_live_stays_200` (integration, real Launcher + heartbeat rewind) + `HealthTest#test_ready_returns_503_when_redis_unreachable` (unit, FailingConn pool). Manually verified end-to-end with a real `redis-cli SHUTDOWN`.

Closes #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in in-worker Kubernetes health check (configurable port, bind, ready_window)
  * /live liveness endpoint (200 while running; 503 when stopping)
  * /ready readiness endpoint (200 only when Redis reachable and heartbeat fresh; 503 otherwise)
  * Supports requesting ephemeral port (port 0) and swarm-mode where only first child binds

* **Documentation**
  * README examples for configuration and Kubernetes probe snippets

* **Tests**
  * New unit and integration tests validating liveness/readiness behaviors and lifecycle

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/developerz-ai/wurk/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->