### PR TITLE
feat: graceful encryption failures + rotation tests (closes #18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ New pushes encrypt under v2; v1 jobs already in the queue keep decrypting with t
 
 ### Graceful failure
 
-If a job can't be decrypted — the key was rotated away, or the ciphertext is corrupt — retrying is pointless (the key won't come back), so Wurk **does not** crash-loop it through 25 retries. Instead the job goes **straight to the dead set in under a second**, tagged `encryption_error` (visible as the `error_class` in the dashboard's Dead tab), the `jobs.encryption_error` statsd counter increments, and your death handlers fire so you can alert on a rotation gap. The still-encrypted payload is preserved on the dead record; fix the key and replay it from the dashboard.
+If a job can't be decrypted — the key was rotated away, or the ciphertext is corrupt — retrying is pointless (the key won't come back), so Wurk **does not** crash-loop it through 25 retries. Instead the job goes **straight to the dead set in under a second**, with `error_class` set to `Wurk::Encryption::DecryptionError` and `error_message` prefixed `encryption_error:` (both visible in the dashboard's Dead tab); the `jobs.encryption_error` statsd counter increments, and your death handlers fire so you can alert on a rotation gap. The still-encrypted payload is preserved on the dead record; fix the key and replay it from the dashboard.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,58 @@ Default is read/write — nothing changes unless you opt in.
 
 ---
 
+## 🔐 Encryption
+
+Drop-in for Sidekiq Enterprise's `Sidekiq::Enterprise::Crypto`. Encrypts the **last** positional argument of a job with AES-256-GCM, transparently — the client middleware seals it on push, the server middleware opens it before `perform` runs. Earlier args stay plaintext so you can still triage on `user_id` / `object_id`.
+
+**Enable it** in `config/initializers/wurk.rb`, pointing at your key source (file, ENV, KMS — anything that maps an integer version to a 32-byte key):
+
+```ruby
+Sidekiq::Enterprise::Crypto.enable(active_version: 1) do |version|
+  File.binread("config/crypto/secret.#{Rails.env}.#{version}.key") # exactly 32 bytes
+end
+```
+
+**Opt a job in** — and make sure `perform` takes at least two args (pass `nil` first if there's no cleartext):
+
+```ruby
+class ChargeCardJob
+  include Sidekiq::Job
+  sidekiq_options encrypt: true
+
+  def perform(user_id, secret_bag)   # secret_bag arrives already decrypted
+    Payments.charge(user_id, secret_bag["pan"], secret_bag["cvv"])
+  end
+end
+```
+
+The dashboard renders the encrypted arg as `"<encrypted>"`; it's never written to Redis in cleartext.
+
+### Key rotation
+
+Keys rotate without downtime. The resolver block **must keep returning every still-in-flight version**, not just the active one, so jobs enqueued under the old key still decrypt:
+
+```ruby
+KEYS = {
+  1 => File.binread("config/crypto/secret.production.1.key"),
+  2 => File.binread("config/crypto/secret.production.2.key"),
+}
+
+# Step 1: ship the new key file + resolver that knows both versions, active still 1.
+Sidekiq::Enterprise::Crypto.enable(active_version: 1) { |v| KEYS.fetch(v) }
+
+# Step 2: once every process has the new key, bump active_version → 2 and redeploy.
+Sidekiq::Enterprise::Crypto.enable(active_version: 2) { |v| KEYS.fetch(v) }
+```
+
+New pushes encrypt under v2; v1 jobs already in the queue keep decrypting with the v1 key. Keep the old key around until you're sure no v1 jobs remain (queues, retries, scheduled set).
+
+### Graceful failure
+
+If a job can't be decrypted — the key was rotated away, or the ciphertext is corrupt — retrying is pointless (the key won't come back), so Wurk **does not** crash-loop it through 25 retries. Instead the job goes **straight to the dead set in under a second**, tagged `encryption_error` (visible as the `error_class` in the dashboard's Dead tab), the `jobs.encryption_error` statsd counter increments, and your death handlers fire so you can alert on a rotation gap. The still-encrypted payload is preserved on the dead record; fix the key and replay it from the dashboard.
+
+---
+
 ## 🤝 Migration
 
 ```diff

--- a/lib/wurk/encryption.rb
+++ b/lib/wurk/encryption.rb
@@ -257,7 +257,17 @@ module Wurk
         return unless args.is_a?(::Array) && !args.empty? && Wurk::Encryption.envelope?(args.last)
 
         job['args'] = args[0..-2] + [Wurk::Encryption.decrypt(args.last)]
-      rescue Wurk::Encryption::Error, ::OpenSSL::Cipher::CipherError => e
+      rescue Wurk::Encryption::Error,
+             ::OpenSSL::Cipher::CipherError,
+             ::ArgumentError,
+             ::TypeError,
+             ::JSON::ParserError => e
+        # Wurk::Encryption::Error covers KeyMissingError / DecryptionError.
+        # OpenSSL::Cipher::CipherError → tampered ciphertext / bad key (tag mismatch).
+        # ArgumentError → Base64.strict_decode64 / Integer() on a malformed envelope.
+        # TypeError    → Integer(nil) on a missing 'v' field.
+        # JSON::ParserError → ciphertext decrypts to non-JSON (different key, but auth tag is gone via GCM → rare,
+        # but cheap to cover so malformed payloads never re-enter the 25× retry loop).
         Wurk::Encryption.route_to_dead(job, e)
         raise Wurk::JobRetry::Skip, "#{Wurk::Encryption::DEAD_REASON}: #{e.class}"
       end

--- a/lib/wurk/encryption.rb
+++ b/lib/wurk/encryption.rb
@@ -4,6 +4,9 @@ require 'base64'
 require 'json'
 require 'openssl'
 require_relative 'middleware'
+require_relative 'dead_set'
+require_relative 'job_retry'
+require_relative 'metrics/statsd'
 
 module Wurk
   # Sidekiq Enterprise encryption. AES-256-GCM over the **last** positional
@@ -45,15 +48,28 @@ module Wurk
   #   * Web UI redacts the last arg when `encrypt: true` is set on the job.
   #
   # Spec: docs/target/sidekiq-ent.md §4.
-  module Encryption
+  module Encryption # rubocop:disable Metrics/ModuleLength
     CIPHER_NAME = 'aes-256-gcm'
     KEY_BYTES = 32
     IV_BYTES = 12 # GCM standard: 96-bit IV.
     TAG_BYTES = 16
     ENVELOPE_MARKER = '__wurk_enc__'
 
+    # Reason tag stamped on the dead-set record when a job can't be
+    # decrypted. Surfaced as `error_class` (dashboard "Dead" column) and the
+    # `encryption_error:` prefix on `error_message`, plus the `jobs.encryption_error`
+    # statsd counter — so operators can alert on rotation gaps.
+    DEAD_REASON = 'encryption_error'
+    DECRYPTION_ERROR_CLASS = 'Wurk::Encryption::DecryptionError'
+
     class Error < StandardError; end
     class KeyMissingError < Error; end
+
+    # Marker for a terminal, non-retryable decryption failure (missing or
+    # rotated-away key, tampered ciphertext). The server middleware raises
+    # JobRetry::Skip after routing the job to the dead set, so this class
+    # is what callers see as the dead record's `error_class`.
+    class DecryptionError < Error; end
 
     class << self
       attr_reader :active_version
@@ -152,6 +168,24 @@ module Wurk
         args[0..-2] + ['<encrypted>']
       end
 
+      # A decryption failure means the key is gone (rotated away) or the
+      # ciphertext is bad — neither heals with time, so retrying 25× over
+      # ~21 days is a pointless crash loop. Instead the server middleware
+      # routes the job straight to the dead set, tagged `encryption_error`,
+      # and ACKs it (raises JobRetry::Skip). Done in <1s, death handlers fire
+      # so operators get paged. The still-encrypted envelope is kept on the
+      # record; earlier plaintext args stay visible for triage (§4.6).
+      def route_to_dead(job, cause)
+        record = job.merge(
+          'error_class' => DECRYPTION_ERROR_CLASS,
+          'error_message' => "#{DEAD_REASON}: #{cause.class}: #{cause.message}",
+          'failed_at' => ::Process.clock_gettime(::Process::CLOCK_REALTIME, :millisecond)
+        )
+        Wurk::Metrics::Statsd.increment('jobs.encryption_error', tags: ["worker:#{job['class']}"])
+        Wurk::DeadSet.new.kill(Wurk.dump_json(record), ex: cause)
+        nil
+      end
+
       private
 
       def build_decrypt_cipher(envelope, key)
@@ -200,22 +234,32 @@ module Wurk
       end
     end
 
-    # Server middleware — peels the envelope before perform runs. Decrypt
-    # failures (bad tag, missing version) raise
-    # `OpenSSL::Cipher::CipherError`; we let it bubble so the standard
-    # retry/dead pipeline handles it. Plaintext args remain visible for
-    # triage per §4.6.
+    # Server middleware — peels the envelope before perform runs. A decrypt
+    # failure (missing/rotated key, bad tag) is terminal and non-retryable,
+    # so rather than let it bubble into the 25× retry pipeline we route the
+    # job straight to the dead set tagged `encryption_error` and ACK it via
+    # JobRetry::Skip — see Wurk::Encryption.route_to_dead. Plaintext args
+    # remain visible for triage per §4.6.
     class ServerMiddleware
       include Wurk::Middleware::ServerMiddleware
 
       def call(_worker, job, _queue)
         return yield unless Wurk::Encryption.enabled? && job['encrypt']
 
-        args = job['args']
-        if args.is_a?(::Array) && !args.empty? && Wurk::Encryption.envelope?(args.last)
-          job['args'] = args[0..-2] + [Wurk::Encryption.decrypt(args.last)]
-        end
+        decrypt_last_arg!(job)
         yield
+      end
+
+      private
+
+      def decrypt_last_arg!(job)
+        args = job['args']
+        return unless args.is_a?(::Array) && !args.empty? && Wurk::Encryption.envelope?(args.last)
+
+        job['args'] = args[0..-2] + [Wurk::Encryption.decrypt(args.last)]
+      rescue Wurk::Encryption::Error, ::OpenSSL::Cipher::CipherError => e
+        Wurk::Encryption.route_to_dead(job, e)
+        raise Wurk::JobRetry::Skip, "#{Wurk::Encryption::DEAD_REASON}: #{e.class}"
       end
     end
   end

--- a/test/unit/encryption_test.rb
+++ b/test/unit/encryption_test.rb
@@ -532,18 +532,18 @@ class EncryptionTest < Wurk::Test::UnitCase
 
   def dead_record(target_jid)
     raw = Wurk.redis { |c| c.call('ZRANGE', Wurk::Keys::DEAD, 0, -1) }
-              .find { |m| m.include?(target_jid) }
+              .find { |m| JSON.parse(m)['jid'] == target_jid }
     raw && JSON.parse(raw)
   end
 
   def retry_count_for(target_jid)
     Wurk.redis { |c| c.call('ZRANGE', Wurk::Keys::RETRY, 0, -1) }
-        .count { |m| m.include?(target_jid) }
+        .count { |m| JSON.parse(m)['jid'] == target_jid }
   end
 
   def drain_dead(target_jid)
     Wurk.redis do |c|
-      mine = c.call('ZRANGE', Wurk::Keys::DEAD, 0, -1).select { |m| m.include?(target_jid) }
+      mine = c.call('ZRANGE', Wurk::Keys::DEAD, 0, -1).select { |m| JSON.parse(m)['jid'] == target_jid }
       c.call('ZREM', Wurk::Keys::DEAD, *mine) unless mine.empty?
     end
   end

--- a/test/unit/encryption_test.rb
+++ b/test/unit/encryption_test.rb
@@ -219,6 +219,34 @@ class EncryptionTest < Wurk::Test::UnitCase
     end
   end
 
+  # #18 "Done when": enable v1, push, rotate to v2, push, both decrypt cleanly
+  # — exercised end-to-end through the real client + server middleware pair.
+  def test_rotation_decrypts_both_versions_through_middleware # rubocop:disable Minitest/MultipleAssertions,Metrics/AbcSize
+    ENABLE_MUTEX.synchronize do
+      keys = { 1 => KEY_V1, 2 => KEY_V2 }
+
+      Wurk::Encryption.enable(active_version: 1) { |v| keys[v] }
+      v1_job = { 'class' => 'X', 'args' => ['uid', { 'pan' => '4111' }], 'encrypt' => true }
+      invoke_client(v1_job)
+
+      assert_equal 1, v1_job['args'].last['v'], 'first push encrypts under v1'
+
+      # Rotate: bump active_version, keep returning the old key for in-flight jobs.
+      Wurk::Encryption.disable!
+      Wurk::Encryption.enable(active_version: 2) { |v| keys[v] }
+      v2_job = { 'class' => 'X', 'args' => ['uid', { 'pan' => '5500' }], 'encrypt' => true }
+      invoke_client(v2_job)
+
+      assert_equal 2, v2_job['args'].last['v'], 'post-rotation push encrypts under v2'
+
+      invoke_server(v1_job) { :ok }
+      invoke_server(v2_job) { :ok }
+
+      assert_equal({ 'pan' => '4111' }, v1_job['args'].last, 'legacy v1 job decrypts')
+      assert_equal({ 'pan' => '5500' }, v2_job['args'].last, 'fresh v2 job decrypts')
+    end
+  end
+
   # ---- envelope? -------------------------------------------------------
 
   def test_envelope_predicate_recognizes_real_envelope
@@ -350,16 +378,91 @@ class EncryptionTest < Wurk::Test::UnitCase
     end
   end
 
-  def test_server_middleware_lets_cipher_error_bubble
+  # #18: a tampered/undecryptable envelope is terminal, not retryable — the
+  # server middleware routes it straight to the dead set (tagged
+  # encryption_error) and ACKs via JobRetry::Skip rather than letting the
+  # CipherError bubble into the 25× retry loop.
+  def test_server_middleware_routes_bad_tag_to_dead_set # rubocop:disable Minitest/MultipleAssertions,Metrics/AbcSize
     ENABLE_MUTEX.synchronize do
       Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
       env = Wurk::Encryption.encrypt('x')
       env['tag'] = ::Base64.strict_encode64("\x00" * 16)
-      job = { 'class' => 'X', 'args' => [nil, env], 'encrypt' => true }
+      job = { 'class' => 'X', 'args' => [nil, env], 'encrypt' => true, 'jid' => jid }
 
-      assert_raises(::OpenSSL::Cipher::CipherError) do
-        invoke_server(job) { :unreached }
+      perform_ran = false
+      assert_raises(Wurk::JobRetry::Skip) do
+        invoke_server(job) { perform_ran = true }
       end
+
+      refute perform_ran, 'perform must not run on a decryption failure'
+      record = dead_record(jid)
+
+      refute_nil record, 'job should be in the dead set'
+      assert_equal Wurk::Encryption::DECRYPTION_ERROR_CLASS, record['error_class']
+      assert_includes record['error_message'], Wurk::Encryption::DEAD_REASON
+      assert_equal 0, retry_count_for(jid), 'must skip the retry pipeline entirely'
+    ensure
+      drain_dead(jid)
+    end
+  end
+
+  # #18 "Done when": missing-key job lands in dead with encryption_error in <1s.
+  def test_missing_key_routes_to_dead_under_one_second # rubocop:disable Minitest/MultipleAssertions,Metrics/AbcSize
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      env = Wurk::Encryption.encrypt('secret')
+      # Operator dropped the v1 key during rotation: resolver no longer has it.
+      Wurk::Encryption.disable!
+      Wurk::Encryption.enable(active_version: 2) { |v| v == 2 ? KEY_V2 : nil }
+      job = { 'class' => 'PrivJob', 'args' => ['uid', env], 'encrypt' => true, 'jid' => jid }
+
+      started = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+      assert_raises(Wurk::JobRetry::Skip) { invoke_server(job) { :unreached } }
+      elapsed = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) - started
+
+      assert_operator elapsed, :<, 1.0, 'must dead-letter in under a second'
+      record = dead_record(jid)
+
+      refute_nil record
+      assert_equal 'uid', record['args'].first, 'plaintext args stay visible for triage'
+      assert Wurk::Encryption.envelope?(record['args'].last), 'undecryptable envelope is preserved'
+    ensure
+      drain_dead(jid)
+    end
+  end
+
+  def test_decryption_failure_fires_death_handlers # rubocop:disable Metrics/AbcSize
+    ENABLE_MUTEX.synchronize do
+      fired = []
+      Wurk.configuration.death_handlers << ->(j, ex) { fired << [j['jid'], ex.class] }
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      env = Wurk::Encryption.encrypt('x')
+      Wurk::Encryption.disable!
+      Wurk::Encryption.enable(active_version: 1) { |_v| nil } # key gone
+      job = { 'class' => 'X', 'args' => [env], 'encrypt' => true, 'jid' => jid }
+
+      assert_raises(Wurk::JobRetry::Skip) { invoke_server(job) { :unreached } }
+      assert_equal [[jid, Wurk::Encryption::KeyMissingError]], fired
+    ensure
+      Wurk.configuration.death_handlers.clear
+      drain_dead(jid)
+    end
+  end
+
+  def test_decryption_failure_emits_statsd_counter
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      env = Wurk::Encryption.encrypt('x')
+      env['tag'] = ::Base64.strict_encode64("\x00" * 16)
+      job = { 'class' => 'CardJob', 'args' => [env], 'encrypt' => true, 'jid' => jid }
+
+      metrics = capture_statsd do
+        assert_raises(Wurk::JobRetry::Skip) { invoke_server(job) { :unreached } }
+      end
+
+      assert_includes metrics, ['jobs.encryption_error', ['worker:CardJob']]
+    ensure
+      drain_dead(jid)
     end
   end
 
@@ -421,5 +524,48 @@ class EncryptionTest < Wurk::Test::UnitCase
     mw = Wurk::Encryption::ServerMiddleware.new
     mw.config = Wurk.configuration
     mw.call(nil, job, job['queue'], &)
+  end
+
+  def jid
+    @jid ||= "enc-#{Process.pid}-#{object_id}-#{rand(1_000_000)}"
+  end
+
+  def dead_record(target_jid)
+    raw = Wurk.redis { |c| c.call('ZRANGE', Wurk::Keys::DEAD, 0, -1) }
+              .find { |m| m.include?(target_jid) }
+    raw && JSON.parse(raw)
+  end
+
+  def retry_count_for(target_jid)
+    Wurk.redis { |c| c.call('ZRANGE', Wurk::Keys::RETRY, 0, -1) }
+        .count { |m| m.include?(target_jid) }
+  end
+
+  def drain_dead(target_jid)
+    Wurk.redis do |c|
+      mine = c.call('ZRANGE', Wurk::Keys::DEAD, 0, -1).select { |m| m.include?(target_jid) }
+      c.call('ZREM', Wurk::Keys::DEAD, *mine) unless mine.empty?
+    end
+  end
+
+  # Records jobs.* statsd increments for the duration of the block. The
+  # increment method is a process-global singleton; encryption_test runs in
+  # its own fork with no parallel threads, but we still guard with the shared
+  # mutex to match the rest of the suite's convention.
+  def capture_statsd
+    Wurk::Test::STATSD_MUTEX.synchronize do
+      calls = []
+      real = Wurk::Metrics::Statsd.method(:increment)
+      Wurk::Metrics::Statsd.singleton_class.send(:define_method, :increment) do |metric, tags: nil, **_|
+        calls << [metric, tags]
+        nil
+      end
+      begin
+        yield
+        calls
+      ensure
+        Wurk::Metrics::Statsd.singleton_class.send(:define_method, :increment, real)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What & why

Closes #18. Args encryption was happy-path only. Per spec §4.6 a decryption failure just raised `OpenSSL::Cipher::CipherError` and flowed into the standard retry pipeline — but a **missing or rotated-away key never comes back**, so that's a pointless ~21-day, 25-retry crash loop on a job that can never succeed. This hardens the failure path and adds the rotation coverage the issue asks for.

## How it works

The **server middleware** now catches a decryption failure and routes the job **straight to the dead set in under a second** instead of retrying:

- `error_class = Wurk::Encryption::DecryptionError`, `error_message` prefixed `encryption_error:` — visible in the dashboard's Dead tab.
- `jobs.encryption_error` statsd counter increments; **death handlers fire** so operators can alert on a rotation gap.
- The still-encrypted envelope is preserved on the dead record; earlier **plaintext args stay visible for triage** (§4.6).
- The job is ACKed via `JobRetry::Skip` — it never enters the retry ZSET, and `perform` never runs.

Low-level `Wurk::Encryption.decrypt` still raises `CipherError` / `KeyMissingError` exactly as before — only the middleware's handling of those errors changed. This mirrors the existing `PoisonPill` precedent (middleware-driven `DeadSet#kill` + `Skip`).

Spec: `docs/target/sidekiq-ent.md` §4 (hardens the §4.6 failure semantics).

## Tests (`test/unit/encryption_test.rb`)

- **Rotation through the real middleware pair**: enable v1 → client-encrypt → rotate `active_version` to v2 (resolver still returns the v1 key) → client-encrypt a fresh job → server middleware decrypts **both** cleanly.
- **Missing-key → dead in <1s**: drop the v1 key, replay → lands in dead set, plaintext arg preserved, envelope preserved, asserted under one second.
- **Bad tag → dead, no retry**: tampered tag routes to dead, `perform` never runs, zero retry-ZSET entries.
- **Death handlers fire** with the job + underlying error.
- **`jobs.encryption_error` statsd counter** emitted with the worker tag.

The pre-existing direct-`decrypt` tests still assert `CipherError` (low-level unchanged). Full `bin/rake test`, `test:parity` (20), and `test:ecosystem` all pass; the only red is the pre-existing `StaticAssetsTest` Vite-manifest pair (needs a Node build; unrelated).

## Docs

New README **🔐 Encryption** section: enabling `Sidekiq::Enterprise::Crypto`, per-job `encrypt: true` opt-in, the zero-downtime key-rotation procedure, and the graceful-failure behavior.

## "Done when" (issue #18)

- [x] Decryption error (missing/rotated key) routes to dead set with a clear reason tag, not a crash loop.
- [x] Key rotation test: enable v1, push, rotate to v2, push, both decrypt cleanly.
- [x] Missing-key job lands in dead set with `encryption_error` reason in <1s.
- [x] Documented setup in README.

## How to test in prod

```ruby
# In a Rails console with encryption enabled (active_version: 2, resolver knows v1+v2):

# 1. Enqueue an encrypted job under the CURRENT key — it runs fine.
ChargeCardJob.perform_async(user_id, { "pan" => "4111111111111111" })

# 2. Simulate a rotation gap: redeploy with a resolver that no longer returns
#    the version some queued job was sealed under (e.g. you deleted the old key
#    file too early). Enqueue/leave a job sealed under that now-missing version.

# 3. Within a second of a worker picking it up, the job appears in the
#    dashboard's **Dead** tab with error_class "Wurk::Encryption::DecryptionError"
#    and an "encryption_error: ..." message — NOT cycling through Retries.
#    The jobs.encryption_error statsd counter ticks; your death_handlers fire.

# 4. Restore the missing key and use the dashboard's "Retry" on the dead job —
#    it decrypts and runs. (The encrypted payload was preserved on the record.)
```

Alert on the `jobs.encryption_error` counter (or a death handler) to catch a key-rotation mistake immediately instead of discovering it 21 days later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced encryption failure handling: decryption failures now route jobs to the dead set immediately with clear error classification, metrics tracking, and death-handler invocation to avoid retries.

* **Documentation**
  * Added comprehensive encryption docs covering enablement, opt-in, dashboard behavior, key rotation requirements, and graceful failure behavior.

* **Tests**
  * Expanded tests for key rotation, dead-lettering on tamper/missing keys, death-handler firing, and metrics emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->