### PR TITLE
feat: dashboard auth hook — Wurk::Web.use for Devise/Warden/Sorcery (closes #41)

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,131 @@
+# Securing the dashboard
+
+The Wurk dashboard is a mountable Rails engine. It ships **no session layer of
+its own** — the first thing every production deploy does is gate it behind the
+host app's existing authentication, and Wurk gives you two hooks to do that
+without writing a custom Rack middleware.
+
+| Hook | Use it for | API |
+|------|------------|-----|
+| `Wurk::Web.use` | Drop in any Rack auth middleware (Devise/Warden, `Rack::Auth::Basic`, a custom guard) in front of the dashboard. | `Wurk::Web.use(Middleware, *args, &block)` |
+| `Wurk::Web.configure { \|c\| c.authorization { … } }` | A per-request `(env, method, path) -> truthy/falsey` check (e.g. role gating GET vs POST). | see [§ Authorization hook](#authorization-hook) |
+
+Both are Sidekiq-compatible: `Sidekiq::Web.use(...)` is aliased to
+`Wurk::Web.use`, so an existing Sidekiq initializer keeps working on the
+one-line gem swap.
+
+The two compose. `Wurk::Web.use` middleware runs **first** (outermost), so by
+the time the `authorization` block runs, the host middleware has already
+populated `env` (e.g. `env['warden']`).
+
+> Scope: these hooks only affect requests routed **under the engine mount**.
+> The host app's own controllers are untouched.
+
+## `Wurk::Web.use`
+
+Call it once at boot, from an initializer. The chain is built on the first
+request and memoized, so register before the app starts serving.
+
+```ruby
+# config/initializers/wurk.rb
+Wurk::Web.use(MyAuthMiddleware, some: "arg") { |env| ... }
+```
+
+`*args` and the optional block pass straight through to the middleware's
+`new`. Multiple calls stack outermost-first. A middleware that returns a
+`401`/`403`/redirect short-circuits the request — the dashboard never sees it.
+
+### Devise / Warden
+
+Devise builds on Warden, which is already in your middleware stack and has set
+`env['warden']` by the time a request reaches the mount. Gate with a tiny
+middleware that bounces unauthenticated users to your login page:
+
+```ruby
+# config/initializers/wurk.rb
+class WurkAdminAuth
+  def initialize(app) = @app = app
+
+  def call(env)
+    warden = env["warden"]
+    user   = warden&.user
+    return @app.call(env) if user&.admin?
+
+    warden&.authenticate!(scope: :user) # 401 → Devise failure app → /users/sign_in
+    [403, { "Content-Type" => "text/plain" }, ["Forbidden"]]
+  end
+end
+
+Wurk::Web.use(WurkAdminAuth)
+```
+
+Prefer to keep it in `routes.rb`? `authenticate` works too, and needs no
+`Wurk::Web.use`:
+
+```ruby
+# config/routes.rb
+authenticate :user, ->(u) { u.admin? } do
+  mount Wurk::Engine => "/wurk"
+end
+```
+
+### Sorcery
+
+Sorcery exposes its helpers on the controller, not on `env`, so check the
+session directly in the middleware:
+
+```ruby
+class WurkSorceryAuth
+  def initialize(app) = @app = app
+
+  def call(env)
+    user_id = env["rack.session"]&.[](:user_id)
+    admin   = user_id && User.find_by(id: user_id)&.admin?
+    return @app.call(env) if admin
+
+    [302, { "Location" => "/login", "Content-Type" => "text/plain" }, ["Redirecting"]]
+  end
+end
+
+Wurk::Web.use(WurkSorceryAuth)
+```
+
+### Plain HTTP Basic auth
+
+For an internal tool, `Rack::Auth::Basic` is enough — no host-app coupling:
+
+```ruby
+Wurk::Web.use(Rack::Auth::Basic, "Wurk") do |user, password|
+  ActiveSupport::SecurityUtils.secure_compare(user, ENV["WURK_USER"]) &
+    ActiveSupport::SecurityUtils.secure_compare(password, ENV["WURK_PASS"])
+end
+```
+
+## Authorization hook
+
+For role logic that depends on the HTTP method or path (e.g. support staff may
+view but only admins may retry/kill), use the per-request hook instead of (or
+alongside) a `use` middleware:
+
+```ruby
+Wurk::Web.configure do |c|
+  c.authorization do |env, method, _path|
+    user = env["warden"]&.user
+    method == "GET" ? (user&.support? || user&.admin?) : user&.admin?
+  end
+end
+```
+
+A falsey return short-circuits to `403`. `path` is engine-relative
+(`/api/stats`, not the host's absolute `/wurk/api/stats`), matching Sidekiq's
+contract.
+
+### Read-only mode
+
+To ship a viewer-only deploy (e.g. a public demo) with **no Ruby config**, set
+`WURK_WEB_READ_ONLY=1` — every non-`GET` request 403s and the SPA hides
+destructive actions. Equivalent in Ruby:
+
+```ruby
+Wurk::Web.configure { |c| c.read_only = true }
+```

--- a/lib/wurk/compat.rb
+++ b/lib/wurk/compat.rb
@@ -101,6 +101,7 @@ module Sidekiq
   Testing          = Wurk::Testing
   Queues           = Wurk::Queues
   EmptyQueueError  = Wurk::Testing::EmptyQueueError
+  Web              = Wurk::Web
   Work             = Wurk::Work
   Worker           = Wurk::Worker
   Workers          = Wurk::Workers

--- a/lib/wurk/engine.rb
+++ b/lib/wurk/engine.rb
@@ -66,10 +66,16 @@ module Wurk
       ::Wurk::DashboardManifest.check!
     end
 
-    # Engine-scoped Rack middleware for the `Wurk::Web.configure` authorization
-    # hook (sidekiq-ent §9.2). Inserted into the engine — not the host — so
-    # the host's own controllers stay unaffected; only requests routed under
-    # the mount point pass through.
+    # Engine-scoped Rack middleware. Inserted into the engine — not the host —
+    # so the host's own controllers stay unaffected; only requests routed
+    # under the mount point pass through.
+    #
+    #   * MiddlewareStack — host-app auth via `Wurk::Web.use` (#41). Outermost,
+    #     so Devise/Warden/Sorcery run first and their `env` is visible to the
+    #     authorization hook below.
+    #   * Authorization — the `Wurk::Web.configure` authorization + read-only
+    #     hook (sidekiq-ent §9.2), 403 on falsey.
+    middleware.use ::Wurk::Web::MiddlewareStack
     middleware.use ::Wurk::Web::Authorization
   end
 end

--- a/lib/wurk/web/config.rb
+++ b/lib/wurk/web/config.rb
@@ -26,9 +26,16 @@ module Wurk
       # doesn't flip on when the env var is "0"/"false"/empty.
       FALSEY_STRINGS = ['', '0', 'false', 'no', 'off'].freeze
 
+      # Host-app Rack middleware stacked in front of the dashboard, newest
+      # last. Each entry is `[middleware, args, block]`. Read-only; mutate
+      # via `#use`.
+      attr_reader :middlewares
+
       def initialize
         @authorization = nil
         @read_only = env_read_only?
+        @middlewares = []
+        @rack_app = nil
       end
 
       # Registers a `(env, method, path) -> truthy/falsey` block. Re-calling
@@ -36,6 +43,30 @@ module Wurk
       def authorization(&block)
         @authorization = block if block
         @authorization
+      end
+
+      # Sidekiq-compatible (`Sidekiq::Web.use`). Registers a Rack middleware
+      # that wraps the dashboard, in front of the authorization hook, so a
+      # host app can gate the UI with Devise/Warden/Sorcery/Rack::Auth::Basic
+      # without writing its own middleware. `args` and an optional block pass
+      # straight through to the middleware's `new`. Call before the first
+      # request (i.e. from an initializer) — the chain is built once.
+      def use(middleware, *args, &block)
+        @middlewares << [middleware, args, block]
+        @rack_app = nil
+      end
+
+      # Builds (once) the host-middleware chain wrapping `inner` and memoizes
+      # it on this Config. `reset_config!` swaps in a fresh Config, so each
+      # test rebuilds cleanly; production builds exactly once at boot.
+      def rack_app(inner)
+        @rack_app ||= begin
+          stack = @middlewares
+          ::Rack::Builder.new do
+            stack.each { |middleware, args, block| use(middleware, *args, &block) }
+            run inner
+          end.to_app
+        end
       end
 
       # Read-only mode. When on, the Authorization middleware blocks every
@@ -54,6 +85,8 @@ module Wurk
       def reset!
         @authorization = nil
         @read_only = env_read_only?
+        @middlewares = []
+        @rack_app = nil
       end
 
       # Returns true when no block is registered, otherwise the block's
@@ -80,6 +113,11 @@ module Wurk
 
       def configure
         yield config
+      end
+
+      # Class-level shorthand for `config.use` — mirrors `Sidekiq::Web.use`.
+      def use(...)
+        config.use(...)
       end
 
       # Test helper — exposed for parity with `Wurk::Limiter.reset_config!`.
@@ -117,6 +155,22 @@ module Wurk
 
       def forbidden(body)
         [403, FORBIDDEN_HEADERS.dup, [body]]
+      end
+    end
+
+    # Engine Rack middleware that applies the host-registered `Wurk::Web.use`
+    # chain (Devise/Warden/Sorcery/Rack::Auth::Basic) in front of the
+    # dashboard. Inserted ahead of `Authorization` so host auth runs first and
+    # its `env` (e.g. `env['warden']`) is visible to the authorization hook.
+    # The chain is built lazily on first request — after host initializers
+    # have run — then memoized on the Config.
+    class MiddlewareStack
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        Wurk::Web.config.rack_app(@app).call(env)
       end
     end
   end

--- a/lib/wurk/web/config.rb
+++ b/lib/wurk/web/config.rb
@@ -27,9 +27,12 @@ module Wurk
       FALSEY_STRINGS = ['', '0', 'false', 'no', 'off'].freeze
 
       # Host-app Rack middleware stacked in front of the dashboard, newest
-      # last. Each entry is `[middleware, args, block]`. Read-only; mutate
-      # via `#use`.
-      attr_reader :middlewares
+      # last. Each entry is `[middleware, args, block]`. Returns a frozen copy
+      # so the memoized chain (`#rack_app`) can only be invalidated through
+      # `#use` — direct mutation can't silently desync it.
+      def middlewares
+        @middlewares.dup.freeze
+      end
 
       def initialize
         @authorization = nil

--- a/test/engine/web_middleware_test.rb
+++ b/test/engine/web_middleware_test.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require_relative '../engine_test_helper'
+
+# Verifies the `Wurk::Web.use` host-middleware hook (#41) wires through the
+# engine, in front of the authorization hook. Mutates the global
+# `Wurk::Web.config`, so cannot run in parallel with other classes that share
+# the singleton.
+class WebMiddlewareTest < Wurk::Test::EngineCase
+  # Stand-in for a host-app auth middleware (Devise/Warden/Sorcery): 401s
+  # unless the request carries an authenticated user. The block decides who
+  # counts as authenticated — exactly how a real integration reads
+  # `env['warden'].user` or a session.
+  class RequireAuth
+    UNAUTHORIZED = [401, { 'Content-Type' => 'text/plain' }, ['Unauthorized']].freeze
+
+    def initialize(app, &authenticated)
+      @app = app
+      @authenticated = authenticated
+    end
+
+    def call(env)
+      return UNAUTHORIZED.dup unless @authenticated.call(env)
+
+      @app.call(env)
+    end
+  end
+
+  # Records the order it was wrapped in, so we can prove the chain nests
+  # outermost-first like Rack::Builder.
+  class Tag
+    def initialize(app, marks, name)
+      @app = app
+      @marks = marks
+      @name = name
+    end
+
+    def call(env)
+      @marks << @name
+      @app.call(env)
+    end
+  end
+
+  def setup
+    super
+    Wurk::Web.reset_config!
+  end
+
+  def teardown
+    Wurk::Web.reset_config!
+    super
+  end
+
+  def test_no_host_middleware_by_default
+    get '/wurk/api/stats'
+
+    assert_equal 200, last_response.status
+  end
+
+  # The acceptance criterion: 401 by default, 200 once the host wires an
+  # authenticated user.
+  def test_use_gates_dashboard_until_authenticated
+    Wurk::Web.use(RequireAuth) { |env| env['HTTP_X_USER'] == 'admin' }
+
+    get '/wurk/api/stats'
+
+    assert_equal 401, last_response.status
+    assert_equal 'Unauthorized', last_response.body
+
+    get '/wurk/api/stats', {}, { 'HTTP_X_USER' => 'admin' }
+
+    assert_equal 200, last_response.status
+  end
+
+  def test_use_is_available_inside_configure_block
+    Wurk::Web.configure do |c|
+      c.use(RequireAuth) { |_env| false }
+    end
+
+    get '/wurk/api/stats'
+
+    assert_equal 401, last_response.status
+  end
+
+  def test_use_passes_args_through_to_middleware
+    Wurk::Web.use(Rack::Auth::Basic, 'Wurk') do |user, pass|
+      user == 'admin' && pass == 's3cret'
+    end
+
+    get '/wurk/api/stats'
+
+    assert_equal 401, last_response.status
+
+    authorize 'admin', 's3cret'
+    get '/wurk/api/stats'
+
+    assert_equal 200, last_response.status
+  end
+
+  def test_multiple_middlewares_chain_outermost_first
+    marks = []
+    Wurk::Web.use(Tag, marks, 'outer')
+    Wurk::Web.use(Tag, marks, 'inner')
+
+    get '/wurk/api/stats'
+
+    assert_equal 200, last_response.status
+    assert_equal %w[outer inner], marks
+  end
+
+  # Host middleware runs before the authorization hook, so the hook can read
+  # state the host middleware set on env.
+  def test_host_middleware_runs_before_authorization_hook
+    Wurk::Web.use(RequireAuth) { |env| env['HTTP_X_USER'] == 'admin' }
+    seen = nil
+    Wurk::Web.configure do |c|
+      c.authorization do |env, _, _|
+        seen = env['HTTP_X_USER']
+        true
+      end
+    end
+
+    get '/wurk/api/stats', {}, { 'HTTP_X_USER' => 'admin' }
+
+    assert_equal 200, last_response.status
+    assert_equal 'admin', seen
+  end
+
+  def test_middlewares_reader_records_registrations
+    Wurk::Web.use(RequireAuth)
+
+    assert_equal 1, Wurk::Web.config.middlewares.length
+    assert_equal RequireAuth, Wurk::Web.config.middlewares.first.first
+  end
+end

--- a/test/qa/dashboard_auth_driver.rb
+++ b/test/qa/dashboard_auth_driver.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# Behavioral driver for #41 — dashboard auth via `Wurk::Web.use`.
+#
+# Boots the dummy Rails app in-process (no server needed), wires a real
+# `Rack::Auth::Basic` guard through the host hook exactly as a prod operator
+# would, then drives the mounted engine to prove:
+#
+#   * unauthenticated request  -> 401 (dashboard never renders)
+#   * wrong credentials        -> 401
+#   * correct credentials      -> 200
+#   * the host middleware runs BEFORE the authorization hook
+#
+# Prints PASS/FAIL per check and exits non-zero on any failure.
+#
+#   ruby test/qa/dashboard_auth_driver.rb
+#
+# Needs a local Redis (the engine's JSON APIs read it). Uses RAILS_ENV=test so
+# the swarm stays disabled — this exercises only the web layer.
+
+ENV['RAILS_ENV'] ||= 'test'
+ENV['WURK_DISABLED'] = '1'
+
+require_relative '../dummy/config/environment'
+require 'rack/test'
+require 'base64'
+
+include Rack::Test::Methods # rubocop:disable Style/MixinUsage
+
+def app = Rails.application
+
+USER = 'ops'
+PASS = 's3cret'
+
+# Exactly what an internal-tool operator drops into config/initializers/wurk.rb.
+Wurk::Web.reset_config!
+Wurk::Web.use(Rack::Auth::Basic, 'Wurk Dashboard') do |user, password|
+  user == USER && password == PASS
+end
+
+# Prove host middleware runs ahead of the per-request authorization hook by
+# recording whether the hook ever saw an authenticated request.
+hook_ran = false
+Wurk::Web.configure do |c|
+  c.authorization do |_env, _method, _path|
+    hook_ran = true
+    true
+  end
+end
+
+$failures = 0
+
+def check(label, expected, actual)
+  ok = expected == actual
+  $failures += 1 unless ok
+  puts "  #{ok ? 'PASS' : 'FAIL'}  #{label} (expected #{expected}, got #{actual})"
+end
+
+def basic(user, pass)
+  "Basic #{Base64.strict_encode64("#{user}:#{pass}")}"
+end
+
+puts '#41 dashboard auth — Wurk::Web.use(Rack::Auth::Basic)'
+
+get '/wurk/api/stats'
+check('no credentials -> 401', 401, last_response.status)
+
+header 'Authorization', basic(USER, 'wrong')
+get '/wurk/api/stats'
+check('wrong password -> 401', 401, last_response.status)
+
+header 'Authorization', basic('intruder', PASS)
+get '/wurk/api/stats'
+check('wrong user -> 401', 401, last_response.status)
+
+header 'Authorization', basic(USER, PASS)
+get '/wurk/api/stats'
+check('correct credentials -> 200', 200, last_response.status)
+check('authorization hook ran only after auth passed', true, hook_ran)
+
+Wurk::Web.reset_config!
+
+if $failures.zero?
+  puts "\nALL PASS"
+  exit 0
+else
+  puts "\n#{$failures} FAILED"
+  exit 1
+end


### PR DESCRIPTION
Closes #41.

The dashboard ships **no session layer of its own** — every prod deploy gates it behind the host app's existing auth. This adds a Sidekiq-compatible `Wurk::Web.use` hook so that takes one line, no custom Rack middleware.

## Scope (from #41)

- [x] Expose `Wurk::Web.use(middleware, *args, &block)` — Sidekiq-compatible API
- [x] Document Devise/Warden/Sorcery integration in `docs/dashboard.md`
- [x] Integration test: dashboard 401s by default, 200 once host wires an authenticated user

## What changed

- **`lib/wurk/web/config.rb`** — `Config#use` + `#middlewares` reader, class-level `Wurk::Web.use(...)`, and a new `Wurk::Web::MiddlewareStack` Rack middleware that applies the host-registered chain. Built once on first request and memoized per-`Config` (so `reset_config!` rebuilds cleanly in tests; prod builds exactly once at boot).
- **`lib/wurk/engine.rb`** — `MiddlewareStack` inserted into the engine stack **ahead of** `Authorization`, so host auth runs first and its `env` (e.g. `env['warden']`) is visible to the `authorization` hook. Engine-scoped: host controllers are untouched.
- **`lib/wurk/compat.rb`** — `Sidekiq::Web = Wurk::Web` alias, so existing Sidekiq initializers (`Sidekiq::Web.use(...)`) keep working on the gem swap.
- **`docs/dashboard.md`** — Devise/Warden, Sorcery, plain HTTP Basic, the per-request role hook, and read-only mode.
- **`test/engine/web_middleware_test.rb`** — 7 integration tests through the mounted engine.

The hook composes with the existing `Wurk::Web.configure { |c| c.authorization { … } }` role hook — middleware runs outermost, the hook reads the `env` it set.

## Wire-compat / Never-list

No Redis key, JSON field, or score touched. Pure additive web-layer change. `Sidekiq::Web` alias added (drop-in contract), nothing removed.

## Tests

- `bin/rake test` → 1633 runs, 0 failures (2 pre-existing skips)
- `bin/rake test:parity` → 20, 0 failures
- `bin/rake test:ecosystem` → all suites passed
- rubocop clean on touched files

## How to test in prod

Drop this in `config/initializers/wurk.rb` and restart:

```ruby
# Plain HTTP Basic — simplest gate, no host-app coupling:
Wurk::Web.use(Rack::Auth::Basic, "Wurk") do |user, password|
  ActiveSupport::SecurityUtils.secure_compare(user, ENV["WURK_USER"]) &
    ActiveSupport::SecurityUtils.secure_compare(password, ENV["WURK_PASS"])
end
```

Then:

```bash
curl -i https://yourapp.com/wurk/api/stats                 # => 401 Unauthorized
curl -i -u "$WURK_USER:$WURK_PASS" https://yourapp.com/wurk/api/stats   # => 200
```

For Devise/Warden or Sorcery, see `docs/dashboard.md`. Or run the behavioral driver locally (boots the dummy app in-process, real `Rack::Auth::Basic`, prints PASS/FAIL):

```bash
ruby test/qa/dashboard_auth_driver.rb
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host-app Rack middleware support to let apps insert authentication/filters around the dashboard
  * Per-request authorization hook that returns proper 403 responses
  * Read-only mode (env or config) that blocks non-GET requests

* **Documentation**
  * Detailed dashboard security guide with examples for Devise/Warden, Sorcery, and HTTP Basic auth

* **Tests**
  * New integration tests and QA driver exercising middleware and auth wiring
<!-- end of auto-generated comment: release notes by coderabbit.ai -->