### PR TITLE
fix: wire topology + fetcher on every boot path (closes #36, #35)

### DIFF
--- a/lib/wurk/capsule.rb
+++ b/lib/wurk/capsule.rb
@@ -2,6 +2,7 @@
 
 require_relative 'redis_pool'
 require_relative 'middleware/chain'
+require_relative 'fetcher/reliable'
 
 module Wurk
   # One processing unit: a set of threads + queues sharing a fetcher and a
@@ -46,6 +47,28 @@ module Wurk
       @weights = parsed.to_h
       @mode = detect_mode(parsed)
       @queues = expand_by_weight(parsed, @mode)
+    end
+
+    # Lossless `name[,weight]` specs (unlike `queues`, which is the
+    # weight-expanded list). Lets Configuration#topology rebuild a slot that
+    # round-trips back through `queues=` without flattening weights.
+    def queue_specs
+      @weights.map { |q, w| w.positive? ? "#{q},#{w}" : q }
+    end
+
+    # Materialize everything that lazy-inits via `||=` and default the fetcher,
+    # BEFORE Configuration#freeze! freezes the capsule — otherwise the first
+    # post-freeze access (a fetch tick, a middleware call) hits a nil fetcher
+    # or FrozenErrors building a pool. The swarm's ChildBoot used to do this
+    # by hand; centralizing it here covers the standalone CLI and embedded
+    # paths too (the bug behind a nil `fetcher` in `exe/wurk`). Idempotent.
+    def prepare!
+      @fetcher ||= Wurk::Fetcher::Reliable.new(self)
+      redis_pool
+      local_redis_pool
+      client_middleware
+      server_middleware
+      self
     end
 
     def client_middleware

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -4,6 +4,7 @@ require 'logger'
 require_relative 'middleware/chain'
 require_relative 'capsule'
 require_relative 'context'
+require_relative 'topology'
 
 module Wurk
   # Owns runtime knobs (concurrency, queues, timeouts, lifecycle events,
@@ -257,7 +258,7 @@ module Wurk
       @logger ||= default_logger
     end
 
-    attr_writer :logger
+    attr_writer :logger, :topology
 
     def handle_exception(ex, ctx = {})
       if error_handlers.empty?
@@ -285,6 +286,14 @@ module Wurk
       @options[:server] == true
     end
 
+    # Worker topology for the swarm. When the host hasn't declared one (the
+    # railtie path), default to a single flat fork running the default
+    # capsule's queues + concurrency. Assign a custom Wurk::Topology (via
+    # `topology=`) for specialized slots.
+    def topology
+      @topology ||= default_topology
+    end
+
     def freeze!
       return self if @frozen
 
@@ -305,6 +314,14 @@ module Wurk
     end
 
     private
+
+    # One flat fork running the default capsule's queues + concurrency. The
+    # railtie boots this when a Rails host mounts the engine without declaring
+    # a topology. queue_specs (not queues) so weights survive the round-trip.
+    def default_topology
+      cap = default_capsule
+      Wurk::Topology.flat(count: 1, queues: cap.queue_specs, concurrency: cap.concurrency)
+    end
 
     def guard_frozen!
       raise FrozenError, 'Wurk::Configuration is frozen' if @frozen

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -258,7 +258,7 @@ module Wurk
       @logger ||= default_logger
     end
 
-    attr_writer :logger, :topology
+    attr_writer :logger
 
     def handle_exception(ex, ctx = {})
       if error_handlers.empty?
@@ -292,6 +292,11 @@ module Wurk
     # `topology=`) for specialized slots.
     def topology
       @topology ||= default_topology
+    end
+
+    def topology=(value)
+      guard_frozen!
+      @topology = value
     end
 
     def freeze!

--- a/lib/wurk/launcher.rb
+++ b/lib/wurk/launcher.rb
@@ -61,6 +61,10 @@ module Wurk
     #      accept k8s probes until the rest of the launcher is up.
     def run(async_beat: true)
       @started_at = Time.now.to_f
+      # Default each capsule's fetcher + materialize its lazy pools/middleware
+      # before the config freezes. Every entry point (swarm child, standalone
+      # CLI, embedded) runs through here, so none boots with a nil fetcher.
+      @config.capsules.each_value(&:prepare!)
       @config.freeze!
       @heartbeat_thread = safe_thread('heartbeat', &method(:start_heartbeat)) if async_beat
       @poller&.start

--- a/lib/wurk/swarm/child_boot.rb
+++ b/lib/wurk/swarm/child_boot.rb
@@ -63,17 +63,9 @@ module Wurk
         cap = @config.default_capsule
         cap.queues = @slot.queues
         cap.concurrency = @slot.concurrency
-        cap.fetcher = Wurk::Fetcher::Reliable.new(cap)
-        # Configuration#freeze! (called by Launcher#run) freezes every
-        # capsule. Capsule's `redis_pool`, `local_redis_pool`,
-        # `server_middleware`, and `client_middleware` lazy-init their
-        # ivars via `||=` — that mutation would FrozenError after
-        # freeze, the first time the processor hit them. Materialize
-        # them now so the post-freeze code paths only read.
-        cap.redis_pool
-        cap.local_redis_pool
-        cap.client_middleware
-        cap.server_middleware
+        # Fetcher defaulting + lazy-ivar materialization now happens in
+        # Configuration#freeze! (Capsule#prepare!), called by Launcher#run
+        # below — for every entry point, not just the swarm.
       end
 
       def install_signal_handlers(launcher)

--- a/test/unit/capsule_test.rb
+++ b/test/unit/capsule_test.rb
@@ -33,6 +33,44 @@ class CapsuleTest < Wurk::Test::UnitCase
     assert_equal ['default'], @capsule.queues
   end
 
+  # --- prepare! / fetcher defaulting (regression #35) -------------------
+
+  def test_prepare_defaults_fetcher_to_reliable
+    assert_nil @capsule.fetcher
+
+    @capsule.prepare!
+
+    assert_instance_of Wurk::Fetcher::Reliable, @capsule.fetcher
+  end
+
+  def test_prepare_preserves_an_explicit_fetcher
+    custom = Wurk::Fetcher::Reliable.new(@capsule)
+    @capsule.fetcher = custom
+
+    @capsule.prepare!
+
+    assert_same custom, @capsule.fetcher
+  end
+
+  def test_prepare_materializes_lazy_pools
+    @capsule.prepare!
+
+    refute_nil @capsule.instance_variable_get(:@redis_pool)
+    refute_nil @capsule.instance_variable_get(:@local_redis_pool)
+  end
+
+  def test_queue_specs_round_trips_weighted_queues
+    @capsule.queues = %w[high,3 default,2]
+
+    assert_equal %w[high,3 default,2], @capsule.queue_specs
+  end
+
+  def test_queue_specs_omits_weight_for_strict_queues
+    @capsule.queues = %w[high default]
+
+    assert_equal %w[high default], @capsule.queue_specs
+  end
+
   def test_default_mode_is_strict
     assert_equal :strict, @capsule.mode
   end

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -419,6 +419,36 @@ class ConfigurationTest < Wurk::Test::UnitCase
     assert_same @config, @config.freeze!
   end
 
+  # --- topology (regression #36) -----------------------------------------
+
+  def test_topology_returns_a_topology
+    assert_instance_of Wurk::Topology, @config.topology
+  end
+
+  def test_topology_defaults_to_one_flat_fork_from_default_capsule
+    @config.queues = %w[critical default]
+    @config.concurrency = 7
+
+    slot = @config.topology.slots.first
+
+    assert_equal 1, @config.topology.total_processes
+    assert_equal %w[critical default], slot.queues
+    assert_equal 7, slot.concurrency
+  end
+
+  def test_topology_default_preserves_weighted_queue_specs
+    @config.queues = %w[high,3 default,2]
+
+    assert_equal %w[high,3 default,2], @config.topology.slots.first.queues
+  end
+
+  def test_topology_respects_a_custom_assignment
+    custom = Wurk::Topology.flat(count: 3, queues: ['bulk'], concurrency: 2)
+    @config.topology = custom
+
+    assert_same custom, @config.topology
+  end
+
   private
 
   def build_exception(message)

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -449,6 +449,12 @@ class ConfigurationTest < Wurk::Test::UnitCase
     assert_same custom, @config.topology
   end
 
+  def test_topology_setter_raises_once_frozen
+    @config.freeze!
+
+    assert_raises(FrozenError) { @config.topology = Wurk::Topology.new }
+  end
+
   private
 
   def build_exception(message)

--- a/test/unit/embedded_test.rb
+++ b/test/unit/embedded_test.rb
@@ -15,7 +15,7 @@ class EmbeddedTest < Wurk::Test::UnitCase
     @config.logger = ::Logger.new(IO::NULL)
     @config.concurrency = 2
     @config.default_capsule.queues = ['default']
-    @config.default_capsule.fetcher = Wurk::Fetcher::Reliable.new(@config.default_capsule)
+    # No manual fetcher wiring — Launcher#run defaults it now (regression #35).
     @config[:tag] = @ns
   end
 

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -18,7 +18,7 @@ class LauncherTest < Wurk::Test::UnitCase
     cap = @config.default_capsule
     cap.queues = ['default']
     cap.concurrency = 2
-    cap.fetcher = Wurk::Fetcher::Reliable.new(cap)
+    # No manual fetcher wiring — Launcher#run defaults it now (regression #35).
     @config[:tag] = @ns
     @pool = cap.redis_pool
     @cleanup_keys = []
@@ -96,6 +96,18 @@ class LauncherTest < Wurk::Test::UnitCase
     launcher.run(async_beat: false)
 
     assert_predicate @config, :frozen?
+  end
+
+  # Regression #35: standalone/embedded boots go through run, which must
+  # default each capsule's fetcher (only ChildBoot used to wire it).
+  def test_run_defaults_the_capsule_fetcher
+    assert_nil @config.default_capsule.fetcher
+    launcher = Wurk::Launcher.new(@config)
+    stub_managers(launcher)
+
+    launcher.run(async_beat: false)
+
+    assert_instance_of Wurk::Fetcher::Reliable, @config.default_capsule.fetcher
   end
 
   def test_run_starts_each_manager


### PR DESCRIPTION
## What & why

Two critical boot-wiring gaps, each breaking a whole run mode. Both surfaced during local QA for #20.

### #36 — a Rails host never forks workers (v1 blocker)
`railtie.rb` boots the swarm with `Wurk::Swarm.new(topology: Wurk.configuration.topology)`, but `Configuration` had **no `topology` method** → `NoMethodError` in `after_initialize` → the swarm never booted. Mount the engine, enqueue a job, and it sits forever (`SMEMBERS processes` empty).

**Fix:** add `Configuration#topology` (+ `topology=`). When the host hasn't declared a topology, default to a single flat fork running the default capsule's queues + concurrency. A new `Capsule#queue_specs` reconstructs `name[,weight]` specs so weighted queues survive the topology → `ChildBoot` round-trip losslessly (vs `queues`, which is the weight-expanded list).

### #35 — `exe/wurk` standalone + embedded crash on a nil fetcher
`Capsule#fetcher` defaults to `nil`, and only the swarm's `ChildBoot` wired it. The standalone CLI and `Wurk::Embedded` paths never hit `ChildBoot`, so each fetch tick hit `nil.retrieve_work` and the queue never drained.

**Fix:** add `Capsule#prepare!` (default the fetcher to `Reliable` + materialize the lazy redis pools/middleware before the capsule freezes) and call it from **`Launcher#run`** — the one path *every* entry point (swarm child, CLI, embedded) shares. `ChildBoot` drops its now-duplicated hand-wiring; `freeze!` stays pure (the prep belongs to boot, not to freezing a config in isolation).

## Verification
- Full suite **1497 runs, 0 failures**; parity 20/0; ecosystem (incl. sidekiq-cron) green.
- New regression tests: `Configuration#topology` (default / custom / weighted-specs), `Capsule#prepare!` + `queue_specs`, `Launcher#run` defaults the fetcher.
- Removed the manual fetcher wiring `launcher_test`/`embedded_test` used to work around #35.
- Behavioral driver: swarm forks + drains via the default topology (#36); a standalone Launcher wires the fetcher + drains a queue (#35).

## How to test in prod

**#36** — mount the engine in a Rails host and boot it (no custom topology declared):
```bash
bundle exec rails server          # railtie boots the swarm in after_initialize
# In another shell — workers now register (was empty before):
bin/rails runner 'p Sidekiq.redis { |c| c.scard("processes") }'   # => >= 1
```
Override the default with a custom topology when you need specialized slots:
```ruby
Wurk.configure { |c| c.topology = Wurk::Topology.new.slot(count: 4, queues: %w[critical default], concurrency: 10) }
```

**#35** — the standalone runner now drains instead of erroring each tick:
```bash
bundle exec exe/wurk -q default   # enqueue a job; it processes (no `nil.retrieve_work`)
```

Closes #36, closes #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added topology configuration for organizing worker queues and concurrency.
  * Added an explicit capsule initialization step to materialize lazy components before freeze.

* **Bug Fixes**
  * Startup now ensures capsules are fully initialized so fetchers and pools are available at boot.

* **Tests**
  * Expanded tests covering topology behavior, capsule initialization, and queue-weight round-trips.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/developerz-ai/wurk/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->