### PR TITLE
feat: split limiter suite + status API + poison brake (closes #16)

### DIFF
--- a/app/controllers/wurk/api/serializers.rb
+++ b/app/controllers/wurk/api/serializers.rb
@@ -79,8 +79,20 @@ module Wurk
           name: name,
           type: meta['type'].to_s,
           fingerprint: meta['fingerprint'].to_s,
-          options: parse_options(meta['options'])
+          options: parse_options(meta['options']),
+          status: limiter_status(name, meta)
         }
+      end
+
+      # Reconstruct the limiter (read-only, `register: false`) just to read
+      # its uniform `{ used, limit, reset_at, available? }` status for the
+      # Limits tab. Best-effort: a malformed meta hash yields nil rather than
+      # 500-ing the whole list.
+      def limiter_status(name, meta)
+        limiter = ::Wurk::Limiter.build(name, meta['type'], parse_options(meta['options']))
+        limiter&.status
+      rescue StandardError
+        nil
       end
 
       def cron_row(loop_obj, now_epoch)

--- a/lib/wurk/limiter.rb
+++ b/lib/wurk/limiter.rb
@@ -11,14 +11,17 @@ module Wurk
   # clock skew across hosts doesn't matter inside one Redis. Spec:
   # docs/target/sidekiq-ent.md §1.
   #
-  # Layout:
+  # Layout (one file per type under `lib/wurk/limiter/`):
   #   * `Limiter::Base` owns the metadata write (lmtr:{name}) + the global
-  #     `lmtr-list` registration so the Web UI can list every limiter.
+  #     `lmtr-list` registration so the Web UI can list every limiter, and
+  #     the uniform `status` shape.
   #   * Per-type subclasses (Concurrent / Bucket / Window / Leaky / Points)
   #     own their acquire/wait loop. Each delegates the atomic step to a
   #     Lua script in `lib/wurk/lua/limiter_*.lua`.
   #   * `Unlimited` is a no-op stub for tests and the `unlimited(*)`
   #     constructor — same `within_limit` surface, never raises.
+  #   * `ServerMiddleware` catches OverLimit, reschedules, and applies the
+  #     poison brake.
   #
   # Wire-compat: every key uses the `lmtr-...:` prefix family from §1.7
   # and the limiter is added to the shared `lmtr-list` SET.
@@ -79,20 +82,39 @@ module Wurk
       def pool
         return nil if @redis.nil?
 
-        @redis_pool ||= case @redis
-                        when Wurk::RedisPool then @redis
-                        when Hash
-                          Wurk::RedisPool.new(
-                            size: @redis[:size] || 10,
-                            url: @redis[:url] || Wurk::RedisPool::DEFAULT_URL,
-                            timeout: @redis[:timeout] || Wurk::RedisPool::DEFAULT_TIMEOUT,
-                            name: 'limiter'
-                          )
-                        else
-                          raise ArgumentError, "Limiter.config.redis must be Hash or RedisPool, got #{@redis.class}"
-                        end
+        @pool ||= case @redis
+                  when Wurk::RedisPool then @redis
+                  when Hash
+                    Wurk::RedisPool.new(
+                      size: @redis[:size] || 10,
+                      url: @redis[:url] || Wurk::RedisPool::DEFAULT_URL,
+                      timeout: @redis[:timeout] || Wurk::RedisPool::DEFAULT_TIMEOUT,
+                      name: 'limiter'
+                    )
+                  else
+                    raise ArgumentError, "Limiter.config.redis must be Hash or RedisPool, got #{@redis.class}"
+                  end
       end
     end
+
+    # `:second :minute :hour :day` symbols → seconds. Window also accepts
+    # a raw Integer; bucket does not (boundary semantics require a unit).
+    INTERVAL_UNITS = {
+      second: 1,
+      minute: 60,
+      hour: 3600,
+      day: 86_400
+    }.freeze
+
+    # Type string (as stored in the `lmtr:{name}` meta hash) → subclass.
+    # Drives `build` for dashboard introspection.
+    TYPE_CLASSES = {
+      'concurrent' => 'Concurrent',
+      'bucket' => 'Bucket',
+      'window' => 'Window',
+      'leaky' => 'Leaky',
+      'points' => 'Points'
+    }.freeze
 
     class << self
       def configure
@@ -172,16 +194,20 @@ module Wurk
         Unlimited.new
       end
 
-      # `:second :minute :hour :day` symbols → seconds. Window also accepts
-      # a raw Integer; bucket does not (boundary semantics require a unit).
-      INTERVAL_UNITS = {
-        second: 1,
-        minute: 60,
-        hour: 3600,
-        day: 86_400
-      }.freeze
+      # Reconstruct a limiter from its persisted metadata for read-only
+      # introspection (the dashboard `status` column). `register: false`
+      # keeps the GET side-effect-free. Returns nil for an unknown type.
+      def build(name, type, options, register: false)
+        return Unlimited.new if type.to_s == 'unlimited'
+
+        klass_name = TYPE_CLASSES[type.to_s]
+        return nil unless klass_name
+
+        const_get(klass_name).new(name, register: register, **coerce_build_options(options))
+      end
 
       def interval_seconds(interval, allow_integer:)
+        interval = interval.to_sym if interval.is_a?(String) && INTERVAL_UNITS.key?(interval.to_sym)
         case interval
         when Symbol
           INTERVAL_UNITS.fetch(interval) do
@@ -197,557 +223,33 @@ module Wurk
           raise ArgumentError, "interval must be Symbol or Integer (got #{interval.class})"
         end
       end
-    end
-
-    # Base class. Holds the public introspection contract documented in
-    # §1.5 — name / type / options / size / status / reset / delete plus
-    # the `within_limit(...) { ... }` block. Subclasses override the
-    # acquire path and the per-type metric/size methods.
-    class Base
-      attr_reader :name, :options
-
-      def initialize(name, **options)
-        unless name.is_a?(String) && NAME_PATTERN.match?(name)
-          raise ArgumentError, "limiter name must match #{NAME_PATTERN.inspect} (got #{name.inspect})"
-        end
-
-        ttl = options[:ttl] || DEFAULT_TTL
-        # Spec §1.2: ttl floor of 24h. Anything tighter risks losing the
-        # metadata hash mid-job and orphaning slots that read it.
-        raise ArgumentError, 'ttl must be >= 86_400' if ttl < 86_400
-
-        @name = name.dup.freeze
-        @options = options
-        register!
-      end
-
-      def type
-        raise NotImplementedError
-      end
-
-      def within_limit(**, &)
-        raise NotImplementedError
-      end
-
-      def size
-        0
-      end
-
-      def status
-        {}
-      end
-
-      def reset
-        Wurk::Limiter.redis do |c|
-          state_keys.each { |k| c.call('DEL', k) }
-        end
-      end
-
-      def delete
-        Wurk::Limiter.redis do |c|
-          (state_keys + [meta_key]).each { |k| c.call('DEL', k) }
-          c.call('SREM', LIST_KEY, @name)
-        end
-      end
-
-      # Stable fingerprint for the limiter — Sidekiq 8.0+ switched from
-      # SHA1 → SHA256 (~10% larger encoding). Web UI groups limiters by
-      # this so that interpolated names (`stripe-#{user_id}`) get a single
-      # row per shape.
-      def fingerprint
-        @fingerprint ||= Digest::SHA256.hexdigest("#{type}|#{@name}|#{JSON.dump(serializable_options)}")
-      end
-
-      protected
-
-      def meta_key
-        "lmtr:#{@name}"
-      end
-
-      def state_keys
-        []
-      end
-
-      def serializable_options
-        @options.transform_values do |v|
-          case v
-          when Proc then '<proc>'
-          when Symbol, Numeric, String, true, false, nil then v
-          else v.to_s
-          end
-        end
-      end
-
-      def register!
-        Wurk::Limiter.redis do |c|
-          c.call('SADD', LIST_KEY, @name)
-          c.call(
-            'HSET', meta_key,
-            'type', type.to_s,
-            'options', JSON.dump(serializable_options),
-            'fingerprint', fingerprint
-          )
-          c.call('EXPIRE', meta_key, @options[:ttl])
-        end
-      end
-
-      def ttl
-        @options[:ttl]
-      end
-
-      # Stable random slot id (Concurrent) / nonce (Window). 16 hex chars
-      # = 8 bytes — wide enough to avoid collision under any realistic
-      # burst and short enough to keep ZSET memory bounded.
-      def random_id
-        SecureRandom.hex(8)
-      end
-
-      def lua(name, keys:, argv:)
-        Wurk::Limiter.redis do |c|
-          Wurk::Lua::Loader.eval_cached(c, name, keys: keys, argv: argv)
-        end
-      end
-    end
-
-    # ---- Concurrent ---------------------------------------------------
-    #
-    # Atomic slot acquisition in a ZSET. Score = expiry epoch; the acquire
-    # script first evicts expired slots (bumping the `reclaimed` metric)
-    # then ZADDs if there's headroom.
-    #
-    # On exhaustion: spin loop with backoff. The spec says "blocks via
-    # Redis stream XREAD" — that's a perf optimization; the visible
-    # behavior is identical: blocks up to `wait_timeout` then OverLimit
-    # (or silent return for `policy: :ignore`).
-    class Concurrent < Base
-      WAIT_SLEEP = 0.05
-
-      def type = :concurrent
-
-      def size
-        Wurk::Limiter.redis { |c| c.call('ZCARD', state_key).to_i }
-      end
-
-      def status
-        h = Wurk::Limiter.redis { |c| c.call('HGETALL', stats_key) }
-        # redis-client returns either a flat array or a hash depending on
-        # the server version — normalize once so callers always see a hash.
-        h = h.each_slice(2).to_h if h.is_a?(Array)
-        %w[held held_time immediate waited wait_time overages reclaimed].each_with_object({}) do |k, out|
-          out[k] = (h[k] || '0').to_i
-        end
-      end
-
-      def within_limit(&block)
-        raise ArgumentError, 'block required' unless block
-
-        started = monotime
-        deadline = started + @options[:wait_timeout]
-        slot = random_id
-        acquired_at = nil
-        loop do
-          result = acquire(slot)
-          if result[0].to_i == 1
-            acquired_at = monotime
-            break
-          end
-
-          return if @options[:policy] == :ignore
-
-          remaining = deadline - monotime
-          if remaining <= 0
-            bump_counter('overages')
-            raise OverLimit.new(self)
-          end
-
-          sleep [remaining, WAIT_SLEEP].min
-        end
-
-        begin
-          incr_immediate_or_waited(acquired_at - started)
-          block.call
-        ensure
-          release(slot)
-          bump_counter('held_time', (monotime - acquired_at).to_i) if acquired_at
-        end
-      end
-
-      protected
-
-      def state_keys
-        [state_key, stats_key]
-      end
 
       private
 
