### PR TITLE
test: harden flaky test isolation (closes #48)

### DIFF
--- a/test/engine/dashboard_routes_test.rb
+++ b/test/engine/dashboard_routes_test.rb
@@ -12,6 +12,8 @@ require_relative '../engine_test_helper'
 # can't help) and — if a run was interrupted mid-test — could overwrite the
 # real build with the stub. Skip instead when no build is present.
 class DashboardRoutesTest < Wurk::Test::EngineCase
+  parallelize_me!
+
   INDEX = ::Wurk::Engine.root.join('vendor', 'assets', 'dashboard', 'index.html')
 
   def setup

--- a/test/engine/dashboard_routes_test.rb
+++ b/test/engine/dashboard_routes_test.rb
@@ -3,34 +3,20 @@
 require_relative '../engine_test_helper'
 
 # Drives Wurk::DashboardController against the booted dummy app. The SPA
-# shell is a literal HTML file that ships in vendor/assets/dashboard at gem
-# release time (built from frontend/ via `bin/rake frontend:build`). Tests
-# stub it so we don't depend on a real frontend build running first.
+# shell (vendor/assets/dashboard/index.html) is a build artifact produced by
+# `bin/rake frontend:build` and always carries the `wurk-root` mount point.
 #
-# Not parallelized: we mutate a shared file under the gem's vendor/ dir.
+# We assert against the real shipped file rather than stubbing it. The old
+# stub-and-restore mutated that shared file, which raced StaticAssetsTest
+# (a concurrent reader, in a separate parallel-runner process where a Mutex
+# can't help) and — if a run was interrupted mid-test — could overwrite the
+# real build with the stub. Skip instead when no build is present.
 class DashboardRoutesTest < Wurk::Test::EngineCase
   INDEX = ::Wurk::Engine.root.join('vendor', 'assets', 'dashboard', 'index.html')
-  STUB = <<~HTML
-    <!doctype html>
-    <html><head><title>Wurk</title></head>
-    <body><div id="wurk-root"></div></body></html>
-  HTML
 
   def setup
     super
-    @prior_contents = INDEX.exist? ? INDEX.read : nil
-    INDEX.parent.mkpath
-    INDEX.write(STUB)
-  end
-
-  def teardown
-    if @prior_contents
-      INDEX.write(@prior_contents)
-    elsif INDEX.exist?
-      INDEX.delete
-    end
-  ensure
-    super
+    skip 'dashboard build missing (run `bin/rake frontend:build`)' unless INDEX.exist?
   end
 
   def test_get_wurk_returns_spa_shell

--- a/test/unit/metrics_history_test.rb
+++ b/test/unit/metrics_history_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../test_helper'
+require 'securerandom'
 
 class MetricsHistoryTest < Wurk::Test::UnitCase
   parallelize_me!
@@ -8,7 +9,10 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
   def setup
     super
     @at = ::Time.utc(2026, 5, 21, 14, 37, 12)
-    @klass = "FooJob#{Process.pid}_#{object_id}"
+    # SecureRandom, not object_id: object_ids are recycled after GC, so a
+    # later instance could inherit an earlier one's bucket field and see a
+    # doubled count. A unique-per-instance class guarantees no field collision.
+    @klass = "FooJob-#{SecureRandom.hex(8)}"
   end
 
   def teardown
@@ -19,9 +23,14 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
         c.call('DEL', *keys) unless keys.empty?
         break if cursor == '0'
       end
-      # HDEL only this class's fields — minute/rollup buckets are shared
-      # with other parallel tests writing at the same UTC minute.
-      [Wurk::Metrics::History.minute_key(@at), Wurk::Metrics::History.rollup_key(@at)].each do |key|
+      # Per-class fields live in shared, non-class-named minute/rollup buckets
+      # that SCAN can't reach. HDEL our fields from every bucket this test
+      # could have written: the fixed @at bucket (record tests) AND the
+      # current-time bucket (middleware tests record at Time.now).
+      bucket_keys = [@at, ::Time.now.utc].flat_map do |t|
+        [Wurk::Metrics::History.minute_key(t), Wurk::Metrics::History.rollup_key(t)]
+      end
+      bucket_keys.uniq.each do |key|
         c.call('HDEL', key, "#{@klass}|p", "#{@klass}|f", "#{@klass}|ms")
       end
     end


### PR DESCRIPTION
## What & why

Two tests flaked under the parallel runner. The `MetricsHistoryTest` one **red-CI'd PR #47** (`Expected "1", Actual "2"`) and passed on re-run — a true intermittent race, not a code failure.

### 1. `MetricsHistoryTest` double-count
`@klass` was `"FooJob#{Process.pid}_#{object_id}"`. Ruby **recycles `object_id` after GC**, so a later test instance could inherit an earlier one's field. Compounding it, the middleware sub-tests record at `Time.now` but teardown only cleaned the **fixed `@at` (2026-05-21) bucket** — so the live-time writes leaked and accumulated in the shared minute/rollup bucket. A recycled id + leftover field → counter reads `2`.

**Fix:** globally-unique `@klass` via `SecureRandom` (the History minute bucket is a *shared, time-keyed* key where only field-level uniqueness is robust — the PID:object_id pattern only protects keys you fully own and clean), and teardown now `HDEL`s our fields from **both** the `@at` and current-time buckets.

### 2. `StaticAssetsTest#test_index_html_contains_hashed_filenames` file race
`dashboard_routes_test` overwrote the shared `vendor/assets/dashboard/index.html` with a hash-less STUB and restored it. Under `parallel_fork` (separate processes — a Ruby `Mutex` can't coordinate) `static_assets_test` could read the file mid-stub; an interrupted run could also permanently clobber the real build via its backup/restore.

**Fix:** `dashboard_routes_test` no longer mutates the file — it asserts `wurk-root` against the real shipped `index.html` (which contains both `wurk-root` and the hashed asset refs), and skips when no build is present. No mutation → no race.

## Verification

12 consecutive `bin/rake test` runs → **0 failures** in either test (previously each flaked intermittently). Parity + ecosystem green. Test-only change; no production code touched.

## How to verify
```bash
# Both tests should stay green across many runs:
for i in $(seq 1 12); do bin/rake test 2>&1 | grep -E "runs,"; done
```
(No prod surface — this is a test-isolation fix. Occasional `api_endpoints retries` (#46) or `poison_pill` (#49) blips are separately-tracked flakes, not this change.)

Closes #48.

## Related flakes found (separately filed, not in scope here)
- #46 — `cron_test` leaks `NoSuchWorker123` into the global `retry` ZSET.
- #49 — `MiddlewarePoisonPillTest` (same `object_id`-namespacing smell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Dashboard route tests now validate against real build artifacts (skipping when the artifact is missing) to ensure routing behavior matches production builds.
  * Metrics history tests improved to use per-test unique identifiers and stricter cleanup of time-based buckets, reducing flakiness and collision-related failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/developerz-ai/wurk/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->