### PR TITLE
feat: StatsD metrics across hot paths (closes #21)

### DIFF
--- a/lib/wurk.rb
+++ b/lib/wurk.rb
@@ -225,6 +225,14 @@ require_relative 'wurk/middleware/poison_pill'
 # Spec: docs/target/sidekiq-ent.md §1.4.
 Wurk.configuration.server_middleware.add(Wurk::Limiter::ServerMiddleware)
 
+# Statsd metrics middleware: per-job count / success / failure / perform_dist
+# emissions. No-op when `config.dogstatsd` is unset (Statsd.client returns
+# nil and the middleware yields straight through), so auto-registering here
+# has zero overhead for users who don't wire up a client. Matches Sidekiq
+# Pro's behavior of installing the middleware as soon as the gem is loaded.
+# Spec: docs/target/sidekiq-pro.md §9.
+Wurk.configuration.server_middleware.add(Wurk::Metrics::Statsd)
+
 # Pro Fast API: Lua-backed Queue#delete_job / #delete_by_class plus
 # SortedSet#scan { |JobRecord| … }. Mixed in via include/prepend on the
 # existing data API classes so the surface is wire-compat with Sidekiq Pro.

--- a/lib/wurk/client.rb
+++ b/lib/wurk/client.rb
@@ -44,6 +44,7 @@ module Wurk
 
       verify_json(payload)
       raw_push([payload])
+      emit_enqueued([payload])
       payload['jid']
     end
 
@@ -150,7 +151,10 @@ module Wurk
         ats     = at_values && at_values[offset, slice.size]
         payloads = build_bulk_payloads(slice, base, ats)
         compacted = payloads.compact
-        raw_push(compacted) if compacted.any?
+        if compacted.any?
+          raw_push(compacted)
+          emit_enqueued(compacted)
+        end
         jids.concat(payloads.map { |p| p && p['jid'] })
       end
       jids
@@ -273,6 +277,19 @@ module Wurk
 
     def pool
       @redis_pool || Thread.current[:wurk_via_pool] || @config.redis_pool
+    end
+
+    # Best-effort `sidekiq.jobs.enqueued` counter — one increment per payload
+    # that actually made it past middleware AND Redis. Tags follow the same
+    # `worker:`/`queue:` shape as Wurk::Metrics::Statsd so dashboards built
+    # for the server-side emissions work unchanged.
+    def emit_enqueued(payloads)
+      payloads.each do |p|
+        Wurk::Metrics::Statsd.increment(
+          'jobs.enqueued',
+          tags: ["worker:#{p['class']}", "queue:#{p['queue']}"]
+        )
+      end
     end
   end
 end

--- a/lib/wurk/heartbeat.rb
+++ b/lib/wurk/heartbeat.rb
@@ -64,6 +64,7 @@ module Wurk
         fire_event(:heartbeat)
       end
       fire_event(:beat, oneshot: false)
+      emit_statsd_gauges
       sigs.compact
     rescue StandardError => e
       @first_heartbeat = true
@@ -161,6 +162,37 @@ module Wurk
 
     def total_concurrency
       @config.capsules.each_value.sum(&:concurrency)
+    end
+
+    # Best-effort statsd snapshot per beat. Emits `sidekiq.busy` (this
+    # process's in-flight job count) and `sidekiq.queue.size` (per queue
+    # LLEN). Tagged with `process:<identity>` so multi-process emissions
+    # of the global `queue.size` are tag-distinguishable downstream — pick
+    # `max` across the process tag in your dashboard. No-op when
+    # `config.dogstatsd` is unset (Statsd.gauge short-circuits on nil
+    # client) so the LLEN pipeline is also skipped.
+    # Spec hint: docs/target/sidekiq-ent.md §5.2 names (`busy`, `queue.size`).
+    def emit_statsd_gauges
+      return unless Wurk::Metrics::Statsd.client
+
+      busy = Processor::WORK_STATE.size
+      Wurk::Metrics::Statsd.gauge('busy', busy, tags: ["process:#{@identity}"])
+      emit_queue_sizes
+    rescue StandardError => e
+      handle_exception(e, { context: 'heartbeat metrics' })
+    end
+
+    def emit_queue_sizes
+      queues = @config.capsules.each_value.flat_map(&:queues).uniq
+      return if queues.empty?
+
+      sizes = redis { |conn| conn.pipelined { |pipe| queues.each { |q| pipe.call('LLEN', "queue:#{q}") } } }
+      queues.zip(sizes).each do |queue, size|
+        Wurk::Metrics::Statsd.gauge(
+          'queue.size', size,
+          tags: ["queue:#{queue}", "process:#{@identity}"]
+        )
+      end
     end
 
     # Linux first via /proc/self/statm[1] (resident pages × 4 KB);

--- a/lib/wurk/job_retry.rb
+++ b/lib/wurk/job_retry.rb
@@ -184,6 +184,10 @@ module Wurk
       redis do |conn|
         conn.call('ZADD', Keys::RETRY, retry_at.to_s, payload)
       end
+      Wurk::Metrics::Statsd.increment(
+        'jobs.retried',
+        tags: ["worker:#{msg['class']}", "queue:#{msg['queue']}"]
+      )
     end
 
     def time_for(item)

--- a/test/unit/client_buffered_test.rb
+++ b/test/unit/client_buffered_test.rb
@@ -126,7 +126,7 @@ class ClientBufferedTest < Wurk::Test::UnitCase
       Wurk::Client.new.push(base_item)
     end
 
-    assert_equal %w[jobs.recovered.push jobs.recovered.push], calls
+    assert_equal %w[jobs.recovered.push jobs.recovered.push], calls.grep('jobs.recovered.push')
   end
 
   # --- ring cap ----------------------------------------------------------

--- a/test/unit/metrics_emissions_test.rb
+++ b/test/unit/metrics_emissions_test.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Covers the StatsD emission sites wired through hot paths (issue #21):
+# Client#push / #push_bulk, JobRetry#schedule_retry, Heartbeat#beat!.
+# Each test sets `Wurk.configuration.dogstatsd` to a recording FakeClient and
+# inspects the calls list. Wrapped in `Wurk::Test::STATSD_MUTEX` because the
+# `Statsd` singleton state is process-global and serializes with the other
+# statsd-touching test files.
+class MetricsEmissionsTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def run(*args, &)
+    Wurk::Test::STATSD_MUTEX.synchronize { super }
+  end
+
+  class FakeClient
+    attr_reader :calls
+
+    def initialize
+      @calls = []
+    end
+
+    def increment(metric, **opts) = @calls << [:increment, metric, opts]
+    def gauge(metric, value, **opts) = @calls << [:gauge, metric, value, opts]
+    def distribution(metric, value, **opts) = @calls << [:distribution, metric, value, opts]
+  end
+
+  def setup
+    super
+    @ns = "me:#{Process.pid}:#{object_id}"
+    @prev_builder = Wurk.configuration.dogstatsd
+    Wurk::Metrics::Statsd.reset!
+    @fake = FakeClient.new
+    Wurk.configuration.dogstatsd = @fake
+  end
+
+  def teardown
+    Wurk.configuration.dogstatsd = @prev_builder
+    Wurk::Metrics::Statsd.reset!
+  ensure
+    super
+  end
+
+  # --- Client#push --------------------------------------------------------
+
+  def test_push_emits_jobs_enqueued_with_worker_and_queue_tags
+    Wurk::Client.new.push('class' => 'MyJob', 'queue' => @ns, 'args' => [])
+
+    enq = @fake.calls.find { |c| c[1] == 'sidekiq.jobs.enqueued' }
+
+    refute_nil enq, 'expected sidekiq.jobs.enqueued increment'
+    assert_equal ["worker:MyJob", "queue:#{@ns}"], enq[2][:tags]
+  ensure
+    cleanup_queue
+  end
+
+  def test_push_skips_emit_when_middleware_halts
+    halt = Class.new do
+      def call(_w, _job, _q, _r); end # returns nil → halt
+    end
+    Wurk.configuration.client_middleware.add(halt)
+    begin
+      Wurk::Client.new.push('class' => 'MyJob', 'queue' => @ns, 'args' => [])
+    ensure
+      Wurk.configuration.client_middleware.remove(halt)
+    end
+
+    assert_nil @fake.calls.find { |c| c[1] == 'sidekiq.jobs.enqueued' }
+  end
+
+  def test_push_bulk_emits_one_jobs_enqueued_per_payload
+    Wurk::Client.new.push_bulk('class' => 'MyJob', 'queue' => @ns, 'args' => [[1], [2], [3]])
+
+    enq = @fake.calls.select { |c| c[1] == 'sidekiq.jobs.enqueued' }
+
+    assert_equal 3, enq.size
+  ensure
+    cleanup_queue
+  end
+
+  # --- JobRetry#schedule_retry -------------------------------------------
+
+  def test_schedule_retry_emits_jobs_retried_with_tags
+    msg = { 'class' => 'FailingJob', 'queue' => @ns, 'jid' => 'abc' }
+    retry_handler = Wurk::JobRetry.new(Wurk.configuration)
+    retry_handler.send(:schedule_retry, msg, 1, 0)
+
+    ret = @fake.calls.find { |c| c[1] == 'sidekiq.jobs.retried' }
+
+    refute_nil ret
+    assert_equal ["worker:FailingJob", "queue:#{@ns}"], ret[2][:tags]
+  ensure
+    Wurk.redis { |c| c.call('ZREMRANGEBYSCORE', Wurk::Keys::RETRY, '-inf', '+inf') if c.call('EXISTS', Wurk::Keys::RETRY) == 1 }
+  end
+
+  # --- Heartbeat#beat! ----------------------------------------------------
+
+  def test_beat_emits_busy_gauge_tagged_with_process_identity
+    hb = build_heartbeat
+    hb.beat!
+
+    busy = @fake.calls.find { |c| c[0] == :gauge && c[1] == 'sidekiq.busy' }
+
+    refute_nil busy
+    assert_equal ["process:#{@identity}"], busy[3][:tags]
+  ensure
+    cleanup_heartbeat
+  end
+
+  def test_beat_emits_queue_size_gauge_per_capsule_queue
+    Wurk.redis { |c| c.call('LPUSH', "queue:#{@ns}", '{}') }
+
+    hb = build_heartbeat
+    hb.beat!
+
+    qs = @fake.calls.find { |c| c[0] == :gauge && c[1] == 'sidekiq.queue.size' }
+
+    refute_nil qs
+    assert_equal 1, qs[2]
+    assert_includes qs[3][:tags], "queue:#{@ns}"
+    assert_includes qs[3][:tags], "process:#{@identity}"
+  ensure
+    Wurk.redis { |c| c.call('UNLINK', "queue:#{@ns}") }
+    cleanup_heartbeat
+  end
+
+  def test_beat_skips_emissions_when_no_dogstatsd_client
+    Wurk.configuration.dogstatsd = nil
+    Wurk::Metrics::Statsd.reset!
+
+    hb = build_heartbeat
+    hb.beat!
+
+    assert_empty @fake.calls
+  ensure
+    cleanup_heartbeat
+  end
+
+  def test_beat_swallows_metrics_failure
+    boom_pool = Object.new
+    boom_pool.define_singleton_method(:gauge) { |*_, **_| raise 'boom' }
+    Wurk.configuration.dogstatsd = boom_pool
+
+    hb = build_heartbeat
+
+    assert_equal [], hb.beat!, 'beat must still return signals when metrics raise'
+  ensure
+    cleanup_heartbeat
+  end
+
+  private
+
+  def build_heartbeat
+    @hb_config = Wurk::Configuration.new
+    @hb_config.logger = ::Logger.new(IO::NULL)
+    cap = @hb_config.default_capsule
+    cap.queues = [@ns]
+    cap.concurrency = 1
+    @identity = "host-#{@ns}:1234:#{object_id.to_s(16)}"
+    @hb_cleanup = [@identity, "#{@identity}:work", "#{@identity}-signals"]
+    Wurk::Heartbeat.new(
+      identity: @identity,
+      config: @hb_config,
+      started_at: Time.now.to_f,
+      embedded: false
+    )
+  end
+
+  def cleanup_heartbeat
+    return unless defined?(@hb_cleanup)
+
+    @hb_config.redis_pool.with do |c|
+      c.call('SREM', Wurk::Keys::PROCESSES, @identity)
+      @hb_cleanup.each { |k| c.call('UNLINK', k) }
+    end
+  end
+
+  def cleanup_queue
+    Wurk.redis { |c| c.call('UNLINK', "queue:#{@ns}") }
+  end
+end

--- a/test/unit/metrics_emissions_test.rb
+++ b/test/unit/metrics_emissions_test.rb
@@ -92,7 +92,10 @@ class MetricsEmissionsTest < Wurk::Test::UnitCase
     refute_nil ret
     assert_equal ["worker:FailingJob", "queue:#{@ns}"], ret[2][:tags]
   ensure
-    Wurk.redis { |c| c.call('ZREMRANGEBYSCORE', Wurk::Keys::RETRY, '-inf', '+inf') if c.call('EXISTS', Wurk::Keys::RETRY) == 1 }
+    # schedule_retry doesn't mutate msg, so the ZADDed payload is exactly
+    # `dump_json(msg)`. ZREM that single entry only — wiping the whole zset
+    # would clobber any concurrently-running parallel test's retry data.
+    Wurk.redis { |c| c.call('ZREM', Wurk::Keys::RETRY, Wurk.dump_json(msg)) } if defined?(msg)
   end
 
   # --- Heartbeat#beat! ----------------------------------------------------


### PR DESCRIPTION
## Summary

- Wires `Wurk::Metrics::Statsd` into the **client push**, **retry**, and **heartbeat** paths so a host app that sets `config.dogstatsd =` gets useful telemetry without any extra middleware setup.
- Auto-registers `Wurk::Metrics::Statsd` on the default server middleware chain. No-op when no `dogstatsd` builder is configured (`Statsd.client` returns `nil`, middleware yields through).
- Four new emissions (all best-effort, all rescue-wrapped on the gauge path):

| Metric | Type | When | Tags |
|---|---|---|---|
| `sidekiq.jobs.enqueued` | counter | `Client#push` / `#push_bulk` per payload past the chain | `worker`, `queue` |
| `sidekiq.jobs.retried` | counter | `JobRetry#schedule_retry` after `ZADD retry` | `worker`, `queue` |
| `sidekiq.busy` | gauge | `Heartbeat#beat!`, per process | `process` |
| `sidekiq.queue.size` | gauge | `Heartbeat#beat!`, one per capsule queue via pipelined LLEN | `queue`, `process` |

- Cardinality: tags limited to `worker`/`queue`/`process`. No per-jid tags.

## Test plan

- [x] `bin/rake test` — 1480 runs, 0 failures
- [x] `bin/rake test:parity` — 16 runs, 0 failures
- [x] `bin/rake test:ecosystem` — all suites pass
- [x] Behavioral driver (see below) — every new emission observed on the wire with the expected tags

## How to test in prod

Drop into any worker process / console where you've already set `config.dogstatsd =`. Drive each emission directly:

```ruby
# 1. Enqueue → sidekiq.jobs.enqueued
Wurk::Client.push("class" => "YourJob", "queue" => "default", "args" => [1])

# 2. Bulk enqueue → 3× sidekiq.jobs.enqueued
Wurk::Client.push_bulk("class" => "YourJob", "queue" => "default", "args" => [[1], [2], [3]])

# 3. Retry → sidekiq.jobs.retried
Wurk::JobRetry.new(Wurk.configuration).send(:schedule_retry,
  { "class" => "YourJob", "queue" => "default", "jid" => "demo" }, 1, 0)

# 4. Per-job middleware (already auto-registered) → count + success/failure + perform + perform_dist
#    Just process a job normally; metrics fire from the middleware chain.

# 5. Heartbeat gauges → sidekiq.busy + sidekiq.queue.size per queue
#    Fire automatically every 10s in any running worker process. To see one beat:
hb = Wurk.configuration.instance_variable_get(:@launcher)&.instance_variable_get(:@heartbeat)
hb&.beat!
```

Or run the self-contained behavioral driver (printed datagrams, no statsd agent needed):

```bash
redis-cli FLUSHDB && bundle exec ruby /tmp/wurk_metrics_qa.rb
```

In Datadog, expect dashboards like:

- `max:sidekiq.queue.size{*} by {queue}` — cluster-wide queue depth (de-duped across processes via `max`)
- `sum:sidekiq.busy{*}` — cluster-wide in-flight jobs
- `sum:sidekiq.jobs.enqueued{*} by {worker}` — push rate per worker class

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic StatsD metrics for job enqueues, retries, and heartbeats with worker/queue/process tags
  * Metrics emit only when the underlying client is present (no-op when unconfigured)

* **Tests**
  * Added comprehensive unit tests covering metrics emissions, failure handling, and middleware interactions
  * Tightened an existing assertion to more precisely validate emitted metrics

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/developerz-ai/wurk/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->