### PR TITLE
fix: strip /wurk-assets prefix before file lookup (closes #37)

### DIFF
--- a/app/controllers/wurk/api/serializers.rb
+++ b/app/controllers/wurk/api/serializers.rb
@@ -9,17 +9,24 @@ module Wurk
     module Serializers
       module_function
 
+      # Wire-shape consumed by the React dashboard's landing page + SSE feed.
+      # Field names match the SPA's `StatsSnapshot` interface in
+      # frontend/src/hooks/useSSE.ts — keep them in sync. The canonical
+      # Sidekiq-compatible accessors on Wurk::Stats use `_size` suffixes;
+      # this serializer renames them for the dashboard's wire shape only.
       def stats_payload(stats)
         {
           processed: stats.processed,
           failed: stats.failed,
           expired: stats.expired,
-          scheduled_size: stats.scheduled_size,
-          retry_size: stats.retry_size,
-          dead_size: stats.dead_size,
-          processes_size: stats.processes_size,
           enqueued: stats.enqueued,
-          default_queue_latency: stats.default_queue_latency
+          busy: stats.workers_size,
+          scheduled: stats.scheduled_size,
+          retries: stats.retry_size,
+          dead: stats.dead_size,
+          processes: stats.processes_size,
+          latency: stats.default_queue_latency,
+          queues: stats.queue_summaries.map { |q| queue_summary(q) }
         }
       end
 

--- a/lib/wurk/engine.rb
+++ b/lib/wurk/engine.rb
@@ -16,15 +16,41 @@ module Wurk
       g.test_framework :minitest, fixtures: false
     end
 
+    # Rack::Files doesn't strip the URL prefix before file lookup, so
+    # `/wurk-assets/assets/foo.js` would resolve under `vendor/assets/dashboard/
+    # wurk-assets/assets/foo.js` — a path that doesn't exist. AssetMount
+    # rewrites PATH_INFO to drop the `/wurk-assets` prefix before delegating
+    # to Rack::Files, then falls through to the next middleware on 404 so
+    # host-app routes outside the mount keep working.
+    class AssetMount
+      PREFIX = '/wurk-assets'
+
+      def initialize(app, root:)
+        @app   = app
+        @files = ::Rack::Files.new(root)
+      end
+
+      def call(env)
+        path = env[::Rack::PATH_INFO]
+        return @app.call(env) unless path == PREFIX || path.start_with?("#{PREFIX}/")
+
+        inner = env.dup
+        stripped = path.delete_prefix(PREFIX)
+        inner[::Rack::PATH_INFO] = stripped.empty? ? '/' : stripped
+        response = @files.call(inner)
+        response[0] == 404 ? @app.call(env) : response
+      end
+    end
+
     # Precompiled SPA lives in vendor/assets/dashboard; the engine serves
-    # those files as static assets under the mount point.
+    # those files as static assets under the /wurk-assets mount point via
+    # AssetMount (above).
     initializer 'wurk.assets' do |app|
       assets_path = Wurk::Engine.root.join('vendor', 'assets', 'dashboard')
       if assets_path.exist?
         app.middleware.insert_before(
           ::ActionDispatch::Static,
-          ::Rack::Static,
-          urls: ['/wurk-assets'],
+          ::Wurk::Engine::AssetMount,
           root: assets_path.to_s
         )
       end

--- a/test/engine/api_endpoints_test.rb
+++ b/test/engine/api_endpoints_test.rb
@@ -10,6 +10,8 @@ require_relative '../engine_test_helper'
 # so all assertions read `last_response` directly — `assert_response` relies on
 # ActionDispatch's `@response` ivar which Rack::Test does not populate.
 class ApiEndpointsTest < Wurk::Test::EngineCase
+  parallelize_me!
+
   def setup
     super
     @ns = "wurkapi:#{::Process.pid}:#{object_id}"
@@ -56,6 +58,7 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
 
     assert_kind_of Array, payload[:queues]
     row = payload[:queues].find { |q| q[:name] == @queue }
+
     refute_nil row, "expected queue #{@queue} embedded in stats payload"
     assert_equal({ size: 1, paused: false }, row.slice(:size, :paused))
     assert_kind_of Numeric, row[:latency]

--- a/test/engine/api_endpoints_test.rb
+++ b/test/engine/api_endpoints_test.rb
@@ -31,8 +31,8 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
   end
 
   STATS_KEYS = %i[
-    processed failed expired scheduled_size retry_size dead_size
-    processes_size enqueued default_queue_latency
+    processed failed expired enqueued busy scheduled retries dead
+    processes latency queues
   ].freeze
 
   def test_stats_payload_includes_every_documented_key
@@ -46,7 +46,19 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
     get '/wurk/api/stats'
     payload = json_body
 
-    assert_kind_of Float, payload[:default_queue_latency]
+    assert_kind_of Float, payload[:latency]
+  end
+
+  def test_stats_payload_includes_queues_array
+    push_to_queue
+    get '/wurk/api/stats'
+    payload = json_body
+
+    assert_kind_of Array, payload[:queues]
+    row = payload[:queues].find { |q| q[:name] == @queue }
+    refute_nil row, "expected queue #{@queue} embedded in stats payload"
+    assert_equal({ size: 1, paused: false }, row.slice(:size, :paused))
+    assert_kind_of Numeric, row[:latency]
   end
 
   def test_queues_returns_array_of_summaries

--- a/test/engine/static_assets_test.rb
+++ b/test/engine/static_assets_test.rb
@@ -32,16 +32,49 @@ class StaticAssetsTest < Wurk::Test::EngineCase
     assert_match %r{\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}}, data['timestamp']
   end
 
