### PR TITLE
feat: metrics history time-series buckets + dashboard charts (closes #22)

### DIFF
--- a/app/controllers/wurk/api/serializers.rb
+++ b/app/controllers/wurk/api/serializers.rb
@@ -113,6 +113,12 @@ module Wurk
         { klass: klass, processed: totals[:p], failed: totals[:f], runtime_ms: totals[:ms] }
       end
 
+      # One point in a cluster-total time-series (Wurk::Metrics::Query.history).
+      # `at` is epoch seconds at the bucket start.
+      def history_point(row)
+        { at: row[:at], processed: row[:p], failed: row[:f], runtime_ms: row[:ms] }
+      end
+
       def parse_options(raw)
         return {} if raw.nil? || raw.to_s.empty?
 

--- a/app/controllers/wurk/api_controller.rb
+++ b/app/controllers/wurk/api_controller.rb
@@ -19,6 +19,9 @@ module Wurk
     STREAM_TICK_SECONDS = 2.0
     STREAM_MAX_DURATION = 600.0
 
+    HISTORY_WINDOW_UNITS = { 's' => 1, 'm' => 60, 'h' => 3600, 'd' => 86_400 }.freeze
+    DEFAULT_HISTORY_WINDOW = 24 * 3600
+
     skip_forgery_protection only: %i[
       stream reset_limiter pause_cron unpause_cron enqueue_cron
     ]
@@ -120,6 +123,17 @@ module Wurk
       render json: { error: e.message }, status: :bad_request
     end
 
+    # Cluster-total throughput/failures time-series for the dashboard charts.
+    # `:bucket` is 1m/5m/1h; `?window=24h` (s/m/h/d suffix) is clamped to the
+    # bucket's retention. Recharts-ready array under `series`.
+    def history
+      window = parse_window(params[:window])
+      series = ::Wurk::Web::Enterprise::Historical.history(params[:bucket].to_s, window: window)
+      render json: { bucket: params[:bucket].to_s, window: window, series: series.map { |row| ::Wurk::Api::Serializers.history_point(row) } }
+    rescue ::ArgumentError => e
+      render json: { error: e.message }, status: :bad_request
+    end
+
     def search
       substr = params[:substr].to_s
       return render(json: { substr: substr, total: 0, hits: [] }) if substr.empty?
@@ -213,6 +227,16 @@ module Wurk
     # Resolves the per-class metrics window. `minutes:` wins when present;
     # `hours:` is used otherwise; default falls back to 60 minutes so callers
     # that pass neither still get a useful series.
+    # `?window=24h` → seconds. Accepts an s/m/h/d suffix (bare number = seconds).
+    # Falls back to 24h on a missing or unparseable value; the Query layer
+    # clamps the result to the bucket's retention.
+    def parse_window(raw)
+      match = raw.to_s.strip.downcase.match(/\A(\d+)([smhd]?)\z/)
+      return DEFAULT_HISTORY_WINDOW unless match
+
+      Integer(match[1]) * HISTORY_WINDOW_UNITS.fetch(match[2].empty? ? 's' : match[2])
+    end
+
     def metrics_window(params)
       pagination = ::Wurk::Api::Pagination
       minutes = pagination.clamp_int(params[:minutes], 1, ::Wurk::Metrics::Query::MAX_MINUTES, 60) if params[:minutes]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Wurk::Engine.routes.draw do
     get  'cron/:lid/history', to: 'api#cron_history', as: :api_cron_history
     get  'metrics',          to: 'api#metrics'
     get  'metrics/:klass',   to: 'api#metrics_for_job', as: :api_metrics_for_job, constraints: { klass: %r{[^/]+} }
+    get  'history/:bucket',  to: 'api#history', as: :api_history
     get  'search',           to: 'api#search'
     get  'stream',           to: 'api#stream' # SSE
   end

--- a/docs/metrics-history.md
+++ b/docs/metrics-history.md
@@ -47,7 +47,7 @@ reclaimed automatically.
 
 ## API
 
-```
+```text
 GET /wurk/api/history/:bucket?window=24h
 ```
 
@@ -67,5 +67,14 @@ Returns a Recharts-ready, gap-filled array (missing buckets read as zero):
 }
 ```
 
-History accrues from the first leader tick after boot; it is not back-filled, so
-a freshly deployed cluster fills its charts in over the retention window.
+## Gaps and self-healing
+
+Each tick re-rolls the last `LOOKBACK_MINUTES` (15) completed source minutes,
+idempotently. Because the source `j|…` minute buckets live `MID_TERM` (3 days),
+a leadership failover or restart shorter than that window self-heals on the next
+tick — the gap minutes are re-read from source and folded back into `jr|…`. Only
+an outage **longer than the 15-minute lookback** leaves a hole, which then ages
+out with the bucket's TTL (best-effort metrics).
+
+History is not back-filled on a cold start (no prior `jr|…` data): a freshly
+deployed cluster fills its charts in going forward over the retention window.

--- a/docs/metrics-history.md
+++ b/docs/metrics-history.md
@@ -1,0 +1,71 @@
+# Metrics history (time-series buckets)
+
+The dashboard's **throughput** and **failures** charts read pre-aggregated,
+cluster-total time-series buckets written by a leader-only rollup thread
+(`Wurk::Metrics::Rollup`). This document covers the retention policy and the
+resulting Redis footprint, which is **bounded entirely by TTL**.
+
+## How it works
+
+Every job execution already writes a per-class minute bucket
+(`j|YYMMDD|H:M`, see `Wurk::Metrics::History`). Once per minute the elected
+cluster leader sums the just-completed minute across all classes and folds the
+total into three resolutions:
+
+| Bucket key        | Resolution | Retention (TTL) | Serves window |
+|-------------------|-----------:|----------------:|---------------|
+| `jr|1m|<epoch>`   | 1 minute   | 24 hours        | up to 24h     |
+| `jr|5m|<epoch>`   | 5 minutes  | 7 days          | up to 7d      |
+| `jr|1h|<epoch>`   | 1 hour     | 30 days         | up to 30d     |
+
+`<epoch>` is the UTC start-of-bucket in integer seconds. Each bucket is a small
+HASH with three integer fields: `p` (processed), `f` (failed), `ms` (total
+runtime). Writes are idempotent `HSET` — the coarse buckets are recomputed from
+their 1-minute children — so a missed tick, a leadership change, or a late
+metric write converges to the same totals and never double-counts.
+
+Only the leader writes (non-leader ticks return early), so N workers don't each
+re-write the same buckets.
+
+## Redis footprint (bounded)
+
+At steady state the rollup keeps at most one live bucket per slot per retention
+window:
+
+| Bucket | Live keys at retention      | Count |
+|--------|-----------------------------|------:|
+| `jr|1m` | 24h × 60                   | 1 440 |
+| `jr|5m` | 7d × 24 × 12               | 2 016 |
+| `jr|1h` | 30d × 24                   |   720 |
+| **Total** |                          | **≈ 4 176** |
+
+Each key is a 3-field integer HASH (tens of bytes), so the whole series costs on
+the order of a few hundred KB regardless of throughput or cluster size. Idle
+minutes write nothing (empty buckets are skipped), so a quiet cluster stores
+even less. Nothing accumulates without bound: every key carries a TTL and is
+reclaimed automatically.
+
+## API
+
+```
+GET /wurk/api/history/:bucket?window=24h
+```
+
+- `:bucket` — `1m`, `5m`, or `1h` (anything else → `400`).
+- `?window=` — `s`/`m`/`h`/`d` suffix (e.g. `24h`, `7d`, `30d`); a bare number is
+  seconds. Defaults to `24h`; clamped to the bucket's retention.
+
+Returns a Recharts-ready, gap-filled array (missing buckets read as zero):
+
+```json
+{
+  "bucket": "1m",
+  "window": 86400,
+  "series": [
+    { "at": 1780000000, "processed": 1200, "failed": 7, "runtime_ms": 48000 }
+  ]
+}
+```
+
+History accrues from the first leader tick after boot; it is not back-filled, so
+a freshly deployed cluster fills its charts in over the retention window.

--- a/docs/metrics-history.md
+++ b/docs/metrics-history.md
@@ -14,9 +14,9 @@ total into three resolutions:
 
 | Bucket key        | Resolution | Retention (TTL) | Serves window |
 |-------------------|-----------:|----------------:|---------------|
-| `jr|1m|<epoch>`   | 1 minute   | 24 hours        | up to 24h     |
-| `jr|5m|<epoch>`   | 5 minutes  | 7 days          | up to 7d      |
-| `jr|1h|<epoch>`   | 1 hour     | 30 days         | up to 30d     |
+| `jr\|1m\|<epoch>` | 1 minute   | 24 hours        | up to 24h     |
+| `jr\|5m\|<epoch>` | 5 minutes  | 7 days          | up to 7d      |
+| `jr\|1h\|<epoch>` | 1 hour     | 30 days         | up to 30d     |
 
 `<epoch>` is the UTC start-of-bucket in integer seconds. Each bucket is a small
 HASH with three integer fields: `p` (processed), `f` (failed), `ms` (total
@@ -34,9 +34,9 @@ window:
 
 | Bucket | Live keys at retention      | Count |
 |--------|-----------------------------|------:|
-| `jr|1m` | 24h × 60                   | 1 440 |
-| `jr|5m` | 7d × 24 × 12               | 2 016 |
-| `jr|1h` | 30d × 24                   |   720 |
+| `jr\|1m` | 24h × 60                  | 1 440 |
+| `jr\|5m` | 7d × 24 × 12              | 2 016 |
+| `jr\|1h` | 30d × 24                 |   720 |
 | **Total** |                          | **≈ 4 176** |
 
 Each key is a 3-field integer HASH (tens of bytes), so the whole series costs on

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -14,12 +14,14 @@ import {
 import { t } from '../i18n';
 import { truncate } from '../utils';
 
+// Matches Wurk::Api::Serializers.metric_row — processed (successes), failed,
+// and total runtime ms across both. Avg latency is derived client-side; there
+// is no per-job percentile histogram, so no p99 here.
 interface TopJob {
-  class: string;
-  total: number;
+  klass: string;
+  processed: number;
   failed: number;
-  avg_ms: number;
-  p99_ms: number;
+  runtime_ms: number;
 }
 
 interface MetricsResponse {
@@ -133,9 +135,9 @@ export default function Metrics() {
   });
 
   const chartData = (data?.top_jobs ?? []).slice(0, 10).map((j) => ({
-    name: j.class.split('::').pop() ?? j.class,
-    fullName: j.class,
-    total: j.total,
+    name: j.klass.split('::').pop() ?? j.klass,
+    fullName: j.klass,
+    total: j.processed + j.failed,
     failed: j.failed,
   }));
 
@@ -216,31 +218,26 @@ export default function Metrics() {
                   <th>Failed</th>
                   <th>Error Rate</th>
                   <th>Avg {t('common.ms')}</th>
-                  <th>P99 {t('common.ms')}</th>
                 </tr>
               </thead>
               <tbody>
                 {data.top_jobs.map((job) => {
-                  const errorRate = job.total > 0 ? (job.failed / job.total) * 100 : 0;
+                  const total = job.processed + job.failed;
+                  const errorRate = total > 0 ? (job.failed / total) * 100 : 0;
+                  const avgMs = total > 0 ? job.runtime_ms / total : 0;
                   return (
-                    <tr key={job.class}>
-                      <td title={job.class} style={{ fontWeight: 500 }}>
-                        {truncate(job.class, 50)}
+                    <tr key={job.klass}>
+                      <td title={job.klass} style={{ fontWeight: 500 }}>
+                        {truncate(job.klass, 50)}
                       </td>
-                      <td style={{ fontVariantNumeric: 'tabular-nums' }}>{job.total.toLocaleString()}</td>
+                      <td style={{ fontVariantNumeric: 'tabular-nums' }}>{total.toLocaleString()}</td>
                       <td style={{ color: job.failed > 0 ? 'var(--danger)' : undefined, fontVariantNumeric: 'tabular-nums' }}>
                         {job.failed.toLocaleString()}
                       </td>
                       <td style={{ color: errorRate > 5 ? 'var(--danger)' : errorRate > 1 ? 'var(--warning)' : 'var(--success)' }}>
                         {errorRate.toFixed(1)}%
                       </td>
-                      <td style={{ fontVariantNumeric: 'tabular-nums' }}>{job.avg_ms.toFixed(1)}</td>
-                      <td style={{
-                        fontVariantNumeric: 'tabular-nums',
-                        color: job.p99_ms > 5000 ? 'var(--danger)' : job.p99_ms > 1000 ? 'var(--warning)' : undefined,
-                      }}>
-                        {job.p99_ms.toFixed(1)}
-                      </td>
+                      <td style={{ fontVariantNumeric: 'tabular-nums' }}>{avgMs.toFixed(1)}</td>
                     </tr>
                   );
                 })}

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -3,6 +3,8 @@ import { useState, useEffect } from 'react';
 import {
   BarChart,
   Bar,
+  LineChart,
+  Line,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -25,7 +27,94 @@ interface MetricsResponse {
   top_jobs: TopJob[];
 }
 
+interface HistoryPoint {
+  at: number;
+  processed: number;
+  failed: number;
+  runtime_ms: number;
+}
+
+interface HistoryResponse {
+  bucket: string;
+  window: number;
+  series: HistoryPoint[];
+}
+
 const MINUTE_OPTIONS = [15, 30, 60, 120, 480] as const;
+
+// Each maps to a rollup bucket + its retention window (see Metrics::Rollup).
+const HISTORY_RANGES = [
+  { label: '24h · 1m', bucket: '1m', window: '24h' },
+  { label: '7d · 5m', bucket: '5m', window: '7d' },
+  { label: '30d · 1h', bucket: '1h', window: '30d' },
+] as const;
+
+const tooltipStyle = {
+  background: 'var(--surface)',
+  border: '1px solid var(--border)',
+  color: 'var(--text)',
+  borderRadius: 6,
+  fontSize: 12,
+};
+
+function HistoryCharts() {
+  const [range, setRange] = useState(0);
+  const { bucket, window } = HISTORY_RANGES[range];
+
+  const { data, isLoading, isError } = useQuery<HistoryResponse>({
+    queryKey: ['history', bucket, window],
+    queryFn: () =>
+      fetch(`/wurk/api/history/${bucket}?window=${window}`).then(
+        (r) => r.json() as Promise<HistoryResponse>
+      ),
+    refetchInterval: 30000,
+  });
+
+  // Hourly buckets span days, so show a date; sub-hour buckets show the clock.
+  const fmt = (at: number) => {
+    const d = new Date(at * 1000);
+    return bucket === '1h'
+      ? `${d.getMonth() + 1}/${d.getDate()} ${String(d.getHours()).padStart(2, '0')}:00`
+      : `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+  };
+  const series = (data?.series ?? []).map((p) => ({ ...p, label: fmt(p.at) }));
+  const hasData = series.some((p) => p.processed > 0 || p.failed > 0);
+
+  return (
+    <div className="card" style={{ marginBottom: '1.5rem' }}>
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '1rem' }}>
+        <div className="section-title">Throughput &amp; Failures</div>
+        <select
+          className="select"
+          style={{ marginLeft: 'auto' }}
+          value={range}
+          onChange={(e) => setRange(Number(e.target.value))}
+        >
+          {HISTORY_RANGES.map((r, i) => (
+            <option key={r.label} value={i}>{r.label}</option>
+          ))}
+        </select>
+      </div>
+
+      {isLoading && <div className="empty-state"><span className="spinner" /></div>}
+      {isError && <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>}
+      {data && !hasData && <div className="empty-state">No history yet — charts fill in as jobs run.</div>}
+
+      {data && hasData && (
+        <ResponsiveContainer width="100%" height={260}>
+          <LineChart data={series} margin={{ top: 4, right: 16, left: 0, bottom: 4 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+            <XAxis dataKey="label" tick={{ fill: 'var(--text-muted)', fontSize: 11 }} minTickGap={48} />
+            <YAxis tick={{ fill: 'var(--text-muted)', fontSize: 11 }} allowDecimals={false} />
+            <Tooltip contentStyle={tooltipStyle} />
+            <Line type="monotone" dataKey="processed" stroke="var(--accent)" strokeWidth={2} dot={false} name="Processed" />
+            <Line type="monotone" dataKey="failed" stroke="var(--danger)" strokeWidth={2} dot={false} name="Failed" />
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  );
+}
 
 export default function Metrics() {
   const [minutes, setMinutes] = useState(60);
@@ -69,6 +158,8 @@ export default function Metrics() {
           </select>
         </div>
       </div>
+
+      <HistoryCharts />
 
       {isLoading && (
         <div className="empty-state"><span className="spinner" /></div>

--- a/lib/wurk/compat.rb
+++ b/lib/wurk/compat.rb
@@ -85,6 +85,7 @@ module Sidekiq
   Limiter          = Wurk::Limiter
   Logger           = Wurk::Logger
   Manager          = Wurk::Manager
+  Metrics          = Wurk::Metrics
   Middleware       = Wurk::Middleware
   ServerMiddleware = Wurk::Middleware::ServerMiddleware
   ClientMiddleware = Wurk::Middleware::ClientMiddleware

--- a/lib/wurk/launcher.rb
+++ b/lib/wurk/launcher.rb
@@ -9,6 +9,7 @@ require_relative 'keys'
 require_relative 'scheduled'
 require_relative 'leader'
 require_relative 'cron'
+require_relative 'metrics/rollup'
 require_relative 'fetcher/reaper'
 
 module Wurk
@@ -40,7 +41,7 @@ module Wurk
     # (Sidekiq's drop-in surface). The single source of truth is Heartbeat.
     BEAT_PAUSE = Heartbeat::BEAT_PAUSE
 
-    attr_accessor :managers, :poller, :cron_poller
+    attr_accessor :managers, :poller, :cron_poller, :metrics_rollup
 
     def initialize(config, embedded: false)
       @config = config
@@ -49,6 +50,7 @@ module Wurk
       @managers = config.capsules.values.map { |cap| Manager.new(cap) }
       @poller = build_poller
       @cron_poller = build_cron_poller
+      @metrics_rollup = build_metrics_rollup
       @leader = build_leader
       @reaper = build_reaper
       @started_at = nil
@@ -78,6 +80,7 @@ module Wurk
       @poller&.start
       @leader&.start
       @cron_poller&.start
+      @metrics_rollup&.start
       @managers.each(&:start)
       @reaper.start
       @health_server&.start
@@ -110,6 +113,7 @@ module Wurk
       # Full shutdown stops periodic firing (it survived #quiet); do this before
       # releasing the lock so no tick races a follower's promotion.
       @cron_poller&.terminate
+      @metrics_rollup&.terminate
       @reaper&.stop
       # CAS-release the cluster lock now (planned shutdown) so a follower can
       # take over immediately instead of waiting out the TTL.
@@ -233,6 +237,14 @@ module Wurk
     # what guarantees exactly one enqueue per (loop, tick) across the cluster.
     def build_cron_poller
       Wurk::Cron::Poller.new(@config)
+    end
+
+    # Leader-only metrics rollup. Every process runs one, but only the elected
+    # leader writes the cluster-total time-series buckets the dashboard charts
+    # read — a non-leader tick returns early. Tune the cadence (tests shrink it)
+    # with `config.metrics_rollup_interval`.
+    def build_metrics_rollup
+      Wurk::Metrics::Rollup.new(@config)
     end
 
     # Every worker process campaigns for the single cluster lock (`dear-leader`);

--- a/lib/wurk/metrics/query.rb
+++ b/lib/wurk/metrics/query.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'history'
+require_relative 'rollup'
 
 module Wurk
   module Metrics
@@ -16,7 +17,7 @@ module Wurk
     #
     # A wider window has no data to read anyway (the buckets are TTL'd out),
     # so we fail loudly rather than silently returning sparse results.
-    module Query
+    module Query # rubocop:disable Metrics/ModuleLength
       MAX_MINUTES = 480
       MAX_HOURS = 72
       TOTAL_FIELDS = %w[p f ms].freeze
@@ -44,6 +45,38 @@ module Wurk
       def for_job(klass, minutes: nil, hours: nil, now: ::Time.now)
         validate_for_job!(klass, minutes, hours)
         minutes ? minute_series(klass, now, cap_minutes!(minutes)) : hour_series(klass, now, cap_hours!(hours))
+      end
+
+      # Cluster-total time-series for the dashboard throughput/failures charts,
+      # read from the compact buckets written by Wurk::Metrics::Rollup. `bucket`
+      # is '1m'/'5m'/'1h'; `window_seconds` is clamped to that bucket's
+      # retention. Returns `[{at:, p:, f:, ms:}, ...]` oldest→newest, gap-filled
+      # with zeros so a chart has a continuous x-axis.
+      def history(bucket, window_seconds, now: ::Time.now)
+        step, ttl = bucket_spec!(bucket)
+        starts = bucket_starts(now, step, clamp_history_window!(window_seconds, ttl))
+        rows = pipeline_hmget(starts.map { |s| Wurk::Metrics::Rollup.bucket_key(bucket, s) }, %w[p f ms])
+        starts.zip(rows).map { |at, (p, f, ms)| { at: at, p: p.to_i, f: f.to_i, ms: ms.to_i } }
+      end
+
+      def bucket_spec!(bucket)
+        Wurk::Metrics::Rollup::BUCKETS.fetch(bucket) do
+          raise ArgumentError, "bucket must be one of #{Wurk::Metrics::Rollup::BUCKETS.keys.inspect}"
+        end
+      end
+
+      def clamp_history_window!(window_seconds, ttl)
+        window = Integer(window_seconds)
+        raise ArgumentError, 'window must be positive' if window <= 0
+
+        [window, ttl].min
+      end
+
+      # The last `window/step` step-aligned bucket starts, oldest→newest, so
+      # they match the keys the rollup writes.
+      def bucket_starts(now, step, window)
+        last = (now.to_i / step) * step
+        (0...(window / step)).map { |i| last - (i * step) }.reverse
       end
 
       def validate_for_job!(klass, minutes, hours)

--- a/lib/wurk/metrics/rollup.rb
+++ b/lib/wurk/metrics/rollup.rb
@@ -40,9 +40,12 @@ module Wurk
       COARSE = %w[5m 1h].freeze
 
       DEFAULT_TICK_SECONDS = 60
-      # Re-finalize the last few completed minutes each tick so a brief leader
-      # gap or a late metric write still lands in the series.
-      LOOKBACK_MINUTES = 3
+      # Re-roll the last N completed minutes from source on every tick
+      # (idempotent). This self-heals a leadership failover / restart or a late
+      # metric write up to N minutes old — the source `j|…` buckets live 3 days,
+      # so re-reading them folds the gap back in. Only outages longer than this
+      # leave a hole that ages out with the bucket TTL (best-effort metrics).
+      LOOKBACK_MINUTES = 15
 
       def self.bucket_key(bucket, epoch)
         "#{PREFIX}|#{bucket}|#{epoch}"

--- a/lib/wurk/metrics/rollup.rb
+++ b/lib/wurk/metrics/rollup.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require_relative '../component'
+require_relative 'history'
+
+module Wurk
+  module Metrics
+    # Leader-only background thread that rolls the per-class minute buckets
+    # written by Wurk::Metrics::History (`j|YYMMDD|H:M`) up into compact,
+    # cluster-total time-series buckets the dashboard "throughput" / "failures"
+    # charts read directly:
+    #
+    #   jr|1m|<epoch>   HASH {p,f,ms}   TTL 24h   (1-minute resolution)
+    #   jr|5m|<epoch>   HASH {p,f,ms}   TTL 7d    (5-minute resolution)
+    #   jr|1h|<epoch>   HASH {p,f,ms}   TTL 30d   (1-hour resolution)
+    #
+    # `<epoch>` is the UTC start-of-bucket as integer seconds. Totals are summed
+    # across every job class, so a 30-day chart reads ~720 small hashes instead
+    # of fanning out over ~43k per-class minute keys.
+    #
+    # Every write is an idempotent HSET. Each tick recomputes the trailing few
+    # 1m buckets from the source minute hash, then recomputes the coarse buckets
+    # from their 1m children. Re-running a tick (a missed tick, a leadership
+    # change, a late metric write) converges to the same totals — it never
+    # double-counts. Storage is bounded purely by the per-bucket TTLs; see
+    # docs/metrics-history.md for the retention math.
+    class Rollup
+      include Component
+
+      PREFIX = 'jr'
+
+      # bucket => [step_seconds, ttl_seconds]. The retention is the issue's
+      # spec: 1m kept 24h, 5m kept 7d, 1h kept 30d.
+      BUCKETS = {
+        '1m' => [60,   24 * 60 * 60],
+        '5m' => [300,  7 * 24 * 60 * 60],
+        '1h' => [3600, 30 * 24 * 60 * 60]
+      }.freeze
+
+      COARSE = %w[5m 1h].freeze
+
+      DEFAULT_TICK_SECONDS = 60
+      # Re-finalize the last few completed minutes each tick so a brief leader
+      # gap or a late metric write still lands in the series.
+      LOOKBACK_MINUTES = 3
+
+      def self.bucket_key(bucket, epoch)
+        "#{PREFIX}|#{bucket}|#{epoch}"
+      end
+
+      def initialize(config)
+        @config = config
+        @done = false
+        @mutex = ::Mutex.new
+        @sleeper = ::ConditionVariable.new
+        @tick_interval = config[:metrics_rollup_interval] || DEFAULT_TICK_SECONDS
+        @thread = nil
+      end
+
+      def start
+        @thread ||= safe_thread('metrics-rollup') do # rubocop:disable Naming/MemoizedInstanceVariableName
+          wait
+          until @done
+            tick
+            wait
+          end
+        end
+      end
+
+      def terminate
+        @mutex.synchronize do
+          @done = true
+          @sleeper.signal
+        end
+      end
+
+      # Leader-gated: only the elected leader writes the cluster-total series,
+      # so N workers don't each HSET the same buckets every minute.
+      def tick(now: ::Time.now)
+        return unless leader?
+
+        roll(now)
+      rescue StandardError => e
+        handle_exception(e, { context: 'metrics-rollup' })
+      end
+
+      # One rollup pass, bypassing the leader gate and the sleep loop. Public so
+      # deterministic specs and a manual "roll now" can drive it directly.
+      def roll(now = ::Time.now)
+        cur_min = floor_min(now)
+        minutes = (1..LOOKBACK_MINUTES).map { |i| cur_min - (i * 60) }
+        minutes.each { |epoch_min| write_minute_bucket(epoch_min) }
+        recompute_coarse(minutes)
+        nil
+      end
+
+      private
+
+      def write_minute_bucket(epoch_min)
+        store('1m', epoch_min, minute_total(epoch_min))
+      end
+
+      # Sum every class's p/f/ms in the source minute hash into a single total.
+      def minute_total(epoch_min)
+        raw = redis { |c| c.call('HGETALL', source_minute_key(epoch_min)) }
+        raw = raw.each_slice(2).to_h if raw.is_a?(::Array)
+        total = { p: 0, f: 0, ms: 0 }
+        raw.each do |field, value|
+          _klass, kind = field.split('|', 2)
+          total[kind.to_sym] += value.to_i if kind && total.key?(kind.to_sym)
+        end
+        total
+      end
+
+      # Re-sum each coarse bucket from its 1m children, for every window the
+      # just-written minutes touched (covers the current window plus any
+      # boundary the lookback crossed).
+      def recompute_coarse(minutes)
+        COARSE.each do |bucket|
+          step, = BUCKETS[bucket]
+          minutes.map { |m| (m / step) * step }.uniq.each { |w| store(bucket, w, child_total(w, step)) }
+        end
+      end
+
+      def child_total(window_start, step)
+        keys = (window_start...(window_start + step)).step(60).map { |s| self.class.bucket_key('1m', s) }
+        sum_pfms(redis { |c| c.pipelined { |p| keys.each { |k| p.call('HMGET', k, 'p', 'f', 'ms') } } })
+      end
+
+      def sum_pfms(rows)
+        rows.each_with_object({ p: 0, f: 0, ms: 0 }) do |(p, f, ms), total|
+          total[:p] += p.to_i
+          total[:f] += f.to_i
+          total[:ms] += ms.to_i
+        end
+      end
+
+      # Skip empty buckets so an idle cluster doesn't litter Redis with zero
+      # rows; a missing bucket reads back as zero on the query side anyway.
+      def store(bucket, epoch, total)
+        return if total.values.all?(&:zero?)
+
+        _step, ttl = BUCKETS[bucket]
+        key = self.class.bucket_key(bucket, epoch)
+        redis do |c|
+          c.call('HSET', key, 'p', total[:p], 'f', total[:f], 'ms', total[:ms])
+          c.call('EXPIRE', key, ttl)
+        end
+      end
+
+      def source_minute_key(epoch_min)
+        Wurk::Metrics::History.minute_key(::Time.at(epoch_min).utc)
+      end
+
+      def floor_min(time)
+        (time.to_i / 60) * 60
+      end
+
+      def wait
+        @mutex.synchronize do
+          @sleeper.wait(@mutex, @tick_interval) unless @done
+        end
+      end
+    end
+  end
+end

--- a/lib/wurk/web/enterprise.rb
+++ b/lib/wurk/web/enterprise.rb
@@ -125,6 +125,13 @@ module Wurk
         def top(minutes: 60, class_filter: nil)
           Wurk::Metrics::Query.top_jobs(minutes: minutes, class_filter: class_filter)
         end
+
+        # Cluster-total time-series for the dashboard charts. `bucket` is
+        # '1m'/'5m'/'1h'; `window` is in seconds (clamped to the bucket's
+        # retention). Returns `[{at:, p:, f:, ms:}, …]` oldest→newest.
+        def history(bucket, window:, now: ::Time.now)
+          Wurk::Metrics::Query.history(bucket, window, now: now)
+        end
       end
     end
   end

--- a/test/engine/api_endpoints_test.rb
+++ b/test/engine/api_endpoints_test.rb
@@ -275,16 +275,15 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
   end
 
   def test_history_returns_recharts_series
-    epoch = ((::Time.now.to_i / 60) * 60) - 60
-    ::Wurk.redis { |c| c.call('HSET', "jr|1m|#{epoch}", 'p', 12, 'f', 3, 'ms', 400) }
-    get '/wurk/api/history/1m?window=10m'
+    epoch, key = seed_history_minute(processed: 12, failed: 3, ms: 400)
+    get '/wurk/api/history/1m?window=24h'
 
     assert_ok
     point = json_body[:series].find { |row| row[:at] == epoch }
 
     assert_equal({ at: epoch, processed: 12, failed: 3, runtime_ms: 400 }, point)
   ensure
-    ::Wurk.redis { |c| c.call('DEL', "jr|1m|#{epoch}") }
+    ::Wurk.redis { |c| c.call('DEL', key) } if key
   end
 
   def test_history_rejects_unknown_bucket
@@ -404,6 +403,17 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
 
     assert_ok
     json_body[:limiters].map { |r| r[:name] }
+  end
+
+  # `jr|1m|<epoch>` is a global (non-namespaced) key, so offset the minute by
+  # this fork's pid/object_id to avoid colliding with a parallel worker; a 24h
+  # query window still covers it. Returns [epoch, key].
+  def seed_history_minute(processed:, failed:, ms:)
+    minutes_back = 1 + ((::Process.pid ^ object_id) % 1000)
+    epoch = ((::Time.now.to_i / 60) * 60) - (minutes_back * 60)
+    key = "jr|1m|#{epoch}"
+    ::Wurk.redis { |c| c.call('HSET', key, 'p', processed, 'f', failed, 'ms', ms) }
+    [epoch, key]
   end
 
   def seed_cron_loop

--- a/test/engine/api_endpoints_test.rb
+++ b/test/engine/api_endpoints_test.rb
@@ -274,6 +274,26 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
     assert_equal ::Wurk::Metrics::Query::MAX_MINUTES, json_body[:minutes]
   end
 
+  def test_history_returns_recharts_series
+    epoch = ((::Time.now.to_i / 60) * 60) - 60
+    ::Wurk.redis { |c| c.call('HSET', "jr|1m|#{epoch}", 'p', 12, 'f', 3, 'ms', 400) }
+    get '/wurk/api/history/1m?window=10m'
+
+    assert_ok
+    point = json_body[:series].find { |row| row[:at] == epoch }
+
+    assert_equal({ at: epoch, processed: 12, failed: 3, runtime_ms: 400 }, point)
+  ensure
+    ::Wurk.redis { |c| c.call('DEL', "jr|1m|#{epoch}") }
+  end
+
+  def test_history_rejects_unknown_bucket
+    get '/wurk/api/history/2m?window=1h'
+
+    assert_equal 400, last_response.status
+    assert_match(/bucket/, json_body[:error])
+  end
+
   # The SSE stream emits one `event: stats` tick and closes when
   # `?max_duration=0` is supplied. Production callers omit the param and the
   # loop runs until `STREAM_MAX_DURATION`.

--- a/test/qa/metrics_history_driver.rb
+++ b/test/qa/metrics_history_driver.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# QA driver for #22 — Metrics history time-series.
+#
+# Seeds ~45 minutes of per-class minute buckets (the source `j|` hashes the
+# History middleware writes), then runs the REAL Wurk::Metrics::Rollup to fold
+# them into the cluster-total jr|1m / jr|5m / jr|1h buckets — exactly what the
+# leader thread does in production. Finally it reads them back via the live
+# /api/history endpoint so you can see end-to-end flow, then points you at the
+# dashboard chart.
+#
+# Usage:
+#   1. Boot the dummy app:   cd test/dummy && bin/rails s   (or use a running one)
+#   2. ruby test/qa/metrics_history_driver.rb               (WURK_QA_BASE overrides port)
+#
+# Re-runnable; cleans up every key it wrote on Enter.
+
+$LOAD_PATH.unshift(File.expand_path('../../lib', __dir__))
+require 'wurk'
+require 'wurk/metrics/rollup'
+require 'net/http'
+require 'json'
+
+BASE = ENV.fetch('WURK_QA_BASE', 'http://localhost:3000')
+MINUTES = 45
+NOW = Time.now.utc
+
+# Seed source minute buckets with a rising throughput curve + a few failures.
+seeded = []
+MINUTES.downto(1) do |i|
+  t = NOW - (i * 60)
+  processed = 20 + ((MINUTES - i) * 3) + rand(10)
+  failed = (i % 7).zero? ? rand(1..4) : 0
+  key = Wurk::Metrics::History.minute_key(t)
+  seeded << key
+  Wurk.redis do |c|
+    c.call('HSET', key, 'DemoJob|p', processed, 'DemoJob|f', failed, 'DemoJob|ms', processed * 35)
+  end
+end
+
+# Run the real rollup once per minute boundary so every bucket is populated.
+rollup = Wurk::Metrics::Rollup.new(Wurk.configuration)
+MINUTES.downto(0) { |i| rollup.roll(NOW - (i * 60)) }
+
+def history(path)
+  res = Net::HTTP.get_response(URI("#{BASE}#{path}"))
+  [res.code, JSON.parse(res.body)]
+rescue Errno::ECONNREFUSED
+  abort "\n✗ Could not reach #{BASE}. Boot the dummy app: cd test/dummy && bin/rails s\n"
+end
+
+puts "Seeded #{MINUTES} minutes of source data and rolled it into jr|1m/5m/1h.\n\n"
+# Widen each query past the seeded span so an hour-boundary tick can't hide the
+# single 1h bucket the data falls in.
+{ '1m' => '2h', '5m' => '3h', '1h' => '6h' }.each do |bucket, window|
+  code, body = history("/wurk/api/history/#{bucket}?window=#{window}")
+  pts = body.is_a?(Hash) ? (body['series'] || []) : []
+  nonzero = pts.count { |p| p['processed'].to_i.positive? }
+  last = pts.reverse.find { |p| p['processed'].to_i.positive? }
+  puts "#{bucket} (#{window}): HTTP #{code}, #{nonzero}/#{pts.size} non-zero points; latest = #{last.inspect}"
+end
+
+puts "\n— Manual check —"
+puts "Open #{BASE}/wurk/#/metrics — the 'Throughput & Failures' card (top) should show a"
+puts "rising Processed line with occasional Failed spikes. Switch the range selector"
+puts "(24h·1m / 7d·5m / 30d·1h) to read the different rollup buckets."
+
+print "\nPress Enter to clean up seeded keys... "
+$stdin.gets
+
+Wurk.redis do |c|
+  c.call('DEL', *seeded) unless seeded.empty?
+  %w[1m 5m 1h].each do |bucket|
+    step = Wurk::Metrics::Rollup::BUCKETS[bucket][0]
+    starts = (0..(3600 / step)).map { |i| ((NOW.to_i / step) * step) - (i * step) }
+    keys = starts.map { |s| Wurk::Metrics::Rollup.bucket_key(bucket, s) }
+    c.call('DEL', *keys)
+  end
+end
+puts 'Cleaned up.'

--- a/test/unit/compat_aliases_test.rb
+++ b/test/unit/compat_aliases_test.rb
@@ -90,6 +90,11 @@ class CompatAliasesTest < Wurk::Test::UnitCase
     assert_same Wurk::Cron, Sidekiq::Cron
   end
 
+  def test_metrics_alias
+    assert_same Wurk::Metrics, Sidekiq::Metrics
+    assert_same Wurk::Metrics::Rollup, Sidekiq::Metrics::Rollup
+  end
+
   def test_dead_set_alias
     assert_same Wurk::DeadSet, Sidekiq::DeadSet
   end

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -93,6 +93,12 @@ class LauncherTest < Wurk::Test::UnitCase
     assert_instance_of Wurk::Cron::Poller, launcher.cron_poller
   end
 
+  def test_initialize_builds_a_metrics_rollup
+    launcher = Wurk::Launcher.new(@config)
+
+    assert_instance_of Wurk::Metrics::Rollup, launcher.metrics_rollup
+  end
+
   # --- run -------------------------------------------------------------
 
   def test_run_freezes_config
@@ -136,6 +142,17 @@ class LauncherTest < Wurk::Test::UnitCase
     launcher.run(async_beat: false)
 
     assert started, 'run should start the periodic (cron) poller'
+  end
+
+  def test_run_starts_the_metrics_rollup
+    launcher = Wurk::Launcher.new(@config)
+    stub_managers(launcher)
+    started = false
+    launcher.metrics_rollup.define_singleton_method(:start) { started = true }
+
+    launcher.run(async_beat: false)
+
+    assert started, 'run should start the metrics rollup'
   end
 
   def test_run_starts_the_orphan_reaper

--- a/test/unit/metrics_rollup_test.rb
+++ b/test/unit/metrics_rollup_test.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'securerandom'
+require 'wurk/metrics/rollup'
+require 'wurk/metrics/query'
+
+# The rollup writes cluster-total buckets keyed only by time (`jr|<bucket>|<epoch>`),
+# so — unlike the per-class history buckets — there's no class field to isolate
+# parallel forks. Each test instead picks a unique minute-aligned epoch from a
+# wide random range so its source `j|` bucket and its `jr|` totals never collide
+# with another fork, then DELs exactly those keys on teardown.
+class MetricsRollupTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @epoch_min = ((SecureRandom.random_number(1_000_000_000) + 2_000_000_000) / 60) * 60
+    @at = ::Time.at(@epoch_min).utc
+    @klass = "RollupJob-#{SecureRandom.hex(6)}"
+    @rollup = Wurk::Metrics::Rollup.new(Wurk.configuration)
+  end
+
+  def teardown
+    Wurk.redis do |c|
+      keys = [Wurk::Metrics::History.minute_key(@at)]
+      Wurk::Metrics::Rollup::BUCKETS.each do |bucket, (step, _ttl)|
+        keys << Wurk::Metrics::Rollup.bucket_key(bucket, (@epoch_min / step) * step)
+      end
+      c.call('DEL', *keys)
+    end
+  ensure
+    super
+  end
+
+  def test_roll_writes_each_total_bucket_from_the_source_minute
+    seed_minute(processed: 10, failed: 2, ms: 500)
+    @rollup.roll(@at + 60)
+    expected = { 'p' => 10, 'f' => 2, 'ms' => 500 }
+
+    assert_equal expected, bucket_hash('1m')
+    assert_equal expected, bucket_hash('5m')
+    assert_equal expected, bucket_hash('1h')
+  end
+
+  def test_roll_sums_across_job_classes
+    seed_minute(processed: 10, failed: 2, ms: 500)
+    Wurk.redis { |c| c.call('HSET', Wurk::Metrics::History.minute_key(@at), 'OtherJob|p', 5, 'OtherJob|ms', 250) }
+    @rollup.roll(@at + 60)
+
+    assert_equal({ 'p' => 15, 'f' => 2, 'ms' => 750 }, bucket_hash('1m'))
+  end
+
+  def test_roll_is_idempotent_across_repeated_passes
+    seed_minute(processed: 7, failed: 1, ms: 300)
+    3.times { @rollup.roll(@at + 60) }
+
+    assert_equal({ 'p' => 7, 'f' => 1, 'ms' => 300 }, bucket_hash('1h'))
+  end
+
+  def test_roll_sets_per_bucket_retention_ttls
+    seed_minute(processed: 1, failed: 0, ms: 10)
+    @rollup.roll(@at + 60)
+
+    Wurk::Metrics::Rollup::BUCKETS.each do |bucket, (step, ttl)|
+      actual = Wurk.redis { |c| c.call('TTL', Wurk::Metrics::Rollup.bucket_key(bucket, (@epoch_min / step) * step)) }
+
+      assert_operator actual, :>, ttl - 120, "#{bucket} ttl too low"
+      assert_operator actual, :<=, ttl, "#{bucket} ttl too high"
+    end
+  end
+
+  def test_roll_skips_empty_minutes
+    @rollup.roll(@at + 60) # no source data seeded
+
+    assert_empty bucket_hash('1m')
+  end
+
+  def test_tick_writes_when_leader
+    seed_minute(processed: 9, failed: 0, ms: 90)
+    @rollup.define_singleton_method(:leader?) { true }
+    @rollup.tick(now: @at + 60)
+
+    assert_equal 9, bucket_hash('1m')['p']
+  end
+
+  def test_tick_is_leader_gated
+    seed_minute(processed: 9, failed: 0, ms: 90)
+    @rollup.define_singleton_method(:leader?) { false }
+    @rollup.tick(now: @at + 60)
+
+    assert_empty bucket_hash('1m')
+  end
+
+  # ---- Query.history reader ------------------------------------------------
+
+  def test_history_reader_returns_gap_filled_series
+    seed_minute(processed: 4, failed: 1, ms: 40)
+    @rollup.roll(@at + 60)
+    series = Wurk::Metrics::Query.history('1m', 300, now: @at + 120)
+    point = series.find { |row| row[:at] == @epoch_min }
+
+    assert_equal({ at: @epoch_min, p: 4, f: 1, ms: 40 }, point)
+    assert_equal 5, series.size
+    assert(series.all? { |row| row[:p].is_a?(Integer) })
+  end
+
+  def test_history_reader_rejects_unknown_bucket
+    assert_raises(ArgumentError) { Wurk::Metrics::Query.history('2m', 300) }
+  end
+
+  def test_history_reader_clamps_window_to_retention
+    series = Wurk::Metrics::Query.history('1m', 48 * 3600, now: @at + 120)
+
+    assert_operator series.size, :<=, 24 * 60
+  end
+
+  private
+
+  def seed_minute(processed:, failed:, ms:)
+    Wurk.redis do |c|
+      c.call('HSET', Wurk::Metrics::History.minute_key(@at),
+             "#{@klass}|p", processed, "#{@klass}|f", failed, "#{@klass}|ms", ms)
+    end
+  end
+
+  def bucket_hash(bucket)
+    step = Wurk::Metrics::Rollup::BUCKETS[bucket][0]
+    raw = Wurk.redis { |c| c.call('HGETALL', Wurk::Metrics::Rollup.bucket_key(bucket, (@epoch_min / step) * step)) }
+    raw = raw.each_slice(2).to_h if raw.is_a?(::Array)
+    raw.transform_values(&:to_i)
+  end
+end

--- a/test/unit/metrics_rollup_test.rb
+++ b/test/unit/metrics_rollup_test.rb
@@ -15,7 +15,12 @@ class MetricsRollupTest < Wurk::Test::UnitCase
 
   def setup
     super
-    @epoch_min = ((SecureRandom.random_number(1_000_000_000) + 2_000_000_000) / 60) * 60
+    # Per-test isolation keyed to PID:object_id (the parallel-runner guideline):
+    # the pid gives each fork a disjoint minute block, object_id separates tests
+    # within a fork. Whole-key writes + the teardown DEL make object_id reuse
+    # after GC harmless here — unlike the shared-field history buckets, which
+    # need SecureRandom to avoid inheriting a recycled id's field.
+    @epoch_min = ((2_000_000_000 + ((Process.pid % 100_000) * 100_000) + (object_id % 100_000)) / 60) * 60
     @at = ::Time.at(@epoch_min).utc
     @klass = "RollupJob-#{SecureRandom.hex(6)}"
     @rollup = Wurk::Metrics::Rollup.new(Wurk.configuration)


### PR DESCRIPTION
Dashboard charts get historical data, not just live SSE.

## Done when (issue acceptance criteria)
- [x] **Dashboard "throughput" + "failures" charts render real historical data** — verified live end-to-end (see QA): the Metrics page's new *Throughput & Failures* line chart reads the rollup buckets via `/api/history/:bucket`.
- [x] **Disk/Redis footprint bounded (documented)** — bounded purely by TTL; ~4.2k tiny hashes total regardless of throughput. Documented in `docs/metrics-history.md`.

## How it works
A **leader-only rollup thread** (`Wurk::Metrics::Rollup`, wired into the Launcher beside the cron poller) folds the existing per-class minute buckets (`j|YYMMDD|H:M`) into compact, cluster-total time-series buckets:

| key | resolution | retention |
|---|---|---|
| `jr\|1m\|<epoch>` | 1 min | 24h |
| `jr\|5m\|<epoch>` | 5 min | 7d |
| `jr\|1h\|<epoch>` | 1 hour | 30d |

Each is a 3-field HASH (`p`/`f`/`ms`). Every write is **idempotent `HSET`** — coarse buckets are recomputed from their 1-minute children — so a missed tick, a leadership change, or a late metric write converges to the same totals and **never double-counts**. Only the elected leader writes (non-leader ticks return early). Storage is bounded entirely by the per-bucket TTLs.

## API
```
GET /wurk/api/history/:bucket?window=24h    # :bucket = 1m|5m|1h
→ { bucket, window, series: [{ at, processed, failed, runtime_ms }, …] }
```
Gap-filled (missing buckets read as zero), oldest→newest, `window` clamped to the bucket's retention; unknown bucket → `400`.

## Tests
- `test/unit/metrics_rollup_test.rb` — bucket totals, cross-class summing, **idempotency**, retention TTLs, empty-minute skip, leader gate, history reader (gap-fill + caps + bad bucket)
- `test/engine/api_endpoints_test.rb` — `/history` envelope + 400 on unknown bucket
- `test/unit/launcher_test.rb` — rollup is built + started
- Full suite **1600 runs, 0 failures** · parity · ecosystem all green

## How to test in prod
```bash
# Drives the REAL rollup over ~45 min of seeded source data, reads it back via
# the live endpoint, then points you at the chart. Cleans up on Enter.
ruby test/qa/metrics_history_driver.rb
```
Then open the dashboard → **Metrics** → the *Throughput & Failures* card shows a rising Processed line with Failed spikes; toggle the **24h·1m / 7d·5m / 30d·1h** range selector to read each rollup resolution. (History accrues from the first leader tick after boot — it is not back-filled.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * History JSON API for aggregated job throughput/failure series with selectable bucket/window.
  * Background metrics rollup that aggregates minute→5m/1h cluster totals.
  * "Throughput & Failures" history chart on Metrics and updated Top Jobs to surface processed, failed and runtime_ms.
  * Sidekiq compatibility alias for metrics.

* **Bug Fixes**
  * History endpoint validates inputs and returns clear 400 errors.

* **Documentation**
  * Added metrics history docs describing rollup behavior, retention and API usage.

* **Tests**
  * Added unit/integration/QA tests covering rollup, history reader, endpoint and launcher lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->