-      def state_key
-        "lmtr-cs:#{@name}"
-      end
-
-      def stats_key
-        "lmtr-stats:#{@name}"
-      end
-
-      def acquire(slot)
-        lua(:limiter_concurrent_acquire,
-            keys: [state_key, stats_key],
-            argv: [@options[:limit], @options[:lock_timeout], slot, ttl])
-      end
-
-      def release(slot)
-        lua(:limiter_concurrent_release, keys: [state_key], argv: [slot])
-      end
-
-      def bump_counter(field, by = 1)
-        Wurk::Limiter.redis do |c|
-          c.call('HINCRBY', stats_key, field, by)
-          c.call('EXPIRE', stats_key, ttl)
+      # Stored options round-trip through JSON, so symbol keys arrive as
+      # strings and unit symbols (`:minute`) as `"minute"`. Restore both so a
+      # rebuilt limiter validates the same as a freshly-constructed one.
+      def coerce_build_options(options)
+        opts = options.transform_keys(&:to_sym)
+        %i[interval drain].each do |k|
+          v = opts[k]
+          opts[k] = v.to_sym if v.is_a?(String) && INTERVAL_UNITS.key?(v.to_sym)
         end
-      end
-
-      def incr_immediate_or_waited(elapsed)
-        if elapsed < WAIT_SLEEP
-          bump_counter('immediate')
-        else
-          bump_counter('waited')
-          bump_counter('wait_time', elapsed.to_i)
-        end
-      end
-
-      def monotime
-        ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
-      end
-    end
-
-    # ---- Bucket -------------------------------------------------------
-    #
-    # Cardinal-boundary counter. Reset at the top of the unit (00:00 of
-    # minute/hour/day). On exhaustion sleep until next boundary, retry,
-    # OverLimit if that exceeds wait_timeout.
-    class Bucket < Base
-      def type = :bucket
-
-      def initialize(name, **options)
-        # Eager interval validation so a typo in `:fortnight` blows up at boot,
-        # not at first call. Lazy validation defers failures to runtime.
-        Limiter.interval_seconds(options[:interval], allow_integer: false)
-        super
-      end
-
-      def size
-        epoch = (::Time.now.to_i / interval_seconds) * interval_seconds
-        key = "lmtr-b:#{@name}:#{epoch / interval_seconds}"
-        Wurk::Limiter.redis { |c| (c.call('GET', key) || '0').to_i }
-      end
-
-      def within_limit(used: 1, &block)
-        raise ArgumentError, 'block required' unless block
-
-        deadline = ::Time.now.to_f + @options[:wait_timeout]
-        loop do
-          ok, _current, secs_to_next = acquire(used)
-          return block.call if ok.to_i == 1
-
-          remaining = deadline - ::Time.now.to_f
-          raise OverLimit.new(self) if remaining <= 0
-
-          sleep [remaining, secs_to_next.to_f, 0.05].compact.min.clamp(0.0, remaining)
-        end
-      end
-
-      protected
-
-      def state_keys
-        # Bucket keys are per-epoch and self-expiring; reset wipes the
-        # current epoch, the only one a caller could care about. Older
-        # epochs already EXPIRE'd.
-        epoch = ::Time.now.to_i / interval_seconds
-        ["lmtr-b:#{@name}:#{epoch}"]
-      end
-
-      private
-
-      def interval_seconds
-        @interval_seconds ||= Limiter.interval_seconds(@options[:interval], allow_integer: false)
-      end
-
-      def acquire(used)
-        lua(:limiter_bucket_acquire,
-            keys: ["lmtr-b:#{@name}"],
-            argv: [@options[:count], interval_seconds, used, ttl])
-      end
-    end
-
-    # ---- Window -------------------------------------------------------
-    #
-    # Sliding window via ZSET of timestamps. Accepts symbolic units or a
-    # raw Integer (in seconds). Used-units expand to N ZADDs in the Lua
-    # script so multi-charge calls remain atomic.
-    class Window < Base
-      WAIT_SLEEP = 0.5
-
-      def type = :window
-
-      def initialize(name, **options)
-        # Symbol or raw Integer (spec §1.2: window accepts both).
-        Limiter.interval_seconds(options[:interval], allow_integer: true)
-        super
-      end
-
-      def size
-        cutoff = ::Time.now.to_f - interval_seconds
-        Wurk::Limiter.redis do |c|
-          c.call('ZREMRANGEBYSCORE', state_key, '-inf', "(#{cutoff}")
-          c.call('ZCARD', state_key).to_i
-        end
-      end
-
-      def within_limit(used: 1, &block)
-        raise ArgumentError, 'block required' unless block
-
-        deadline = ::Time.now.to_f + @options[:wait_timeout]
-        loop do
-          ok, _current, _oldest = acquire(used)
-          return block.call if ok.to_i == 1
-
-          remaining = deadline - ::Time.now.to_f
-          raise OverLimit.new(self) if remaining <= 0
-
-          sleep [remaining, WAIT_SLEEP].min
-        end
-      end
-
-      protected
-
-      def state_keys
-        [state_key]
-      end
-
-      private
-
-      def state_key
-        "lmtr-w:#{@name}"
-      end
-
-      def interval_seconds
-        @interval_seconds ||= Limiter.interval_seconds(@options[:interval], allow_integer: true)
-      end
-
-      def acquire(used)
-        lua(:limiter_window_acquire,
-            keys: [state_key],
-            argv: [@options[:count], interval_seconds, used, ttl, random_id])
-      end
-    end
-
-    # ---- Leaky --------------------------------------------------------
-    #
-    # Leaky bucket: drain rate = bucket_size / drain ops/sec. Stored as a
-    # HASH of {level, last} — Lua compares level vs bucket_size after
-    # leaking elapsed * drain_per_sec.
-    class Leaky < Base
-      WAIT_SLEEP = 0.05
-
-      def type = :leaky
-
-      def size
-        h = Wurk::Limiter.redis { |c| c.call('HGET', state_key, 'level') }
-        h.to_f
-      end
-
-      def within_limit(&block)
-        raise ArgumentError, 'block required' unless block
-
-        deadline = ::Time.now.to_f + @options[:wait_timeout]
-        loop do
-          ok, _level = acquire
-          return block.call if ok.to_i == 1
-
-          remaining = deadline - ::Time.now.to_f
-          raise OverLimit.new(self) if remaining <= 0
-
-          sleep [remaining, WAIT_SLEEP].min
-        end
-      end
-
-      protected
-
-      def state_keys
-        [state_key]
-      end
-
-      private
-
-      def state_key
-        "lmtr-l:#{@name}"
-      end
-
-      def drain_interval_seconds
-        case @options[:drain]
-        when Symbol
-          Limiter.interval_seconds(@options[:drain], allow_integer: false)
-        when Integer
-          @options[:drain]
-        else
-          raise ArgumentError, "drain must be Symbol or Integer (got #{@options[:drain].class})"
-        end
-      end
-
-      # bucket_size / drain → ops per second.
-      def drain_per_sec
-        @drain_per_sec ||= @options[:bucket_size].to_f / drain_interval_seconds
-      end
-
-      def acquire
-        lua(:limiter_leaky_acquire,
-            keys: [state_key],
-            argv: [@options[:bucket_size], drain_per_sec, ttl])
-      end
-    end
-
-    # ---- Points -------------------------------------------------------
-    #
-    # Token-bucket with explicit `estimate:` per call. Refills at
-    # `refill_per_second` capped at `initial_points`. Failure mode is
-    # immediate (spec §1.4 — no sleep loop). The block is invoked with a
-    # `Handle` so user code may refund/over-charge via `handle.points_used`.
-    class Points < Base
-      class Handle
-        def initialize(limiter, estimate)
-          @limiter = limiter
-          @estimate = estimate
-        end
-
-        # Positive delta returns points to the bucket; negative records an
-        # under-estimate. Either way, clamped to [0, cap].
-        def points_used(actual)
-          delta = @estimate - actual
-          @limiter.send(:refund, delta)
-        end
-      end
-
-      def type = :points
-
-      # Apply refill on read so the size matches what the *next* acquire
-      # would see. Stored balance only updates on acquire/refund; without
-      # this, a fully-refilled bucket reports stale low numbers.
-      def size
-        cap = @options[:initial].to_f
-        data = Wurk::Limiter.redis { |c| c.call('HMGET', state_key, 'points', 'last') }
-        stored = data[0]
-        return cap if stored.nil?
-
-        last = (data[1] || ::Time.now.to_f).to_f
-        elapsed = [::Time.now.to_f - last, 0.0].max
-        [cap, stored.to_f + (elapsed * @options[:refill].to_f)].min
-      end
-
-      def within_limit(estimate:, &block)
-        raise ArgumentError, 'block required' unless block
-        raise ArgumentError, 'estimate must be positive' if estimate <= 0
-
-        ok, _remaining = acquire(estimate)
-        raise OverLimit.new(self) unless ok.to_i == 1
-
-        handle = Handle.new(self, estimate)
-        block.call(handle)
-      end
-
-      protected
-
-      def state_keys
-        [state_key]
-      end
-
-      private
-
-      def state_key
-        "lmtr-p:#{@name}"
-      end
-
-      def acquire(estimate)
-        lua(:limiter_points_acquire,
-            keys: [state_key],
-            argv: [@options[:initial], @options[:refill], estimate, ttl])
-      end
-
-      def refund(delta)
-        lua(:limiter_points_refund,
-            keys: [state_key],
-            argv: [delta, @options[:initial], ttl]).to_f
-      end
-    end
-
-    # ---- Unlimited ----------------------------------------------------
-    #
-    # No-op for the tests + bypass scenarios documented in §1.8. The
-    # within_limit block runs unconditionally and the introspection
-    # methods all return zeros so dashboards render predictably.
-    class Unlimited
-      def name = 'unlimited'
-      def type = :unlimited
-      def options = {}
-      def size = 0
-      def status = {}
-      def fingerprint = Digest::SHA256.hexdigest('unlimited')
-      def reset = nil
-      def delete = nil
-
-      # Accept all the kwargs the other limiters take so a worker can swap
-      # `limiter = Sidekiq::Limiter.unlimited` in tests without touching
-      # call sites. `points`-style callers pass an `estimate:` and expect a
-      # `|handle|` block param — we yield a zero-cost handle just in case.
-      def within_limit(**_kwargs, &block)
-        raise ArgumentError, 'block required' unless block
-
-        if block.arity == 0
-          block.call
-        else
-          block.call(Points::Handle.new(self, 0))
-        end
-      end
-    end
-
-    # ---- Server Middleware --------------------------------------------
-    #
-    # Catches OverLimit (and any class registered in
-    # `Limiter.config.errors`), bumps `job['overrated']`, computes the
-    # backoff, and reschedules to the same queue via `Client.push` with
-    # `at: Time.now + backoff`. Once `overrated >= reschedule`, re-raises
-    # so the normal retry/dead pipeline takes over.
-    class ServerMiddleware
-      include Wurk::Middleware::ServerMiddleware
-
-      def call(_worker, job, _queue)
-        yield
-      rescue StandardError => e
-        raise unless over_limit?(e)
-
-        handle_over_limit(job, e)
-      end
-
-      private
-
-      def over_limit?(exc)
-        Wurk::Limiter.config.errors.any? { |k| exc.is_a?(k) }
-      end
-
-      def handle_over_limit(job, exc)
-        job['overrated'] = job.fetch('overrated', 0).to_i + 1
-        limiter = exc.respond_to?(:limiter) ? exc.limiter : nil
-        exc.job = job if exc.respond_to?(:job=)
-        reschedule_cap = (limiter && limiter.options[:reschedule]) || Wurk::Limiter::DEFAULT_RESCHEDULE
-        raise exc if job['overrated'] >= reschedule_cap
-
-        backoff_proc = (limiter && limiter.options[:backoff]) || Wurk::Limiter.config.backoff
-        delay = backoff_proc.call(limiter, job, exc).to_f
-        Wurk::Client.new.push(job.merge('at' => ::Time.now.to_f + delay))
+        opts
       end
     end
   end
 end
 