-  def test_rack_static_middleware_is_configured
-    # The engine initializer configures Rack::Static to serve
-    # files from vendor/assets/dashboard under the /wurk-assets prefix
+  def test_asset_mount_middleware_is_configured
     middleware = Rails.application.middleware
 
-    static_middleware = middleware.find do |m|
-      m.klass == ::Rack::Static
-    end
+    mount = middleware.find { |m| m.klass == ::Wurk::Engine::AssetMount }
 
-    assert static_middleware, "Rack::Static middleware should be configured"
+    assert mount, "Wurk::Engine::AssetMount middleware should be configured"
+  end
+
+  # Regression for #37: Rack::Static didn't strip the URL prefix before
+  # file lookup, so /wurk-assets/assets/foo.js 404'd because it resolved
+  # under vendor/assets/dashboard/wurk-assets/assets/foo.js. AssetMount
+  # rewrites PATH_INFO before delegating to Rack::Files.
+  def test_hashed_asset_under_wurk_assets_returns_200
+    asset = Dir.glob(ASSETS_DIR.join('assets', '*.js')).first
+    skip "no built JS asset to probe" unless asset
+
+    name = File.basename(asset)
+    get "/wurk-assets/assets/#{name}"
+
+    assert_equal 200, last_response.status,
+                 "expected 200 for /wurk-assets/assets/#{name}, body: #{last_response.body[0, 200]}"
+    assert_equal File.binread(asset), last_response.body
+  end
+
+  def test_index_html_under_wurk_assets_returns_200
+    skip "index.html missing" unless ASSETS_DIR.join('index.html').exist?
+
+    get '/wurk-assets/index.html'
+
+    assert_equal 200, last_response.status
+  end
+
+  def test_unknown_asset_falls_through_with_404
+    get '/wurk-assets/assets/does-not-exist-xyz.js'
+
+    assert_equal 404, last_response.status
+  end
+
+  def test_non_mount_path_is_untouched_by_asset_mount
+    # Hitting a host-app path outside /wurk-assets must not be intercepted.
+    get '/__definitely_not_a_real_route__'
+
+    refute_equal 200, last_response.status
   end
 
   def test_vite_manifest_exists_for_asset_resolution

--- a/test/engine/static_assets_test.rb
+++ b/test/engine/static_assets_test.rb
@@ -2,10 +2,12 @@
 
 require_relative '../engine_test_helper'
 
-# Verifies that Rack::Static middleware is wired to serve precompiled SPA
+# Verifies that Wurk::Engine::AssetMount is wired to serve precompiled SPA
 # assets from vendor/assets/dashboard. Tests hashed filename serving and
 # manifest validation.
 class StaticAssetsTest < Wurk::Test::EngineCase
