### PR TITLE
feat: run the cluster leader + consolidate periodic onto it (closes #15)

### DIFF
--- a/docs/target/sidekiq-ent.md
+++ b/docs/target/sidekiq-ent.md
@@ -278,7 +278,12 @@ ct.verify(&PERIODIC_JOBS)   # raises if klass constant missing or cron invalid
 | `periodic`                   | SET  | All loop IDs                                     |
 | `loops:{lid}`                | HASH | `{schedule, klass, options(json), tz, paused}`   |
 | `loop-history:{lid}`         | LIST | Recent fire records (capped)                     |
-| `cron-leader`                | STR  | Leader lock (TTL ≈ 30s, refreshed every 15s)     |
+
+> **Wurk divergence (#15):** periodic enqueue is gated by the *single* cluster
+> leader (§6, via `Component#leader?`), not a separate `cron-leader` lock.
+> Upstream's per-feature lock flaps under Wurk's cadence (60s tick vs 30s TTL);
+> the cluster leader renews every 15s and is the single source of truth for
+> "am I leader?" across periodic, metrics rollup, etc.
 
 ---
 

--- a/lib/wurk/cron.rb
+++ b/lib/wurk/cron.rb
@@ -28,9 +28,9 @@ module Wurk
   #   * `Cron::LoopSet` — Enumerable view (`each`/`size`/`fetch(lid)`).
   #   * `Cron::ConfigTester` — boot-time validator. Verifies cron syntax and
   #     that every worker class constant resolves.
-  #   * `Cron::Poller` — once-per-minute tick loop. The cluster leader
-  #     (`Component#leader?` / `dear-leader`) gates enqueue; non-leaders still
-  #     parse but never push.
+  #   * `Cron::Poller` — once-per-minute tick loop. Only the cluster leader
+  #     (`Component#leader?` / `dear-leader`) enqueues; non-leaders return
+  #     early without iterating loops.
   #
   # Wire-compat: `periodic`, `loops:{lid}`, `loop-history:{lid}` per
   # docs/target/sidekiq-ent.md §2.7. Periodic enqueue is gated by the single
@@ -374,10 +374,10 @@ module Wurk
       end
     end
 
-    # Once-per-minute tick driver. Leader-only enqueue per loop. Followers
-    # still iterate the LoopSet (cheap) so they're warm if leadership
-    # transfers mid-tick. Missed-tick warning when wall-clock has drifted
-    # more than `MISSED_TICK_THRESHOLD` seconds past the expected fire.
+    # Once-per-minute tick driver. Only the cluster leader iterates the LoopSet
+    # and enqueues; non-leaders return early. Missed-tick warning when
+    # wall-clock has drifted more than `MISSED_TICK_THRESHOLD` seconds past the
+    # expected fire.
     class Poller
       include Component
 
@@ -408,9 +408,9 @@ module Wurk
       end
 
       # Leader-gated by the single cluster lock (Component#leader? reads
-      # `dear-leader`); followers still warm the LoopSet so they're ready if
-      # leadership transfers. The Launcher owns the lock's renewal — the
-      # poller no longer runs (or expires) its own.
+      # `dear-leader`): non-leaders return early and never iterate the LoopSet.
+      # The Launcher owns the lock's renewal — the poller no longer runs (or
+      # expires) its own.
       def tick
         return unless leader?
 

--- a/lib/wurk/cron.rb
+++ b/lib/wurk/cron.rb
@@ -28,20 +28,21 @@ module Wurk
   #   * `Cron::LoopSet` — Enumerable view (`each`/`size`/`fetch(lid)`).
   #   * `Cron::ConfigTester` — boot-time validator. Verifies cron syntax and
   #     that every worker class constant resolves.
-  #   * `Cron::Poller` — once-per-minute tick loop. `Wurk::Leader` gates
-  #     enqueue; non-leaders still parse but never push.
+  #   * `Cron::Poller` — once-per-minute tick loop. The cluster leader
+  #     (`Component#leader?` / `dear-leader`) gates enqueue; non-leaders still
+  #     parse but never push.
   #
-  # Wire-compat: `periodic`, `loops:{lid}`, `loop-history:{lid}`, `cron-leader`
-  # — all per docs/target/sidekiq-ent.md §2.7.
+  # Wire-compat: `periodic`, `loops:{lid}`, `loop-history:{lid}` per
+  # docs/target/sidekiq-ent.md §2.7. Periodic enqueue is gated by the single
+  # cluster leader (§6, `Component#leader?`) rather than a separate
+  # `cron-leader` lock — see the §2.7 divergence note.
   module Cron
     PERIODIC_KEY = 'periodic'
     LOOP_PREFIX = 'loops:'
     HISTORY_PREFIX = 'loop-history:'
-    LEADER_KEY = 'cron-leader'
 
     HISTORY_CAP = 25
     DEFAULT_TICK_SECONDS = 60
-    DEFAULT_LEADER_TTL = 30
     MISSED_TICK_THRESHOLD = 90
 
     # 5-field crontab + `@aliases`. No seconds field, no DOW name aliases
@@ -385,7 +386,6 @@ module Wurk
         @done = false
         @mutex = ::Mutex.new
         @sleeper = ::ConditionVariable.new
-        @leader = Leader.new(key: LEADER_KEY, ttl: DEFAULT_LEADER_TTL)
         @client = Client.new(config: config)
         @thread = nil
         @tick_interval = DEFAULT_TICK_SECONDS
@@ -397,7 +397,6 @@ module Wurk
             tick
             wait
           end
-          @leader.release
         end
       end
 
@@ -408,9 +407,12 @@ module Wurk
         end
       end
 
+      # Leader-gated by the single cluster lock (Component#leader? reads
+      # `dear-leader`); followers still warm the LoopSet so they're ready if
+      # leadership transfers. The Launcher owns the lock's renewal — the
+      # poller no longer runs (or expires) its own.
       def tick
-        @leader.acquire
-        return unless @leader.leader?
+        return unless leader?
 
         LoopSet.new.each { |lp| enqueue_if_due(lp) }
       rescue StandardError => e
@@ -520,7 +522,7 @@ module Wurk
           lids.each do |lid|
             c.call('DEL', "#{LOOP_PREFIX}#{lid}", "#{HISTORY_PREFIX}#{lid}")
           end
-          c.call('DEL', PERIODIC_KEY, LEADER_KEY)
+          c.call('DEL', PERIODIC_KEY)
         end
       end
 

--- a/lib/wurk/launcher.rb
+++ b/lib/wurk/launcher.rb
@@ -7,6 +7,7 @@ require_relative 'heartbeat'
 require_relative 'health'
 require_relative 'keys'
 require_relative 'scheduled'
+require_relative 'leader'
 
 module Wurk
   # Top-level supervisor inside each worker process. Owns the Manager pool
@@ -45,6 +46,7 @@ module Wurk
       @done = false
       @managers = config.capsules.values.map { |cap| Manager.new(cap) }
       @poller = build_poller
+      @leader = build_leader
       @started_at = nil
       @heartbeat = nil
       @heartbeat_thread = nil
@@ -68,6 +70,7 @@ module Wurk
       @config.freeze!
       @heartbeat_thread = safe_thread('heartbeat', &method(:start_heartbeat)) if async_beat
       @poller&.start
+      @leader&.start
       @managers.each(&:start)
       @health_server&.start
     end
@@ -93,6 +96,9 @@ module Wurk
       stoppers = @managers.map { |m| Thread.new { m.stop(deadline) } }
       fire_event(:shutdown, reverse: true)
       stoppers.each(&:join)
+      # CAS-release the cluster lock now (planned shutdown) so a follower can
+      # take over immediately instead of waiting out the TTL.
+      @leader&.stop
       clear_heartbeat
       fire_event(:exit, reverse: true)
     end
@@ -205,6 +211,19 @@ module Wurk
 
     def build_poller
       Wurk::Scheduled::Poller.new(@config)
+    end
+
+    # Every worker process campaigns for the single cluster lock (`dear-leader`);
+    # one wins and renews it, the rest follow and promote on its death. Cadence
+    # falls back to the spec defaults (TTL 30 / renew 15 / follower 60) unless
+    # the host tunes it. `Leader#start` no-ops under `WURK_LEADER=false`.
+    def build_leader
+      Wurk::Leader.new(
+        config: @config,
+        ttl: @config[:leader_ttl] || Wurk::Leader::DEFAULT_TTL,
+        renew_interval: @config[:leader_renew_interval] || Wurk::Leader::DEFAULT_RENEW_INTERVAL,
+        follower_interval: @config[:leader_follower_interval] || Wurk::Leader::DEFAULT_FOLLOWER_INTERVAL
+      )
     end
 
     # Returns a Health::Server when `config.health_check(...)` has set

--- a/test/unit/cron_test.rb
+++ b/test/unit/cron_test.rb
@@ -370,10 +370,8 @@ class CronTest < Wurk::Test::UnitCase
     @lids << lp.lid
 
     poller = Wurk::Cron::Poller.new(Wurk.configuration)
-    # Stub leader to deny acquisition.
-    leader = poller.instance_variable_get(:@leader)
-    leader.define_singleton_method(:acquire) { false }
-    leader.define_singleton_method(:leader?) { false }
+    # Not the cluster leader → never enqueues.
+    poller.define_singleton_method(:leader?) { false }
 
     poller.tick
 
@@ -409,9 +407,7 @@ class CronTest < Wurk::Test::UnitCase
     @lids << lp.lid
 
     poller = Wurk::Cron::Poller.new(Wurk.configuration)
-    leader = poller.instance_variable_get(:@leader)
-    leader.define_singleton_method(:acquire) { true }
-    leader.define_singleton_method(:leader?) { true }
+    poller.define_singleton_method(:leader?) { true }
 
     poller.tick
 
@@ -460,7 +456,6 @@ class CronTest < Wurk::Test::UnitCase
   def test_constants_match_spec_keys
     assert_equal 'periodic', Wurk::Cron::PERIODIC_KEY
     assert_equal 'loops:', Wurk::Cron::LOOP_PREFIX
-    assert_equal 'cron-leader', Wurk::Cron::LEADER_KEY
   end
 
   private
@@ -486,9 +481,8 @@ class CronTest < Wurk::Test::UnitCase
 
   def build_leader_poller
     poller = Wurk::Cron::Poller.new(Wurk.configuration)
-    leader = poller.instance_variable_get(:@leader)
-    leader.define_singleton_method(:acquire) { true }
-    leader.define_singleton_method(:leader?) { true }
+    # Pretend this process holds the cluster lock.
+    poller.define_singleton_method(:leader?) { true }
     poller
   end
 

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -110,8 +110,20 @@ class LauncherTest < Wurk::Test::UnitCase
     assert_instance_of Wurk::Fetcher::Reliable, @config.default_capsule.fetcher
   end
 
+  def test_run_starts_the_cluster_leader
+    launcher = Wurk::Launcher.new(@config)
+    stub_managers(launcher)
+    started = false
+    launcher.instance_variable_get(:@leader).define_singleton_method(:start) { started = true }
+
+    launcher.run(async_beat: false)
+
+    assert started, 'run should start the cluster leader'
+  end
+
   def test_run_starts_each_manager
     launcher = Wurk::Launcher.new(@config)
+    stub_managers(launcher)
     started = []
     launcher.managers.each { |m| m.define_singleton_method(:start) { started << self } }
 
@@ -202,6 +214,18 @@ class LauncherTest < Wurk::Test::UnitCase
     assert_predicate launcher, :stopping?
     assert_equal launcher.managers.size, received.size
     received.each { |d| assert_kind_of Float, d }
+  end
+
+  def test_stop_stops_the_cluster_leader
+    @config[:timeout] = 0
+    launcher = Wurk::Launcher.new(@config)
+    silence_managers(launcher)
+    stopped = false
+    launcher.instance_variable_get(:@leader).define_singleton_method(:stop) { stopped = true }
+
+    launcher.stop
+
+    assert stopped, 'stop should release the cluster leader'
   end
 
   def test_stop_fires_shutdown_then_exit_in_reverse
@@ -471,6 +495,8 @@ class LauncherTest < Wurk::Test::UnitCase
 
   def stub_managers(launcher)
     launcher.managers.each { |m| m.define_singleton_method(:start) { nil } }
+    # Don't campaign for the global `dear-leader` lock during unit run-tests.
+    launcher.instance_variable_get(:@leader).define_singleton_method(:start) { nil }
   end
 
   def silence_managers(launcher)
@@ -478,6 +504,7 @@ class LauncherTest < Wurk::Test::UnitCase
       m.define_singleton_method(:quiet) { nil }
       m.define_singleton_method(:stop) { |_d| nil }
     end
+    launcher.instance_variable_get(:@leader).define_singleton_method(:stop) { nil }
   end
 
   def silence_beat(launcher)

--- a/test/unit/leader_test.rb
+++ b/test/unit/leader_test.rb
@@ -94,6 +94,19 @@ class LeaderTest < Wurk::Test::UnitCase
     refute_predicate b, :leader?
   end
 
+  # Failover primitive: once the holder steps down, a different owner wins.
+  def test_competitor_acquires_after_holder_releases
+    a = build_leader(owner: 'a-owner')
+    b = build_leader(owner: 'b-owner')
+    a.acquire
+
+    refute b.acquire, 'competitor blocked while the lock is held'
+    a.release
+
+    assert b.acquire, 'competitor takes over once the holder releases'
+    assert_predicate b, :leader?
+  end
+
   def test_re_acquire_refreshes_ttl
     ldr = build_leader(ttl: 30)
     ldr.acquire


### PR DESCRIPTION
## What & why

`Wurk::Leader` already had the renew/follower loop, fencing token, and clean CAS-release — but **nothing actually ran a cluster leader**:

- The `Launcher` never built/started one, so `dear-leader` was never held → `Component#leader?` was always false → no leader-gated work ever ran on a real leader.
- `Cron::Poller` ran its **own** `cron-leader` lock with a flapping bug: it ticks every 60s but the lock TTL is 30s, so periodic leadership lapsed every minute.

## Changes

- **`lib/wurk/launcher.rb`** — build + `start` the cluster `Leader` in `run` (renews while leader, promotes as follower on a dead leader), and `stop` it during shutdown so SIGTERM does a clean CAS-release (no waiting out the TTL). Cadence defaults to the spec (TTL 30 / renew 15 / follower 60); `config[:leader_ttl]`, `config[:leader_renew_interval]`, `config[:leader_follower_interval]` tune it.
- **`lib/wurk/cron.rb`** — gate periodic enqueue on the single cluster leader (`Component#leader?` / `dear-leader`) instead of a separate `cron-leader` lock. Single source of truth, and the per-minute flap is gone.
- **`docs/target/sidekiq-ent.md` §2.7** — documents the divergence: periodic uses the cluster leader, not a separate `cron-leader` key (the spec was internally inconsistent — §2.7 listed `cron-leader` while §6 mandates one `leader?` predicate; real Sidekiq Ent gates periodic on the cluster leader).

## Done-when (verified)
- **Kill the leader → a follower takes over within one TTL** — `test/qa/leader_failover_driver.rb` boots a real 2-child swarm, `kill -9`s the leader, and the survivor takes over in seconds.
- **Periodic only enqueues on the current leader** — cron gated on `Component#leader?`.

## Verification
- Full suite **1501 runs, 0 failures** (×3, no `dear-leader` flakiness); parity 20/0; ecosystem (incl. sidekiq-cron/scheduler) green.
- New tests: launcher starts/stops the leader, cron uses the cluster leader, leader failover (competitor acquires after the holder releases). Unit suite stubs `leader?` so it never contends for the global lock.

## How to test in prod

Boot 2+ worker processes. Exactly one holds the lock; check who:
```ruby
Sidekiq.redis { |c| c.get("dear-leader") }   # => "<host>:<pid>:<nonce>" of the leader
```
Kill that process (`kill -9 <pid>`); within ~one TTL (default 30s) another process takes over — re-run the GET and the pid changes. Periodic (cron) jobs keep firing exactly once per tick, now from the new leader. Tune failover speed with `config.leader_ttl=` / `leader_renew_interval=` / `leader_follower_interval=` if desired.

Closes #15. Unblocks #14 (periodic manager builds on this single leader).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Periodic job scheduling now uses the cluster-wide elected leader for enqueue gating, simplifying leader handling.
  * Launcher now participates in cluster leader election to improve failover responsiveness and release behavior.

* **Bug Fixes**
  * Followers no longer attempt periodic enqueueing when not the leader.

* **Tests**
  * Updated leader-related tests and added a failover test to validate leader transition behavior.

* **Documentation**
  * Docs updated to reflect the unified leader coordination model.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/developerz-ai/wurk/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->