### PR TITLE
feat: release plumbing — v1.0.0, CHANGELOG, release:check gate (closes #27)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,17 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    services:
+      redis:
+        image: redis:7.4
+        ports: ["6379:6379"]
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+    env:
+      REDIS_URL: redis://localhost:6379/0
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
@@ -19,7 +30,16 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
       - name: build frontend
         run: bundle exec rake frontend:build
+      - name: dummy app setup
+        run: |
+          cd test/dummy
+          bundle install
+          bin/rails db:prepare
+      - name: release gate
+        run: bundle exec rake release:check
       - name: build & push gem
         uses: rubygems/release-gem@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,37 @@ All notable changes to Wurk are recorded here. Format: [Keep a Changelog](https:
 
 ## [Unreleased]
 
-### Added
-- Repository skeleton: gem layout, Rails engine scaffold, dummy app, test harness, frontend skeleton, CI workflows, bench harness.
+## [1.0.0] - 2026-05-31
+
+First public release. Wurk is a 100% API-compatible drop-in replacement for Sidekiq + Sidekiq Pro + Sidekiq Enterprise — same Redis key schema, same job JSON, same Ruby DSL — with fork-based real parallelism, the full Pro + Enterprise feature set in one free gem (no license check), and a precompiled React dashboard.
+
+### Runtime
+- Fork-based Swarm: parent forks N children with PID supervision, rolling restart (SIGUSR1), graceful drain (SIGTERM/SIGINT) to `shutdown_timeout`, and global pause/resume (SIGTSTP/SIGCONT).
+- Reliable fetcher — atomic `BLMOVE` from the main queue to a per-process private list — with orphan reclamation on boot; Processor runs the middleware chain; Manager owns the thread pool, lifecycle, and heartbeat.
+- Scheduled-set and retry pollers; EVALSHA-cached Lua on the hot paths; per-fork Redis pool over redis-client; Redis-outage client buffer.
+- `reliable_push` opt-in `:raise` overflow policy with a background drainer.
+- Cluster leader election with periodic firing consolidated onto the leader.
+- StatsD metrics across hot paths; liveness HTTP endpoint for Kubernetes probes; expired-job counter for `expires_in`.
+
+### Batches
+- Sidekiq Pro Batch API: `on(:success/:complete/:death)` callbacks, live progress, nested batches, autoflush + linger, nested death cascade, and per-callback rescue.
+
+### Limiters
+- Enterprise rate limiters — concurrent, bucket, window, leaky, and points — each exposing a uniform live `#status` (`used`/`limit`/`reset_at`/`available?`); concurrent additionally reports metric counters. Includes a poison-pill brake.
+
+### Periodic
+- Cron loops (sidekiq-cron compatible): schedule parsing with timezone/DST handling, leader-gated firing, pause/resume, enqueue-now, and fire history.
+
+### Encryption
+- Transparent job-payload encryption with key rotation and graceful failure modes (a decryption failure degrades rather than crashing the worker).
+
+### Dashboard
+- Precompiled React + TypeScript SPA mounted under the engine — consumers never run Node. Tabs: queues, retries, scheduled, dead, busy, processes, batches (+ per-batch detail), limiters, periodic, metrics, and search. SSE live updates, read-only mode, pagination, i18n with host-app override, and a dark default theme.
+
+### Compat
+- `Sidekiq::*` aliases for every public `Wurk::*` class (`Sidekiq::Worker`, `Sidekiq::Batch`, `Sidekiq::Limiter`, `Sidekiq.configure_server`, …) — the drop-in contract.
+- ActiveJob adapter, `IterableJob`, embedded mode, and a standalone `exe/wurk` runner.
+- Sidekiq client/server middleware contract; third-party ecosystem suites (sidekiq-cron, sidekiq-unique-jobs, sidekiq-scheduler, sidekiq-status, sidekiq-failures, sidekiq-throttled) pass against Wurk.
+
+[Unreleased]: https://github.com/developerz-ai/wurk/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/developerz-ai/wurk/releases/tag/v1.0.0

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,58 @@
+# Releasing Wurk
+
+Wurk follows [Semantic Versioning](https://semver.org/). The version of record is
+`Wurk::VERSION` in `lib/wurk/version.rb`; the gemspec reads it directly.
+
+The dashboard bundle under `vendor/assets/dashboard/` is **built, not committed**
+(it's git-ignored). It must be freshly baked before the gem is packaged so the
+precompiled SPA ships inside the gem — consumers never run Node.
+
+## Cutting a release
+
+1. **Bump the version** in `lib/wurk/version.rb` (e.g. `1.0.0` → `1.1.0`).
+
+2. **Update `CHANGELOG.md`.** Add a dated section whose header matches the new
+   version exactly — `## [1.1.0] - YYYY-MM-DD` — with changes grouped under the
+   standard headings: Runtime, Batches, Limiters, Periodic, Encryption,
+   Dashboard, Compat. Update the compare/link footnotes at the bottom.
+
+3. **Build the dashboard bundle:**
+   ```bash
+   bundle exec rake frontend:build
+   ```
+
+4. **Run the gate:**
+   ```bash
+   bundle exec rake release:check
+   ```
+   It must pass before you tag (see below for what it validates).
+
+5. **Commit** the version + CHANGELOG bump on a branch, open a PR, and merge to
+   `main` once green.
+
+6. **Tag and push** the merge commit:
+   ```bash
+   git tag v1.1.0
+   git push origin v1.1.0
+   ```
+   The `release` workflow (`.github/workflows/release.yml`) triggers on `v*`
+   tags: it rebuilds the dashboard, runs `rake release:check`, then builds and
+   publishes the gem to RubyGems via trusted publishing. RubyGems MFA is
+   required (`rubygems_mfa_required` is set in the gemspec).
+
+## What `rake release:check` validates
+
+| Check | Detail |
+|---|---|
+| **Dashboard bundle present** | `vendor/assets/dashboard/index.html` plus a non-empty `assets/*.js` exist. Run `rake frontend:build` if missing. |
+| **Version ↔ CHANGELOG** | `CHANGELOG.md` contains a `## [<Wurk::VERSION>]` section header. |
+| **Clean tree** | `git status --porcelain` is empty, ignoring `vendor/assets/` (built output). |
+| **Tests green** | `rake test` (unit + integration + engine) passes. |
+
+The same task runs in CI on the tagged commit, so a release cannot publish unless
+the gate passes there too.
+
+## Local one-shot publish (maintainers)
+
+`rake release:full` chains `frontend:build → build → push`. Prefer the
+tag-driven CI flow above; use this only for an out-of-band manual push.

--- a/Rakefile
+++ b/Rakefile
@@ -2,10 +2,40 @@
 
 require "bundler/gem_tasks"
 require "rake/testtask"
+require_relative "lib/wurk/version"
 
 GEM_ROOT = File.expand_path(__dir__)
 FRONTEND_DIR = File.join(GEM_ROOT, "frontend")
 VENDOR_ASSETS_DIR = File.join(GEM_ROOT, "vendor", "assets")
+
+# --- release:check helpers ---------------------------------------------
+# Each aborts (non-zero exit) with an actionable message so the gate fails
+# loudly in CI and locally. The dashboard bundle is built, not committed, so
+# the clean-tree check ignores vendor/assets/.
+def release_dashboard_bundle_present!
+  dir = File.join(VENDOR_ASSETS_DIR, "dashboard")
+  index = File.join(dir, "index.html")
+  scripts = Dir.glob(File.join(dir, "assets", "*.js"))
+  return if File.file?(index) && scripts.any? { |f| File.size(f).positive? }
+
+  abort "release:check ✗ dashboard bundle missing in vendor/assets/dashboard " \
+        "(run `bundle exec rake frontend:build` first)"
+end
+
+def release_changelog_has_version!(version)
+  changelog = File.read(File.join(GEM_ROOT, "CHANGELOG.md"))
+  return if changelog.match?(/^## \[#{Regexp.escape(version)}\]/)
+
+  abort "release:check ✗ CHANGELOG.md has no `## [#{version}]` section " \
+        "matching Wurk::VERSION"
+end
+
+def release_tree_clean!
+  dirty = `git status --porcelain`.lines.reject { |line| line.include?("vendor/assets/") }
+  return if dirty.empty?
+
+  abort "release:check ✗ working tree has uncommitted changes:\n#{dirty.join}"
+end
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
@@ -90,6 +120,18 @@ namespace :frontend do
 end
 
 namespace :release do
+  desc "Pre-release gate: dashboard bundle present, version matches CHANGELOG, clean tree, tests green"
+  task :check do
+    version = Wurk::VERSION
+    puts "release:check — Wurk #{version}"
+    release_dashboard_bundle_present!
+    release_changelog_has_version!(version)
+    release_tree_clean!
+    puts "release:check — static checks passed; running tests…"
+    Rake::Task["test"].invoke
+    puts "release:check ✓ ready to release v#{version}"
+  end
+
   desc "Build frontend, bake into vendor/assets, build the gem, push to RubyGems"
   task full: ["frontend:build", "build", "push"]
 end

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 .vite/
 *.log
+*.tsbuildinfo

--- a/lib/wurk/version.rb
+++ b/lib/wurk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wurk
-  VERSION = "0.0.1"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
Preps the repo for the actual RubyGems push.

## Done when (issue acceptance criteria)
- [x] **`bin/rake release:check` passes locally** — verified: static checks + full `rake test` (1586 runs, 0 failures) → `release:check ✓ ready to release v1.0.0` (exit 0).
- [x] **…and in CI on a tagged commit** — wired into `.github/workflows/release.yml`: the `v*`-tag job now builds the dashboard, sets up the dummy, runs `rake release:check`, and only then publishes the gem. (The tag-CI run executes at real release time — pushing a tag triggers the gem publish, so it isn't dry-run here.)

## What's in it
- **Version** → `1.0.0` (`lib/wurk/version.rb`; the gemspec and the dashboard manifest both read it).
- **CHANGELOG.md** → grouped `## [1.0.0]` section: Runtime, Batches, Limiters, Periodic, Encryption, Dashboard, Compat.
- **`rake release:check`** validates, in order:
  | Check | Detail |
  |---|---|
  | Dashboard bundle present | `vendor/assets/dashboard/index.html` + non-empty `assets/*.js` |
  | Version ↔ CHANGELOG | `CHANGELOG.md` has a `## [<Wurk::VERSION>]` header |
  | Clean tree | `git status --porcelain` empty, ignoring built `vendor/assets/` |
  | Tests green | `rake test` (unit + integration + engine) |
- **RELEASE.md** documents the cut-a-release flow and what the gate checks.
- **CI**: `release.yml` gains a Redis service + dummy setup + the `release:check` step before the publish (so a red gate blocks the push).
- gitignore `frontend/*.tsbuildinfo` (a `tsc -b` artifact that would otherwise dirty the CI tree).

## Notes
- The dashboard bundle is **built, not committed** (git-ignored). `release:check` requires it present, so `rake frontend:build` must run first — which is exactly what the release CI does. The bundle's `wurk-manifest.json` bakes `Wurk::VERSION` at build time, so the version bump + rebuild stay in lockstep (a `static_assets_test` asserts this).

## How to test
```bash
bundle exec rake frontend:build      # bake the 1.0.0 dashboard bundle
bundle exec rake release:check       # full gate; exits non-zero on any failure
```
Negative paths also abort with an actionable message: missing bundle, a version/CHANGELOG mismatch, a dirty tree, or a failing test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * v1.0.0 release introducing comprehensive job processing capabilities: batching, rate limiting, scheduled jobs, periodic execution, encryption with key rotation, and a precompiled dashboard with real-time updates.
  * Full API compatibility with Sidekiq/Pro/Enterprise for seamless migration.

* **Chores**
  * Established automated release process with validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->