### PR TITLE
fix: test-isolation + metrics flakes (cron verify rollback, poison-pill scope, rollup double-count)

### DIFF
--- a/lib/wurk/cron.rb
+++ b/lib/wurk/cron.rb
@@ -356,6 +356,12 @@ module Wurk
         block.call(mgr)
         mgr.loops.each { |lp| resolve_klass!(lp.klass) }
         mgr.loops
+      rescue StandardError
+        # register persists each loop immediately, so a validation failure
+        # would otherwise leave partially-applied loops in the live LoopSet —
+        # they'd fire on the next poll. Roll the whole batch back, then re-raise.
+        mgr&.loops&.each { |lp| Cron.unregister(lp.lid) }
+        raise
       end
 
       private

--- a/lib/wurk/metrics/history.rb
+++ b/lib/wurk/metrics/history.rb
@@ -88,7 +88,14 @@ module Wurk
           class_ms = "#{klass}|ms"
           conn.pipelined do |pipe|
             incr_bucket(pipe, buckets[:minute], [class_outcome, class_ms, ms, MID_TERM])
-            incr_bucket(pipe, buckets[:rollup], [class_outcome, class_ms, ms, SHORT_TERM])
+            # The minute key and the 10-min rollup key coincide whenever the
+            # minute ends in 0 (rollup zeroes the last digit). Writing both
+            # would double-count the shared field — the minute write above
+            # already lands on it — so skip the rollup write then. Minutes
+            # x1..x9 still accumulate into the x0 rollup key as normal.
+            unless buckets[:rollup] == buckets[:minute]
+              incr_bucket(pipe, buckets[:rollup], [class_outcome, class_ms, ms, SHORT_TERM])
+            end
             incr_bucket(pipe, buckets[:hour], [outcome, 'ms', ms, MID_TERM])
           end
         end

--- a/test/unit/metrics_history_test.rb
+++ b/test/unit/metrics_history_test.rb
@@ -99,6 +99,21 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
     assert_equal '1', val
   end
 
+  # Regression: at minutes ending in 0 the minute and rollup keys coincide,
+  # so record must write the shared field once (not twice → "2").
+  def test_record_does_not_double_count_at_rollup_boundary
+    at = ::Time.utc(2026, 5, 21, 14, 30, 0)
+    minute = Wurk::Metrics::History.minute_key(at)
+    Wurk::Metrics::History.record(@klass, 5, success: true, at: at)
+
+    assert_equal minute, Wurk::Metrics::History.rollup_key(at), 'precondition: keys collide at x0 minutes'
+    val = Wurk.redis { |c| c.call('HGET', minute, "#{@klass}|p") }
+
+    assert_equal '1', val
+  ensure
+    Wurk.redis { |c| c.call('HDEL', minute, "#{@klass}|p", "#{@klass}|f", "#{@klass}|ms") } if minute
+  end
+
   def test_record_writes_hourly_bucket
     Wurk::Metrics::History.record(@klass, 20, success: true, at: @at)
     Wurk::Metrics::History.record(@klass, 30, success: false, at: @at)

--- a/test/unit/middleware_poison_pill_test.rb
+++ b/test/unit/middleware_poison_pill_test.rb
@@ -52,7 +52,8 @@ class MiddlewarePoisonPillTest < Wurk::Test::UnitCase
     2.times { Wurk::Middleware::PoisonPill.track!(payload_json, queue: @queue) }
 
     assert_equal 2, Wurk::Middleware::PoisonPill.recovery_count(@jid)
-    assert_equal 0, dead_size
+    # jid-scoped: a global ZCARD races other parallel tests / stray dead jobs.
+    assert_equal 0, dead_for_jid_count, 'a job below the poison threshold must not be in the dead set'
   end
 
   def test_third_recovery_returns_poison_and_writes_to_dead
@@ -182,10 +183,6 @@ class MiddlewarePoisonPillTest < Wurk::Test::UnitCase
         Wurk::Metrics::Statsd.singleton_class.send(:define_method, :increment, real)
       end
     end
-  end
-
-  def dead_size
-    @pool.with { |c| c.call('ZCARD', Wurk::Keys::DEAD) }.to_i
   end
 
   def dead_for_jid_count


### PR DESCRIPTION
## What & why

Hardens three flaky/incorrect behaviors uncovered while clearing the flake backlog. All were intermittently red-CI'ing PRs.

### 1. Cron config validation leaves orphan loops on failure (#46)
`Cron::ConfigTester#verify` registers each loop (persists to the live `LoopSet`) and validates class resolution **after**, so a failed validation (e.g. `NoSuchWorker123`) left the loop persisted. The cron poller fired it into `queue:default`, a processor ran it → `retry`, and the scheduled poller kept reviving it — perpetual global `retry`/`dead` junk that starved the `api_endpoints` retries test.
**Fix:** `verify` rolls the batch back on any failure, then re-raises (also real product correctness — boot-time validation must not leave partial cron state).

### 2. Metrics double-counted at x0 minutes (#52)
`rollup_key` zeroes the last digit of the minute, so at any minute ending in 0 it equals `minute_key` and `record` incremented the shared `<klass>` fields **twice** → 2× metrics overcount for ~10% of minutes, and the `MetricsHistoryTest` middleware flake (the *real* cause; #48's `SecureRandom` change misdiagnosed it).
**Fix:** skip the rollup write when its key equals the minute key (the minute write already covers it; x1..x9 still build the x0 rollup). Added a deterministic boundary regression test.

### 3. Poison-pill test asserted global dead set (#49)
`test_second_recovery_does_not_yet_poison` checked `ZCARD DEAD` (global) — fragile to any parallel/stray dead entry.
**Fix:** assert the jid-scoped `dead_for_jid_count` instead.

## Verification
- 15× full-suite runs with no Redis clearing → 0 failures, `retry/dead/queue:default` stay at 0 (no poison accumulation).
- Metrics probe at minute 20 now records `1` (was `2`).
- Full suite, parity (20/0), ecosystem (incl. sidekiq-cron) all green.

Closes #46, closes #49, closes #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Periodic cron entries are cleaned up when validation fails, preventing leftover scheduled jobs.
  * Metrics rollups no longer double-count at minute-boundary rollup times.

* **Tests**
  * Updated/added tests to verify poison-pill dead-set behavior and to prevent regression of the rollup double-count issue.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/developerz-ai/wurk/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->