+require_relative 'limiter/base'
+require_relative 'limiter/concurrent'
+require_relative 'limiter/bucket'
+require_relative 'limiter/window'
+require_relative 'limiter/leaky'
+require_relative 'limiter/points'
+require_relative 'limiter/unlimited'
 require_relative 'middleware'
+require_relative 'limiter/server_middleware'
 # Server-middleware registration happens in wurk.rb after the Wurk
 # `class << self` block defines `Wurk.configuration` — limiter.rb
 # loads earlier than that, so trying to call it here would NoMethodError.

--- a/lib/wurk/limiter/base.rb
+++ b/lib/wurk/limiter/base.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'digest'
+require 'securerandom'
+
+module Wurk
+  module Limiter
+    # Shared base for every limiter type. Holds the public introspection
+    # contract documented in §1.5 — name / type / options / size / status /
+    # reset / delete plus the `within_limit(...) { ... }` block. Subclasses
+    # override the acquire path and the per-type metric/size methods.
+    #
+    # `status` is uniform across types (#16): `{ used:, limit:, reset_at:,
+    # available? }`. Subclasses supply the three values via `build_status`;
+    # Concurrent additionally merges its metric counters.
+    class Base
+      attr_reader :name, :options
+
+      # `register:` defaults true so constructing a limiter publishes its
+      # metadata + `lmtr-list` membership. The dashboard reconstructs limiters
+      # purely to read `status` on a GET, so it passes `register: false` to
+      # keep introspection side-effect-free.
+      def initialize(name, register: true, **options)
+        unless name.is_a?(String) && NAME_PATTERN.match?(name)
+          raise ArgumentError, "limiter name must match #{NAME_PATTERN.inspect} (got #{name.inspect})"
+        end
+
+        ttl = options[:ttl] || DEFAULT_TTL
+        # Spec §1.2: ttl floor of 24h. Anything tighter risks losing the
+        # metadata hash mid-job and orphaning slots that read it.
+        raise ArgumentError, 'ttl must be >= 86_400' if ttl < 86_400
+
+        @name = name.dup.freeze
+        @options = options
+        register! if register
+      end
+
+      def type
+        raise NotImplementedError
+      end
+
+      def within_limit(**, &)
+        raise NotImplementedError
+      end
+
+      def size
+        0
+      end
+
+      # Uniform across types (#16). Subclasses override to fill in real
+      # numbers; the default reports an idle, unlimited shape.
+      def status
+        build_status(used: 0, limit: nil, reset_at: nil)
+      end
+
+      def reset
+        Wurk::Limiter.redis do |c|
+          state_keys.each { |k| c.call('DEL', k) }
+        end
+      end
+
+      def delete
+        Wurk::Limiter.redis do |c|
+          (state_keys + [meta_key]).each { |k| c.call('DEL', k) }
+          c.call('SREM', LIST_KEY, @name)
+        end
+      end
+
+      # Stable fingerprint for the limiter — Sidekiq 8.0+ switched from
+      # SHA1 → SHA256 (~10% larger encoding). Web UI groups limiters by
+      # this so that interpolated names (`stripe-#{user_id}`) get a single
+      # row per shape.
+      def fingerprint
+        @fingerprint ||= Digest::SHA256.hexdigest("#{type}|#{@name}|#{JSON.dump(serializable_options)}")
+      end
+
+      protected
+
+      # Assemble the uniform status hash. `available?` is derived: an
+      # unlimited (nil) limit is always available; otherwise headroom remains
+      # while `used < limit`. `reset_at` is an epoch-seconds Float (or nil
+      # when the type has no clock-driven reset).
+      def build_status(used:, limit:, reset_at:)
+        { used: used, limit: limit, reset_at: reset_at,
+          available?: limit.nil? || used < limit }
+      end
+
+      def meta_key
+        "lmtr:#{@name}"
+      end
+
+      def state_keys
+        []
+      end
+
+      def serializable_options
+        @options.transform_values do |v|
+          case v
+          when Proc then '<proc>'
+          when Symbol, Numeric, String, true, false, nil then v
+          else v.to_s
+          end
+        end
+      end
+
+      def register!
+        Wurk::Limiter.redis do |c|
+          c.call('SADD', LIST_KEY, @name)
+          c.call(
+            'HSET', meta_key,
+            'type', type.to_s,
+            'options', JSON.dump(serializable_options),
+            'fingerprint', fingerprint
+          )
+          c.call('EXPIRE', meta_key, @options[:ttl])
+        end
+      end
+
+      def ttl
+        @options[:ttl]
+      end
+
+      # Stable random slot id (Concurrent) / nonce (Window). 16 hex chars
+      # = 8 bytes — wide enough to avoid collision under any realistic
+      # burst and short enough to keep ZSET memory bounded.
+      def random_id
+        SecureRandom.hex(8)
+      end
+
+      def lua(name, keys:, argv:)
+        Wurk::Limiter.redis do |c|
+          Wurk::Lua::Loader.eval_cached(c, name, keys: keys, argv: argv)
+        end
+      end
+    end
+  end
+end

