### PR TITLE
feat: reliable-fetch orphan reclamation (closes #12)

### DIFF
--- a/lib/wurk/fetcher/reaper.rb
+++ b/lib/wurk/fetcher/reaper.rb
@@ -71,8 +71,9 @@ module Wurk
           return @thread if @thread
 
           @done = false
+          @thread = spawn_loop_thread
         end
-        @thread = spawn_loop_thread
+        @thread
       end
 
       def stop

--- a/lib/wurk/fetcher/reaper.rb
+++ b/lib/wurk/fetcher/reaper.rb
@@ -1,0 +1,263 @@
+# frozen_string_literal: true
+
+require_relative '../component'
+require_relative '../keys'
+require_relative '../middleware/poison_pill'
+
+module Wurk
+  class Fetcher
+    # Orphan reclamation for the reliable fetcher (Pro super_fetch §3.2).
+    #
+    # The Reliable fetcher moves each job from a public queue into a
+    # per-process private list (`queue:<public>|<host>|<pid>|<idx>`) and
+    # leaves it there until the Processor ACKs. A SIGKILLed or crashed
+    # worker therefore strands its in-flight jobs in private lists that
+    # nobody will ever ACK. The Reaper is the recovery half: it periodically
+    # scans for private lists whose owning process is gone and atomically
+    # moves their jobs back to the public queue so a live worker re-runs them.
+    #
+    # Liveness is decided per owner:
+    #   * same host — the OS is authoritative: `Process.kill(0, pid)`. This
+    #     is instant and ignores a stale `processes` SET entry whose 60s TTL
+    #     hasn't lapsed yet, so a `kill -9`ed sibling is reclaimed the moment
+    #     the supervisor reaps it rather than 60s later. (Pid reuse by an
+    #     unrelated local process is the one blind spot — the supervisor
+    #     respawns with a fresh pid, so it does not arise in practice.)
+    #   * other host — we cannot ping the pid, so we trust the heartbeat:
+    #     the owner is alive iff some live `processes` member (one whose
+    #     `info` hash still exists) shares its `host:pid`. Cross-host reclaim
+    #     therefore waits out the 60s heartbeat TTL, exactly as the spec says.
+    #
+    # Re-pushed jobs run through Wurk::Middleware::PoisonPill, which caps a
+    # job at RECOVERY_THRESHOLD recoveries within 72h: past the cap the job
+    # is killed into the dead set instead of re-queued, so a job that crashes
+    # its worker every time can't loop forever.
+    #
+    # SCANs are scoped to the public queues this process serves and gated by
+    # a cluster-wide `SET NX EX` lock, so across a fleet only one process
+    # sweeps per interval ("1/min within process group" in the spec) and the
+    # keyspace touched is bounded to known queues.
+    #
+    # Spec: docs/target/sidekiq-pro.md §3.2.
+    class Reaper
+      include Component
+
+      # Sweep cadence in seconds; also the cluster-lock TTL so exactly one
+      # process sweeps per interval. 60s matches the heartbeat TTL — the
+      # floor below which cross-host orphans can't be detected anyway.
+      DEFAULT_INTERVAL = 60
+
+      LOCK_KEY = 'super_fetch:reaper'
+      SCAN_COUNT = 100
+      THREAD_NAME = 'wurk-reaper'
+
+      attr_reader :interval
+
+      def initialize(config, interval: DEFAULT_INTERVAL, lock_key: LOCK_KEY)
+        @config = config
+        @interval = interval
+        @lock_key = lock_key
+        @thread = nil
+        @done = false
+        @mutex = ::Mutex.new
+        @sleeper = ::ConditionVariable.new
+      end
+
+      # Spawns the sweep loop. Idempotent. The loop waits one interval before
+      # its first sweep so booting processes don't dogpile Redis and so an
+      # un-stopped launcher in a unit test never touches the keyspace.
+      def start
+        @mutex.synchronize do
+          return @thread if @thread
+
+          @done = false
+        end
+        @thread = spawn_loop_thread
+      end
+
+      def stop
+        @mutex.synchronize do
+          @done = true
+          @sleeper.signal
+        end
+        @thread&.join
+        @thread = nil
+      end
+
+      def running?
+        !@thread.nil? && @thread.alive?
+      end
+
+      # One cluster-gated sweep: a no-op (returns 0) unless this process wins
+      # the interval's lock. Used by the loop.
+      def reap
+        return 0 unless acquire_lock?
+
+        reclaim!
+      end
+
+      # One unguarded sweep over every served queue. Returns the number of
+      # jobs reclaimed (re-queued or killed). Public so boot paths and tests
+      # can drive a deterministic pass without the cluster lock.
+      def reclaim!
+        prefixes = live_process_prefixes
+        served_queues.sum { |public_q| reclaim_queue(public_q, prefixes) }
+      end
+
+      private
+
+      # Union of `queue:<name>` keys across every capsule this process serves.
+      # Scoping the scan to these keeps the keyspace we touch bounded and lets
+      # parallel test namespaces stay isolated.
+      def served_queues
+        @config.capsules.each_value
+               .flat_map(&:queues)
+               .uniq
+               .map { |name| Keys.queue(name) }
+      end
+
+      # SCAN for this public queue's private lists, reclaim the orphaned ones.
+      def reclaim_queue(public_q, prefixes)
+        reclaimed = 0
+        each_private_list(public_q) do |key, host, pid|
+          next if owner_alive?(host, pid, prefixes)
+
+          reclaimed += drain(key, public_q)
+        end
+        reclaimed
+      end
+
+      # Yields [private_list_key, host, pid] for each private list of
+      # `public_q`. MATCH `<public_q>|*` matches only this queue's private
+      # lists (public queue keys carry no `|`).
+      def each_private_list(public_q)
+        cursor = '0'
+        loop do
+          cursor, keys = redis { |c| c.call('SCAN', cursor, 'MATCH', "#{public_q}|*", 'COUNT', SCAN_COUNT) }
+          keys.each do |key|
+            host, pid = parse_owner(public_q, key)
+            yield key, host, pid if pid
+          end
+          break if cursor == '0'
+        end
+      end
+
+      # `<public_q>|<host>|<pid>|<idx>` → [host, pid] (pid as Integer), or
+      # [nil, nil] when the suffix isn't a well-formed `host|pid|idx` triple.
+      # Splitting the suffix off the known public-queue prefix tolerates a
+      # `|` inside the queue name itself.
+      def parse_owner(public_q, key)
+        suffix = key.delete_prefix("#{public_q}|")
+        return [nil, nil] if suffix == key
+
+        host, pid, idx = suffix.split('|')
+        return [nil, nil] unless host && integer?(pid) && integer?(idx)
+
+        [host, pid.to_i]
+      end
+
+      def integer?(str)
+        str.is_a?(String) && str.match?(/\A\d+\z/)
+      end
+
+      def owner_alive?(host, pid, prefixes)
+        return local_pid_alive?(pid) if host == hostname
+
+        prefixes.include?("#{host}:#{pid}")
+      end
+
+      def local_pid_alive?(pid)
+        ::Process.kill(0, pid)
+        true
+      rescue Errno::ESRCH
+        false
+      rescue Errno::EPERM
+        true
+      end
+
+      # `host:pid` of every live process — a member of `processes` whose
+      # `info` hash still exists. A bare SET membership isn't enough: the
+      # member lingers after its 60s hash TTL until ProcessSet#cleanup prunes
+      # it, and we must treat that window as dead for cross-host reclaim.
+      def live_process_prefixes
+        redis do |conn|
+          members = conn.call('SMEMBERS', Keys::PROCESSES)
+          next ::Set.new if members.empty?
+
+          infos = conn.pipelined { |pipe| members.each { |m| pipe.call('HGET', m, 'info') } }
+          members.zip(infos).each_with_object(::Set.new) do |(member, info), set|
+            set << host_pid(member) if info
+          end
+        end
+      end
+
+      # identity is `<host>:<pid>:<nonce>`; the owner prefix is `<host>:<pid>`.
+      def host_pid(identity)
+        identity.split(':')[0..1].join(':')
+      end
+
+      # Drain one orphaned private list back to its public queue. Each job is
+      # moved with an atomic LMOVE (private tail → public tail) BEFORE the
+      # poison check, so a crash mid-drain leaves the job safely in the public
+      # queue (at-least-once), never lost. Poison jobs are killed to the dead
+      # set by PoisonPill.track! and then LREM'd out of the public queue.
+      def drain(private_list, public_q)
+        queue_name = public_q.delete_prefix(Keys::QUEUE_PREFIX)
+        count = 0
+        loop do
+          job = redis { |c| c.call('LMOVE', private_list, public_q, 'RIGHT', 'RIGHT') }
+          break unless job
+
+          count += 1
+          poison_off(public_q, job, queue_name)
+        end
+        count
+      rescue StandardError => e
+        handle_exception(e, context: THREAD_NAME)
+        count
+      end
+
+      def poison_off(public_q, job, queue_name)
+        return unless Middleware::PoisonPill.track!(job, queue: queue_name) == :poison
+
+        # track! already ZADDed the payload to the dead set; pull the copy we
+        # just LMOVE'd onto the public tail so it isn't also re-run.
+        redis { |c| c.call('LREM', public_q, -1, job) }
+      end
+
+      def acquire_lock?
+        redis { |c| c.call('SET', @lock_key, '1', 'NX', 'EX', @interval) } == 'OK'
+      end
+
+      def spawn_loop_thread
+        t = Thread.new { run_loop }
+        t.name = THREAD_NAME
+        t.report_on_exception = false
+        t
+      end
+
+      def run_loop
+        until done?
+          wait_next
+          break if done?
+
+          tick_once
+        end
+      end
+
+      def tick_once
+        reap
+      rescue StandardError => e
+        handle_exception(e, context: THREAD_NAME) if @config.respond_to?(:handle_exception)
+      end
+
+      def wait_next
+        @mutex.synchronize { @sleeper.wait(@mutex, @interval) unless @done }
+      end
+
+      def done?
+        @mutex.synchronize { @done }
+      end
+    end
+  end
+end

--- a/lib/wurk/launcher.rb
+++ b/lib/wurk/launcher.rb
@@ -8,6 +8,7 @@ require_relative 'health'
 require_relative 'keys'
 require_relative 'scheduled'
 require_relative 'leader'
+require_relative 'fetcher/reaper'
 
 module Wurk
   # Top-level supervisor inside each worker process. Owns the Manager pool
@@ -47,6 +48,7 @@ module Wurk
       @managers = config.capsules.values.map { |cap| Manager.new(cap) }
       @poller = build_poller
       @leader = build_leader
+      @reaper = build_reaper
       @started_at = nil
       @heartbeat = nil
       @heartbeat_thread = nil
@@ -72,6 +74,7 @@ module Wurk
       @poller&.start
       @leader&.start
       @managers.each(&:start)
+      @reaper.start
       @health_server&.start
     end
 
@@ -96,6 +99,7 @@ module Wurk
       stoppers = @managers.map { |m| Thread.new { m.stop(deadline) } }
       fire_event(:shutdown, reverse: true)
       stoppers.each(&:join)
+      @reaper&.stop
       # CAS-release the cluster lock now (planned shutdown) so a follower can
       # take over immediately instead of waiting out the TTL.
       @leader&.stop
@@ -226,6 +230,17 @@ module Wurk
       )
     end
 
