### PR TITLE
feat: dashboard batches/limiters/periodic pages + pagination fix (closes #25)

### DIFF
--- a/app/controllers/wurk/api/serializers.rb
+++ b/app/controllers/wurk/api/serializers.rb
@@ -104,6 +104,7 @@ module Wurk
           tz: loop_obj.tz_name,
           paused: loop_obj.paused?,
           args: loop_obj.args,
+          last_fire_at: loop_obj.last_fired_at,
           next_fire_at: loop_obj.next_fire_at(now_epoch)
         }
       end

--- a/app/controllers/wurk/api_controller.rb
+++ b/app/controllers/wurk/api_controller.rb
@@ -65,6 +65,8 @@ module Wurk
 
     def batch
       status = ::Wurk::Batch::Status.new(params[:bid].to_s)
+      return render(json: { error: 'unknown batch' }, status: :not_found) unless status.exists?
+
       render json: status.data.transform_keys(&:to_sym)
     rescue ::ArgumentError
       render json: { error: 'unknown batch' }, status: :not_found

--- a/app/controllers/wurk/api_controller.rb
+++ b/app/controllers/wurk/api_controller.rb
@@ -63,9 +63,17 @@ module Wurk
       render json: { total: set.size, page: page[:page], count: page[:count], batches: rows }
     end
 
+    def batch
+      status = ::Wurk::Batch::Status.new(params[:bid].to_s)
+      render json: status.data.transform_keys(&:to_sym)
+    rescue ::ArgumentError
+      render json: { error: 'unknown batch' }, status: :not_found
+    end
+
     def limiters
       names = ::Wurk::Web::Enterprise::Limits.list(filter: params[:substr])
-      render json: names.map { |name| ::Wurk::Api::Serializers.limiter_row(name, limiter_meta(name)) }
+      page = ::Wurk::Api::Pagination.window(params)
+      render json: { total: names.size, page: page[:page], count: page[:count], limiters: limiter_rows(names, page) }
     end
 
     def reset_limiter
@@ -140,6 +148,15 @@ module Wurk
       total = set.size
       entries = ::Wurk::Api::Pagination.slice(set, page) { |entry| ::Wurk::Api::Serializers.sorted_entry(entry) }
       render json: { total: total, page: page[:page], count: page[:count], entries: entries }
+    end
+
+    # substr is already applied by Limits.list (matches on name), so slice the
+    # filtered names directly — only the page's rows pay the per-limiter Redis
+    # reads in limiter_row (which folds in live status).
+    def limiter_rows(names, page)
+      (names.slice(page[:page] * page[:count], page[:count]) || []).map do |name|
+        ::Wurk::Api::Serializers.limiter_row(name, limiter_meta(name))
+      end
     end
 
     def limiter_meta(name)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Wurk::Engine.routes.draw do
     get  'dead',             to: 'api#dead'
     get  'processes',        to: 'api#processes'
     get  'batches',          to: 'api#batches'
+    get  'batches/:bid',     to: 'api#batch', as: :api_batch
     get  'limiters',         to: 'api#limiters'
     post 'limiters/:name/reset', to: 'api#reset_limiter', as: :api_reset_limiter
     get  'cron',             to: 'api#cron'

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 .vite/
 *.log
+*.tsbuildinfo

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import Scheduled from './pages/Scheduled';
 import Dead from './pages/Dead';
 import Busy from './pages/Busy';
 import Batches from './pages/Batches';
+import BatchDetail from './pages/BatchDetail';
 import Limiters from './pages/Limiters';
 import Cron from './pages/Cron';
 import Metrics from './pages/Metrics';
@@ -80,6 +81,7 @@ export default function App() {
               <Route path="/dead" element={<Dead />} />
               <Route path="/busy" element={<Busy />} />
               <Route path="/batches" element={<Batches />} />
+              <Route path="/batches/:bid" element={<BatchDetail />} />
               <Route path="/limiters" element={<Limiters />} />
               <Route path="/cron" element={<Cron />} />
               <Route path="/metrics" element={<Metrics />} />

--- a/frontend/src/pages/BatchDetail.tsx
+++ b/frontend/src/pages/BatchDetail.tsx
@@ -66,9 +66,10 @@ export default function BatchDetail() {
   const { data, isLoading, isError } = useQuery<BatchDetailData>({
     queryKey: ['batch', bid],
     queryFn: () =>
-      fetch(`/wurk/api/batches/${encodeURIComponent(bid)}`).then(
-        (r) => r.json() as Promise<BatchDetailData>
-      ),
+      fetch(`/wurk/api/batches/${encodeURIComponent(bid)}`).then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json() as Promise<BatchDetailData>;
+      }),
   });
 
   if (isLoading) return <div className="empty-state"><span className="spinner" /></div>;