--- a/lib/wurk/limiter/bucket.rb
+++ b/lib/wurk/limiter/bucket.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Wurk
+  module Limiter
+    # Cardinal-boundary counter. Reset at the top of the unit (00:00 of
+    # minute/hour/day). On exhaustion sleep until next boundary, retry,
+    # OverLimit if that exceeds wait_timeout.
+    class Bucket < Base
+      def type = :bucket
+
+      def initialize(name, **options)
+        # Eager interval validation so a typo in `:fortnight` blows up at boot,
+        # not at first call. Lazy validation defers failures to runtime.
+        Limiter.interval_seconds(options[:interval], allow_integer: false)
+        super
+      end
+
+      def size
+        Wurk::Limiter.redis { |c| (c.call('GET', epoch_key) || '0').to_i }
+      end
+
+      # used = this period's count; limit = count; reset_at = the next
+      # cardinal boundary, when the counter rolls back to zero (#16).
+      def status
+        build_status(used: size, limit: @options[:count], reset_at: next_boundary)
+      end
+
+      def within_limit(used: 1, &block)
+        raise ArgumentError, 'block required' unless block
+
+        deadline = ::Time.now.to_f + @options[:wait_timeout]
+        loop do
+          ok, _current, secs_to_next = acquire(used)
+          return block.call if ok.to_i == 1
+
+          remaining = deadline - ::Time.now.to_f
+          raise OverLimit, self if remaining <= 0
+
+          sleep [remaining, secs_to_next.to_f, 0.05].compact.min.clamp(0.0, remaining)
+        end
+      end
+
+      protected
+
+      def state_keys
+        # Bucket keys are per-epoch and self-expiring; reset wipes the
+        # current epoch, the only one a caller could care about. Older
+        # epochs already EXPIRE'd.
+        epoch = ::Time.now.to_i / interval_seconds
+        ["lmtr-b:#{@name}:#{epoch}"]
+      end
+
+      private
+
+      def epoch_index
+        ::Time.now.to_i / interval_seconds
+      end
+
+      def epoch_key
+        "lmtr-b:#{@name}:#{epoch_index}"
+      end
+
+      def next_boundary
+        (epoch_index + 1).to_f * interval_seconds
+      end
+
+      def interval_seconds
+        @interval_seconds ||= Limiter.interval_seconds(@options[:interval], allow_integer: false)
+      end
+
+      def acquire(used)
+        lua(:limiter_bucket_acquire,
+            keys: ["lmtr-b:#{@name}"],
+            argv: [@options[:count], interval_seconds, used, ttl])
+      end
+    end
+  end
+end

--- a/lib/wurk/limiter/concurrent.rb
+++ b/lib/wurk/limiter/concurrent.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Wurk
+  module Limiter
+    # Atomic slot acquisition in a ZSET. Score = expiry epoch; the acquire
+    # script first evicts expired slots (bumping the `reclaimed` metric)
+    # then ZADDs if there's headroom.
+    #
+    # On exhaustion: spin loop with backoff. The spec says "blocks via
+    # Redis stream XREAD" — that's a perf optimization; the visible
+    # behavior is identical: blocks up to `wait_timeout` then OverLimit
+    # (or silent return for `policy: :ignore`).
+    class Concurrent < Base
+      WAIT_SLEEP = 0.05
+
+      METRIC_FIELDS = %w[held held_time immediate waited wait_time overages reclaimed].freeze
+
+      def type = :concurrent
+
+      def size
+        Wurk::Limiter.redis { |c| c.call('ZCARD', state_key).to_i }
+      end
+
+      # Uniform `{ used:, limit:, reset_at:, available? }` (#16) merged with
+      # the concurrent-only metric counters (§1.5) the dashboard already
+      # renders. Slots free on release rather than on a clock, so `reset_at`
+      # is the soonest in-flight slot expiry (a worst-case "available by"),
+      # or nil when idle.
+      def status
+        used = size
+        build_status(used: used, limit: @options[:limit], reset_at: soonest_expiry)
+          .merge(metrics)
+      end
+
+      def within_limit(&block)
+        raise ArgumentError, 'block required' unless block
+
+        started = monotime
+        deadline = started + @options[:wait_timeout]
+        slot = random_id
+        acquired_at = nil
+        loop do
+          result = acquire(slot)
+          if result[0].to_i == 1
+            acquired_at = monotime
+            break
+          end
+
+          return if @options[:policy] == :ignore
+
+          remaining = deadline - monotime
+          if remaining <= 0
+            bump_counter('overages')
+            raise OverLimit, self
+          end
+
+          sleep [remaining, WAIT_SLEEP].min
+        end
+
+        begin
+          incr_immediate_or_waited(acquired_at - started)
+          block.call
+        ensure
+          release(slot)
+          bump_counter('held_time', (monotime - acquired_at).to_i) if acquired_at
+        end
+      end
+
+      protected
+
+      def state_keys
+        [state_key, stats_key]
+      end
+
+      private
+
+      def metrics
+        h = Wurk::Limiter.redis { |c| c.call('HGETALL', stats_key) }
+        # redis-client returns either a flat array or a hash depending on
+        # the server version — normalize once so callers always see a hash.
+        h = h.each_slice(2).to_h if h.is_a?(Array)
+        METRIC_FIELDS.to_h { |k| [k, (h[k] || '0').to_i] }
+      end
+
+      # Lowest slot expiry epoch (the next slot to free), or nil when empty.
+      def soonest_expiry
+        row = Wurk::Limiter.redis { |c| c.call('ZRANGE', state_key, 0, 0, 'WITHSCORES') }
+        row && !row.empty? ? row[1].to_f : nil
+      end
+
+      def state_key
+        "lmtr-cs:#{@name}"
+      end
+
+      def stats_key
+        "lmtr-stats:#{@name}"
+      end
+
+      def acquire(slot)
+        lua(:limiter_concurrent_acquire,
+            keys: [state_key, stats_key],
+            argv: [@options[:limit], @options[:lock_timeout], slot, ttl])
+      end
+
+      def release(slot)
+        lua(:limiter_concurrent_release, keys: [state_key], argv: [slot])
+      end
+
+      def bump_counter(field, by = 1)
+        Wurk::Limiter.redis do |c|
+          c.call('HINCRBY', stats_key, field, by)
+          c.call('EXPIRE', stats_key, ttl)
+        end
+      end
+
+      def incr_immediate_or_waited(elapsed)
+        if elapsed < WAIT_SLEEP
+          bump_counter('immediate')
+        else
+          bump_counter('waited')
+          bump_counter('wait_time', elapsed.to_i)
+        end
+      end
+
+      def monotime
+        ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+      end
+    end
+  end
+end