+    # Reliable-fetch orphan reclamation. Every worker runs one; a cluster
+    # `SET NX EX` lock ensures only one actually sweeps per interval, so this
+    # is leader-independent (it keeps working if the leader dies). Tune the
+    # cadence with `config.super_fetch_reaper_interval`.
+    def build_reaper
+      Wurk::Fetcher::Reaper.new(
+        @config,
+        interval: @config[:super_fetch_reaper_interval] || Wurk::Fetcher::Reaper::DEFAULT_INTERVAL
+      )
+    end
+
     # Returns a Health::Server when `config.health_check(...)` has set
     # `:health_check_options`; nil otherwise. Off by default — the listener
     # is opt-in to keep the worker's port surface minimal.
@@ -235,8 +250,8 @@ module Wurk
 
       Health::Server.new(
         self,
-        port:         opts.fetch(:port, Health::DEFAULT_PORT),
-        bind:         opts.fetch(:bind, Health::DEFAULT_BIND),
+        port: opts.fetch(:port, Health::DEFAULT_PORT),
+        bind: opts.fetch(:bind, Health::DEFAULT_BIND),
         ready_window: opts.fetch(:ready_window, Health::DEFAULT_READY_WINDOW)
       )
     end

--- a/test/integration/reaper_kill9_test.rb
+++ b/test/integration/reaper_kill9_test.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Top-level so the forked children (which inherit the constant table but not
+# the test's lexical scope) can resolve the class by name.
+#
+# Each job records completion idempotently in a Redis SET and bumps a global
+# execution counter. SET membership means a job re-run after a `kill -9`
+# (at-least-once) collapses to a single "done" entry, while the exec counter
+# still reflects every actual run — so the test can prove both "every job
+# finished" (zero loss) and "no job ran unboundedly" (poison cap holds).
+class ReaperKill9Worker
+  include Wurk::Job
+
+  def perform(redis_url, done_key, exec_key, job_id)
+    client = RedisClient.config(url: redis_url).new_client
+    client.call('INCR', exec_key)
+    client.call('SADD', done_key, job_id)
+    client.call('EXPIRE', done_key, 120)
+    client.call('EXPIRE', exec_key, 120)
+  ensure
+    client&.close
+  end
+end
+
+# Real forks, real Redis, real `kill -9`. Boots a swarm, floods it with jobs,
+# repeatedly SIGKILLs random children mid-run, and asserts the reliable-fetch
+# reaper recovers every stranded job: zero loss, zero infinite re-runs.
+#
+# NEVER mock Redis here. `install_signals: false` so the swarm doesn't poison
+# the test process's own signal handlers.
+#
+# Spec: docs/target/sidekiq-pro.md §3.2. Closes #12 "Done when".
+class ReaperKill9Test < Wurk::Test::UnitCase
+  parallelize_me!
+
+  REDIS_URL     = ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')
+  JOB_COUNT     = 1000
+  CHILDREN      = 3
+  CONCURRENCY   = 2
+  KILL_ROUNDS   = 8
+  DRAIN_TIMEOUT = 90.0
+  POLL_INTERVAL = 0.1
+
+  def setup
+    super
+    @ns         = "reapkill-#{Process.pid}-#{object_id}"
+    @queue_name = "#{@ns}-q"
+    @done_key   = "#{@ns}-done"
+    @exec_key   = "#{@ns}-execs"
+    @config     = Wurk::Configuration.new
+    @config.logger = ::Logger.new(IO::NULL)
+    @config[:timeout] = 5
+    # Sweep aggressively so a kill -9 victim's stranded jobs are reclaimed
+    # within ~1s instead of waiting out the 60s default.
+    @config[:super_fetch_reaper_interval] = 1
+    @observer = RedisClient.config(url: REDIS_URL).new_client
+  end
+
+  def teardown
+    @observer&.call('DEL', @done_key, @exec_key, "queue:#{@queue_name}")
+    cleanup_private_lists
+    @observer&.close
+    @config&.reset_redis_pools!
+  ensure
+    super
+  end
+
+  def test_kill_9_storm_loses_no_jobs_and_never_loops_forever # rubocop:disable Metrics/AbcSize
+    enqueue_jobs
+    swarm = Wurk::Swarm.new(topology: topology, config: @config, shutdown_timeout: 5)
+    swarm.boot(install_signals: false)
+    supervisor = Thread.new { swarm.supervise }
+
+    begin
+      kill_random_children(swarm)
+      completed = wait_for_drain
+
+      assert completed, "only #{done_count}/#{JOB_COUNT} jobs finished within #{DRAIN_TIMEOUT}s"
+      assert_equal JOB_COUNT, done_count, 'every enqueued job must complete at least once (zero loss)'
+
+      # Poison cap (threshold 3) bounds re-runs; an infinite loop would blow
+      # this past the ceiling (or hang the drain above). Generous slack for
+      # legitimate at-least-once re-execution of killed-mid-flight jobs.
+      ceiling = JOB_COUNT * (Wurk::Middleware::PoisonPill::RECOVERY_THRESHOLD + 2)
+
+      assert_operator exec_count, :<=, ceiling, 'executions unbounded — reclaim is looping'
+    ensure
+      swarm.shutdown(timeout: 5)
+      supervisor&.join(15)
+    end
+  end
+
+  private
+
+  def topology
+    Wurk::Topology.flat(count: CHILDREN, queues: [@queue_name], concurrency: CONCURRENCY)
+  end
+
+  def enqueue_jobs
+    client = Wurk::Client.new(pool: capsule_pool, config: @config)
+    JOB_COUNT.times do |i|
+      client.push('class' => ReaperKill9Worker.name,
+                  'args' => [REDIS_URL, @done_key, @exec_key, i.to_s],
+                  'queue' => @queue_name)
+    end
+  end
+
+  def capsule_pool
+    cap = @config.default_capsule
+    cap.queues = [@queue_name]
+    cap.redis_pool
+  end
+
+  # SIGKILL a random live child each round, leaving at least one alive. The
+  # supervisor respawns victims; their in-flight jobs strand in now-orphaned
+  # private lists for the reaper to reclaim.
+  def kill_random_children(swarm)
+    KILL_ROUNDS.times do
+      break if done_count >= JOB_COUNT
+
+      pids = live_child_pids(swarm)
+      break if pids.size <= 1
+
+      victim = pids.sample
+      kill9(victim)
+      sleep 0.4
+    end
+  end
+
+  def live_child_pids(swarm)
+    swarm.children.keys.dup.select { |pid| pid_alive?(pid) }
+  rescue StandardError
+    []
+  end
+
+  def kill9(pid)
+    ::Process.kill('KILL', pid)
+  rescue Errno::ESRCH, Errno::EPERM
+    nil
+  end
+
+  def wait_for_drain # rubocop:disable Naming/PredicateMethod
+    deadline = monotonic_now + DRAIN_TIMEOUT
+    while monotonic_now < deadline
+      return true if done_count >= JOB_COUNT
+
+      sleep POLL_INTERVAL
+    end
+    done_count >= JOB_COUNT
+  end
+
+  def done_count
+    @observer.call('SCARD', @done_key).to_i
+  end
+
+  def exec_count
+    @observer.call('GET', @exec_key).to_i
+  end
+
+  def cleanup_private_lists
+    keys = @observer.call('KEYS', "queue:#{@queue_name}|*")
+    @observer.call('DEL', *keys) unless keys.empty?
+  rescue StandardError
+    nil
+  end
+
+  def pid_alive?(pid)
+    ::Process.kill(0, pid)
+    true
+  rescue Errno::ESRCH, Errno::EPERM
+    false
+  end
+
+  def monotonic_now
+    ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+  end
+end

--- a/test/unit/fetcher_reaper_test.rb
+++ b/test/unit/fetcher_reaper_test.rb
@@ -1,0 +1,269 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'securerandom'
+
+# Drives Wurk::Fetcher::Reaper against real Redis. Each test owns a unique
+# public queue + simulated private lists keyed to a dead/alive pid, so
+# parallel runs never collide. The periodic thread is never started here —
+# tests call the unguarded `reclaim!` for determinism; the locked `reap`
+# and the loop lifecycle get their own focused cases.
+#
+# Spec: docs/target/sidekiq-pro.md §3.2.
+class FetcherReaperTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  DEAD_PID = 999_999 # never a running pid in CI/dev
+
+  def setup # rubocop:disable Metrics/AbcSize -- linear fixture wiring, no branching
+    super
+    @ns           = "reaper-#{Process.pid}-#{object_id}"
+    @queue_name   = "#{@ns}-q"
+    @public_queue = Wurk::Keys.queue(@queue_name)
+    @config       = Wurk::Configuration.new
+    @config.logger = ::Logger.new(IO::NULL)
+    @capsule = @config.default_capsule
+    @capsule.queues = [@queue_name]
+    @pool         = @capsule.redis_pool
+    @host         = ENV['DYNO'] || Socket.gethostname
+    # Salt every default jid so the global, 72h-TTL PoisonPill counter at
+    # `super_fetch:recovered:<jid>` can't accumulate across runs and tip an
+    # otherwise-recoverable job over the poison threshold.
+    @salt         = SecureRandom.hex(8)
+    @reaper       = Wurk::Fetcher::Reaper.new(@config, interval: 1, lock_key: "#{Wurk::Fetcher::Reaper::LOCK_KEY}:#{@ns}")
+    Wurk::Middleware::PoisonPill.reset!
+  end
+
+  def teardown
+    Wurk::Middleware::PoisonPill.reset!
+    @pool.with do |c|
+      keys = c.call('KEYS', "#{@public_queue}*")
+      c.call('DEL', *keys) unless keys.empty?
+      c.call('DEL', "#{Wurk::Fetcher::Reaper::LOCK_KEY}:#{@ns}")
+    end
+    cleanup_dead_set
+    cleanup_recovery_counters
+    @config.reset_redis_pools!
+  ensure
+    super
+  end
+
+  # --- orphan reclamation ------------------------------------------------
+
+  def test_reclaims_orphaned_private_list_back_to_public_queue
+    seed_private_list(DEAD_PID, %w[a b c])
+
+    reclaimed = @reaper.reclaim!
+
+    assert_equal 3, reclaimed
+    assert_equal 0, llen(private_list(DEAD_PID)), 'private list should be drained'
+    assert_equal 3, llen(@public_queue), 'jobs should be back on the public queue'
+  end
+
+  def test_reclaimed_jobs_land_on_the_public_tail_for_prompt_rerun
+    # A job already waiting at the head; reclaimed jobs must sit behind it on
+    # the tail (RIGHT) so they are fetched next, matching #bulk_requeue.
+    @pool.with { |c| c.call('LPUSH', @public_queue, payload('existing')) }
+    seed_private_list(DEAD_PID, %w[recovered])
+
+    @reaper.reclaim!
+
+    # Fetch order is RIGHT (tail); the reclaimed job must be the tail element.
+    assert_equal payload('recovered'), lindex(@public_queue, -1)
+  end
+
+  def test_does_not_reclaim_a_live_owners_private_list
+    seed_private_list(Process.pid, %w[live]) # this very process is alive
+
+    reclaimed = @reaper.reclaim!
+
+    assert_equal 0, reclaimed
+    assert_equal 1, llen(private_list(Process.pid)), 'a live owner keeps its in-flight jobs'
+    assert_equal 0, llen(@public_queue)
+  end
+
+  def test_empty_when_no_private_lists_exist
+    assert_equal 0, @reaper.reclaim!
+  end
+
+  def test_only_scans_served_queues
+    other = Wurk::Keys.queue("#{@ns}-unserved")
+    other_priv = "#{other}|#{@host}|#{DEAD_PID}|0"
+    @pool.with { |c| c.call('RPUSH', other_priv, payload('x')) }
+
+    reclaimed = @reaper.reclaim!
+
+    assert_equal 0, reclaimed, 'queues this process does not serve are left untouched'
+    assert_equal 1, llen(other_priv)
+  ensure
+    @pool.with { |c| c.call('DEL', other_priv) }
+  end
+
+  # --- poison-pill cap ---------------------------------------------------
+
+  # rubocop:disable Metrics/AbcSize, Minitest/MultipleAssertions
+  def test_recovery_past_threshold_kills_to_dead_set_instead_of_requeue
+    jid = SecureRandom.hex(12)
+    job = payload('poison', jid: jid)
+    # Two prior recoveries on record; this reclaim is the 3rd → poison.
+    Wurk.redis { |c| c.call('SET', recovery_key(jid), '2') }
+    @pool.with { |c| c.call('RPUSH', private_list(DEAD_PID), job) }
+
+    reclaimed = @reaper.reclaim!
+
+    assert_equal 1, reclaimed
+    assert_equal 0, llen(@public_queue), 'a poison job must not be re-queued'
+    assert_equal 0, llen(private_list(DEAD_PID)), 'and must be drained from the private list'
+    assert_includes dead_payloads, job, 'poison job belongs in the dead set'
+  ensure
+    Wurk.redis { |c| c.call('DEL', recovery_key(jid)) }
+  end
+  # rubocop:enable Metrics/AbcSize, Minitest/MultipleAssertions
+
+  def test_under_threshold_recovery_requeues_and_bumps_counter
+    jid = SecureRandom.hex(12)
+    @pool.with { |c| c.call('RPUSH', private_list(DEAD_PID), payload('ok', jid: jid)) }
+
+    @reaper.reclaim!
+
+    assert_equal 1, llen(@public_queue)
+    assert_equal 1, Wurk::Middleware::PoisonPill.recovery_count(jid)
+  ensure
+    Wurk.redis { |c| c.call('DEL', recovery_key(jid)) }
+  end
+
+  # --- liveness: cross-host ----------------------------------------------
+
+  def test_cross_host_owner_with_live_heartbeat_is_skipped
+    other_host = 'other-host.example'
+    register_process(other_host, DEAD_PID, info: true)
+    seed_private_list(DEAD_PID, %w[remote], host: other_host)
+
+    reclaimed = @reaper.reclaim!
+
+    assert_equal 0, reclaimed, 'a beating cross-host owner keeps its jobs'
+  ensure
+    unregister_process(other_host, DEAD_PID)
+  end
+
+  def test_cross_host_owner_without_info_hash_is_reclaimed
+    other_host = 'other-host.example'
+    register_process(other_host, DEAD_PID, info: false) # SET member, expired hash
+    seed_private_list(DEAD_PID, %w[remote], host: other_host)
+
+    reclaimed = @reaper.reclaim!
+
+    assert_equal 1, reclaimed, 'a SET member whose heartbeat lapsed is dead'
+  ensure
+    unregister_process(other_host, DEAD_PID)
+  end
+
+  # --- key parsing -------------------------------------------------------
+
+  def test_ignores_malformed_private_list_keys
+    @pool.with do |c|
+      c.call('RPUSH', "#{@public_queue}|#{@host}|notapid|0", payload('bad'))
+      c.call('RPUSH', "#{@public_queue}|#{@host}|#{DEAD_PID}|notanidx", payload('bad2'))
+    end
+
+    assert_equal 0, @reaper.reclaim!, 'non-numeric pid/idx suffixes are not reclaimable'
+  end
+
+  # --- cluster lock ------------------------------------------------------
+
+  def test_reap_is_a_noop_when_the_lock_is_held_elsewhere
+    seed_private_list(DEAD_PID, %w[a])
+    @pool.with { |c| c.call('SET', "#{Wurk::Fetcher::Reaper::LOCK_KEY}:#{@ns}", 'other', 'EX', 30) }
+
+    assert_equal 0, @reaper.reap, 'a process that loses the lock does not sweep'
+    assert_equal 1, llen(private_list(DEAD_PID))
+  end
+
+  def test_reap_sweeps_when_the_lock_is_free
+    seed_private_list(DEAD_PID, %w[a b])
+
+    assert_equal 2, @reaper.reap
+  end
+
+  # --- thread lifecycle --------------------------------------------------
+
+  def test_start_is_idempotent_and_stop_joins # rubocop:disable Minitest/MultipleAssertions
+    refute_predicate @reaper, :running?
+    first = @reaper.start
+    second = @reaper.start
+
+    assert_same first, second, 'start must not spawn a second thread'
+    assert_predicate @reaper, :running?
+
+    @reaper.stop
+
+    refute_predicate @reaper, :running?
+  end
+
+  private
+
+  def seed_private_list(pid, tokens, host: @host)
+    key = "#{@public_queue}|#{host}|#{pid}|0"
+    @pool.with { |c| tokens.each { |t| c.call('RPUSH', key, payload(t)) } }
+    key
+  end
+
+  def private_list(pid, host: @host)
+    "#{@public_queue}|#{host}|#{pid}|0"
+  end
+
+  def payload(token, jid: nil)
+    Wurk.dump_json('class' => 'ReaperTestJob', 'args' => [token],
+                   'queue' => @queue_name, 'jid' => jid || "#{@salt}:#{token}")
+  end
+
+  def recovery_key(jid)
+    "#{Wurk::Middleware::PoisonPill::KEY_PREFIX}#{jid}"
+  end
+
+  def register_process(host, pid, info:)
+    identity = "#{host}:#{pid}:#{SecureRandom.hex(6)}"
+    @registered ||= {}
+    @registered[[host, pid]] = identity
+    Wurk.redis do |c|
+      c.call('SADD', Wurk::Keys::PROCESSES, identity)
+      c.call('HSET', identity, 'info', '{}') if info
+    end
+  end
+
+  def unregister_process(host, pid)
+    identity = @registered&.delete([host, pid])
+    return unless identity
+
+    Wurk.redis do |c|
+      c.call('SREM', Wurk::Keys::PROCESSES, identity)
+      c.call('DEL', identity)
+    end
+  end
+
+  def dead_payloads
+    Wurk.redis { |c| c.call('ZRANGE', Wurk::Keys::DEAD, 0, -1) }
+  end
+
+  def cleanup_dead_set
+    Wurk.redis do |c|
+      mine = c.call('ZRANGE', Wurk::Keys::DEAD, 0, -1).select { |m| m.include?(@queue_name) }
+      c.call('ZREM', Wurk::Keys::DEAD, *mine) unless mine.empty?
+    end
+  end
+
+  def cleanup_recovery_counters
+    Wurk.redis do |c|
+      keys = c.call('KEYS', "#{Wurk::Middleware::PoisonPill::KEY_PREFIX}#{@salt}:*")
+      c.call('DEL', *keys) unless keys.empty?
+    end
+  end
+
+  def llen(key)
+    @pool.with { |c| c.call('LLEN', key) }
+  end
+
+  def lindex(key, idx)
+    @pool.with { |c| c.call('LINDEX', key, idx) }
+  end
+end

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -121,6 +121,17 @@ class LauncherTest < Wurk::Test::UnitCase
     assert started, 'run should start the cluster leader'
   end
 
+  def test_run_starts_the_orphan_reaper
+    launcher = Wurk::Launcher.new(@config)
+    stub_managers(launcher)
+    started = false
+    launcher.instance_variable_get(:@reaper).define_singleton_method(:start) { started = true }
+
+    launcher.run(async_beat: false)
+
+    assert started, 'run should start the reliable-fetch reaper'
+  end
+
   def test_run_starts_each_manager
     launcher = Wurk::Launcher.new(@config)
     stub_managers(launcher)
@@ -226,6 +237,18 @@ class LauncherTest < Wurk::Test::UnitCase
     launcher.stop
 
     assert stopped, 'stop should release the cluster leader'
+  end
+
+  def test_stop_stops_the_orphan_reaper
+    @config[:timeout] = 0
+    launcher = Wurk::Launcher.new(@config)
+    silence_managers(launcher)
+    stopped = false
+    launcher.instance_variable_get(:@reaper).define_singleton_method(:stop) { stopped = true }
+
+    launcher.stop
+
+    assert stopped, 'stop should halt the reaper thread'
   end
 
   def test_stop_fires_shutdown_then_exit_in_reverse


### PR DESCRIPTION
## What & why

Closes #12. The reliable fetcher's happy path (BLMOVE a job into a per-process private list `queue:<public>|<host>|<pid>|<idx>` until the Processor ACKs) was already in place, but the **recovery half** was missing: a SIGKILLed or crashed worker strands its in-flight jobs in private lists nobody will ever ACK. `Wurk::Middleware::PoisonPill` (the recovery-count cap) existed but had no caller. This PR adds the caller — the orphan reaper — and wires it in.

## How it works

`Wurk::Fetcher::Reaper` — a background sweep started by the Launcher, **leader-independent** and gated by a cluster-wide `SET NX EX` lock so only one process sweeps per interval ("1/min within process group", spec §3.2):

- **Scoped SCAN** of the private lists for the public queues this process serves — keeps the touched keyspace bounded.
- **Liveness per owner:** same host trusts the OS (`Process.kill(0, pid)` — instant, and ignores a stale `processes` SET entry whose 60s TTL hasn't lapsed); other host trusts a still-beating heartbeat (`info` hash present), so cross-host reclaim waits out the 60s TTL exactly as the spec describes.
- **Atomic, loss-free drain:** each orphaned job is `LMOVE`d back to the public tail *before* the poison check, so a crash mid-drain leaves the job safely re-queued (at-least-once), never lost.
- **Poison cap:** every re-pushed job runs through `PoisonPill`, which caps recoveries at 3 within 72h and kills the job into the dead set past the cap — a worker-crashing poison pill can't loop forever.

Boot reclamation is the reaper's first tick; graceful-shutdown requeue is already handled by `Manager#hard_shutdown`'s `bulk_requeue`. Tunable via `config.super_fetch_reaper_interval` (default 60s).

Spec: `docs/target/sidekiq-pro.md` §3.2.

## Tests

- **Unit** (`test/unit/fetcher_reaper_test.rb`, 13 cases): orphan reclaim, live-owner skip, same-host vs cross-host liveness, poison-pill cap → dead set, malformed-key parsing, cluster-lock arbitration, served-queue scoping, thread lifecycle. Stable across repeated runs.
- **Integration** (`test/integration/reaper_kill9_test.rb`): 1000 jobs through a real swarm under a random `kill -9` storm — asserts **zero job loss** and **bounded re-execution** (no infinite loops). ~9s, real forks + real Redis.
- **Launcher** wiring tests added (start in `run`, stop in `stop`).
- Full `bin/rake test`, `test:parity` (20), and `test:ecosystem` all pass. The only failures in the full run are the pre-existing `StaticAssetsTest` Vite-manifest checks (require a Node build; unrelated to this change).

## "Done when" (issue #12)

- [x] Background reclamation thread scanning dead processes' private lists → main queue.
- [x] Per-job recovery-count cap short-circuiting poison-pill cycles into the dead set.
- [x] Bulk requeue path at boot (reaper first tick) and graceful shutdown (`hard_shutdown`).
- [x] Kill -9 a worker mid-job → another worker re-runs it within one reclamation tick.
- [x] Integration test: 1000 jobs, random kill -9, zero loss, zero infinite re-runs.

## How to test in prod

The reaper runs automatically on every worker — no config needed. To watch it work:

```ruby
# 1. In a Rails console, enqueue a slow job and note its jid.
jid = SlowJob.perform_async   # something that sleeps a few seconds

# 2. Find the worker that picked it up and kill -9 it mid-run:
#    (from a shell on the worker host)
#    pgrep -f 'wurk' ; kill -9 <pid-of-a-busy-child>

# 3. The supervisor respawns the slot; within one reaper interval the
#    stranded job is moved back to its queue and re-run by another worker.
#    Confirm it completed (it ran at least once) rather than vanishing.
```

Tune the sweep cadence if you want faster recovery in a demo:

```ruby
Sidekiq.configure_server do |config|
  config.super_fetch_reaper_interval = 5   # seconds; default 60
end
```

Operator visibility: poison kills land in the dead set (the dashboard "Dead" tab) and emit the `jobs.poison` / `jobs.recovered.fetch` statsd counters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background reaper that recovers jobs from failed workers back to queues, preserving at-least-once delivery.
  * Poison-pill protection to bound retries and drop truly failing jobs.
  * Reaper lifecycle managed by the launcher (starts/stops with the process).

* **Chores**
  * Added unit and integration tests validating recovery, retry limits, and lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->