--- a/frontend/src/pages/BatchDetail.tsx
+++ b/frontend/src/pages/BatchDetail.tsx
@@ -1,0 +1,119 @@
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, type ReactNode } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { t } from '../i18n';
+import { relativeTime } from '../utils';
+
+interface BatchDetailData {
+  bid: string;
+  description: string | null;
+  total: number;
+  pending: number;
+  failures: number;
+  complete: boolean;
+  invalidated: boolean;
+  created_at: number | null;
+  complete_at: number | null;
+  success_at: number | null;
+  death_at: number | null;
+  parent_bid: string | null;
+  tags: string[];
+  child_count: number;
+  failed_jids: string[];
+  dead_jids: string[];
+}
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <span style={{ fontSize: 11, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+        {label}
+      </span>
+      <span style={{ fontVariantNumeric: 'tabular-nums' }}>{children}</span>
+    </div>
+  );
+}
+
+function JidList({ label, jids }: { label: string; jids: string[] }) {
+  if (jids.length === 0) return null;
+  return (
+    <div style={{ marginTop: '1.5rem' }}>
+      <h2 style={{ fontSize: 14, margin: '0 0 0.5rem' }}>
+        {label} <span className="badge badge-muted">{jids.length}</span>
+      </h2>
+      <div className="table-wrapper">
+        <table>
+          <tbody>
+            {jids.map((jid) => (
+              <tr key={jid}>
+                <td style={{ fontFamily: 'monospace', fontSize: 12 }}>{jid}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default function BatchDetail() {
+  const { bid = '' } = useParams();
+
+  useEffect(() => {
+    document.title = `${t('nav.batches')} — Wurk`;
+  }, []);
+
+  const { data, isLoading, isError } = useQuery<BatchDetailData>({
+    queryKey: ['batch', bid],
+    queryFn: () =>
+      fetch(`/wurk/api/batches/${encodeURIComponent(bid)}`).then(
+        (r) => r.json() as Promise<BatchDetailData>
+      ),
+  });
+
+  if (isLoading) return <div className="empty-state"><span className="spinner" /></div>;
+  if (isError || !data) return <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>;
+
+  const done = data.total - data.pending;
+  const pct = data.total > 0 ? Math.round((done / data.total) * 100) : 0;
+
+  return (
+    <div>
+      <div className="section-header" style={{ gap: '0.75rem' }}>
+        <Link to="/batches" className="btn btn-sm">← {t('nav.batches')}</Link>
+        <h1 className="page-title" style={{ margin: 0, fontFamily: 'monospace', fontSize: 16 }}>{data.bid}</h1>
+        {data.complete ? (
+          <span className="badge badge-success">complete</span>
+        ) : (
+          <span className="badge badge-accent">{pct}%</span>
+        )}
+        {data.invalidated && <span className="badge badge-danger">invalidated</span>}
+      </div>
+
+      {data.description && (
+        <p style={{ color: 'var(--text-muted)', marginTop: 0 }}>{data.description}</p>
+      )}
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))',
+          gap: '1rem',
+          marginTop: '1rem',
+        }}
+      >
+        <Field label="Total">{data.total.toLocaleString()}</Field>
+        <Field label="Pending">{data.pending.toLocaleString()}</Field>
+        <Field label="Failures">{data.failures.toLocaleString()}</Field>
+        <Field label="Children">{data.child_count.toLocaleString()}</Field>
+        <Field label="Created">{data.created_at ? relativeTime(data.created_at) : '—'}</Field>
+        <Field label="Completed">{data.complete_at ? relativeTime(data.complete_at) : '—'}</Field>
+        {data.parent_bid && <Field label="Parent">{data.parent_bid}</Field>}
+        {data.tags.length > 0 && <Field label="Tags">{data.tags.join(', ')}</Field>}
+      </div>
+
+      <JidList label="Failed jobs" jids={data.failed_jids} />
+      <JidList label="Dead jobs" jids={data.dead_jids} />
+    </div>
+  );
+}

--- a/frontend/src/pages/Batches.tsx
+++ b/frontend/src/pages/Batches.tsx
@@ -1,17 +1,19 @@
 import { useQuery } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { Pagination } from '../components/Pagination';
 import { t } from '../i18n';
 import { relativeTime, truncate } from '../utils';
 
 interface Batch {
   bid: string;
-  description: string;
+  description: string | null;
   total: number;
   pending: number;
-  failed: number;
-  created_at: number;
-  expires_at: number;
+  failures: number;
+  complete: boolean;
+  created_at: number | null;
+  complete_at: number | null;
 }
 
 interface BatchesResponse {
@@ -33,7 +35,7 @@ export default function Batches() {
   const { data, isLoading, isError } = useQuery<BatchesResponse>({
     queryKey: ['batches', page],
     queryFn: () =>
-      fetch(`/wurk/api/batches?page=${page}&count=${PAGE_SIZE}`).then(
+      fetch(`/wurk/api/batches?page=${page - 1}&count=${PAGE_SIZE}`).then(
         (r) => r.json() as Promise<BatchesResponse>
       ),
   });
@@ -60,7 +62,7 @@ export default function Batches() {
                   <th>Description</th>
                   <th>{t('table.total')}</th>
                   <th>{t('table.pending')}</th>
-                  <th>Failed</th>
+                  <th>Failures</th>
                   <th>Progress</th>
                   <th>Created</th>
                 </tr>
@@ -71,19 +73,18 @@ export default function Batches() {
                   const pct = batch.total > 0 ? (done / batch.total) * 100 : 0;
                   return (
                     <tr key={batch.bid}>
-                      <td
-                        title={batch.bid}
-                        style={{ fontFamily: 'monospace', fontSize: 12, color: 'var(--text-muted)' }}
-                      >
-                        {truncate(batch.bid, 14)}
+                      <td style={{ fontFamily: 'monospace', fontSize: 12 }}>
+                        <Link to={`/batches/${batch.bid}`} title={batch.bid}>
+                          {truncate(batch.bid, 14)}
+                        </Link>
                       </td>
-                      <td title={batch.description}>{truncate(batch.description, 40)}</td>
+                      <td title={batch.description ?? ''}>{truncate(batch.description ?? '—', 40)}</td>
                       <td>{batch.total.toLocaleString()}</td>
                       <td style={{ color: batch.pending > 0 ? 'var(--warning)' : 'var(--success)' }}>
                         {batch.pending.toLocaleString()}
                       </td>
-                      <td style={{ color: batch.failed > 0 ? 'var(--danger)' : undefined }}>
-                        {batch.failed.toLocaleString()}
+                      <td style={{ color: batch.failures > 0 ? 'var(--danger)' : undefined }}>
+                        {batch.failures.toLocaleString()}
                       </td>
                       <td style={{ width: 100 }}>
                         <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
@@ -92,7 +93,7 @@ export default function Batches() {
                               className="progress-bar-fill"
                               style={{
                                 width: `${pct}%`,
-                                background: batch.failed > 0 ? 'var(--danger)' : 'var(--success)',
+                                background: batch.failures > 0 ? 'var(--danger)' : 'var(--success)',
                               }}
                             />
                           </div>
@@ -101,7 +102,7 @@ export default function Batches() {
                           </span>
                         </div>
                       </td>
-                      <td>{relativeTime(batch.created_at)}</td>
+                      <td>{batch.created_at ? relativeTime(batch.created_at) : '—'}</td>
                     </tr>
                   );
                 })}

--- a/frontend/src/pages/Cron.tsx
+++ b/frontend/src/pages/Cron.tsx
@@ -1,42 +1,49 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { t } from '../i18n';
 import { relativeTime, truncate } from '../utils';
+import { useMeta } from '../hooks/useMeta';
 
-interface CronEntry {
-  name: string;
-  cron: string;
-  class: string;
-  args: unknown;
-  last_run: number | null;
-  next_run: number | null;
-  status: string;
-}
-
-function statusBadge(status: string) {
-  switch (status.toLowerCase()) {
-    case 'active':
-    case 'ok':
-      return <span className="badge badge-success">{status}</span>;
-    case 'error':
-    case 'failed':
-      return <span className="badge badge-danger">{status}</span>;
-    case 'disabled':
-      return <span className="badge badge-muted">{status}</span>;
-    default:
-      return <span className="badge badge-accent">{status}</span>;
-  }
+interface CronLoop {
+  lid: string;
+  schedule: string;
+  klass: string;
+  queue: string;
+  tz: string | null;
+  paused: boolean;
+  args: unknown[];
+  last_fire_at: number | null;
+  next_fire_at: number | null;
 }
 
 export default function Cron() {
+  const qc = useQueryClient();
+  const { data: meta } = useMeta();
+  const readOnly = meta?.read_only ?? false;
+
   useEffect(() => {
     document.title = `${t('nav.cron')} — Wurk`;
   }, []);
 
-  const { data, isLoading, isError } = useQuery<CronEntry[]>({
+  const { data, isLoading, isError } = useQuery<CronLoop[]>({
     queryKey: ['cron'],
-    queryFn: () => fetch('/wurk/api/cron').then((r) => r.json() as Promise<CronEntry[]>),
+    queryFn: () => fetch('/wurk/api/cron').then((r) => r.json() as Promise<CronLoop[]>),
     refetchInterval: 15000,
+  });
+
+  // pause/unpause/enqueue skip CSRF (see ApiController#skip_forgery_protection).
+  const post = (lid: string, action: string) =>
+    fetch(`/wurk/api/cron/${lid}/${action}`, { method: 'POST' });
+
+  const setPaused = useMutation({
+    mutationFn: ({ lid, paused }: { lid: string; paused: boolean }) =>
+      post(lid, paused ? 'unpause' : 'pause'),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['cron'] }),
+  });
+
+  const enqueueNow = useMutation({
+    mutationFn: (lid: string) => post(lid, 'enqueue'),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['cron'] }),
   });
 
   if (isLoading) return <div className="empty-state"><span className="spinner" /></div>;
@@ -56,27 +63,56 @@ export default function Cron() {
           <table>
             <thead>
               <tr>
-                <th>Name</th>
                 <th>Schedule</th>
                 <th>{t('table.class')}</th>
-                <th>{t('table.last_run')}</th>
-                <th>{t('table.next_run')}</th>
+                <th>{t('table.queue')}</th>
+                <th>Last fire</th>
+                <th>Next fire</th>
                 <th>{t('table.status')}</th>
+                {!readOnly && <th />}
               </tr>
             </thead>
             <tbody>
-              {data.map((entry) => (
-                <tr key={entry.name}>
-                  <td style={{ fontWeight: 500 }} title={entry.name}>{truncate(entry.name, 30)}</td>
-                  <td style={{ fontFamily: 'monospace', fontSize: 12 }}>{entry.cron}</td>
-                  <td title={entry.class}>{truncate(entry.class, 35)}</td>
+              {data.map((loop) => (
+                <tr key={loop.lid}>
+                  <td style={{ fontFamily: 'monospace', fontSize: 12 }} title={loop.tz ?? undefined}>
+                    {loop.schedule}
+                  </td>
+                  <td title={loop.klass}>{truncate(loop.klass, 32)}</td>
+                  <td>{loop.queue}</td>
                   <td style={{ color: 'var(--text-muted)' }}>
-                    {entry.last_run ? relativeTime(entry.last_run) : '—'}
+                    {loop.last_fire_at ? relativeTime(loop.last_fire_at) : '—'}
                   </td>
-                  <td style={{ color: 'var(--accent)' }}>
-                    {entry.next_run ? relativeTime(entry.next_run) : '—'}
+                  <td style={{ color: loop.paused ? 'var(--text-muted)' : 'var(--accent)' }}>
+                    {loop.paused ? '—' : loop.next_fire_at ? relativeTime(loop.next_fire_at) : '—'}
                   </td>
-                  <td>{statusBadge(entry.status)}</td>
+                  <td>
+                    {loop.paused ? (
+                      <span className="badge badge-muted">paused</span>
+                    ) : (
+                      <span className="badge badge-success">active</span>
+                    )}
+                  </td>
+                  {!readOnly && (
+                    <td>
+                      <div style={{ display: 'flex', gap: '0.4rem' }}>
+                        <button
+                          className="btn btn-sm"
+                          disabled={setPaused.isPending}
+                          onClick={() => setPaused.mutate({ lid: loop.lid, paused: loop.paused })}
+                        >
+                          {loop.paused ? 'Resume' : 'Pause'}
+                        </button>
+                        <button
+                          className="btn btn-sm"
+                          disabled={enqueueNow.isPending}
+                          onClick={() => enqueueNow.mutate(loop.lid)}
+                        >
+                          Enqueue
+                        </button>
+                      </div>
+                    </td>
+                  )}
                 </tr>
               ))}
             </tbody>

--- a/frontend/src/pages/Dead.tsx
+++ b/frontend/src/pages/Dead.tsx
@@ -33,7 +33,7 @@ export default function Dead() {
   const { data, isLoading, isError } = useQuery<DeadResponse>({
     queryKey: ['dead', page],
     queryFn: () =>
-      fetch(`/wurk/api/dead?page=${page}&count=${PAGE_SIZE}`).then(
+      fetch(`/wurk/api/dead?page=${page - 1}&count=${PAGE_SIZE}`).then(
         (r) => r.json() as Promise<DeadResponse>
       ),
   });

--- a/frontend/src/pages/Limiters.tsx
+++ b/frontend/src/pages/Limiters.tsx
@@ -1,23 +1,63 @@
-import { useQuery } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useState, useEffect } from 'react';
+import { Pagination } from '../components/Pagination';
 import { t } from '../i18n';
+import { useMeta } from '../hooks/useMeta';
+
+// Uniform live status every limiter type reports (Wurk::Limiter#status).
+// `concurrent` additionally merges its metric counters (held/immediate/…),
+// which we surface in the row title; `limit: null` means unlimited.
+interface LimiterStatus {
+  used: number;
+  limit: number | null;
+  reset_at: number | null;
+  'available?': boolean;
+  [metric: string]: number | boolean | null;
+}
 
 interface Limiter {
   name: string;
-  current: number;
-  limit: number;
-  window_seconds: number;
+  type: string;
+  fingerprint: string;
+  options: Record<string, unknown>;
+  status: LimiterStatus | null;
 }
 
+interface LimitersResponse {
+  total: number;
+  page: number;
+  count: number;
+  limiters: Limiter[];
+}
+
+const PAGE_SIZE = 25;
+
 export default function Limiters() {
+  const qc = useQueryClient();
+  const { data: meta } = useMeta();
+  const readOnly = meta?.read_only ?? false;
+  const [page, setPage] = useState(1);
+
   useEffect(() => {
     document.title = `${t('nav.limiters')} — Wurk`;
   }, []);
 
-  const { data, isLoading, isError } = useQuery<Limiter[]>({
-    queryKey: ['limiters'],
-    queryFn: () => fetch('/wurk/api/limiters').then((r) => r.json() as Promise<Limiter[]>),
+  // UI is 1-indexed for humans; the API is 0-indexed, so send page - 1.
+  const { data, isLoading, isError } = useQuery<LimitersResponse>({
+    queryKey: ['limiters', page],
+    queryFn: () =>
+      fetch(`/wurk/api/limiters?page=${page - 1}&count=${PAGE_SIZE}`).then(
+        (r) => r.json() as Promise<LimitersResponse>
+      ),
     refetchInterval: 5000,
+  });
+
+  // Drops the limiter's stats/state keys (counters → 0); skips CSRF, see
+  // ApiController#skip_forgery_protection.
+  const reset = useMutation({
+    mutationFn: (name: string) =>
+      fetch(`/wurk/api/limiters/${encodeURIComponent(name)}/reset`, { method: 'POST' }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['limiters'] }),
   });
 
   if (isLoading) return <div className="empty-state"><span className="spinner" /></div>;
@@ -27,53 +67,91 @@ export default function Limiters() {
     <div>
       <div className="section-header">
         <h1 className="page-title" style={{ margin: 0 }}>{t('nav.limiters')}</h1>
-        <span className="badge badge-muted" style={{ marginLeft: 'auto' }}>{data.length}</span>
+        <span className="badge badge-muted" style={{ marginLeft: 'auto' }}>{data.total.toLocaleString()}</span>
       </div>
 
-      {data.length === 0 ? (
+      {data.limiters.length === 0 ? (
         <div className="empty-state">{t('common.empty')}</div>
       ) : (
-        <div className="table-wrapper">
-          <table>
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Current</th>
-                <th>Limit</th>
-                <th>Window</th>
-                <th>Usage</th>
-              </tr>
-            </thead>
-            <tbody>
-              {data.map((limiter) => {
-                const pct = limiter.limit > 0 ? (limiter.current / limiter.limit) * 100 : 0;
-                const color =
-                  pct > 90 ? 'var(--danger)' : pct > 70 ? 'var(--warning)' : 'var(--success)';
-                return (
-                  <tr key={limiter.name}>
-                    <td style={{ fontWeight: 500 }}>{limiter.name}</td>
-                    <td style={{ fontVariantNumeric: 'tabular-nums' }}>{limiter.current.toLocaleString()}</td>
-                    <td style={{ fontVariantNumeric: 'tabular-nums' }}>{limiter.limit.toLocaleString()}</td>
-                    <td style={{ color: 'var(--text-muted)' }}>{limiter.window_seconds}s</td>
-                    <td style={{ width: 200 }}>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                        <div className="progress-bar-track" style={{ flex: 1 }}>
-                          <div
-                            className="progress-bar-fill"
-                            style={{ width: `${pct}%`, background: color }}
-                          />
-                        </div>
-                        <span style={{ fontSize: 12, color: 'var(--text-muted)', minWidth: 36 }}>
-                          {Math.round(pct)}%
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+        <>
+          <div className="table-wrapper">
+            <table>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Used</th>
+                  <th>Limit</th>
+                  <th>Usage</th>
+                  <th>Status</th>
+                  {!readOnly && <th />}
+                </tr>
+              </thead>
+              <tbody>
+                {data.limiters.map((limiter) => {
+                  const s = limiter.status;
+                  const used = s?.used ?? 0;
+                  const limit = s?.limit ?? null;
+                  const pct = limit && limit > 0 ? Math.min((used / limit) * 100, 100) : 0;
+                  const color = pct > 90 ? 'var(--danger)' : pct > 70 ? 'var(--warning)' : 'var(--success)';
+                  const available = s?.['available?'] ?? true;
+                  // Concurrent rows carry extra metric counters — show them on hover.
+                  const metricTitle = s
+                    ? Object.entries(s)
+                        .filter(([k]) => !['used', 'limit', 'reset_at', 'available?'].includes(k))
+                        .map(([k, v]) => `${k}=${v}`)
+                        .join('  ')
+                    : '';
+                  return (
+                    <tr key={limiter.name}>
+                      <td style={{ fontWeight: 500 }} title={limiter.name}>{limiter.name}</td>
+                      <td><span className="badge badge-accent">{limiter.type}</span></td>
+                      <td style={{ fontVariantNumeric: 'tabular-nums' }} title={metricTitle}>
+                        {used.toLocaleString()}
+                      </td>
+                      <td style={{ fontVariantNumeric: 'tabular-nums' }}>
+                        {limit == null ? '∞' : limit.toLocaleString()}
+                      </td>
+                      <td style={{ width: 160 }}>
+                        {limit == null ? (
+                          <span style={{ color: 'var(--text-muted)' }}>—</span>
+                        ) : (
+                          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                            <div className="progress-bar-track" style={{ flex: 1 }}>
+                              <div className="progress-bar-fill" style={{ width: `${pct}%`, background: color }} />
+                            </div>
+                            <span style={{ fontSize: 12, color: 'var(--text-muted)', minWidth: 36 }}>
+                              {Math.round(pct)}%
+                            </span>
+                          </div>
+                        )}
+                      </td>
+                      <td>
+                        {available ? (
+                          <span className="badge badge-success">available</span>
+                        ) : (
+                          <span className="badge badge-danger">exhausted</span>
+                        )}
+                      </td>
+                      {!readOnly && (
+                        <td>
+                          <button
+                            className="btn btn-sm"
+                            disabled={reset.isPending}
+                            onClick={() => reset.mutate(limiter.name)}
+                          >
+                            Reset
+                          </button>
+                        </td>
+                      )}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+          <Pagination page={page} total={data.total} count={PAGE_SIZE} onChange={setPage} />
+        </>
       )}
     </div>
   );

--- a/frontend/src/pages/Queues.tsx
+++ b/frontend/src/pages/Queues.tsx
@@ -38,7 +38,7 @@ function QueueJobs({ name }: { name: string }) {
   const { data, isLoading, isError } = useQuery<QueueDetail>({
     queryKey: ['queue', name, page],
     queryFn: () =>
-      fetch(`/wurk/api/queues/${encodeURIComponent(name)}?page=${page}&count=${PAGE_SIZE}`).then(
+      fetch(`/wurk/api/queues/${encodeURIComponent(name)}?page=${page - 1}&count=${PAGE_SIZE}`).then(
         (r) => r.json() as Promise<QueueDetail>
       ),
   });

--- a/frontend/src/pages/Retries.tsx
+++ b/frontend/src/pages/Retries.tsx
@@ -36,7 +36,7 @@ export default function Retries() {
   const { data, isLoading, isError } = useQuery<RetriesResponse>({
     queryKey: ['retries', page],
     queryFn: () =>
-      fetch(`/wurk/api/retries?page=${page}&count=${PAGE_SIZE}`).then(
+      fetch(`/wurk/api/retries?page=${page - 1}&count=${PAGE_SIZE}`).then(
         (r) => r.json() as Promise<RetriesResponse>
       ),
   });

--- a/frontend/src/pages/Scheduled.tsx
+++ b/frontend/src/pages/Scheduled.tsx
@@ -31,7 +31,7 @@ export default function Scheduled() {
   const { data, isLoading, isError } = useQuery<ScheduledResponse>({
     queryKey: ['scheduled', page],
     queryFn: () =>
-      fetch(`/wurk/api/scheduled?page=${page}&count=${PAGE_SIZE}`).then(
+      fetch(`/wurk/api/scheduled?page=${page - 1}&count=${PAGE_SIZE}`).then(
         (r) => r.json() as Promise<ScheduledResponse>
       ),
   });

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -71,7 +71,7 @@ export default function Search() {
   const { data: retries } = useQuery<RetriesResponse>({
     queryKey: ['search-retries'],
     queryFn: () =>
-      fetch('/wurk/api/retries?page=1&count=200').then(
+      fetch('/wurk/api/retries?page=0&count=200').then(
         (r) => r.json() as Promise<RetriesResponse>
       ),
     enabled: submitted.length >= 2,
@@ -80,7 +80,7 @@ export default function Search() {
   const { data: scheduled } = useQuery<ScheduledResponse>({
     queryKey: ['search-scheduled'],
     queryFn: () =>
-      fetch('/wurk/api/scheduled?page=1&count=200').then(
+      fetch('/wurk/api/scheduled?page=0&count=200').then(
         (r) => r.json() as Promise<ScheduledResponse>
       ),
     enabled: submitted.length >= 2,
@@ -89,7 +89,7 @@ export default function Search() {
   const { data: dead } = useQuery<DeadResponse>({
     queryKey: ['search-dead'],
     queryFn: () =>
-      fetch('/wurk/api/dead?page=1&count=200').then(
+      fetch('/wurk/api/dead?page=0&count=200').then(
         (r) => r.json() as Promise<DeadResponse>
       ),
     enabled: submitted.length >= 2,

--- a/lib/wurk/batch/status.rb
+++ b/lib/wurk/batch/status.rb
@@ -23,6 +23,11 @@ module Wurk
         reload!
       end
 
+      # False when no `b-<bid>` hash exists — a well-formed bid that was never
+      # created (or has expired). Lets callers 404 instead of serving an
+      # all-zero phantom batch.
+      def exists? = !@data.empty?
+
       def total            = @data['total'].to_i
       def pending          = @data['pending'].to_i
       def failures         = @data['failures'].to_i

--- a/lib/wurk/cron.rb
+++ b/lib/wurk/cron.rb
@@ -254,6 +254,18 @@ module Wurk
         end
       end
 
+      # Epoch of the most recent fire, or nil if this loop has never run. The
+      # poller LPUSHes `[fired_at, jid]` tuples so index 0 is newest; we read
+      # only that one entry instead of the whole history list.
+      def last_fired_at
+        raw = Wurk.redis { |c| c.call('LINDEX', "#{HISTORY_PREFIX}#{@lid}", 0) }
+        return nil if raw.nil?
+
+        JSON.parse(raw)[0]
+      rescue JSON::ParserError
+        nil
+      end
+
       def to_redis_hash
         {
           'schedule' => @schedule,

--- a/lib/wurk/cron.rb
+++ b/lib/wurk/cron.rb
@@ -261,7 +261,11 @@ module Wurk
         raw = Wurk.redis { |c| c.call('LINDEX', "#{HISTORY_PREFIX}#{@lid}", 0) }
         return nil if raw.nil?
 
-        JSON.parse(raw)[0]
+        entry = JSON.parse(raw)
+        return nil unless entry.is_a?(Array)
+
+        fired_at = entry[0]
+        fired_at.is_a?(Numeric) ? fired_at.to_i : nil
       rescue JSON::ParserError
         nil
       end

--- a/test/engine/api_endpoints_test.rb
+++ b/test/engine/api_endpoints_test.rb
@@ -178,6 +178,13 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
     cleanup_batch(bid)
   end
 
+  def test_batch_detail_unknown_bid_returns_404
+    get "/wurk/api/batches/no-such-batch-#{@ns}"
+
+    assert_equal 404, last_response.status
+    assert_equal 'unknown batch', json_body[:error]
+  end
+
   def test_limiters_envelope
     name = seed_limiter
     get '/wurk/api/limiters'

--- a/test/engine/api_endpoints_test.rb
+++ b/test/engine/api_endpoints_test.rb
@@ -149,22 +149,75 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
     assert_equal 0, payload[:page]
   end
 
-  def test_limiters_array # rubocop:disable Minitest/MultipleAssertions
+  def test_batches_row_carries_status_and_progress # rubocop:disable Minitest/MultipleAssertions
+    bid = seed_batch
+    get '/wurk/api/batches'
+
+    assert_ok
+    row = json_body[:batches].find { |b| b[:bid] == bid }
+
+    refute_nil row, 'expected seeded batch in list'
+    assert_equal({ bid: bid, total: 10, pending: 4, failures: 1 }, row.slice(:bid, :total, :pending, :failures))
+    refute row[:complete]
+  ensure
+    cleanup_batch(bid)
+  end
+
+  def test_batch_detail_by_bid # rubocop:disable Minitest/MultipleAssertions
+    bid = seed_batch
+    get "/wurk/api/batches/#{bid}"
+
+    assert_ok
+    payload = json_body
+
+    assert_equal bid, payload[:bid]
+    assert_equal 10, payload[:total]
+    assert_equal 'Nightly export', payload[:description]
+    assert_kind_of Array, payload[:failed_jids]
+  ensure
+    cleanup_batch(bid)
+  end
+
+  def test_limiters_envelope
     name = seed_limiter
     get '/wurk/api/limiters'
 
     assert_ok
-    row = json_body.find { |r| r[:name] == name }
+    row = json_body[:limiters].find { |r| r[:name] == name }
 
     assert_equal({ name: name, type: 'concurrent' }, row.slice(:name, :type))
-    # #16: each limiter row carries its uniform live status (concurrent
-    # additionally merges its metric counters, so assert a subset).
-    status = row[:status]
-
-    refute_nil status, 'limiter row should include a status'
-    %i[used limit reset_at available?].each { |k| assert status.key?(k), "status missing #{k}" }
+    # #16: each row carries the uniform live status keys (concurrent merges
+    # extra metric counters on top; asserted in the counters test).
+    assert_equal(%i[available? limit reset_at used],
+                 row[:status].slice(:used, :limit, :reset_at, :available?).keys.sort)
   ensure
     cleanup_limiter(name)
+  end
+
+  def test_limiter_row_carries_concurrent_status_counters
+    name = seed_limiter
+    ::Wurk.redis { |c| c.call('HSET', "lmtr-stats:#{name}", 'held', '3', 'immediate', '120', 'overages', '2') }
+    get '/wurk/api/limiters'
+
+    assert_ok
+    status = json_body[:limiters].find { |r| r[:name] == name }[:status]
+
+    assert_equal({ held: 3, immediate: 120, overages: 2, reclaimed: 0 },
+                 status.slice(:held, :immediate, :overages, :reclaimed))
+  ensure
+    ::Wurk.redis { |c| c.call('DEL', "lmtr-stats:#{name}") }
+    cleanup_limiter(name)
+  end
+
+  def test_limiters_pagination_second_page_offsets
+    names = (0..2).map { |i| seed_limiter(i.to_s) }
+    first = limiter_page_names(0)
+    second = limiter_page_names(1)
+
+    assert_equal 2, first.size
+    assert_empty(first & second)
+  ensure
+    names&.each { |n| cleanup_limiter(n) }
   end
 
   def test_cron_array
@@ -179,6 +232,21 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
       row.slice(:schedule, :klass, :queue)
     )
   ensure
+    cleanup_cron_loop(lid)
+  end
+
+  def test_cron_row_carries_last_fire_at
+    lid = seed_cron_loop
+    fired_at = ::Time.now.to_i - 30
+    push_fire_history(lid, fired_at)
+    get '/wurk/api/cron'
+
+    assert_ok
+    row = json_body.find { |r| r[:lid] == lid }
+
+    assert_equal fired_at, row[:last_fire_at]
+  ensure
+    ::Wurk.redis { |c| c.call('DEL', "#{::Wurk::Cron::HISTORY_PREFIX}#{lid}") }
     cleanup_cron_loop(lid)
   end
 
@@ -259,8 +327,37 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
     }
   end
 
-  def seed_limiter
-    name = "lmt-#{@ns}"
+  def push_fire_history(lid, fired_at)
+    ::Wurk.redis do |c|
+      c.call('LPUSH', "#{::Wurk::Cron::HISTORY_PREFIX}#{lid}", ::Wurk.dump_json([fired_at, 'abc123']))
+    end
+  end
+
+  def seed_batch
+    bid = "bid-#{@ns}"[0, 24]
+    ::Wurk.redis do |c|
+      c.call('ZADD', 'batches', ::Time.now.to_f.to_s, bid)
+      c.call(
+        'HSET', "b-#{bid}",
+        'total', '10', 'pending', '4', 'failures', '1',
+        'created_at', ::Time.now.to_f.to_s, 'description', 'Nightly export'
+      )
+      # Status#complete? recomputes from the live jids set when the `complete`
+      # field is absent; seed live jids so the batch reads as in-progress.
+      c.call('SADD', "b-#{bid}-jids", 'j1', 'j2', 'j3', 'j4')
+    end
+    bid
+  end
+
+  def cleanup_batch(bid)
+    ::Wurk.redis do |c|
+      c.call('ZREM', 'batches', bid)
+      c.call('DEL', "b-#{bid}", "b-#{bid}-jids", "b-#{bid}-failed", "b-#{bid}-died", "b-#{bid}-kids")
+    end
+  end
+
+  def seed_limiter(suffix = '')
+    name = "lmt-#{@ns}#{suffix}"
     ::Wurk.redis do |c|
       c.call('SADD', ::Wurk::Limiter::LIST_KEY, name)
       c.call('HSET', "lmtr:#{name}", 'type', 'concurrent', 'fingerprint', 'fp', 'options', '{"limit":5}')
@@ -273,6 +370,13 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
       c.call('SREM', ::Wurk::Limiter::LIST_KEY, name)
       c.call('DEL', "lmtr:#{name}")
     end
+  end
+
+  def limiter_page_names(page)
+    get "/wurk/api/limiters?page=#{page}&count=2"
+
+    assert_ok
+    json_body[:limiters].map { |r| r[:name] }
   end
 
   def seed_cron_loop

--- a/test/engine/web_extensions_test.rb
+++ b/test/engine/web_extensions_test.rb
@@ -81,7 +81,7 @@ class WebExtensionsTest < Wurk::Test::EngineCase
     get "/wurk/api/limiters?substr=#{@ns.split(':').last}"
 
     assert_ok
-    row = json_body.find { |r| r[:name] == @limiter }
+    row = json_body[:limiters].find { |r| r[:name] == @limiter }
 
     refute_nil row
   end

--- a/test/qa/dashboard_api_25_driver.rb
+++ b/test/qa/dashboard_api_25_driver.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+# QA driver for #25 — Dashboard API: batches, limiters, periodic pages.
+#
+# Seeds one of each entity into the dummy app's Redis (db 0, no namespace in
+# dev) and exercises the three JSON endpoints against a running server, so you
+# can see real data flow end-to-end.
+#
+# Usage:
+#   1. Boot the dummy app in another terminal:
+#        cd test/dummy && bin/rails s
+#   2. Run this driver:
+#        ruby test/qa/dashboard_api_25_driver.rb
+#   3. Open http://localhost:3000/wurk/#/batches , /#/limiters , /#/cron
+#      and confirm the seeded rows render (then click the batch bid → detail).
+#
+# Re-runnable: it cleans up its own keys at the end.
+
+require 'redis-client'
+require 'json'
+require 'net/http'
+require 'securerandom'
+
+BASE  = ENV.fetch('WURK_QA_BASE', 'http://localhost:3000')
+REDIS = RedisClient.new(url: ENV.fetch('REDIS_URL', 'redis://localhost:6379/0'))
+SUFFIX = SecureRandom.hex(3)
+
+LIMITER = "qa-stripe-#{SUFFIX}"
+BID     = "qa-batch-#{SUFFIX}"
+LID     = "qa-loop-#{SUFFIX}"
+
+def seed
+  # Concurrent limiter + live metric counters (the #status hash the page reads).
+  REDIS.call('SADD', 'lmtr-list', LIMITER)
+  REDIS.call('HSET', "lmtr:#{LIMITER}", 'type', 'concurrent', 'fingerprint', 'qa',
+             'options', JSON.dump('limit' => 5))
+  REDIS.call('HSET', "lmtr-stats:#{LIMITER}", 'held', '2', 'immediate', '417', 'waited', '13', 'overages', '1')
+
+  # In-progress batch with one failure (4 live jids of 10 → 40% done).
+  REDIS.call('ZADD', 'batches', Time.now.to_f.to_s, BID)
+  REDIS.call('HSET', "b-#{BID}", 'total', '10', 'pending', '4', 'failures', '1',
+             'created_at', Time.now.to_f.to_s, 'description', "QA nightly export #{SUFFIX}")
+  REDIS.call('SADD', "b-#{BID}-jids", 'j1', 'j2', 'j3', 'j4')
+  REDIS.call('SADD', "b-#{BID}-failed", 'jf1')
+
+  # Periodic loop that fired 30s ago.
+  REDIS.call('SADD', 'periodic', LID)
+  REDIS.call('HSET', "loops:#{LID}", 'schedule', '*/5 * * * *', 'klass', 'HardJob',
+             'queue', 'default', 'options', '{}', 'tz', '', 'paused', '0')
+  REDIS.call('LPUSH', "loop-history:#{LID}", JSON.dump([Time.now.to_i - 30, 'qa-jid']))
+end
+
+def cleanup
+  REDIS.call('SREM', 'lmtr-list', LIMITER)
+  REDIS.call('DEL', "lmtr:#{LIMITER}", "lmtr-stats:#{LIMITER}")
+  REDIS.call('ZREM', 'batches', BID)
+  REDIS.call('DEL', "b-#{BID}", "b-#{BID}-jids", "b-#{BID}-failed")
+  REDIS.call('SREM', 'periodic', LID)
+  REDIS.call('DEL', "loops:#{LID}", "loop-history:#{LID}")
+end
+
+def get(path)
+  res = Net::HTTP.get_response(URI("#{BASE}#{path}"))
+  [res.code, JSON.parse(res.body)]
+rescue Errno::ECONNREFUSED
+  abort "\n✗ Could not reach #{BASE}. Boot the dummy app first:\n    cd test/dummy && bin/rails s\n"
+end
+
+def show(title, path)
+  code, body = get(path)
+  rows = body.is_a?(Hash) ? (body['batches'] || body['limiters'] || body['entries'] || [body]) : body
+  puts "\n#{title}  (#{path})  → HTTP #{code}, #{rows.is_a?(Array) ? rows.size : 1} row(s)"
+  puts JSON.pretty_generate(body)
+end
+
+seed
+puts "Seeded limiter=#{LIMITER}  batch=#{BID}  loop=#{LID}"
+
+show 'LIMITERS', '/wurk/api/limiters'
+show 'BATCHES',  '/wurk/api/batches'
+show 'BATCH DETAIL', "/wurk/api/batches/#{BID}"
+show 'PERIODIC', '/wurk/api/cron'
+
+puts "\n— Manual check —"
+puts "Open #{BASE}/wurk/ and visit Limiters / Batches / Cron in the sidebar."
+puts "On Limiters: row '#{LIMITER}' (concurrent) shows a usage gauge (used/limit) + 'available'"
+puts "             badge and a Reset button; hover Used to see its metric counters."
+puts "On Batches:  row '#{BID}' is 40% with 1 failure; click the bid → detail page."
+puts "On Cron:     row schedule '*/5 * * * *' shows a 'Last fire' ~30s ago, Pause/Enqueue buttons."
+
+print "\nPress Enter to clean up seeded keys... "
+$stdin.gets
+cleanup
+puts 'Cleaned up.'

--- a/test/qa/limiters_seed.rb
+++ b/test/qa/limiters_seed.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Seed a handful of sample limiters into the dummy app's Redis so the
+# dashboard Limiters tab has something to show — then test the per-row Reset
+# button (it zeroes the concurrent counters live).
+#
+# Usage:
+#   ruby test/qa/limiters_seed.rb          # seed (rows persist for browsing)
+#   ruby test/qa/limiters_seed.rb cleanup  # remove the seeded rows
+#
+# Open http://localhost:3009/wurk/#/limiters (or your dummy app's port).
+# Click "Reset" on `qa-stripe` and watch Held/Immediate/Waited/Overages → 0.
+
+require 'redis-client'
+require 'json'
+
+REDIS = RedisClient.new(url: ENV.fetch('REDIS_URL', 'redis://localhost:6379/0'))
+LIST_KEY = 'lmtr-list'
+
+# name => [type, options-hash, stats-hash-or-nil]
+# Only `concurrent` carries metric counters; the others render `—` per spec.
+SAMPLES = {
+  'qa-stripe' => ['concurrent', { 'limit' => 5 },
+                  { 'held' => 3, 'immediate' => 1240, 'waited' => 88, 'wait_time' => 4100,
+                    'overages' => 2, 'reclaimed' => 5 }],
+  'qa-mailgun' => ['concurrent', { 'limit' => 20 },
+                   { 'held' => 0, 'immediate' => 50_310, 'waited' => 0, 'overages' => 0, 'reclaimed' => 12 }],
+  'qa-reports' => ['window', { 'count' => 100, 'interval' => 'minute' }, nil],
+  'qa-exports' => ['bucket', { 'count' => 10, 'interval' => 'second' }, nil]
+}.freeze
+
+def seed
+  SAMPLES.each do |name, (type, options, stats)|
+    REDIS.call('SADD', LIST_KEY, name)
+    REDIS.call('HSET', "lmtr:#{name}", 'type', type, 'fingerprint', 'qa', 'options', JSON.dump(options))
+    REDIS.call('HSET', "lmtr-stats:#{name}", *stats.flatten.map(&:to_s)) if stats
+  end
+  puts "Seeded #{SAMPLES.size} limiters: #{SAMPLES.keys.join(', ')}"
+  puts 'Open the Limiters tab to see each type with a usage gauge + status badge.'
+  puts 'Click Reset on `qa-stripe` to clear its counters (hover Used to inspect them).'
+end
+
+def cleanup
+  SAMPLES.each_key do |name|
+    REDIS.call('SREM', LIST_KEY, name)
+    REDIS.call('DEL', "lmtr:#{name}", "lmtr-stats:#{name}")
+  end
+  puts "Removed #{SAMPLES.size} seeded limiters."
+end
+
+ARGV.first == 'cleanup' ? cleanup : seed

--- a/test/qa/pagination_demo.rb
+++ b/test/qa/pagination_demo.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Seed > 1 page of limiters AND batches so you can verify the pagination fix
+# in the running dummy app:
+#   * Page 1 now shows the FIRST rows (the old off-by-one showed an empty page
+#     whenever total <= page size, and skipped the first 25 otherwise).
+#   * Next/Prev move between pages with no overlap.
+#
+# Usage:
+#   ruby test/qa/pagination_demo.rb          # seed 30 limiters + 30 batches
+#   ruby test/qa/pagination_demo.rb cleanup  # remove them
+#
+# Then open the dummy app's Limiters and Batches tabs (default port below).
+
+require 'redis-client'
+require 'json'
+
+REDIS = RedisClient.new(url: ENV.fetch('REDIS_URL', 'redis://localhost:6379/0'))
+N = Integer(ENV.fetch('WURK_QA_N', '30'))
+
+def lname(i) = format('pg-lmt-%02d', i)
+def bid(i)   = format('pg-batch-%02d', i)
+
+def seed
+  N.times do |i|
+    REDIS.call('SADD', 'lmtr-list', lname(i))
+    REDIS.call('HSET', "lmtr:#{lname(i)}", 'type', 'concurrent', 'fingerprint', 'qa',
+               'options', JSON.dump('limit' => 10))
+    REDIS.call('HSET', "lmtr-stats:#{lname(i)}", 'immediate', (i * 7).to_s)
+
+    REDIS.call('ZADD', 'batches', (Time.now.to_f + i).to_s, bid(i))
+    REDIS.call('HSET', "b-#{bid(i)}", 'total', '10', 'pending', (i % 5).to_s, 'failures', '0',
+               'created_at', Time.now.to_f.to_s, 'description', "QA pagination batch #{i}")
+    REDIS.call('SADD', "b-#{bid(i)}-jids", 'j1', 'j2')
+  end
+  puts "Seeded #{N} limiters (pg-lmt-*) and #{N} batches (pg-batch-*)."
+  puts 'Limiters/Batches tabs should show "Page 1 of 2", rows starting at #00, Next/Prev working.'
+end
+
+def cleanup
+  N.times do |i|
+    REDIS.call('SREM', 'lmtr-list', lname(i))
+    REDIS.call('DEL', "lmtr:#{lname(i)}", "lmtr-stats:#{lname(i)}")
+    REDIS.call('ZREM', 'batches', bid(i))
+    REDIS.call('DEL', "b-#{bid(i)}", "b-#{bid(i)}-jids")
+  end
+  puts "Removed #{N} limiters and #{N} batches."
+end
+
+ARGV.first == 'cleanup' ? cleanup : seed

--- a/test/unit/cron_test.rb
+++ b/test/unit/cron_test.rb
@@ -434,6 +434,30 @@ class CronTest < Wurk::Test::UnitCase
     assert ts.is_a?(Integer) && jid.is_a?(String) && !jid.empty?
   end
 
+  def test_last_fired_at_nil_when_never_fired
+    lp = register_loop("CronTest::LastNil#{@suffix}", queue: "cron-ln-#{@suffix}")
+
+    assert_nil lp.last_fired_at
+  end
+
+  def test_last_fired_at_returns_newest_timestamp
+    lp = register_loop("CronTest::LastTs#{@suffix}", queue: "cron-lt-#{@suffix}")
+    Wurk.redis { |c| c.call('LPUSH', "#{Wurk::Cron::HISTORY_PREFIX}#{lp.lid}", JSON.dump([1_700_000_000, 'jid-x'])) }
+
+    assert_equal 1_700_000_000, lp.last_fired_at
+  ensure
+    Wurk.redis { |c| c.call('DEL', "#{Wurk::Cron::HISTORY_PREFIX}#{lp.lid}") }
+  end
+
+  def test_last_fired_at_nil_on_non_tuple_payload
+    lp = register_loop("CronTest::LastBad#{@suffix}", queue: "cron-lb-#{@suffix}")
+    Wurk.redis { |c| c.call('LPUSH', "#{Wurk::Cron::HISTORY_PREFIX}#{lp.lid}", JSON.dump('not-an-array')) }
+
+    assert_nil lp.last_fired_at
+  ensure
+    Wurk.redis { |c| c.call('DEL', "#{Wurk::Cron::HISTORY_PREFIX}#{lp.lid}") }
+  end
+
   def test_poller_tick_interval_defaults_to_60
     poller = Wurk::Cron::Poller.new(Wurk.configuration)
 


### PR DESCRIPTION
Backing JSON endpoints + React pages for the three remaining dashboard tabs, completing #25.

## Done when (issue acceptance criteria)
- [x] **All three pages render real data from a running dummy app** — verified live (see QA below): Batches list + detail, Limiters gauge/metrics, Periodic last/next fire.
- [x] **Empty states + pagination handled** — every list page has an empty state; pagination is correct end-to-end (fixes a dashboard-wide off-by-one, below).

## What's in it
**Batches** — `GET /batches/:bid` detail endpoint + status/progress row; `BatchDetail` page linked from the list (failed/dead jids, parent/children, tags).

**Limiters** — paginated envelope `{total,page,count,limiters}`. The page renders the uniform live status shipped by #59 — `used / limit` usage gauge + `available` badge for every type, with `concurrent` metric counters (held/immediate/waited/…) on hover — plus a per-row **Reset** wired to the existing reset endpoint (hidden in read-only mode).

**Periodic** — `Cron#last_fired_at`; the page shows last/next fire with pause / resume / enqueue-now actions (read-only aware).

## Drive-by fix: dashboard-wide pagination off-by-one
The 1-indexed UI sent `?page=1` to the 0-indexed API, so **every** list tab skipped its first page — showing empty whenever `total <= page size`. Pages now send `page - 1`; Search fetches page 0. Affects **Batches, Retries, Scheduled, Dead, Queues, Search**. (Happy to split this into its own PR if you'd prefer cleaner attribution.)

## Tests
- `bin/rake test` 1591 runs, 0 failures · `test:parity` 20/0 · `test:ecosystem` all pass
- New engine tests: batch detail, batch status row, limiters envelope + status keys, concurrent metric counters, pagination offsets
- Frontend builds clean (`tsc -b` + vite)

## How to test in prod
On any app running Wurk, open the dashboard and check the three tabs render and paginate:

```bash
# Seed a few sample limiters of each type (concurrent gets live counters):
ruby -e '
require "redis-client"; require "json"
r = RedisClient.new(url: ENV.fetch("REDIS_URL","redis://localhost:6379/0"))
r.call("SADD","lmtr-list","demo-stripe")
r.call("HSET","lmtr:demo-stripe","type","concurrent","fingerprint","x","options",JSON.dump("limit"=>5))
r.call("HSET","lmtr-stats:demo-stripe","held","3","immediate","1240","overages","2")
puts "seeded demo-stripe"'
```

Then: **Limiters** → `demo-stripe` shows a usage gauge + `available` badge + **Reset** (click it → counters clear). **Batches** → click a bid → detail page. **Cron** → Last/Next fire + Pause/Enqueue. Cleanup: `redis-cli SREM lmtr-list demo-stripe && redis-cli DEL lmtr:demo-stripe lmtr-stats:demo-stripe`.

A scripted local QA driver lives at `test/qa/dashboard_api_25_driver.rb` (+ `test/qa/limiters_seed.rb`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch detail page and route: view batch metadata, progress, timestamps, and failed job lists; BIDs link to detail pages; unknown BIDs return 404.
  * Cron table: shows last-fired timestamp and simplified status; per-row pause/unpause and enqueue actions.
  * Limiters: paginated table with expanded usage/status metrics, availability badges, and a reset action.

* **Bug Fixes**
  * Fixed pagination off-by-one issues across batches, retries, scheduled, dead, queue, and limiter pages.

* **Chore**
  * Frontend build artifacts ignored (*.tsbuildinfo).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->