--- a/lib/wurk/limiter/leaky.rb
+++ b/lib/wurk/limiter/leaky.rb
@@ -58,15 +58,27 @@ module Wurk
         when Symbol
           Limiter.interval_seconds(@options[:drain], allow_integer: false)
         when Integer
+          raise ArgumentError, "drain must be > 0 (got #{@options[:drain]})" unless @options[:drain].positive?
+
           @options[:drain]
         else
           raise ArgumentError, "drain must be Symbol or Integer (got #{@options[:drain].class})"
         end
       end
 
-      # bucket_size / drain → ops per second.
+      # bucket_size / drain → ops per second. A zero/negative bucket_size would
+      # silently produce a non-positive rate (and a 1/0 in `status` reset_at);
+      # fail fast at the boundary so callers see the bad config, not a NaN.
       def drain_per_sec
-        @drain_per_sec ||= @options[:bucket_size].to_f / drain_interval_seconds
+        @drain_per_sec ||= begin
+          rate = @options[:bucket_size].to_f / drain_interval_seconds
+          unless rate.positive?
+            raise ArgumentError,
+                  "drain_per_sec must be > 0 (bucket_size=#{@options[:bucket_size]}, drain=#{@options[:drain]})"
+          end
+
+          rate
+        end
       end
 
       def acquire

--- a/lib/wurk/limiter/leaky.rb
+++ b/lib/wurk/limiter/leaky.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Wurk
+  module Limiter
+    # Leaky bucket: drain rate = bucket_size / drain ops/sec. Stored as a
+    # HASH of {level, last} — Lua compares level vs bucket_size after
+    # leaking elapsed * drain_per_sec.
+    class Leaky < Base
+      WAIT_SLEEP = 0.05
+
+      def type = :leaky
+
+      def size
+        h = Wurk::Limiter.redis { |c| c.call('HGET', state_key, 'level') }
+        h.to_f
+      end
+
+      # used = current fill level; limit = bucket_size; reset_at = when the
+      # steady drip frees a slot (only meaningful while full), else nil (#16).
+      def status
+        level = size
+        cap = @options[:bucket_size]
+        reset_at = level >= cap ? ::Time.now.to_f + ((level - cap + 1) / drain_per_sec) : nil
+        build_status(used: level, limit: cap, reset_at: reset_at)
+      end
+
+      def within_limit(&block)
+        raise ArgumentError, 'block required' unless block
+
+        deadline = ::Time.now.to_f + @options[:wait_timeout]
+        loop do
+          ok, _level = acquire
+          return block.call if ok.to_i == 1
+
+          remaining = deadline - ::Time.now.to_f
+          raise OverLimit, self if remaining <= 0
+
+          sleep [remaining, WAIT_SLEEP].min
+        end
+      end
+
+      protected
+
+      def state_keys
+        [state_key]
+      end
+
+      private
+
+      def state_key
+        "lmtr-l:#{@name}"
+      end
+
+      def drain_interval_seconds
+        case @options[:drain]
+        when Symbol
+          Limiter.interval_seconds(@options[:drain], allow_integer: false)
+        when Integer
+          @options[:drain]
+        else
+          raise ArgumentError, "drain must be Symbol or Integer (got #{@options[:drain].class})"
+        end
+      end
+
+      # bucket_size / drain → ops per second.
+      def drain_per_sec
+        @drain_per_sec ||= @options[:bucket_size].to_f / drain_interval_seconds
+      end
+
+      def acquire
+        lua(:limiter_leaky_acquire,
+            keys: [state_key],
+            argv: [@options[:bucket_size], drain_per_sec, ttl])
+      end
+    end
+  end
+end

--- a/lib/wurk/limiter/points.rb
+++ b/lib/wurk/limiter/points.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Wurk
+  module Limiter
+    # Token-bucket with explicit `estimate:` per call. Refills at
+    # `refill_per_second` capped at `initial_points`. Failure mode is
+    # immediate (spec §1.4 — no sleep loop). The block is invoked with a
+    # `Handle` so user code may refund/over-charge via `handle.points_used`.
+    class Points < Base
+      class Handle
+        def initialize(limiter, estimate)
+          @limiter = limiter
+          @estimate = estimate
+        end
+
+        # Positive delta returns points to the bucket; negative records an
+        # under-estimate. Either way, clamped to [0, cap].
+        def points_used(actual)
+          delta = @estimate - actual
+          @limiter.send(:refund, delta)
+        end
+      end
+
+      def type = :points
+
+      # Apply refill on read so the size matches what the *next* acquire
+      # would see. Stored balance only updates on acquire/refund; without
+      # this, a fully-refilled bucket reports stale low numbers.
+      def size
+        cap = @options[:initial].to_f
+        data = Wurk::Limiter.redis { |c| c.call('HMGET', state_key, 'points', 'last') }
+        stored = data[0]
+        return cap if stored.nil?
+
+        last = (data[1] || ::Time.now.to_f).to_f
+        elapsed = [::Time.now.to_f - last, 0.0].max
+        [cap, stored.to_f + (elapsed * @options[:refill].to_f)].min
+      end
+
+      # used = points consumed (cap − available); limit = the cap; reset_at =
+      # when the bucket refills to full, or nil when already full (#16).
+      def status
+        cap = @options[:initial].to_f
+        available = size
+        used = cap - available
+        refill = @options[:refill].to_f
+        reset_at = available < cap && refill.positive? ? ::Time.now.to_f + ((cap - available) / refill) : nil
+        build_status(used: used, limit: cap, reset_at: reset_at)
+      end
+
+      def within_limit(estimate:, &block)
+        raise ArgumentError, 'block required' unless block
+        raise ArgumentError, 'estimate must be positive' if estimate <= 0
+
+        ok, _remaining = acquire(estimate)
+        raise OverLimit, self unless ok.to_i == 1
+
+        handle = Handle.new(self, estimate)
+        block.call(handle)
+      end
+
+      protected
+
+      def state_keys
+        [state_key]
+      end
+
+      private
+
+      def state_key
+        "lmtr-p:#{@name}"
+      end
+
+      def acquire(estimate)
+        lua(:limiter_points_acquire,
+            keys: [state_key],
+            argv: [@options[:initial], @options[:refill], estimate, ttl])
+      end
+
+      def refund(delta)
+        lua(:limiter_points_refund,
+            keys: [state_key],
+            argv: [delta, @options[:initial], ttl]).to_f
+      end
+    end
+  end
+end

