### PR TITLE
feat: dashboard read-only mode (closes #24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,30 @@ Knobs: `health_check(port:, bind: '0.0.0.0', ready_window: 30)`. In swarm mode o
 
 ---
 
+## 🚀 Deployment
+
+### Read-only dashboard
+
+Ship a viewer-only dashboard (e.g. a public demo, or a shared read-only board) without bolting on your own auth. When read-only mode is on, every mutating request to the mounted dashboard (retry, kill, requeue, delete, pause/resume, clear) returns **403**, the SPA hides destructive actions, and a **"Read-only mode"** banner makes it unambiguous. Reads (GET) keep working.
+
+Enable it either way:
+
+```sh
+# Simplest — works in every process, including the web server.
+WURK_WEB_READ_ONLY=1
+```
+
+```ruby
+# Or in a Rails initializer (config/initializers/wurk.rb):
+Wurk::Web.configure { |c| c.read_only = true }
+```
+
+> The dashboard runs in your **web** process (Puma), not the worker — so set the flag there. The env var is read by every process, which is why it's the easiest option. `Wurk.configure { |c| c.web.read_only = true }` reaches the same setting (`config.web` is the `Wurk::Web` config).
+
+Default is read/write — nothing changes unless you opt in.
+
+---
+
 ## 🤝 Migration
 
 ```diff

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ WURK_WEB_READ_ONLY=1
 Wurk::Web.configure { |c| c.read_only = true }
 ```
 
-> The dashboard runs in your **web** process (Puma), not the worker — so set the flag there. The env var is read by every process, which is why it's the easiest option. `Wurk.configure { |c| c.web.read_only = true }` reaches the same setting (`config.web` is the `Wurk::Web` config).
+> The dashboard runs in your **web** process (Puma), not the worker — so set the flag there. The env var is read by every process, which is why it's the easiest option. `Wurk.configuration.web.read_only = true` reaches the same setting — `config.web` delegates to the `Wurk::Web` config singleton.
 
 Default is read/write — nothing changes unless you opt in.
 

--- a/app/controllers/wurk/api_controller.rb
+++ b/app/controllers/wurk/api_controller.rb
@@ -23,6 +23,13 @@ module Wurk
       stream reset_limiter pause_cron unpause_cron enqueue_cron
     ]
 
+    # Boot-time flags the SPA reads once to shape the UI (e.g. hide destructive
+    # actions and show the read-only banner). Always a GET, so it stays
+    # reachable while read-only mode blocks mutations.
+    def meta
+      render json: { read_only: ::Wurk::Web.config.read_only? }
+    end
+
     def stats
       render json: ::Wurk::Api::Serializers.stats_payload(::Wurk::Stats.new)
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Wurk::Engine.routes.draw do
 
   # JSON APIs consumed by the SPA. Nested under whatever mount the host chose.
   scope :api, defaults: { format: :json } do
+    get  'meta',             to: 'api#meta'
     get  'stats',            to: 'api#stats'
     get  'queues',           to: 'api#queues'
     get  'queues/:name',     to: 'api#queue', as: :api_queue

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useTheme } from './hooks/useTheme';
 import { useSSE } from './hooks/useSSE';
+import { useMeta } from './hooks/useMeta';
+import { t } from './i18n';
 import Nav from './components/Nav';
 import Dashboard from './pages/Dashboard';
 import Queues from './pages/Queues';
@@ -24,6 +26,28 @@ const qc = new QueryClient({
     },
   },
 });
