### PR TITLE
feat: Sidekiq::Testing inline/fake/disable modes + test helpers (closes #26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Wurk are recorded here. Format: [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Added
+- `Sidekiq::Testing` drop-in: `inline!` / `fake!` / `disable!` (global or block-scoped), the in-memory `Sidekiq::Queues` store, and the `Worker`/`Job` test helpers (`.jobs`, `.clear`, `.drain`, `.perform_one`, `.process_job`, `.drain_all`, `.clear_all`) + `Sidekiq::EmptyQueueError`.
+
 ## [1.0.0] - 2026-05-31
 
 First public release. Wurk is a 100% API-compatible drop-in replacement for Sidekiq + Sidekiq Pro + Sidekiq Enterprise — same Redis key schema, same job JSON, same Ruby DSL — with fork-based real parallelism, the full Pro + Enterprise feature set in one free gem (no license check), and a precompiled React dashboard.

--- a/lib/wurk.rb
+++ b/lib/wurk.rb
@@ -22,6 +22,8 @@ require_relative 'wurk/worker'
 require_relative 'wurk/worker/setter'
 require_relative 'wurk/job'
 require_relative 'wurk/job/options'
+require_relative 'wurk/queues'
+require_relative 'wurk/testing'
 require_relative 'wurk/iterable_job'
 require_relative 'wurk/job_retry'
 require_relative 'wurk/job_record'
@@ -157,22 +159,13 @@ module Wurk
 
     # --- mode flags --------------------------------------------------
 
-    # Sets the testing mode. Real behavior (inline/fake/disable) is wired
-    # up when the test harness loads; this just records the setting.
-    def testing!(mode = :fake)
-      @testing_mode = mode
-      return @testing_mode unless block_given?
+    # Sidekiq-compatible test-mode entry point. Delegates to Wurk::Testing
+    # (the single source of truth for the mode): a block scopes the mode to the
+    # current thread; no block sets it globally. `Sidekiq.testing!` aliases here.
+    def testing!(mode = :fake, &) = Wurk::Testing.__set_test_mode(mode, &)
 
-      begin
-        yield
-      ensure
-        @testing_mode = nil
-      end
-    end
-
-    def testing?
-      !!@testing_mode
-    end
+    # True when in :fake or :inline mode (i.e. not pushing to real Redis).
+    def testing? = Wurk::Testing.enabled?
 
     # True inside the swarm/manager process (set by exe/wurk / the railtie).
     def server?

--- a/lib/wurk/client.rb
+++ b/lib/wurk/client.rb
@@ -215,16 +215,25 @@ module Wurk
     # the pipeline size — a bulk push of 100 with N=2 must flush 2/2/... not
     # 100 in one shot.
     def raw_push(payloads)
+      # Test modes short-circuit the Redis write (and the batch buffer): :fake
+      # collects payloads in-memory, :inline runs them now. Client middleware
+      # has already run by this point, matching Sidekiq.
+      return ::Wurk::Testing.dispatch_push(payloads) if ::Wurk::Testing.enabled?
+
       buffer = Thread.current[Wurk::Batch::BUFFER_KEY]
-      if buffer && payloads.all? { |p| p['bid'] && !p['at'] }
-        payloads.each do |payload|
-          buffer.add([payload])
-          flush_batched(buffer.drain) if buffer.ready?
-        end
-        return
-      end
+      return buffer_add(buffer, payloads) if buffer && payloads.all? { |p| p['bid'] && !p['at'] }
 
       pool.with { |conn| atomic_push(conn, payloads) }
+    end
+
+    # Batch autoflush path: accumulate each non-scheduled batched payload into
+    # the active buffer, flushing every N adds (when `buffer.ready?`).
+    def buffer_add(buffer, payloads)
+      payloads.each do |payload|
+        buffer.add([payload])
+        flush_batched(buffer.drain) if buffer.ready?
+      end
+      nil
     end
 
     def atomic_push(conn, payloads)

--- a/lib/wurk/compat.rb
+++ b/lib/wurk/compat.rb
@@ -98,6 +98,9 @@ module Sidekiq
   ScheduledSet     = Wurk::ScheduledSet
   Shutdown         = Wurk::Shutdown
   Stats            = Wurk::Stats
+  Testing          = Wurk::Testing
+  Queues           = Wurk::Queues
+  EmptyQueueError  = Wurk::Testing::EmptyQueueError
   Work             = Wurk::Work
   Worker           = Wurk::Worker
   Workers          = Wurk::Workers

--- a/lib/wurk/job.rb
+++ b/lib/wurk/job.rb
@@ -23,5 +23,11 @@ module Wurk
     def self.included(base)
       base.include(Wurk::Worker)
     end
+
+    # Mirror the module-level test helpers so `Sidekiq::Job.jobs /
+    # clear_all / drain_all` work the same as `Sidekiq::Worker.*`.
+    def self.jobs       = Wurk::Worker.jobs
+    def self.clear_all  = Wurk::Worker.clear_all
+    def self.drain_all  = Wurk::Worker.drain_all
   end
 end

--- a/lib/wurk/queues.rb
+++ b/lib/wurk/queues.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Wurk
+  # In-memory job store for `:fake` test mode (aliased to Sidekiq::Queues).
+  # Wurk::Client#raw_push routes payloads here instead of Redis when
+  # `Wurk::Testing.fake?`. Thread-safe so parallel test threads / a job that
+  # enqueues more jobs during `drain` don't corrupt the store.
+  #
+  # Spec: docs/target/sidekiq-free.md §24.2.
+  module Queues
+    @lock = ::Mutex.new
+    @by_queue = ::Hash.new { |h, k| h[k] = [] }
+
+    class << self
+      def [](queue)
+        @lock.synchronize { @by_queue[queue.to_s].dup }
+      end
+
+      def push(queue, _klass, job)
+        @lock.synchronize { @by_queue[queue.to_s] << job }
+      end
+
+      def jobs_by_queue
+        @lock.synchronize { @by_queue.transform_values(&:dup) }
+      end
+
+      def jobs_by_class
+        @lock.synchronize { @by_queue.values.flatten.group_by { |j| j['class'].to_s } }
+      end
+      alias jobs_by_worker jobs_by_class
+
+      # Every enqueued payload across all queues, flattened.
+      def jobs
+        @lock.synchronize { @by_queue.values.flatten }
+      end
+
+      def delete_for(jid, queue, _klass)
+        @lock.synchronize { @by_queue[queue.to_s].reject! { |j| j['jid'] == jid } }
+      end
+
+      def clear_for(queue, klass)
+        klass = klass.to_s
+        @lock.synchronize { @by_queue[queue.to_s].reject! { |j| j['class'].to_s == klass } }
+      end
+
+      def clear_all
+        @lock.synchronize { @by_queue.clear }
+      end
+
+      # --- drain helpers (lock released before the job runs, so a job that
+      # enqueues more work doesn't deadlock on the same Mutex) ---------------
+
+      def clear_class(klass)
+        klass = klass.to_s
+        @lock.synchronize { @by_queue.each_value { |jobs| jobs.reject! { |j| j['class'].to_s == klass } } }
+      end
+
+      def shift_class(klass)
+        klass = klass.to_s
+        @lock.synchronize do
+          @by_queue.each_value do |jobs|
+            idx = jobs.index { |j| j['class'].to_s == klass }
+            return jobs.delete_at(idx) if idx
+          end
+          nil
+        end
+      end
+
+      def shift_any
+        @lock.synchronize do
+          @by_queue.each_value { |jobs| return jobs.shift unless jobs.empty? }
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/wurk/queues.rb
+++ b/lib/wurk/queues.rb
@@ -12,16 +12,19 @@ module Wurk
     @by_queue = ::Hash.new { |h, k| h[k] = [] }
 
     class << self
+      # Live array reference (not a copy), so the Sidekiq idiom
+      # `Sidekiq::Queues["q"].clear` mutates the underlying store like stock.
       def [](queue)
-        @lock.synchronize { @by_queue[queue.to_s].dup }
+        @lock.synchronize { @by_queue[queue.to_s] }
       end
 
       def push(queue, _klass, job)
         @lock.synchronize { @by_queue[queue.to_s] << job }
       end
 
+      # Live hash of queue => [jobs], matching Sidekiq::Queues.jobs_by_queue.
       def jobs_by_queue
-        @lock.synchronize { @by_queue.transform_values(&:dup) }
+        @lock.synchronize { @by_queue }
       end
 
       def jobs_by_class

--- a/lib/wurk/testing.rb
+++ b/lib/wurk/testing.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require_relative 'queues'
+require_relative 'middleware/chain'
+
+module Wurk
+  # Sidekiq::Testing-compatible test harness (aliased to Sidekiq::Testing).
+  # Three modes control how `Wurk::Client#raw_push` behaves:
+  #
+  #   :disable — real Redis push (the default; production behavior)
+  #   :fake    — payloads collected in the in-memory Wurk::Queues store
+  #   :inline  — jobs executed synchronously the instant they're pushed
+  #
+  # A block form switches the mode for the duration of the block on the current
+  # thread only (`fake! { ... }`); the no-block form sets it process-globally.
+  #
+  # Spec: docs/target/sidekiq-free.md §24.
+  module Testing
+    class TestModeAlreadySetError < ::RuntimeError; end
+    # Raised by `Worker.perform_one` / `drain` when no fake job is available.
+    class EmptyQueueError < ::RuntimeError; end
+
+    THREAD_KEY = :__wurk_testing_mode
+
+    class << self
+      def disable!(&) = __set_test_mode(:disable, &)
+      def fake!(&)    = __set_test_mode(:fake, &)
+      def inline!(&)  = __set_test_mode(:inline, &)
+
+      def disabled? = mode == :disable
+      def enabled?  = !disabled?
+      def fake?     = mode == :fake
+      def inline?   = mode == :inline
+
+      # Thread-local override (set by a block) wins over the global mode, so a
+      # `fake! { ... }` block is isolated to the calling thread.
+      def mode
+        ::Thread.current[THREAD_KEY] || @mode || :disable
+      end
+
+      # Block → thread-local for the block's duration; no block → global.
+      def __set_test_mode(new_mode, &block)
+        return @mode = new_mode unless block
+
+        prev = ::Thread.current[THREAD_KEY]
+        ::Thread.current[THREAD_KEY] = new_mode
+        begin
+          block.call
+        ensure
+          ::Thread.current[THREAD_KEY] = prev
+        end
+      end
+
+      # In-process server-middleware chain used for inline execution. Empty by
+      # default — configure with `Sidekiq::Testing.server_middleware { |c| ... }`.
+      def server_middleware
+        @server_middleware ||= ::Wurk::Middleware::Chain.new(::Wurk.configuration)
+        yield @server_middleware if block_given?
+        @server_middleware
+      end
+
+      # --- push hooks invoked by Wurk::Client#raw_push -------------------
+
+      # Route a push through the active test mode (only called when enabled?).
+      def dispatch_push(payloads)
+        inline? ? inline_push(payloads) : fake_push(payloads)
+      end
+
+      # Collect payloads into the in-memory store. `enqueued_at` is stamped now
+      # unless the job is scheduled (`at`), mirroring the real client.
+      def fake_push(payloads)
+        now = ::Process.clock_gettime(::Process::CLOCK_REALTIME, :millisecond)
+        payloads.each do |payload|
+          payload['enqueued_at'] = now unless payload['at']
+          ::Wurk::Queues.push(payload['queue'], payload['class'], payload)
+        end
+        payloads.last['jid']
+      end
+
+      # Execute each payload immediately through the inline server chain.
+      def inline_push(payloads)
+        payloads.each { |payload| ::Object.const_get(payload['class'].to_s).process_job(payload) }
+        payloads.last['jid']
+      end
+
+      # Run every fake job across all classes until the store is empty.
+      def drain_all
+        count = 0
+        while (job = ::Wurk::Queues.shift_any)
+          ::Object.const_get(job['class'].to_s).process_job(job)
+          count += 1
+        end
+        count
+      end
+    end
+  end
+end

--- a/lib/wurk/testing.rb
+++ b/lib/wurk/testing.rb
@@ -39,15 +39,20 @@ module Wurk
       end
 
       # Block → thread-local for the block's duration; no block → global.
+      # Nesting block forms (`fake! { inline! { ... } }`) is rejected, matching
+      # Sidekiq 8.
       def __set_test_mode(new_mode, &block)
         return @mode = new_mode unless block
 
-        prev = ::Thread.current[THREAD_KEY]
+        if ::Thread.current[THREAD_KEY]
+          raise TestModeAlreadySetError, 'Nested Sidekiq::Testing block modes are not allowed'
+        end
+
         ::Thread.current[THREAD_KEY] = new_mode
         begin
           block.call
         ensure
-          ::Thread.current[THREAD_KEY] = prev
+          ::Thread.current[THREAD_KEY] = nil
         end
       end
 

--- a/lib/wurk/worker.rb
+++ b/lib/wurk/worker.rb
@@ -22,6 +22,13 @@ module Wurk
       end
     end
 
+    # Module-level test helpers: `Sidekiq::Worker.jobs / clear_all / drain_all`
+    # operate across every job class (spec §24.3). Resolved lazily so the
+    # testing constants need not be loaded when Worker is.
+    def self.jobs       = ::Wurk::Queues.jobs
+    def self.clear_all  = ::Wurk::Queues.clear_all
+    def self.drain_all  = ::Wurk::Testing.drain_all
+
     def logger
       Wurk.logger
     end
@@ -58,7 +65,7 @@ module Wurk
       batch.valid?
     end
 
-    module ClassMethods
+    module ClassMethods # rubocop:disable Metrics/ModuleLength
       def sidekiq_options(opts = {})
         merged = get_sidekiq_options.merge(opts.transform_keys(&:to_s))
         @sidekiq_options_hash = merged
@@ -116,6 +123,58 @@ module Wurk
       def build_client
         pool = get_sidekiq_options['pool']
         Wurk::Client.new(pool: pool)
+      end
+
+      # --- Sidekiq::Testing class-level helpers (spec §24.3) --------------
+      # Only meaningful in :fake / :inline mode; the in-memory store is empty
+      # otherwise.
+
+      def queue
+        get_sidekiq_options['queue']
+      end
+
+      # Fake jobs enqueued for this class, across every queue.
+      def jobs
+        ::Wurk::Queues.jobs_by_class[to_s] || []
+      end
+
+      def clear
+        ::Wurk::Queues.clear_class(to_s)
+      end
+
+      # Run & remove every fake job for this class — including ones it enqueues
+      # mid-drain. Returns the count processed.
+      def drain
+        count = 0
+        while (job = ::Wurk::Queues.shift_class(to_s))
+          process_job(job)
+          count += 1
+        end
+        count
+      end
+
+      # Run & remove the first fake job for this class; EmptyQueueError if none.
+      def perform_one
+        job = ::Wurk::Queues.shift_class(to_s)
+        raise ::Wurk::Testing::EmptyQueueError, "no #{self} jobs were found" if job.nil?
+
+        process_job(job)
+      end
+
+      # Execute a normalized job hash through the inline server-middleware chain
+      # (empty by default — see Wurk::Testing.server_middleware).
+      def process_job(job_hash)
+        instance = new
+        instance.jid = job_hash['jid']
+        instance.bid = job_hash['bid'] if instance.respond_to?(:bid=)
+        ::Wurk::Testing.server_middleware.invoke(instance, job_hash, job_hash['queue'] || queue) do
+          execute_job(instance, job_hash['args'])
+        end
+        instance
+      end
+
+      def execute_job(worker, args)
+        worker.perform(*args)
       end
 
       def delay(*)

--- a/lib/wurk/worker.rb
+++ b/lib/wurk/worker.rb
@@ -163,6 +163,9 @@ module Wurk
 
       # Execute a normalized job hash through the inline server-middleware chain
       # (empty by default — see Wurk::Testing.server_middleware).
+      # Returns the value of the server-middleware `invoke` (i.e. the worker's
+      # `perform` return), matching Sidekiq::Testing — so `perform_one` yields
+      # the job result.
       def process_job(job_hash)
         instance = new
         instance.jid = job_hash['jid']
@@ -170,7 +173,6 @@ module Wurk
         ::Wurk::Testing.server_middleware.invoke(instance, job_hash, job_hash['queue'] || queue) do
           execute_job(instance, job_hash['args'])
         end
-        instance
       end
 
       def execute_job(worker, args)

--- a/test/unit/job_util_test.rb
+++ b/test/unit/job_util_test.rb
@@ -344,7 +344,7 @@ class WurkTopLevelTest < Wurk::Test::UnitCase
 
       assert_predicate Wurk, :testing?
     ensure
-      Wurk.instance_variable_set(:@testing_mode, nil)
+      Wurk::Testing.disable!
     end
   end
 
@@ -355,6 +355,8 @@ class WurkTopLevelTest < Wurk::Test::UnitCase
 
       assert seen
       refute_predicate Wurk, :testing?
+    ensure
+      Wurk::Testing.disable!
     end
   end
 

--- a/test/unit/testing_test.rb
+++ b/test/unit/testing_test.rb
@@ -148,6 +148,21 @@ class TestingModesTest < Wurk::Test::UnitCase
     assert_predicate Wurk::Testing, :disabled?
   end
 
+  def test_nested_block_modes_raise
+    Wurk::Testing.fake! do
+      assert_raises(Wurk::Testing::TestModeAlreadySetError) do
+        Wurk::Testing.inline! { :never }
+      end
+    end
+  end
+
+  def test_queues_index_returns_a_live_reference
+    Wurk::Testing.fake! { FakeJob.perform_async(1) }
+    Wurk::Queues['testq'].clear
+
+    assert_empty FakeJob.jobs
+  end
+
   def test_predicate_helpers
     Wurk::Testing.inline! do
       assert_predicate Wurk::Testing, :enabled?

--- a/test/unit/testing_test.rb
+++ b/test/unit/testing_test.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Wurk::Testing inline/fake/disable modes + the Sidekiq::Testing helper surface.
+# The mode flag and the in-memory Queues store are process-global, but the
+# parallel runner forks, so each worker has its own copy — teardown still resets
+# both so sequential tests in the same fork don't leak.
+class TestingModesTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  class FakeJob
+    include Wurk::Job
+
+    sidekiq_options queue: 'testq'
+
+    def self.ran
+      @ran ||= []
+    end
+
+    def perform(arg)
+      self.class.ran << arg
+    end
+  end
+
+  class BoomJob
+    include Wurk::Job
+
+    def perform(*)
+      raise 'boom'
+    end
+  end
+
+  def setup
+    super
+    FakeJob.ran.clear
+  end
+
+  def teardown
+    Wurk::Testing.disable!
+    Wurk::Queues.clear_all
+    Thread.current[Wurk::Testing::THREAD_KEY] = nil
+  ensure
+    super
+  end
+
+  # --- fake mode ----------------------------------------------------------
+
+  def test_fake_collects_jobs_without_running
+    Wurk::Testing.fake! do
+      FakeJob.perform_async(1)
+      FakeJob.perform_async(2)
+    end
+
+    assert_equal 2, FakeJob.jobs.size
+    assert_empty FakeJob.ran
+    assert_equal([1, 2], FakeJob.jobs.map { |j| j['args'].first })
+  end
+
+  def test_fake_push_returns_a_jid
+    jid = Wurk::Testing.fake! { FakeJob.perform_async(1) }
+
+    assert_kind_of String, jid
+    assert_equal 24, jid.length
+  end
+
+  def test_fake_payload_carries_wire_fields
+    Wurk::Testing.fake! { FakeJob.perform_async(7) }
+    job = FakeJob.jobs.first
+
+    assert_equal({ 'class' => 'TestingModesTest::FakeJob', 'queue' => 'testq', 'args' => [7] },
+                 job.slice('class', 'queue', 'args'))
+    assert_kind_of String, job['jid']
+    assert_kind_of Integer, job['enqueued_at']
+  end
+
+  def test_drain_runs_and_clears
+    Wurk::Testing.fake! do
+      FakeJob.perform_async(1)
+      FakeJob.perform_async(2)
+    end
+
+    assert_equal 2, FakeJob.drain
+    assert_equal [1, 2], FakeJob.ran
+    assert_empty FakeJob.jobs
+  end
+
+  def test_perform_one_runs_first_then_raises_when_empty
+    Wurk::Testing.fake! { FakeJob.perform_async(9) }
+    FakeJob.perform_one
+
+    assert_equal [9], FakeJob.ran
+    assert_raises(Wurk::Testing::EmptyQueueError) { FakeJob.perform_one }
+  end
+
+  def test_clear_drops_only_this_class
+    Wurk::Testing.fake! do
+      FakeJob.perform_async(1)
+      BoomJob.perform_async
+    end
+    FakeJob.clear
+
+    assert_empty FakeJob.jobs
+    assert_equal 1, BoomJob.jobs.size
+  end
+
+  # --- inline mode --------------------------------------------------------
+
+  def test_inline_runs_immediately
+    Wurk::Testing.inline! { FakeJob.perform_async(42) }
+
+    assert_equal [42], FakeJob.ran
+    assert_empty FakeJob.jobs
+  end
+
+  def test_inline_propagates_job_errors
+    error = assert_raises(RuntimeError) { Wurk::Testing.inline! { BoomJob.perform_async } }
+
+    assert_equal 'boom', error.message
+  end
+
+  # --- module-level helpers ----------------------------------------------
+
+  def test_worker_drain_all_runs_every_class
+    Wurk::Testing.fake! do
+      FakeJob.perform_async(1)
+      FakeJob.perform_async(2)
+    end
+
+    assert_equal 2, Wurk::Worker.drain_all
+    assert_equal [1, 2], FakeJob.ran
+  end
+
+  def test_worker_clear_all_empties_the_store
+    Wurk::Testing.fake! { FakeJob.perform_async(1) }
+    Wurk::Worker.clear_all
+
+    assert_empty Wurk::Worker.jobs
+  end
+
+  # --- mode plumbing ------------------------------------------------------
+
+  def test_block_form_restores_previous_mode
+    Wurk::Testing.disable!
+
+    Wurk::Testing.fake! { assert_predicate Wurk::Testing, :fake? }
+
+    assert_predicate Wurk::Testing, :disabled?
+  end
+
+  def test_predicate_helpers
+    Wurk::Testing.inline! do
+      assert_predicate Wurk::Testing, :enabled?
+      refute_predicate Wurk::Testing, :disabled?
+      assert_predicate Wurk::Testing, :inline?
+    end
+  end
+
+  # --- Sidekiq drop-in aliases -------------------------------------------
+
+  def test_sidekiq_aliases
+    assert_same Wurk::Testing, Sidekiq::Testing
+    assert_same Wurk::Queues, Sidekiq::Queues
+    assert_same Wurk::Testing::EmptyQueueError, Sidekiq::EmptyQueueError
+  end
+
+  def test_sidekiq_testing_bang_delegates
+    Sidekiq::Testing.fake! { FakeJob.perform_async(5) }
+
+    assert_equal 1, FakeJob.jobs.size
+  end
+end


### PR DESCRIPTION
Drop-in users expect `Sidekiq::Testing.inline! / fake! / disable!` to keep working — now they do.

## Done when (issue acceptance criteria)
- [x] **Three modes wired into the Client** — `Client#raw_push` routes through the active mode (after client middleware runs, matching Sidekiq): `:fake` collects payloads in-memory, `:inline` runs them immediately, `:disable` hits real Redis.
- [x] **Aliases under `Sidekiq::Testing`** — `Sidekiq::Testing`, `Sidekiq::Queues`, `Sidekiq::EmptyQueueError` all resolve to the Wurk classes; `Sidekiq.testing!(:fake|:inline|:disable, &)` delegates too.
- [x] **Helpers** — `MyJob.jobs/.clear/.drain/.perform_one/.process_job/.execute_job/.queue` and module-level `Sidekiq::Worker.jobs/.clear_all/.drain_all` (+ `Sidekiq::Job.*`).
- [x] **Ecosystem suites pass** — `rake test:ecosystem` green (the suites that use `Sidekiq::Testing` now have the surface they call).

## How it works
| Mode | `perform_async` behavior |
|---|---|
| `disable!` (default) | normal Redis enqueue |
| `fake!` | payload collected in the in-memory `Wurk::Queues` store (`MyJob.jobs`) |
| `inline!` | job executed synchronously through the inline server-middleware chain |

A **block** form scopes the mode thread-locally (`fake! { ... }` restores the prior mode after); a no-block call sets it process-globally. `Wurk.testing!`/`testing?` now delegate to `Wurk::Testing` as the single source of truth.

`:fake` payloads carry the real wire fields (`class`, `queue`, `args`, `jid`, `enqueued_at`). `drain` re-runs jobs a worker enqueues mid-drain; `perform_one` raises `EmptyQueueError` when empty. Spec: `docs/target/sidekiq-free.md` §24.

## Tests
- `test/unit/testing_test.rb` (14 tests): fake collects-without-running, payload shape, jid return, drain, perform_one + EmptyQueueError, clear (class-scoped), inline runs + propagates errors, `drain_all`/`clear_all`, block restores prior mode, predicates, Sidekiq aliases.
- Reconciled the existing `Wurk.testing!` tests to the new delegation.
- Full suite **1624 runs, 0 failures** · parity · ecosystem all green; rubocop clean.

## How to test in prod / locally
```ruby
require "wurk"   # or "sidekiq" in a drop-in app
Sidekiq::Testing.fake!
MyJob.perform_async(1, 2)
MyJob.jobs.size        # => 1   (not enqueued to Redis)
MyJob.drain            # runs it
Sidekiq::Testing.inline! { MyJob.perform_async(3) }   # runs immediately, then restores mode
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-process testing mode with fake (in-memory queues), inline (immediate execution), and disabled strategies.
  * In-memory queue store and helpers for enqueuing, inspecting, draining, clearing, and single-job execution; added EmptyQueueError.
  * Module-level test helpers on worker and job namespaces; Sidekiq-compatible testing/queues/error aliases.

* **Tests**
  * Added comprehensive tests covering modes, queue behavior, helpers, and Sidekiq compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->