--- a/lib/wurk/limiter/server_middleware.rb
+++ b/lib/wurk/limiter/server_middleware.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Wurk
+  module Limiter
+    # Catches OverLimit (and any class registered in `Limiter.config.errors`),
+    # bumps `job['overrated']`, and decides what to do next:
+    #
+    #   * reschedule disabled (`reschedule: 0`) → re-raise so the normal
+    #     retry/dead pipeline handles it (spec §1.2/§1.4 behaviour).
+    #   * still under the cap → reschedule onto the same queue at
+    #     `Time.now + backoff` via `Client.push`.
+    #   * cap reached (`overrated >= reschedule`, default 20) → **poison
+    #     brake** (#16): a job that's still rate-limited after N reschedules
+    #     is saturating the limiter, so instead of dumping it into another
+    #     25× retry loop we route it straight to the dead set tagged
+    #     `rate_limited`, bumping `jobs.rate_limited` and firing death
+    #     handlers. Bounded: termination at exactly `reschedule` attempts.
+    class ServerMiddleware
+      include Wurk::Middleware::ServerMiddleware
+
+      DEAD_REASON = 'rate_limited'
+
+      def call(_worker, job, _queue)
+        yield
+      rescue StandardError => e
+        raise unless over_limit?(e)
+
+        handle_over_limit(job, e)
+      end
+
+      private
+
+      def over_limit?(exc)
+        Wurk::Limiter.config.errors.any? { |k| exc.is_a?(k) }
+      end
+
+      def handle_over_limit(job, exc)
+        job['overrated'] = job.fetch('overrated', 0).to_i + 1
+        limiter = exc.respond_to?(:limiter) ? exc.limiter : nil
+        exc.job = job if exc.respond_to?(:job=)
+        cap = reschedule_cap(limiter)
+
+        raise exc if cap.zero? # rescheduling disabled → normal retry/dead pipeline
+        return route_to_dead(job, exc) if job['overrated'] >= cap
+
+        reschedule(job, exc, limiter)
+      end
+
+      # nil (concurrent/leaky/points never set it) → the default 20.
+      def reschedule_cap(limiter)
+        return DEFAULT_RESCHEDULE unless limiter
+
+        cap = limiter.options[:reschedule]
+        cap.nil? ? DEFAULT_RESCHEDULE : cap
+      end
+
+      def reschedule(job, exc, limiter)
+        backoff_proc = (limiter && limiter.options[:backoff]) || Wurk::Limiter.config.backoff
+        delay = backoff_proc.call(limiter, job, exc).to_f
+        Wurk::Client.new.push(job.merge('at' => ::Time.now.to_f + delay))
+      end
+
+      # Poison brake: stamp a clear reason, drop the job in the dead set, and
+      # ACK by returning normally (no re-raise) so it isn't also retried.
+      def route_to_dead(job, exc)
+        record = job.merge(
+          'error_class' => exc.class.name,
+          'error_message' => "#{DEAD_REASON}: #{exc.message} (overrated=#{job['overrated']})",
+          'failed_at' => ::Process.clock_gettime(::Process::CLOCK_REALTIME, :millisecond)
+        )
+        Wurk::Metrics::Statsd.increment('jobs.rate_limited', tags: ["worker:#{job['class']}"])
+        Wurk::DeadSet.new.kill(Wurk.dump_json(record), ex: exc)
+        nil
+      end
+    end
+  end
+end

--- a/lib/wurk/limiter/unlimited.rb
+++ b/lib/wurk/limiter/unlimited.rb
@@ -34,6 +34,15 @@ module Wurk
           block.call(Points::Handle.new(self, 0))
         end
       end
+
+      private
+
+      # Points::Handle#points_used calls `refund` on the limiter; without this
+      # no-op an Unlimited swap-in would raise NoMethodError the moment user
+      # code records actual usage. Drop-in contract trumps purity.
+      def refund(_delta)
+        0.0
+      end
     end
   end
 end

--- a/lib/wurk/limiter/unlimited.rb
+++ b/lib/wurk/limiter/unlimited.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative 'points'
+
+module Wurk
+  module Limiter
+    # No-op for the tests + bypass scenarios documented in §1.8. The
+    # within_limit block runs unconditionally and the introspection
+    # methods all return zeros so dashboards render predictably.
+    class Unlimited
+      def name = 'unlimited'
+      def type = :unlimited
+      def options = {}
+      def size = 0
+      def fingerprint = Digest::SHA256.hexdigest('unlimited')
+      def reset = nil
+      def delete = nil
+
+      # Uniform status shape (#16): no limit, always available.
+      def status
+        { used: 0, limit: nil, reset_at: nil, available?: true }
+      end
+
+      # Accept all the kwargs the other limiters take so a worker can swap
+      # `limiter = Sidekiq::Limiter.unlimited` in tests without touching
+      # call sites. `points`-style callers pass an `estimate:` and expect a
+      # `|handle|` block param — we yield a zero-cost handle just in case.
+      def within_limit(**_kwargs, &block)
+        raise ArgumentError, 'block required' unless block
+
+        if block.arity.zero?
+          block.call
+        else
+          block.call(Points::Handle.new(self, 0))
+        end
+      end
+    end
+  end
+end

--- a/lib/wurk/limiter/window.rb
+++ b/lib/wurk/limiter/window.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Wurk
+  module Limiter
+    # Sliding window via ZSET of timestamps. Accepts symbolic units or a
+    # raw Integer (in seconds). Used-units expand to N ZADDs in the Lua
+    # script so multi-charge calls remain atomic.
+    class Window < Base
+      WAIT_SLEEP = 0.5
+
+      def type = :window
+
+      def initialize(name, **options)
+        # Symbol or raw Integer (spec §1.2: window accepts both).
+        Limiter.interval_seconds(options[:interval], allow_integer: true)
+        super
+      end
+
+      def size
+        cutoff = ::Time.now.to_f - interval_seconds
+        Wurk::Limiter.redis do |c|
+          c.call('ZREMRANGEBYSCORE', state_key, '-inf', "(#{cutoff}")
+          c.call('ZCARD', state_key).to_i
+        end
+      end
+
+      # used = entries still inside the window; limit = count; reset_at =
+      # when the oldest entry slides out (freeing a slot), or nil when
+      # idle (#16).
+      def status
+        build_status(used: size, limit: @options[:count], reset_at: oldest_expiry)
+      end
+
+      def within_limit(used: 1, &block)
+        raise ArgumentError, 'block required' unless block
+
+        deadline = ::Time.now.to_f + @options[:wait_timeout]
+        loop do
+          ok, _current, _oldest = acquire(used)
+          return block.call if ok.to_i == 1
+
+          remaining = deadline - ::Time.now.to_f
+          raise OverLimit, self if remaining <= 0
+
+          sleep [remaining, WAIT_SLEEP].min
+        end
+      end
+
+      protected
+
+      def state_keys
+        [state_key]
+      end
+
+      private
+
+      def state_key
+        "lmtr-w:#{@name}"
+      end
+
+      # Oldest timestamp + interval = the moment it leaves the window.
+      def oldest_expiry
+        row = Wurk::Limiter.redis { |c| c.call('ZRANGE', state_key, 0, 0, 'WITHSCORES') }
+        row && !row.empty? ? row[1].to_f + interval_seconds : nil
+      end
+
+      def interval_seconds
+        @interval_seconds ||= Limiter.interval_seconds(@options[:interval], allow_integer: true)
+      end
+
+      def acquire(used)
+        lua(:limiter_window_acquire,
+            keys: [state_key],
+            argv: [@options[:count], interval_seconds, used, ttl, random_id])
+      end
+    end
+  end
+end

--- a/test/engine/api_endpoints_test.rb
+++ b/test/engine/api_endpoints_test.rb
@@ -149,7 +149,7 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
     assert_equal 0, payload[:page]
   end
 
-  def test_limiters_array
+  def test_limiters_array # rubocop:disable Minitest/MultipleAssertions
     name = seed_limiter
     get '/wurk/api/limiters'
 
@@ -157,6 +157,12 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
     row = json_body.find { |r| r[:name] == name }
 
     assert_equal({ name: name, type: 'concurrent' }, row.slice(:name, :type))
+    # #16: each limiter row carries its uniform live status (concurrent
+    # additionally merges its metric counters, so assert a subset).
+    status = row[:status]
+
+    refute_nil status, 'limiter row should include a status'
+    %i[used limit reset_at available?].each { |k| assert status.key?(k), "status missing #{k}" }
   ensure
     cleanup_limiter(name)
   end