+
+function ReadOnlyBanner() {
+  const { data: meta } = useMeta();
+  if (!meta?.read_only) return null;
+
+  return (
+    <div
+      role="status"
+      style={{
+        background: 'var(--warning)',
+        color: '#1a1a1a',
+        textAlign: 'center',
+        padding: '0.4rem 1rem',
+        fontWeight: 600,
+        fontSize: 13,
+        letterSpacing: '0.01em',
+      }}
+    >
+      {t('readonly.banner')}
+    </div>
+  );
+}
 
 export default function App() {
   const { theme, toggle } = useTheme();
@@ -47,6 +71,7 @@ export default function App() {
             className="main-content"
             style={{ flex: 1, padding: '1.5rem', marginRight: 'var(--nav-width)' }}
           >
+            <ReadOnlyBanner />
             <Routes>
               <Route path="/" element={<Dashboard sse={sse} />} />
               <Route path="/queues" element={<Queues />} />

--- a/frontend/src/hooks/useMeta.ts
+++ b/frontend/src/hooks/useMeta.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+
+export interface Meta {
+  read_only: boolean;
+}
+
+// Boot-time dashboard flags. Fetched once and cached forever — these only
+// change on a server restart, so there's no point re-polling.
+export function useMeta() {
+  return useQuery<Meta>({
+    queryKey: ['meta'],
+    queryFn: () => fetch('/wurk/api/meta').then((r) => r.json() as Promise<Meta>),
+    staleTime: Infinity,
+  });
+}

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -57,6 +57,9 @@
     "search": "Search",
     "refresh": "Refresh"
   },
+  "readonly": {
+    "banner": "Read-only mode"
+  },
   "common": {
     "loading": "Loading…",
     "error": "Error loading data",

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -218,6 +218,19 @@ module Wurk
       @periodic_manager
     end
 
+    # --- Web dashboard ----------------------------------------------------
+
+    # Web UI configuration: the authorization hook and read-only mode. Returns
+    # the process-wide `Wurk::Web.config` singleton so `config.web.read_only =
+    # true` and the engine middleware share one source of truth. Lazy-requires
+    # the web layer to keep standalone boot lean.
+    #
+    # Spec: docs/target/sidekiq-ent.md §9.2.
+    def web
+      require_relative 'web/config'
+      Wurk::Web.config
+    end
+
     # --- K8s liveness/readiness probes -----------------------------------
 
     # Opt-in thin HTTP listener inside the worker process for k8s probes.

--- a/lib/wurk/web/config.rb
+++ b/lib/wurk/web/config.rb
@@ -22,6 +22,10 @@ module Wurk
     # When no block is registered, every request is authorized (matches
     # Sidekiq's default — no auth until the user opts in).
     class Config
+      # String forms that mean "off" — so `config.web.read_only = ENV[...]`
+      # doesn't flip on when the env var is "0"/"false"/empty.
+      FALSEY_STRINGS = ['', '0', 'false', 'no', 'off'].freeze
+
       def initialize
         @authorization = nil
         @read_only = env_read_only?
@@ -40,7 +44,7 @@ module Wurk
       # Defaults from WURK_WEB_READ_ONLY=1 so a viewer-only deploy (e.g. the
       # public demo) needs no Ruby config.
       def read_only=(value)
-        @read_only = !!value
+        @read_only = value.is_a?(String) ? !FALSEY_STRINGS.include?(value.strip.downcase) : !!value
       end
 
       def read_only?

--- a/lib/wurk/web/config.rb
+++ b/lib/wurk/web/config.rb
@@ -24,6 +24,7 @@ module Wurk
     class Config
       def initialize
         @authorization = nil
+        @read_only = env_read_only?
       end
 
       # Registers a `(env, method, path) -> truthy/falsey` block. Re-calling
@@ -33,8 +34,22 @@ module Wurk
         @authorization
       end
 
+      # Read-only mode. When on, the Authorization middleware blocks every
+      # non-GET request (retry/kill/requeue/delete/pause/resume/clear) with
+      # 403, and the SPA hides destructive actions via the /api/meta flag.
+      # Defaults from WURK_WEB_READ_ONLY=1 so a viewer-only deploy (e.g. the
+      # public demo) needs no Ruby config.
+      def read_only=(value)
+        @read_only = !!value
+      end
+
+      def read_only?
+        @read_only
+      end
+
       def reset!
         @authorization = nil
+        @read_only = env_read_only?
       end
 
       # Returns true when no block is registered, otherwise the block's
@@ -45,6 +60,12 @@ module Wurk
         return true if @authorization.nil?
 
         !!@authorization.call(env, method, path)
+      end
+
+      private
+
+      def env_read_only?
+        ENV['WURK_WEB_READ_ONLY'] == '1'
       end
     end
 
@@ -69,7 +90,10 @@ module Wurk
     # is stripped via `SCRIPT_NAME` so the callback sees engine-relative paths.
     class Authorization
       FORBIDDEN_BODY = 'Forbidden'
+      READ_ONLY_BODY = 'Read-only mode'
       FORBIDDEN_HEADERS = { 'Content-Type' => 'text/plain' }.freeze
+      # Methods allowed while read-only. Anything else is a mutation and 403s.
+      SAFE_METHODS = %w[GET HEAD OPTIONS].freeze
 
       def initialize(app)
         @app = app
@@ -78,15 +102,17 @@ module Wurk
       def call(env)
         method = env['REQUEST_METHOD']
         path = env['PATH_INFO'].to_s
-        return forbidden unless Wurk::Web.config.authorized?(env, method, path)
+        config = Wurk::Web.config
+        return forbidden(FORBIDDEN_BODY) unless config.authorized?(env, method, path)
+        return forbidden(READ_ONLY_BODY) if config.read_only? && !SAFE_METHODS.include?(method)
 
         @app.call(env)
       end
 
       private
 
-      def forbidden
-        [403, FORBIDDEN_HEADERS.dup, [FORBIDDEN_BODY]]
+      def forbidden(body)
+        [403, FORBIDDEN_HEADERS.dup, [body]]
       end
     end
   end

--- a/test/engine/web_authorization_test.rb
+++ b/test/engine/web_authorization_test.rb
@@ -67,4 +67,39 @@ class WebAuthorizationTest < Wurk::Test::EngineCase
 
     assert_equal 403, last_response.status
   end
+
+  # --- Read-only mode ---------------------------------------------------
+
+  def test_read_only_blocks_mutating_endpoint
+    Wurk::Web.configure { |c| c.read_only = true }
+
+    post '/wurk/api/cron/no-such/pause'
+
+    assert_equal 403, last_response.status
+    assert_equal 'Read-only mode', last_response.body
+  end
+
+  def test_read_only_allows_read_endpoint
+    Wurk::Web.configure { |c| c.read_only = true }
+
+    get '/wurk/api/stats'
+
+    assert_equal 200, last_response.status
+  end
+
+  def test_meta_reports_read_write_by_default
+    get '/wurk/api/meta'
+
+    assert_equal 200, last_response.status
+    assert_equal false, JSON.parse(last_response.body)['read_only']
+  end
+
+  def test_meta_reports_read_only_when_enabled
+    Wurk::Web.configure { |c| c.read_only = true }
+
+    get '/wurk/api/meta'
+
+    assert_equal 200, last_response.status
+    assert_equal true, JSON.parse(last_response.body)['read_only']
+  end
 end

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -87,6 +87,14 @@ class ConfigurationTest < Wurk::Test::UnitCase
     assert_kind_of Array, @config.dig(:lifecycle_events, :startup)
   end
 
+  # --- web ---------------------------------------------------------------
+
+  # Non-mutating: just asserts the delegation target, so it stays safe to run
+  # in parallel with classes that mutate the Wurk::Web.config singleton.
+  def test_web_delegates_to_web_config_singleton
+    assert_same Wurk::Web.config, @config.web
+  end
+
   # --- default capsule shortcuts ----------------------------------------
 
   def test_concurrency_reads_default_capsule

--- a/test/unit/web_config_test.rb
+++ b/test/unit/web_config_test.rb
@@ -111,6 +111,14 @@ class WebConfigTest < Wurk::Test::UnitCase
     assert_equal true, Wurk::Web.config.read_only?
   end
 
+  def test_read_only_writer_treats_falsey_strings_as_off
+    ['0', 'false', 'FALSE', 'no', 'off', ' ', ''].each do |off|
+      Wurk::Web.configure { |c| c.read_only = off }
+
+      assert_equal false, Wurk::Web.config.read_only?, "expected #{off.inspect} to be off"
+    end
+  end
+
   def test_read_only_defaults_from_env
     with_env('WURK_WEB_READ_ONLY', '1') do
       Wurk::Web.reset_config!

--- a/test/unit/web_config_test.rb
+++ b/test/unit/web_config_test.rb
@@ -99,7 +99,69 @@ class WebConfigTest < Wurk::Test::UnitCase
     assert_equal %w[DELETE /api/dead/123], captured
   end
 
+  # --- Read-only mode ---------------------------------------------------
+
+  def test_read_only_defaults_off
+    refute Wurk::Web.config.read_only?
+  end
+
+  def test_read_only_writer_coerces_to_boolean
+    Wurk::Web.configure { |c| c.read_only = 'yes' }
+
+    assert_equal true, Wurk::Web.config.read_only?
+  end
+
+  def test_read_only_defaults_from_env
+    with_env('WURK_WEB_READ_ONLY', '1') do
+      Wurk::Web.reset_config!
+
+      assert Wurk::Web.config.read_only?
+    end
+  end
+
+  def test_read_only_blocks_mutating_request
+    Wurk::Web.configure { |c| c.read_only = true }
+    app = ->(_env) { [200, {}, ['should not run']] }
+    mw = Wurk::Web::Authorization.new(app)
+
+    status, headers, body = mw.call(rack_env('POST', '/api/cron/x/pause'))
+
+    assert_equal 403, status
+    assert_equal 'text/plain', headers['Content-Type']
+    assert_equal ['Read-only mode'], body
+  end
+
+  def test_read_only_allows_get_request
+    Wurk::Web.configure { |c| c.read_only = true }
+    mw = Wurk::Web::Authorization.new(->(_env) { [200, {}, ['ok']] })
+
+    status, _headers, body = mw.call(rack_env('GET', '/api/stats'))
+
+    assert_equal 200, status
+    assert_equal ['ok'], body
+  end
+
+  def test_authorization_block_runs_before_read_only_check
+    Wurk::Web.configure do |c|
+      c.authorization { |_, _, _| false }
+      c.read_only = true
+    end
+    mw = Wurk::Web::Authorization.new(->(_env) { [200, {}, []] })
+
+    _status, _headers, body = mw.call(rack_env('GET', '/api/stats'))
+
+    assert_equal ['Forbidden'], body
+  end
+
   private
+
+  def with_env(key, value)
+    previous = ENV[key]
+    ENV[key] = value
+    yield
+  ensure
+    previous.nil? ? ENV.delete(key) : ENV[key] = previous
+  end
 
   def rack_env(method, path)
     { 'REQUEST_METHOD' => method, 'PATH_INFO' => path }


### PR DESCRIPTION
## Summary
- Adds a first-class **read-only mode** for the dashboard so a viewer-only deploy (incl. the public demo) ships without bolting on auth.
- `Wurk::Web::Config` gains a `read_only` flag (default off, opt in via `WURK_WEB_READ_ONLY=1` or `Wurk::Web.configure { |c| c.read_only = true }` / `config.web.read_only = true`).
- The existing engine `Authorization` middleware now **403s every non-GET request** (`Read-only mode`) when the flag is on — generic, so it covers retry/kill/requeue/delete/pause/resume/clear and any future mutating route.
- New `GET /wurk/api/meta` exposes `{ read_only }`; the SPA fetches it once and renders a **"Read-only mode"** banner. (The current SPA has no destructive buttons yet — the meta flag is plumbed so future ones can gate on it.)
- README gets a **Deployment** section documenting both opt-in paths.

## Design notes
- Enforcement lives in the engine-scoped `Wurk::Web::Authorization` middleware (the existing request-permission gate), not per-controller — one place, catches every mutating route. The auth hook is checked first, then read-only.
- `config.web` returns the process-wide `Wurk::Web.config` singleton, so the env var, the Ruby config block, and the middleware all share one source of truth. The dashboard runs in your **web** process (Puma), so the env var is the simplest cross-process switch.

## How to test in prod
Flip the dashboard to read-only with a single env var on your web process — no code change, no redeploy of workers needed:

```sh
# On the process serving the mounted dashboard (Puma/web), set:
WURK_WEB_READ_ONLY=1
# then restart that process.
```

Verify against the live mount (replace host + mount path):

```sh
# 1. Meta flag flips on
curl -s https://your-app/wurk/api/meta            # => {"read_only":true}

# 2. Reads still work
curl -s -o /dev/null -w '%{http_code}\n' https://your-app/wurk/api/stats   # => 200

# 3. Every mutation is blocked
curl -s -o /dev/null -w '%{http_code}\n' -X POST https://your-app/wurk/api/cron/SOME_LID/pause   # => 403
curl -s -X POST https://your-app/wurk/api/cron/SOME_LID/pause                                     # => Read-only mode
```

Open the dashboard in a browser → a **"Read-only mode"** banner sits at the top. Remove the env var and restart to return to read/write (default).

## Test plan
- [x] `bin/rake test TEST=test/unit/web_config_test.rb` — read_only default/env/writer + middleware block precedence
- [x] `bin/rake test TEST=test/unit/configuration_test.rb` — `config.web` delegates to the singleton
- [x] `bin/rake test TEST=test/engine/web_authorization_test.rb` — POST 403'd, GET allowed, `/api/meta` reports both states
- [x] `bin/rake test TEST=test/engine/api_endpoints_test.rb` + `dashboard_routes_test.rb` — new route doesn't disturb existing ones
- [x] `npx tsc -b --noEmit` (frontend typecheck) clean
- [x] Live boot of `test/dummy` with `WURK_WEB_READ_ONLY=1`: meta=`true`, POST→403 "Read-only mode", GET stats→200
- [x] Browser check of the banner (needs Vite dev or a rebuilt bundle): `cd frontend && npm run dev`, then `WURK_VITE_DEV=1 WURK_WEB_READ_ONLY=1` dummy server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read-only (viewer-only) dashboard mode: mutating actions return 403, destructive UI controls hidden, and a prominent "Read-only mode" banner is shown. SPA reads boot-time read-only state via a new meta endpoint so the UI reflects mode on load.

* **Documentation**
  * Deployment guide for enabling read-only mode via environment variable or application configuration (applies at web process start).

* **Tests**
  * Added tests covering read-only behavior and the meta flag.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/developerz-ai/wurk/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->