### PR TITLE
feat: wire + harden leader-gated periodic firing (closes #14)

### DIFF
--- a/lib/wurk/cron.rb
+++ b/lib/wurk/cron.rb
@@ -280,11 +280,34 @@ module Wurk
         nxt = next_fire_at(advance_from)
         return nxt if nxt.nil? || local_components(nxt) != local_components(fired_slot)
 
+        # Only suppress the fold duplicate for fixed once-per-day schedules.
+        # Cadence schedules (hourly, sub-daily step patterns) land on *different*
+        # minutes, so a second fold instant is legitimate. Detect cadence by
+        # checking if minute == 0 and hour is not fixed (hourly), or if minute
+        # field has multiple values (sub-hourly step).
+        return next_fire_at(nxt) if cadence_schedule?
+
         next_fire_at(nxt)
       end
 
       def local_components(epoch)
         parser.local_components(epoch, @tz)
+      end
+
+      # Detect cadence schedules (hourly, sub-daily steps) vs fixed daily.
+      # Hourly: minute == 0, hour is wildcard (multiple values).
+      # Sub-hourly: minute has multiple values (step pattern like */30).
+      def cadence_schedule?
+        min_field = parser.fields[0]
+        hour_field = parser.fields[1]
+
+        # Sub-hourly cadence: minute field has multiple values.
+        return true if min_field.size > 1
+
+        # Hourly cadence: minute is exactly 0 and hour is not fixed.
+        return true if min_field.size == 1 && min_field.include?(0) && hour_field.size > 1
+
+        false
       end
 
       def tz_name
@@ -517,14 +540,21 @@ module Wurk
       def read_fire_marks(lid)
         @config.redis do |c|
           vals = c.call('HMGET', "#{LOOP_PREFIX}#{lid}", 'lf', 'nf')
-          [vals[0]&.to_i, vals[1]&.to_i]
+          next_fire = vals[1]
+          # Preserve nil: treat missing or empty 'nf' as nil, not 0.
+          [vals[0]&.to_i, next_fire.nil? || next_fire.empty? ? nil : next_fire.to_i]
         end
       end
 
       def record_fire(loop_obj, jid, fired_at, future)
         history_entry = Wurk.dump_json([fired_at, jid])
         @config.redis do |c|
-          c.call('HSET', "#{LOOP_PREFIX}#{loop_obj.lid}", 'lf', fired_at.to_s, 'nf', future.to_s)
+          if future.nil?
+            c.call('HSET', "#{LOOP_PREFIX}#{loop_obj.lid}", 'lf', fired_at.to_s)
+            c.call('HDEL', "#{LOOP_PREFIX}#{loop_obj.lid}", 'nf')
+          else
+            c.call('HSET', "#{LOOP_PREFIX}#{loop_obj.lid}", 'lf', fired_at.to_s, 'nf', future.to_s)
+          end
           c.call('LPUSH', "#{HISTORY_PREFIX}#{loop_obj.lid}", history_entry)
           c.call('LTRIM', "#{HISTORY_PREFIX}#{loop_obj.lid}", 0, HISTORY_CAP - 1)
         end

--- a/lib/wurk/cron.rb
+++ b/lib/wurk/cron.rb
@@ -270,44 +270,31 @@ module Wurk
 
       # Next scheduled fire after firing at `fired_slot`. `advance_from` (the
       # poller passes `now`) is the search origin so missed ticks are not
-      # backfilled. The DST guard: on a fall-back, the clock rolls back and the
-      # same wall-clock minute recurs at a later UTC instant — a once-daily
-      # loop must not fire it twice, so we skip a successor whose local
-      # wall-clock equals the slot we just fired. A frequency loop (e.g.
-      # `*/30`) lands on a *different* minute, so its real-time cadence is kept.
-      # Spec: no DST double-fire (sidekiq-ent.md §2.6).
+      # backfilled. The DST guard: on a fall-back the clock rolls back, so the
+      # same wall-clock minute recurs at a later UTC instant. That equality
+      # alone isn't enough to skip — it would also drop a legitimate hourly run
+      # whose repeated hour is real. So we only suppress the duplicate for a
+      # FIXED daily slot; an hourly schedule (wildcard hour) keeps both fold
+      # hours. A sub-hourly schedule (e.g. `*/30`) lands on a different minute,
+      # so the equality never even triggers. Spec: no DST double-fire without
+      # skipping legitimate hourly runs (sidekiq-ent.md §2.6).
       def next_fire_after(fired_slot, advance_from = fired_slot)
         nxt = next_fire_at(advance_from)
         return nxt if nxt.nil? || local_components(nxt) != local_components(fired_slot)
+        return nxt if hourly? # repeated fall-back hour is a genuine second run
 
-        # Only suppress the fold duplicate for fixed once-per-day schedules.
-        # Cadence schedules (hourly, sub-daily step patterns) land on *different*
-        # minutes, so a second fold instant is legitimate. Detect cadence by
-        # checking if minute == 0 and hour is not fixed (hourly), or if minute
-        # field has multiple values (sub-hourly step).
-        return next_fire_at(nxt) if cadence_schedule?
-
-        next_fire_at(nxt)
+        next_fire_at(nxt) # fixed daily slot: drop the fold duplicate
       end
 
       def local_components(epoch)
         parser.local_components(epoch, @tz)
       end
 
-      # Detect cadence schedules (hourly, sub-daily steps) vs fixed daily.
-      # Hourly: minute == 0, hour is wildcard (multiple values).
-      # Sub-hourly: minute has multiple values (step pattern like */30).
-      def cadence_schedule?
-        min_field = parser.fields[0]
-        hour_field = parser.fields[1]
-
-        # Sub-hourly cadence: minute field has multiple values.
-        return true if min_field.size > 1
-
-        # Hourly cadence: minute is exactly 0 and hour is not fixed.
-        return true if min_field.size == 1 && min_field.include?(0) && hour_field.size > 1
-
-        false
+      # True when the schedule fires every hour (hour field is `*` / all 24).
+      # Only such a schedule legitimately runs in both repeated fall-back hours;
+      # a fixed-hour slot (even a multi-hour one like `0 1,2 * * *`) must dedup.
+      def hourly?
+        parser.fields[1].size == 24
       end
 
       def tz_name

--- a/lib/wurk/cron.rb
+++ b/lib/wurk/cron.rb
@@ -96,6 +96,13 @@ module Wurk
         match_components?(wall_clock(time.to_i, tz))
       end
 
+      # Local wall-clock [min, hour, day, mon, dow] for `epoch` in `tz`. Public
+      # so the Loop/Poller can detect a DST fall-back fold — two distinct UTC
+      # instants that share the same local minute — and avoid a double-fire.
+      def local_components(epoch, tz = nil)
+        wall_clock(epoch, tz)
+      end
+
       private
 
       def match_components?(components)
@@ -261,6 +268,25 @@ module Wurk
         parser.next_fire_at(from_epoch, @tz)
       end
 
+      # Next scheduled fire after firing at `fired_slot`. `advance_from` (the
+      # poller passes `now`) is the search origin so missed ticks are not
+      # backfilled. The DST guard: on a fall-back, the clock rolls back and the
+      # same wall-clock minute recurs at a later UTC instant — a once-daily
+      # loop must not fire it twice, so we skip a successor whose local
+      # wall-clock equals the slot we just fired. A frequency loop (e.g.
+      # `*/30`) lands on a *different* minute, so its real-time cadence is kept.
+      # Spec: no DST double-fire (sidekiq-ent.md §2.6).
+      def next_fire_after(fired_slot, advance_from = fired_slot)
+        nxt = next_fire_at(advance_from)
+        return nxt if nxt.nil? || local_components(nxt) != local_components(fired_slot)
+
+        next_fire_at(nxt)
+      end
+
+      def local_components(epoch)
+        parser.local_components(epoch, @tz)
+      end
+
       def tz_name
         return nil if @tz.nil?
         return @tz.name if @tz.respond_to?(:name)
@@ -314,12 +340,17 @@ module Wurk
     class LoopSet
       include ::Enumerable
 
-      def initialize(_config = nil); end
+      # `config` scopes Redis to that config's per-fork pool — the leader poller
+      # runs inside a swarm child and must not reach for the parent-inherited
+      # global socket. Dashboard/CLI callers pass nothing and get Wurk.redis.
+      def initialize(config = nil)
+        @config = config
+      end
 
       def each
         return enum_for(:each) unless block_given?
 
-        Wurk.redis do |c|
+        redis do |c|
           lids = c.call('SMEMBERS', PERIODIC_KEY)
           lids.each do |lid|
             h = c.call('HGETALL', "#{LOOP_PREFIX}#{lid}")
@@ -331,17 +362,23 @@ module Wurk
       end
 
       def size
-        Wurk.redis { |c| c.call('SCARD', PERIODIC_KEY).to_i }
+        redis { |c| c.call('SCARD', PERIODIC_KEY).to_i }
       end
 
       def fetch(lid)
-        h = Wurk.redis { |c| c.call('HGETALL', "#{LOOP_PREFIX}#{lid}") }
+        h = redis { |c| c.call('HGETALL', "#{LOOP_PREFIX}#{lid}") }
         return nil if h.nil? || h.empty?
 
         h = h.each_slice(2).to_h if h.is_a?(Array)
         return nil if h.empty?
 
         Loop.from_redis(lid, h)
+      end
+
+      private
+
+      def redis(&)
+        @config ? @config.redis(&) : Wurk.redis(&)
       end
     end
 
@@ -388,11 +425,17 @@ module Wurk
         @sleeper = ::ConditionVariable.new
         @client = Client.new(config: config)
         @thread = nil
-        @tick_interval = DEFAULT_TICK_SECONDS
+        # Operators never need to touch this; integration tests shrink it so a
+        # due loop fires within the test window instead of waiting a full minute.
+        @tick_interval = config[:cron_tick_interval] || DEFAULT_TICK_SECONDS
       end
 
       def start
         @poller_thread ||= safe_thread('cron-poller') do # rubocop:disable Naming/MemoizedInstanceVariableName
+          # Wait one interval before the first tick: don't fire a catch-up burst
+          # the instant we boot (the leader is barely settled), and let a
+          # short-lived process exit without ticking at all.
+          wait
           until @done
             tick
             wait
@@ -414,7 +457,7 @@ module Wurk
       def tick
         return unless leader?
 
-        LoopSet.new.each { |lp| enqueue_if_due(lp) }
+        LoopSet.new(@config).each { |lp| enqueue_if_due(lp) }
       rescue StandardError => e
         handle_exception(e, { context: 'cron-poller' })
       end
@@ -429,8 +472,19 @@ module Wurk
 
         warn_missed_tick(loop_obj, next_fire, now)
         jid = enqueue!(loop_obj)
-        future = loop_obj.next_fire_at(now)
+        future = loop_obj.next_fire_after(next_fire, now)
         record_fire(loop_obj, jid, now, future)
+        jid
+      end
+
+      # Fire one loop right now, bypassing both the leader gate and the
+      # schedule due-check, recording history + advancing the fire marks
+      # exactly like a real tick. Powers Cron.fire! (deterministic specs /
+      # manual "run now"); the scheduled, leader-gated path stays #tick.
+      def fire(loop_obj)
+        now = ::Time.now.to_i
+        jid = enqueue!(loop_obj)
+        record_fire(loop_obj, jid, now, loop_obj.next_fire_at(now))
         jid
       end
 
@@ -461,7 +515,7 @@ module Wurk
       end
 
       def read_fire_marks(lid)
-        Wurk.redis do |c|
+        @config.redis do |c|
           vals = c.call('HMGET', "#{LOOP_PREFIX}#{lid}", 'lf', 'nf')
           [vals[0]&.to_i, vals[1]&.to_i]
         end
@@ -469,7 +523,7 @@ module Wurk
 
       def record_fire(loop_obj, jid, fired_at, future)
         history_entry = Wurk.dump_json([fired_at, jid])
-        Wurk.redis do |c|
+        @config.redis do |c|
           c.call('HSET', "#{LOOP_PREFIX}#{loop_obj.lid}", 'lf', fired_at.to_s, 'nf', future.to_s)
           c.call('LPUSH', "#{HISTORY_PREFIX}#{loop_obj.lid}", history_entry)
           c.call('LTRIM', "#{HISTORY_PREFIX}#{loop_obj.lid}", 0, HISTORY_CAP - 1)
@@ -528,6 +582,19 @@ module Wurk
 
       def jobs
         LoopSet.new
+      end
+
+      # Test/ops helper: fire one registered loop immediately, ignoring the
+      # leader gate and the schedule due-check. Records history + advances the
+      # fire marks just like a leader tick, so specs can assert on the enqueue
+      # and history deterministically without waiting on wall-clock or
+      # stubbing leadership. Returns the enqueued jid, or nil for an unknown
+      # lid. Aliased as `Sidekiq::Periodic.fire!`.
+      def fire!(lid)
+        loop_obj = LoopSet.new.fetch(lid)
+        return nil if loop_obj.nil?
+
+        Poller.new(Wurk.configuration).fire(loop_obj)
       end
     end
   end

--- a/lib/wurk/launcher.rb
+++ b/lib/wurk/launcher.rb
@@ -8,6 +8,7 @@ require_relative 'health'
 require_relative 'keys'
 require_relative 'scheduled'
 require_relative 'leader'
+require_relative 'cron'
 
 module Wurk
   # Top-level supervisor inside each worker process. Owns the Manager pool
@@ -38,7 +39,7 @@ module Wurk
     # (Sidekiq's drop-in surface). The single source of truth is Heartbeat.
     BEAT_PAUSE = Heartbeat::BEAT_PAUSE
 
-    attr_accessor :managers, :poller
+    attr_accessor :managers, :poller, :cron_poller
 
     def initialize(config, embedded: false)
       @config = config
@@ -46,6 +47,7 @@ module Wurk
       @done = false
       @managers = config.capsules.values.map { |cap| Manager.new(cap) }
       @poller = build_poller
+      @cron_poller = build_cron_poller
       @leader = build_leader
       @started_at = nil
       @heartbeat = nil
@@ -57,7 +59,9 @@ module Wurk
     #   1. freeze! the config so mutations after fork are visible mistakes.
     #   2. spawn the heartbeat thread BEFORE the managers so the dashboard
     #      sees the process the moment it can pick up jobs.
-    #   3. start the poller (scheduler).
+    #   3. start the scheduler poller + the cron poller (both leader-gated for
+    #      what they enqueue; safe to start before leadership is settled since
+    #      a non-leader tick just returns early).
     #   4. start the managers (which start their processors).
     #   5. start the health probe server LAST so the listener doesn't
     #      accept k8s probes until the rest of the launcher is up.
@@ -71,6 +75,7 @@ module Wurk
       @heartbeat_thread = safe_thread('heartbeat', &method(:start_heartbeat)) if async_beat
       @poller&.start
       @leader&.start
+      @cron_poller&.start
       @managers.each(&:start)
       @health_server&.start
     end
@@ -84,6 +89,9 @@ module Wurk
       @done = true
       @managers.each(&:quiet)
       @poller&.terminate
+      # The cron poller is intentionally NOT terminated here: a USR1-quieted
+      # leader still enqueues periodic jobs — it only stops fetching for itself.
+      # Loops stop only on full shutdown (#stop). Spec: sidekiq-ent.md §2.6.
       fire_event(:quiet, reverse: true)
     end
 
@@ -96,6 +104,9 @@ module Wurk
       stoppers = @managers.map { |m| Thread.new { m.stop(deadline) } }
       fire_event(:shutdown, reverse: true)
       stoppers.each(&:join)
+      # Full shutdown stops periodic firing (it survived #quiet); do this before
+      # releasing the lock so no tick races a follower's promotion.
+      @cron_poller&.terminate
       # CAS-release the cluster lock now (planned shutdown) so a follower can
       # take over immediately instead of waiting out the TTL.
       @leader&.stop
@@ -211,6 +222,13 @@ module Wurk
 
     def build_poller
       Wurk::Scheduled::Poller.new(@config)
+    end
+
+    # Periodic (cron) tick loop. Like the scheduler poller, every process runs
+    # one, but only the elected leader enqueues — the single-leader invariant is
+    # what guarantees exactly one enqueue per (loop, tick) across the cluster.
+    def build_cron_poller
+      Wurk::Cron::Poller.new(@config)
     end
 
     # Every worker process campaigns for the single cluster lock (`dear-leader`);

--- a/test/integration/periodic_leader_test.rb
+++ b/test/integration/periodic_leader_test.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Top-level so the forked child resolves the constant — children inherit the
+# constant table but not the Minitest test-class lexical scope.
+class PeriodicLeaderWorker
+  include Wurk::Job
+
+  def perform; end
+end
+
+# Real forks, real Redis, real leader election. Issue #14 done-when: with two
+# worker processes and one registered loop, the loop fires EXACTLY ONCE per
+# tick — the single cluster-leader invariant gates periodic enqueues so a
+# follower never double-enqueues. We assert on the loop's fire history (one
+# audit entry per enqueue, written only by the enqueuing leader).
+#
+# Isolation: the whole swarm runs against a DEDICATED Redis DB. A wired cron
+# poller becomes the cluster leader and would otherwise fire *every* loop in
+# the shared `periodic` set (flaking parallel unit tests). A private DB scopes
+# the leader lock, periodic set, queue, and history to this test alone.
+# NEVER mock Redis here.
+class PeriodicLeaderTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  ISOLATED_DB = 15
+  REDIS_URL = (ENV.fetch('REDIS_URL', 'redis://localhost:6379/0').sub(%r{/\d+\z}, '') + "/#{ISOLATED_DB}").freeze
+  POLL_TIMEOUT = 20.0
+  POLL_INTERVAL = 0.1
+
+  def setup
+    super
+    @ns = "periodic-leader-#{Process.pid}-#{object_id}"
+    @queue = "#{@ns}-q"
+    @config = Wurk::Configuration.new
+    @config.logger = ::Logger.new(IO::NULL)
+    @config.redis = { url: REDIS_URL }
+    @config[:timeout] = 5
+    # Tick fast so the due loop fires within the test window instead of after a
+    # full minute; campaign/renew aggressively so a leader settles quickly.
+    @config[:cron_tick_interval] = 0.2
+    @config[:leader_ttl] = 3
+    @config[:leader_renew_interval] = 0.5
+    @config[:leader_follower_interval] = 0.5
+    @observer = RedisClient.config(url: REDIS_URL).new_client
+    @observer.call('DEL', Wurk::Leader::DEFAULT_KEY)
+    @lid = nil
+  end
+
+  def teardown
+    if @lid
+      @observer.call('SREM', Wurk::Cron::PERIODIC_KEY, @lid)
+      @observer.call('DEL', "#{Wurk::Cron::LOOP_PREFIX}#{@lid}", "#{Wurk::Cron::HISTORY_PREFIX}#{@lid}")
+    end
+    @observer.call('DEL', Wurk::Leader::DEFAULT_KEY, "queue:#{@queue}")
+    @observer.call('SREM', 'queues', @queue)
+    @observer&.close
+    @config&.reset_redis_pools!
+  ensure
+    super
+  end
+
+  def test_two_workers_fire_one_loop_exactly_once
+    @lid = register_loop
+
+    swarm = Wurk::Swarm.new(topology: topology_n(2), config: @config, shutdown_timeout: 5)
+    swarm.boot(install_signals: false)
+    supervisor = nil
+
+    begin
+      supervisor = Thread.new { swarm.supervise }
+
+      assert wait_for_history, "loop #{@lid} never fired within #{POLL_TIMEOUT}s — " \
+                               'the leader cron poller is not enqueuing'
+      assert_equal 1, history_len,
+                   'two workers + one loop must enqueue exactly once per tick (no follower double-fire)'
+    ensure
+      swarm.shutdown(timeout: 5)
+      supervisor&.join(10)
+    end
+  end
+
+  private
+
+  def topology_n(count)
+    Wurk::Topology.flat(count: count, queues: [@queue], concurrency: 1)
+  end
+
+  # Persist the loop straight through the observer client (db-isolated), so the
+  # parent never opens the global pool that the forked children would inherit.
+  # Seed `nf` (next-fire) to one second ago so the loop is due on the leader's
+  # very first tick — deterministic, no waiting on the next wall-clock minute.
+  def register_loop
+    lp = Wurk::Cron::Loop.new(
+      schedule: '* * * * *', klass: PeriodicLeaderWorker.name, options: { 'queue' => @queue }
+    )
+    @observer.call('SADD', Wurk::Cron::PERIODIC_KEY, lp.lid)
+    @observer.call('HSET', "#{Wurk::Cron::LOOP_PREFIX}#{lp.lid}",
+                   *lp.to_redis_hash.flatten, 'nf', (Time.now.to_i - 1).to_s)
+    lp.lid
+  end
+
+  def history_len
+    @observer.call('LLEN', "#{Wurk::Cron::HISTORY_PREFIX}#{@lid}").to_i
+  end
+
+  def wait_for_history
+    deadline = monotonic_now + POLL_TIMEOUT
+    while monotonic_now < deadline
+      return true if history_len >= 1
+
+      sleep POLL_INTERVAL
+    end
+    false
+  end
+
+  def monotonic_now
+    ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+  end
+end

--- a/test/unit/cron_test.rb
+++ b/test/unit/cron_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../test_helper'
+require 'tzinfo'
 
 class CronTest < Wurk::Test::UnitCase
   parallelize_me!
@@ -13,6 +14,9 @@ class CronTest < Wurk::Test::UnitCase
   end
 
   class BarWorker # rubocop:disable Lint/EmptyClass
+  end
+
+  class DSTWorker # rubocop:disable Lint/EmptyClass
   end
 
   def setup
@@ -430,6 +434,156 @@ class CronTest < Wurk::Test::UnitCase
     assert ts.is_a?(Integer) && jid.is_a?(String) && !jid.empty?
   end
 
+  def test_poller_tick_interval_defaults_to_60
+    poller = Wurk::Cron::Poller.new(Wurk.configuration)
+
+    assert_equal 60, poller.instance_variable_get(:@tick_interval)
+  end
+
+  def test_poller_tick_interval_reads_config
+    cfg = Wurk::Configuration.new
+    cfg[:cron_tick_interval] = 0.25
+
+    assert_equal 0.25, Wurk::Cron::Poller.new(cfg).instance_variable_get(:@tick_interval)
+  end
+
+  # ---- DST / timezone edge cases (US / EU / AU) -----------------------
+  #
+  # 2026 transitions (confirmed via TZInfo):
+  #   America/New_York  spring 03-08 02:00→03:00   fall 11-01 02:00→01:00
+  #   Europe/London     spring 03-29 01:00→02:00   fall 10-25 02:00→01:00
+  #   Australia/Sydney  spring 10-04 02:00→03:00   fall 04-05 03:00→02:00
+  # TZInfo objects (not IANA strings) so the parser uses #utc_to_local and we
+  # don't mutate the process-global ENV['TZ'] under the parallel runner.
+
+  # --- fall-back fold: the once-daily slot must fire exactly once ---
+
+  def test_dst_fall_back_fires_once_new_york
+    fires = simulate_fires('30 1 * * *', tz('America/New_York'),
+                           Time.utc(2026, 11, 1, 4, 0), Time.utc(2026, 11, 1, 8, 0))
+
+    assert_equal 1, fires.size, 'daily 01:30 must fire once across the US fall-back fold'
+  end
+
+  def test_dst_fall_back_fires_once_london
+    fires = simulate_fires('30 1 * * *', tz('Europe/London'),
+                           Time.utc(2026, 10, 25, 0, 0), Time.utc(2026, 10, 25, 2, 0))
+
+    assert_equal 1, fires.size, 'daily 01:30 must fire once across the EU fall-back fold'
+  end
+
+  def test_dst_fall_back_fires_once_sydney
+    fires = simulate_fires('30 2 * * *', tz('Australia/Sydney'),
+                           Time.utc(2026, 4, 4, 15, 0), Time.utc(2026, 4, 4, 17, 0))
+
+    assert_equal 1, fires.size, 'daily 02:30 must fire once across the AU fall-back fold'
+  end
+
+  # --- the parser itself enumerates the fold twice (why the dedup exists) ---
+
+  def test_dst_parser_enumerates_fall_back_fold_twice
+    tzobj = tz('America/New_York')
+    parser = Wurk::Cron::Parser.new('30 1 * * *')
+    first = parser.next_fire_at(Time.utc(2026, 11, 1, 4, 0).to_i, tzobj)
+    second = parser.next_fire_at(first, tzobj)
+
+    refute_equal first, second
+    assert_equal parser.local_components(first, tzobj), parser.local_components(second, tzobj),
+                 'both fold instants share the same local wall-clock — the source of a double-fire'
+  end
+
+  def test_dst_next_fire_after_skips_the_fold
+    loop_obj = dst_loop('30 1 * * *', tz('America/New_York'))
+    first = loop_obj.next_fire_at(Time.utc(2026, 11, 1, 4, 0).to_i)
+    fold_dup = loop_obj.next_fire_at(first)
+
+    skipped = loop_obj.next_fire_after(first, first)
+
+    refute_equal fold_dup, skipped, 'next_fire_after must not return the fold duplicate'
+    assert_operator skipped, :>, Time.utc(2026, 11, 1, 8, 0).to_i, 'should jump to the next day'
+  end
+
+  # --- a frequency loop keeps its real-time cadence across the fold ---
+
+  def test_dst_fall_back_frequency_loop_keeps_cadence
+    # */30 across the US fold spans six real half-hours (05:00..07:30 UTC) and
+    # must fire all six — the dedup only suppresses an identical wall-clock minute.
+    fires = simulate_fires('*/30 * * * *', tz('America/New_York'),
+                           Time.utc(2026, 11, 1, 4, 30), Time.utc(2026, 11, 1, 7, 30))
+
+    assert_equal 6, fires.size
+  end
+
+  # --- spring-forward gap: the missing slot is skipped to the next valid day ---
+
+  def test_dst_spring_forward_skips_gap_new_york
+    nxt = next_local_fire('30 2 * * *', tz('America/New_York'), Time.utc(2026, 3, 8, 5, 0))
+
+    assert_equal [30, 2], nxt[0, 2], 'fires at 02:30…'
+    assert_equal 9, nxt[2], '…on 03-09, having skipped the non-existent 03-08 02:30'
+  end
+
+  def test_dst_spring_forward_skips_gap_london
+    nxt = next_local_fire('30 1 * * *', tz('Europe/London'), Time.utc(2026, 3, 29, 0, 0))
+
+    assert_equal [30, 1], nxt[0, 2]
+    assert_equal 30, nxt[2], 'skips the non-existent 03-29 01:30, fires 03-30'
+  end
+
+  def test_dst_spring_forward_skips_gap_sydney
+    nxt = next_local_fire('30 2 * * *', tz('Australia/Sydney'), Time.utc(2026, 10, 3, 14, 0))
+
+    assert_equal [30, 2], nxt[0, 2]
+    assert_equal 5, nxt[2], 'skips the non-existent 10-04 02:30, fires 10-05'
+  end
+
+  # ---- Cron.fire! (deterministic test/ops helper) ---------------------
+
+  def test_fire_bang_enqueues_the_loop_job
+    queue = "cron-fire-#{@suffix}"
+    lp = register_loop("CronTest::FireOne#{@suffix}", queue: queue, schedule: '0 4 * * *')
+
+    Wurk::Cron.fire!(lp.lid)
+    raw = Wurk.redis { |c| c.call('RPOP', "queue:#{queue}") }
+    cleanup_queue(queue)
+
+    refute_nil raw, 'fire! should enqueue even when the loop is not due'
+    assert_equal "CronTest::FireOne#{@suffix}", JSON.parse(raw)['class']
+  end
+
+  def test_fire_bang_records_one_history_entry
+    lp = register_loop("CronTest::FireHist#{@suffix}", queue: "cron-fh-#{@suffix}")
+
+    Wurk::Cron.fire!(lp.lid)
+    len = Wurk.redis { |c| c.call('LLEN', "#{Wurk::Cron::HISTORY_PREFIX}#{lp.lid}") }
+    cleanup_queue("cron-fh-#{@suffix}")
+
+    assert_equal 1, len
+  end
+
+  def test_fire_bang_returns_jid
+    lp = register_loop("CronTest::FireJid#{@suffix}", queue: "cron-fj-#{@suffix}")
+
+    jid = Wurk::Cron.fire!(lp.lid)
+    cleanup_queue("cron-fj-#{@suffix}")
+
+    assert jid.is_a?(String) && !jid.empty?
+  end
+
+  def test_fire_bang_returns_nil_for_unknown_lid
+    assert_nil Wurk::Cron.fire!("no-such-lid-#{@suffix}")
+  end
+
+  def test_fire_bang_aliased_under_sidekiq_periodic
+    queue = "cron-alias-#{@suffix}"
+    lp = register_loop("CronTest::FireAlias#{@suffix}", queue: queue)
+
+    jid = Sidekiq::Periodic.fire!(lp.lid)
+    cleanup_queue(queue)
+
+    refute_nil jid
+  end
+
   # ---- Configuration#periodic -----------------------------------------
 
   def test_configure_server_periodic_block_yields_manager
@@ -465,6 +619,45 @@ class CronTest < Wurk::Test::UnitCase
       c.call('DEL', "queue:#{queue}")
       c.call('SREM', 'queues', queue)
     end
+  end
+
+  def register_loop(klass, queue:, schedule: '* * * * *', **opts)
+    mgr = Wurk::Cron::Manager.new
+    lp = mgr.register(schedule, klass, queue: queue, **opts)
+    @lids << lp.lid
+    lp
+  end
+
+  def tz(name)
+    TZInfo::Timezone.get(name)
+  end
+
+  def dst_loop(schedule, tzobj)
+    Wurk::Cron::Loop.new(schedule: schedule, klass: 'CronTest::DSTWorker', tz: tzobj)
+  end
+
+  # Replays the leader poller's fire-advance (next_fire_after) across
+  # [from_utc, to_utc], returning the fired UTC epochs. Bounded so a regression
+  # that loops can't hang the suite.
+  def simulate_fires(schedule, tzobj, from_utc, to_utc)
+    loop_obj = dst_loop(schedule, tzobj)
+    fires = []
+    slot = loop_obj.next_fire_at(from_utc.to_i)
+    500.times do
+      break if slot.nil? || slot > to_utc.to_i
+
+      fires << slot
+      slot = loop_obj.next_fire_after(slot, slot)
+    end
+    fires
+  end
+
+  # Local [min, hour, day] of the first fire at/after `from_utc`.
+  def next_local_fire(schedule, tzobj, from_utc)
+    loop_obj = dst_loop(schedule, tzobj)
+    nf = loop_obj.next_fire_at(from_utc.to_i)
+    refute_nil nf, 'next_fire_at must resolve a future fire across the spring-forward gap'
+    loop_obj.local_components(nf)[0, 3]
   end
 
   def register_for_persist_test

--- a/test/unit/cron_test.rb
+++ b/test/unit/cron_test.rb
@@ -514,6 +514,27 @@ class CronTest < Wurk::Test::UnitCase
     assert_equal 6, fires.size
   end
 
+  def test_dst_fall_back_hourly_keeps_both_fold_hours
+    # An hourly loop must run in BOTH repeated 01:00 fall-back hours (01:00 EDT
+    # and 01:00 EST) — the fold dedup is only for fixed daily slots, never for
+    # an hourly cadence whose repeated hour is a genuine second run.
+    nyt = tz('America/New_York')
+    fires = simulate_fires('0 * * * *', nyt, Time.utc(2026, 11, 1, 4, 0), Time.utc(2026, 11, 1, 7, 0))
+    one_am = fires.count { |f| lc = nyt.utc_to_local(Time.at(f)); lc.hour == 1 && lc.min.zero? }
+
+    assert_equal 2, one_am, 'hourly 0 * * * * must fire in both fold 01:00 hours, not skip one'
+  end
+
+  def test_dst_fall_back_hourly_nonzero_minute_keeps_both_fold_hours
+    # Guards the discriminator: "hourly" means the hour field is a wildcard, NOT
+    # "minute == 0". 15 * * * * must also keep both repeated fall-back hours.
+    nyt = tz('America/New_York')
+    fires = simulate_fires('15 * * * *', nyt, Time.utc(2026, 11, 1, 4, 0), Time.utc(2026, 11, 1, 7, 0))
+    one_fifteen = fires.count { |f| lc = nyt.utc_to_local(Time.at(f)); lc.hour == 1 && lc.min == 15 }
+
+    assert_equal 2, one_fifteen
+  end
+
   # --- spring-forward gap: the missing slot is skipped to the next valid day ---
 
   def test_dst_spring_forward_skips_gap_new_york
@@ -582,6 +603,27 @@ class CronTest < Wurk::Test::UnitCase
     cleanup_queue(queue)
 
     refute_nil jid
+  end
+
+  # ---- nil next-fire marks (no resolvable future occurrence) -----------
+
+  def test_record_fire_clears_nf_when_future_is_nil
+    # A loop with no resolvable next fire (e.g. Feb 31) yields next_fire_at => nil.
+    # record_fire must NOT persist nf as "" — read_fire_marks would coerce "" to 0
+    # and every subsequent tick would treat the loop as immediately due forever.
+    poller = Wurk::Cron::Poller.new(Wurk.configuration)
+    lp = register_loop("CronTest::NoFuture#{@suffix}", queue: "cron-nf-#{@suffix}")
+    key = "#{Wurk::Cron::LOOP_PREFIX}#{lp.lid}"
+    Wurk.redis { |c| c.call('HSET', key, 'nf', '9999999999') } # pre-existing mark to clear
+
+    poller.send(:record_fire, lp, 'jid-nofuture', Time.now.to_i, nil)
+
+    raw_nf = Wurk.redis { |c| c.call('HGET', key, 'nf') }
+    marks = poller.send(:read_fire_marks, lp.lid)
+    cleanup_queue("cron-nf-#{@suffix}")
+
+    assert_nil raw_nf, 'nil future must clear the nf field, not write ""'
+    assert_nil marks[1], 'read_fire_marks must read an absent/empty nf as nil, not 0'
   end
 
   # ---- Configuration#periodic -----------------------------------------

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -87,6 +87,12 @@ class LauncherTest < Wurk::Test::UnitCase
     assert_instance_of Wurk::Scheduled::Poller, launcher.poller
   end
 
+  def test_initialize_builds_a_cron_poller
+    launcher = Wurk::Launcher.new(@config)
+
+    assert_instance_of Wurk::Cron::Poller, launcher.cron_poller
+  end
+
   # --- run -------------------------------------------------------------
 
   def test_run_freezes_config
@@ -119,6 +125,17 @@ class LauncherTest < Wurk::Test::UnitCase
     launcher.run(async_beat: false)
 
     assert started, 'run should start the cluster leader'
+  end
+
+  def test_run_starts_the_cron_poller
+    launcher = Wurk::Launcher.new(@config)
+    stub_managers(launcher)
+    started = false
+    launcher.cron_poller.define_singleton_method(:start) { started = true }
+
+    launcher.run(async_beat: false)
+
+    assert started, 'run should start the periodic (cron) poller'
   end
 
   def test_run_starts_each_manager
@@ -175,6 +192,19 @@ class LauncherTest < Wurk::Test::UnitCase
     assert_equal launcher.managers, quieted
   end
 
+  # Spec sidekiq-ent.md §2.6: a USR1-quieted leader keeps enqueuing periodic
+  # jobs — only full shutdown stops the loops. So quiet must NOT terminate it.
+  def test_quiet_does_not_terminate_cron_poller
+    launcher = Wurk::Launcher.new(@config)
+    launcher.managers.each { |m| m.define_singleton_method(:quiet) { nil } }
+    terminated = false
+    launcher.cron_poller.define_singleton_method(:terminate) { terminated = true }
+
+    launcher.quiet
+
+    refute terminated, 'quiet must leave the cron poller running (quieted leader still enqueues)'
+  end
+
   def test_quiet_is_idempotent
     launcher = Wurk::Launcher.new(@config)
     calls = 0
@@ -226,6 +256,18 @@ class LauncherTest < Wurk::Test::UnitCase
     launcher.stop
 
     assert stopped, 'stop should release the cluster leader'
+  end
+
+  def test_stop_terminates_cron_poller
+    @config[:timeout] = 0
+    launcher = Wurk::Launcher.new(@config)
+    silence_managers(launcher)
+    terminated = false
+    launcher.cron_poller.define_singleton_method(:terminate) { terminated = true }
+
+    launcher.stop
+
+    assert terminated, 'full shutdown should stop periodic firing'
   end
 
   def test_stop_fires_shutdown_then_exit_in_reverse
@@ -497,6 +539,8 @@ class LauncherTest < Wurk::Test::UnitCase
     launcher.managers.each { |m| m.define_singleton_method(:start) { nil } }
     # Don't campaign for the global `dear-leader` lock during unit run-tests.
     launcher.instance_variable_get(:@leader).define_singleton_method(:start) { nil }
+    # Don't spawn the real cron tick thread (it would poll Redis on a timer).
+    launcher.cron_poller.define_singleton_method(:start) { nil }
   end
 
   def silence_managers(launcher)


### PR DESCRIPTION
## Summary
The periodic *implementation* (parser, manager, leader-gated `Cron::Poller`) landed with #15, but the **poller was never wired into the boot path** — so registered loops persisted to Redis and a leader was elected, yet **periodic jobs never actually fired in a running cluster**. This wires it up and closes the remaining #14 acceptance gaps.

- **Launcher** starts the cron poller in `#run` and terminates it in `#stop` — but **not** in `#quiet`: a `USR1`-quieted leader still enqueues cron, it only stops fetching (ent §2.6).
- **Fork-safe poller**: reads loops / fire-marks / history through its injected `@config` per-fork pool instead of the global `Wurk.redis` (CLAUDE.md: never share a socket across forks). `LoopSet.new(config)` is now config-scoped.
- **No boot-time burst**: the poller waits one tick interval before its first tick (mirrors `Scheduled::Poller`'s initial wait), so a freshly-elected leader doesn't fire a catch-up burst and short-lived processes never tick. Tick interval is configurable (`config[:cron_tick_interval]`).
- **DST correctness** (`Loop#next_fire_after`): on a fall-back fold the same wall-clock minute recurs at a later UTC instant — a once-daily loop now fires it **once** (no double-fire, ent §2.6), while a frequency loop (`*/30`) keeps its real-time cadence. Spring-forward gaps are skipped to the next valid day.
- **`Wurk::Cron.fire!`** / `Poller#fire` — deterministic manual-fire helper for specs/ops (aliased `Sidekiq::Periodic.fire!`).

## Done-when (issue #14)
- [x] Registration DSL (already present from #15)
- [x] Tick loop fires from the leader only — **now actually wired & running**
- [x] DST spring-forward gap + fall-back fold covered for US / EU / AU
- [x] Testing helper to manually fire a tick (`Cron.fire!`)
- [x] Two workers, one loop → exactly one enqueue per tick (integration test)

## Design notes
- The DST fold dedup lives on `Loop` (schedule semantics), not the pure `Parser` (which faithfully enumerates both matching instants) — the `Poller` just calls `loop.next_fire_after(fired_slot, now)`. Advancing from `now` preserves "no backfill of missed ticks."
- The two-worker integration test runs on a **dedicated Redis DB**: a wired cron poller becomes the cluster leader and would otherwise fire *every* loop in the shared `periodic` set, flaking parallel unit tests. The private DB scopes the leader lock, periodic set, queue, and history to the test alone.

## Test plan
- [x] `bin/rake test` — full suite: 1522 runs, 0 failures, 0 errors
- [x] `bin/rake test:parity` — 20/0
- [x] `bin/rake test:ecosystem` — all suites passed
- [x] `bin/rake test TEST=test/integration/periodic_leader_test.rb` — two-worker exactly-once (ran 3× clean)
- [x] DST: `bin/rake test TEST=test/unit/cron_test.rb TESTOPTS="--name=/dst/"`

## How to test in prod
Periodic firing now happens automatically once the swarm boots — no action needed beyond registering loops:

```ruby
Wurk.configure_server do |config|
  config.periodic do |mgr|
    mgr.register("*/5 * * * *", "MyWorker")
  end
end
```

After deploy, confirm on any worker host (loops fire from the elected leader; followers stay idle):

```sh
# A loop's fire history grows ~once per scheduled tick (audit rows are
# [unix_ts, jid]); replace <lid> with the loop id from the Periodic dashboard tab.
redis-cli LRANGE loop-history:<lid> 0 5

# Who's the current leader doing the enqueuing:
redis-cli GET dear-leader
```

To force a run on demand (e.g. smoke-testing a new loop) from a Rails/console:

```ruby
Sidekiq::Periodic.fire!(lid)   # enqueues immediately, records history
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DST-aware cron scheduling to avoid duplicate/missed executions.
  * Manual immediate firing of scheduled cron jobs (returns nil for unknown IDs) and records/advances fire history.
  * Configurable cron tick interval and launcher-managed cron poller; cron persistence scoped via configuration.

* **Bug Fixes**
  * Suppresses duplicate fires during fall-back folds and skips missing slots in spring-forward.
  * Ensures next-fire marks are cleared when no future fire is scheduled.
  * Launcher quiet now leaves cron polling running; stop cleanly terminates the cron poller.

* **Tests**
  * New unit and integration tests covering DST edge cases, leader-periodic behavior, manual fire, and launcher cron lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->