--- a/test/integration/limiter_stress_test.rb
+++ b/test/integration/limiter_stress_test.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Contention stress for the Lua-backed limiters (#16 "Done when"). Real
+# Redis, real threads: hammer a concurrent limiter from many threads and
+# assert the atomic slot count is never breached — i.e. the acquire Lua
+# script is genuinely atomic and EVALSHA-cached under load.
+class LimiterStressTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  REDIS_URL = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
+  THREADS = 50
+  PER_THREAD = 20 # THREADS * PER_THREAD = 1000 acquires
+
+  def setup
+    super
+    @suffix = "stress#{Process.pid}#{object_id}"
+    # A pool wide enough that 50 threads never starve on a connection (which
+    # would surface as a pool timeout, not a limiter decision).
+    @pool = Wurk::RedisPool.new(size: THREADS + 8, url: REDIS_URL, timeout: 5, name: 'lstress')
+    @pool.with { |c| Wurk::Lua::Loader.script_load_all(c) }
+    Wurk::Limiter.reset_config!
+    Wurk::Limiter.config.redis = @pool
+  end
+
+  def teardown
+    Wurk::Limiter.concurrent("c-#{@suffix}", 1).delete
+    Wurk::Limiter.reset_config!
+    @pool.disconnect!
+  ensure
+    super
+  end
+
+  def test_1000_concurrent_acquires_never_exceed_the_limit # rubocop:disable Minitest/MultipleAssertions,Metrics/AbcSize
+    limit = 5
+    limiter = Wurk::Limiter.concurrent("c-#{@suffix}", limit, wait_timeout: 15, lock_timeout: 30)
+
+    mutex = ::Mutex.new
+    in_flight = 0
+    max_seen = 0
+    acquired = 0
+    over_limit = 0
+
+    threads = Array.new(THREADS) do
+      ::Thread.new do
+        PER_THREAD.times do
+          limiter.within_limit do
+            mutex.synchronize do
+              in_flight += 1
+              max_seen = in_flight if in_flight > max_seen
+              acquired += 1
+            end
+            sleep 0.002 # widen the window so any non-atomic slip would overlap
+            mutex.synchronize { in_flight -= 1 }
+          end
+        rescue Wurk::Limiter::OverLimit
+          mutex.synchronize { over_limit += 1 }
+        end
+      end
+    end
+    threads.each(&:join)
+
+    assert_operator max_seen, :<=, limit,
+                    "atomicity breached: saw #{max_seen} concurrent holders for a limit of #{limit}"
+    assert_equal 0, over_limit, "no acquire should time out with a 15s wait (#{over_limit} did)"
+    assert_equal THREADS * PER_THREAD, acquired, 'every acquire should eventually succeed'
+    assert_equal 0, limiter.size, 'every slot released at the end'
+  end
+
+  # All limiter acquire/release scripts ship as files, get a precomputed SHA,
+  # and run via EVALSHA (with NOSCRIPT recovery) — never re-uploaded per call.
+  def test_all_limiter_lua_scripts_are_evalsha_cached
+    %i[limiter_concurrent_acquire limiter_concurrent_release limiter_bucket_acquire
+       limiter_window_acquire limiter_leaky_acquire limiter_points_acquire
+       limiter_points_refund].each do |name|
+      assert Wurk::Lua::SCRIPTS.key?(name), "missing Lua script #{name}"
+      assert_match(/\A[0-9a-f]{40}\z/, Wurk::Lua::SHAS[name], "no precomputed SHA for #{name}")
+    end
+
+    # EVALSHA path resolves even after a SCRIPT FLUSH (NOSCRIPT → reload).
+    @pool.with { |c| c.call('SCRIPT', 'FLUSH') }
+    l = Wurk::Limiter.concurrent("flush-#{@suffix}", 1)
+    ran = false
+    l.within_limit { ran = true }
+
+    assert ran, 'acquire should recover from a flushed script cache'
+  ensure
+    Wurk::Limiter.concurrent("flush-#{@suffix}", 1).delete
+  end
+end

--- a/test/integration/limiter_stress_test.rb
+++ b/test/integration/limiter_stress_test.rb
@@ -15,7 +15,7 @@ class LimiterStressTest < Wurk::Test::UnitCase
 
   def setup
     super
-    @suffix = "stress#{Process.pid}#{object_id}"
+    @suffix = "stress#{Process.pid}:#{object_id}"
     # A pool wide enough that 50 threads never starve on a connection (which
     # would surface as a pool timeout, not a limiter decision).
     @pool = Wurk::RedisPool.new(size: THREADS + 8, url: REDIS_URL, timeout: 5, name: 'lstress')

--- a/test/unit/limiter_leaky_test.rb
+++ b/test/unit/limiter_leaky_test.rb
@@ -81,6 +81,21 @@ class LimiterLeakyTest < Wurk::Test::UnitCase
     assert_raises(ArgumentError) { l.within_limit {} }
   end
 
+  # Non-positive drain / bucket_size silently produces 0 or negative
+  # drain_per_sec → division-by-zero in `status` reset_at and degenerate
+  # acquire behavior. Fail fast at the boundary instead.
+  def test_zero_or_negative_drain_raises
+    [0, -1].each do |bad|
+      l = Wurk::Limiter.leaky("f0-#{@suffix}-#{bad}", 10, bad)
+      assert_raises(ArgumentError) { l.within_limit { nil } }
+    end
+  end
+
+  def test_zero_or_negative_bucket_size_raises
+    l = Wurk::Limiter.leaky("fb-#{@suffix}", 0, 60)
+    assert_raises(ArgumentError) { l.within_limit { nil } }
+  end
+
   def test_reset_clears_level
     l = Wurk::Limiter.leaky("g-#{@suffix}", 3, 60)
     l.within_limit {}

--- a/test/unit/limiter_test.rb
+++ b/test/unit/limiter_test.rb
@@ -162,6 +162,61 @@ class LimiterTest < Wurk::Test::UnitCase
     assert_match(/\A[0-9a-f]{64}\z/, l.fingerprint)
   end
 
+  # ----- uniform status (#16) ------------------------------------------
+
+  def test_status_uniform_shape_for_every_type
+    limiters = {
+      concurrent: Wurk::Limiter.concurrent("sc-#{@suffix}", 3),
+      bucket: Wurk::Limiter.bucket("sb-#{@suffix}", 10, :minute),
+      window: Wurk::Limiter.window("sw-#{@suffix}", 5, :hour),
+      leaky: Wurk::Limiter.leaky("sl-#{@suffix}", 4, 2),
+      points: Wurk::Limiter.points("sp-#{@suffix}", 100, 10),
+      unlimited: Wurk::Limiter.unlimited
+    }
+    limiters.each do |type, l|
+      s = l.status
+
+      %i[used limit reset_at available?].each { |k| assert s.key?(k), "#{type} status missing #{k}" }
+    end
+  end
+
+  def test_bucket_status_tracks_usage_and_reset_boundary # rubocop:disable Minitest/MultipleAssertions
+    l = Wurk::Limiter.bucket("sbu-#{@suffix}", 3, :minute, wait_timeout: 0)
+    2.times { l.within_limit {} }
+    s = l.status
+
+    assert_equal 2, s[:used]
+    assert_equal 3, s[:limit]
+    assert s[:available?]
+    assert_operator s[:reset_at], :>, ::Time.now.to_f, 'reset_at is the next cardinal boundary'
+  end
+
+  def test_bucket_status_unavailable_when_full
+    l = Wurk::Limiter.bucket("sbf-#{@suffix}", 2, :minute, wait_timeout: 0)
+    2.times { l.within_limit {} }
+
+    refute l.status[:available?], 'a saturated bucket reports unavailable'
+  end
+
+  def test_concurrent_status_merges_uniform_and_metrics
+    l = Wurk::Limiter.concurrent("scm-#{@suffix}", 2)
+    l.within_limit {}
+    s = l.status
+
+    assert_equal 2, s[:limit]
+    assert s.key?(:available?)
+    assert s.key?('immediate'), 'concurrent status keeps its metric counters'
+  end
+
+  def test_points_status_reflects_consumption
+    l = Wurk::Limiter.points("spc-#{@suffix}", 100, 0)
+    l.within_limit(estimate: 30) { |_h| }
+    s = l.status
+
+    assert_in_delta 30, s[:used], 1.0
+    assert_in_delta(100.0, s[:limit])
+  end
+
   # ----- server middleware reschedule path -----------------------------
 
   def test_server_middleware_reschedules_on_over_limit
@@ -186,15 +241,43 @@ class LimiterTest < Wurk::Test::UnitCase
     end
   end
 
-  def test_server_middleware_reraises_after_reschedule_cap
+  # #16 poison brake: once `overrated` reaches the reschedule cap the job is
+  # rate-limit-poison — instead of re-raising into the 25× retry pipeline,
+  # the middleware drops it straight into the dead set tagged `rate_limited`.
+  def test_server_middleware_routes_to_dead_after_reschedule_cap # rubocop:disable Minitest/MultipleAssertions,Metrics/AbcSize
     l = Wurk::Limiter.bucket("cap-#{@suffix}", 1, :minute, wait_timeout: 0, reschedule: 2)
-    job = { 'class' => 'NoopWorker', 'args' => [], 'queue' => 'default', 'jid' => 'jjj', 'overrated' => 1 }
+    jid = "capj#{@suffix}"
+    job = { 'class' => 'NoopWorker', 'args' => [], 'queue' => 'default', 'jid' => jid, 'overrated' => 1 }
+    mw = Wurk::Limiter::ServerMiddleware.new
+    mw.config = Wurk.configuration
+
+    # No re-raise: the brake ACKs by returning normally.
+    mw.call(nil, job, 'default') { raise Wurk::Limiter::OverLimit.new(l, job) }
+
+    assert_equal 2, job['overrated']
+    dead = Wurk.redis { |c| c.call('ZRANGE', Wurk::Keys::DEAD, 0, -1) }.find { |p| p.include?(jid) }
+
+    refute_nil dead, 'job should be dead-lettered once the reschedule cap is hit'
+    record = JSON.parse(dead)
+
+    assert_equal 'Wurk::Limiter::OverLimit', record['error_class']
+    assert_includes record['error_message'], Wurk::Limiter::ServerMiddleware::DEAD_REASON
+  ensure
+    Wurk.redis do |c|
+      c.call('ZRANGE', Wurk::Keys::DEAD, 0, -1).each { |p| c.call('ZREM', Wurk::Keys::DEAD, p) if p.include?(jid) }
+    end
+  end
+
+  # reschedule: 0 disables limiter rescheduling entirely (§1.2) — OverLimit
+  # then re-raises into the normal retry/dead pipeline, no poison brake.
+  def test_server_middleware_reraises_when_reschedule_disabled
+    l = Wurk::Limiter.bucket("nz-#{@suffix}", 1, :minute, wait_timeout: 0, reschedule: 0)
+    job = { 'class' => 'NoopWorker', 'args' => [], 'queue' => 'default', 'jid' => "nzj#{@suffix}" }
     mw = Wurk::Limiter::ServerMiddleware.new
     mw.config = Wurk.configuration
 
     assert_raises(Wurk::Limiter::OverLimit) do
       mw.call(nil, job, 'default') { raise Wurk::Limiter::OverLimit.new(l, job) }
     end
-    assert_equal 2, job['overrated']
   end
 end

--- a/test/unit/limiter_test.rb
+++ b/test/unit/limiter_test.rb
@@ -90,6 +90,17 @@ class LimiterTest < Wurk::Test::UnitCase
     assert ran
   end
 
+  # Drop-in contract: Points::Handle calls `refund` on the limiter via
+  # `points_used`. Unlimited must answer that as a no-op or it raises
+  # NoMethodError the moment a worker swaps to `Wurk::Limiter.unlimited`.
+  def test_unlimited_handles_points_used_callback
+    l = Wurk::Limiter.unlimited
+    captured = nil
+    l.within_limit(estimate: 50) { |h| captured = h.points_used(10) }
+
+    assert_equal 0.0, captured
+  end
+
   # ----- OverLimit shape ------------------------------------------------
 
   def test_over_limit_exposes_limiter_and_job
@@ -182,7 +193,7 @@ class LimiterTest < Wurk::Test::UnitCase
 
   def test_bucket_status_tracks_usage_and_reset_boundary # rubocop:disable Minitest/MultipleAssertions
     l = Wurk::Limiter.bucket("sbu-#{@suffix}", 3, :minute, wait_timeout: 0)
-    2.times { l.within_limit {} }
+    2.times { l.within_limit { nil } }
     s = l.status
 
     assert_equal 2, s[:used]
@@ -193,14 +204,14 @@ class LimiterTest < Wurk::Test::UnitCase
 
   def test_bucket_status_unavailable_when_full
     l = Wurk::Limiter.bucket("sbf-#{@suffix}", 2, :minute, wait_timeout: 0)
-    2.times { l.within_limit {} }
+    2.times { l.within_limit { nil } }
 
     refute l.status[:available?], 'a saturated bucket reports unavailable'
   end
 
   def test_concurrent_status_merges_uniform_and_metrics
     l = Wurk::Limiter.concurrent("scm-#{@suffix}", 2)
-    l.within_limit {}
+    l.within_limit { nil }
     s = l.status
 
     assert_equal 2, s[:limit]
@@ -210,7 +221,7 @@ class LimiterTest < Wurk::Test::UnitCase
 
   def test_points_status_reflects_consumption
     l = Wurk::Limiter.points("spc-#{@suffix}", 100, 0)
-    l.within_limit(estimate: 30) { |_h| }
+    l.within_limit(estimate: 30) { |_h| nil }
     s = l.status
 
     assert_in_delta 30, s[:used], 1.0


### PR DESCRIPTION
## What & why

Closes #16. The five rate limiters lived in one 753-line file with a concurrent-only `status` and a server middleware that, at the reschedule cap, re-raised `OverLimit` back into the normal 25× retry pipeline. This splits the file and closes the behavioural gaps.

## Changes

**Split — one file per type under `lib/wurk/limiter/`:** `base`, `concurrent`, `bucket`, `window`, `leaky`, `points`, `unlimited`, `server_middleware`. `limiter.rb` stays the module entry (constants, `Config`, `OverLimit`, constructors) and gains a `build` reconstructor for read-only dashboard introspection. The `Wurk::Limiter` / `Sidekiq::Limiter` public surface is unchanged.

**Uniform `status` (§1.5 + #16):** every type now answers
```ruby
limiter.status #=> { used:, limit:, reset_at:, available? }
```
computed from live state — bucket → next cardinal boundary, window → when the oldest entry slides out, leaky → drip-to-free, points → refill-to-full, concurrent → soonest slot expiry. Concurrent **merges** its existing metric counters (`held`/`waited`/`reclaimed`/…) so the Limits tab keeps them. The `/api/limiters` JSON now carries a `status` per row (rebuilt with `register: false` so the GET stays side-effect-free).

**Poison brake (#16):** once a job's `overrated` reaches the reschedule cap it's rate-limit poison — instead of dumping it into another 25× retry loop, the middleware drops it **straight into the dead set tagged `rate_limited`**, increments `jobs.rate_limited`, and fires death handlers. Bounded termination at exactly `reschedule` attempts. `reschedule: 0` still **disables** rescheduling (re-raise to the normal pipeline) per §1.2.

**Lua atomicity:** verified all limiter scripts are EVALSHA-cached with NOSCRIPT recovery, and atomic under contention.

## Tests

- Per-type uniform-status cases (shape + usage tracking + `available?` flip + `reset_at`).
- Middleware: dead-set routing at the cap (`rate_limited` reason) and re-raise when `reschedule: 0`.
- `api_endpoints_test` asserts the new `status` field on each limiter row.
- **Stress** (`test/integration/limiter_stress_test.rb`): 1000 acquires across 50 threads never exceed the limit (atomicity), all slots released, plus EVALSHA-cache + post-`SCRIPT FLUSH` recovery for every limiter script.
- Full `bin/rake test`, `test:parity` (20), and `test:ecosystem` all pass; the only red is the pre-existing `StaticAssetsTest` Vite-manifest pair (needs a Node build; unrelated).

## "Done when" (issue #16)

- [x] `limiter.rb` split into one file per type with a shared base.
- [x] `Limiter#status` returns `{ used:, limit:, reset_at:, available? }` per type.
- [x] Reschedule count tracked; routes to dead set after the configurable threshold.
- [x] All limiter Lua scripts EVALSHA-cached + atomic under contention.
- [x] Status endpoint exposed in the dashboard JSON API.
- [x] Stress test: 1000 concurrent acquires, no over-limit slip.
- [x] Poison pill on `OverLimit` no longer loops indefinitely.

## How to test in prod

```ruby
# Read live limiter status (also surfaced on the dashboard Limits tab / /api/limiters):
lim = Sidekiq::Limiter.bucket("stripe-#{account_id}", 100, :minute)
lim.status   #=> { used: 12, limit: 100, reset_at: 1780224000.0, available?: true }

# Watch the poison brake: a job that stays rate-limited past its reschedule
# cap stops cycling and lands in the dashboard's Dead tab with
# error_class "Wurk::Limiter::OverLimit" and a "rate_limited: …" message,
# while the jobs.rate_limited statsd counter ticks. Alert on that counter
# to catch a wedged limit instead of an ever-growing Scheduled set.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API now returns richer limiter status (used, limit, reset time, availability).
  * Added multiple limiter strategies (Bucket, Concurrent, Leaky, Points, Window) plus an unlimited no-op limiter.
  * Server middleware enhanced to handle rate-limited jobs with configurable rescheduling/dead-routing.

* **Bug Fixes**
  * Limiter metadata parsing is more resilient; malformed metadata no longer breaks listing.

* **Tests**
  * New unit and stress tests covering limiter behavior and status consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->