+  parallelize_me!
+
   ASSETS_DIR = ::Wurk::Engine.root.join('vendor', 'assets', 'dashboard')
   MANIFEST = ASSETS_DIR.join('wurk-manifest.json')
 
@@ -35,9 +37,13 @@ class StaticAssetsTest < Wurk::Test::EngineCase
   def test_asset_mount_middleware_is_configured
     middleware = Rails.application.middleware
 
-    mount = middleware.find { |m| m.klass == ::Wurk::Engine::AssetMount }
+    mount_index = middleware.each_with_index.find { |m, _i| m.klass == ::Wurk::Engine::AssetMount }&.last
+    static_index = middleware.each_with_index.find { |m, _i| m.klass == ::ActionDispatch::Static }&.last
 
-    assert mount, "Wurk::Engine::AssetMount middleware should be configured"
+    assert mount_index, "Wurk::Engine::AssetMount middleware should be configured"
+    assert static_index, "::ActionDispatch::Static middleware should be configured"
+    assert_operator mount_index, :<, static_index,
+                    "Wurk::Engine::AssetMount should be inserted before ActionDispatch::Static"
   end
 
   # Regression for #37: Rack::Static didn't strip the URL prefix before


### PR DESCRIPTION
## What & why

`Rack::Static` doesn't strip the URL prefix before resolving a file. So `GET /wurk-assets/assets/index-*.js` resolved under `vendor/assets/dashboard/wurk-assets/assets/index-*.js` — a path that never exists — 404ing the SPA bundle + CSS and leaving the dashboard a blank page (#37).

**Fix:** replace `Rack::Static` with a thin `AssetMount` middleware that drops the `/wurk-assets` prefix from `PATH_INFO` before delegating to `Rack::Files`, with 404 fall-through so host-app routes outside the mount keep working.

**Also in this PR:** align the `/api/stats` serializer with the SPA's `StatsSnapshot` contract — adds `busy`/`latency`/`queues`, renames `*_size` → `scheduled`/`retries`/`dead`/`processes`. Surfaced during local QA: the dashboard crashed on undefined `stats.latency`/`stats.queues` (`.toFixed` on undefined). This is the dashboard API wire-shape only; the Sidekiq-compatible `Wurk::Stats` accessors are untouched.

## Tests
- `test/engine/static_assets_test.rb` — pins the regression: hashed asset + index.html return 200, unknown asset 404s, non-mount path untouched.
- `test/engine/api_endpoints_test.rb` — stats payload contains every SPA-required key incl. embedded `queues`.

## How to test in prod

Mount the engine in any Rails host, boot it, then:

```bash
# 1. The bug: the hashed SPA bundle must now return 200 (was 404)
ASSET=$(curl -s http://localhost:3000/wurk | grep -oE '/wurk-assets/assets/[^"]+\.js' | head -1)
curl -sI "http://localhost:3000${ASSET}"        # expect: HTTP/1.1 200 OK, content-type: text/javascript

# 2. CSS too
CSS=$(curl -s http://localhost:3000/wurk | grep -oE '/wurk-assets/assets/[^"]+\.css' | head -1)
curl -sI "http://localhost:3000${CSS}"           # expect: 200

# 3. Unknown asset falls through to a normal 404 (mount doesn't swallow everything)
curl -sI http://localhost:3000/wurk-assets/assets/does-not-exist.js   # expect: 404

# 4. Stats API exposes the fields the SPA reads (no blank/crashed dashboard)
curl -s http://localhost:3000/wurk/api/stats | jq 'keys'
# expect to include: busy, latency, queues, scheduled, retries, dead, processes
```

Then open `http://localhost:3000/wurk` in a browser — the dashboard should render fully (no blank page).

Closes #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard stats API now emits concise fields (busy, scheduled, retries, dead, processes, latency) and includes per-queue summaries.

* **Improvements**
  * Dashboard SPA assets are now served under a dedicated mount point, ensuring hashed assets and index.html are served correctly while leaving other app routes intact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/developerz-ai/wurk/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->