### PR TITLE
feat: self-healing demo workload generator (closes #33) + capsule middleware fix (closes #69)

### DIFF
--- a/lib/wurk/capsule.rb
+++ b/lib/wurk/capsule.rb
@@ -72,13 +72,16 @@ module Wurk
     end
 
     def client_middleware
-      chain = (@client_chain ||= @config.client_middleware.dup)
+      chain = (@client_chain ||= @config.client_middleware.copy_for(self))
       yield chain if block_given?
       chain
     end
 
     def server_middleware
-      chain = (@server_chain ||= @config.server_middleware.dup)
+      # copy_for(self) — not dup — binds the chain's `@config` to this capsule,
+      # so middleware that reach for `redis_pool`/`redis`/`logger` resolve them
+      # instead of hitting `nil` (a plain dup leaves @config nil).
+      chain = (@server_chain ||= @config.server_middleware.copy_for(self))
       yield chain if block_given?
       chain
     end

--- a/test/dummy/app/jobs/demo/batch_callback.rb
+++ b/test/dummy/app/jobs/demo/batch_callback.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Demo
+  # Batch callback target. Wurk invokes `new.on_<event>(status, options)` when a
+  # batch reaches the registered event (see Wurk::Batch::CallbackJob), so the
+  # Batches widget shows batches that actually fired success/complete callbacks.
+  class BatchCallback
+    def on_success(_status, _options); end
+
+    def on_complete(_status, _options); end
+  end
+end

--- a/test/dummy/app/jobs/demo/batch_child_job.rb
+++ b/test/dummy/app/jobs/demo/batch_child_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Demo
+  # A member of a demo batch. Mostly succeeds; a small slice dies (retry: 0) so
+  # the batch's failure count and the :death callback get exercised too.
+  class BatchChildJob
+    include Wurk::Job
+
+    sidekiq_options retry: 0
+
+    def perform(*)
+      sleep(rand * 0.01)
+      raise 'batch child failed' if rand < 0.1
+    end
+  end
+end

--- a/test/dummy/app/jobs/demo/fast_job.rb
+++ b/test/dummy/app/jobs/demo/fast_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Demo
+  # The bulk of demo throughput: tiny work that almost always succeeds, spread
+  # across queues so the Queues widget and the throughput chart show signal.
+  class FastJob
+    include Wurk::Job
+
+    def perform(*)
+      sleep(rand * 0.02)
+    end
+  end
+end

--- a/test/dummy/app/jobs/demo/flaky_job.rb
+++ b/test/dummy/app/jobs/demo/flaky_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Demo
+  # Fails about half the time, then recovers on a short backoff — keeps the
+  # Retries widget and the failure-rate chart populated without jobs lingering
+  # for the default exponential backoff (which would take minutes to show).
+  class FlakyJob
+    include Wurk::Job
+
+    sidekiq_options retry: 5
+
+    # 1s, 2s, 3s… so a retry is visible in the dashboard but clears quickly.
+    sidekiq_retry_in { |count, _ex| count + 1 }
+
+    def perform(*)
+      raise 'flaky: transient failure' if rand < 0.5
+    end
+  end
+end

--- a/test/dummy/app/jobs/demo/poison_job.rb
+++ b/test/dummy/app/jobs/demo/poison_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Demo
+  # Always fails with no retries, so it lands in the Dead set on the first
+  # attempt — gives the Dead widget signal within seconds of cold start.
+  class PoisonJob
+    include Wurk::Job
+
+    sidekiq_options retry: 0
+
+    def perform(*)
+      raise 'poison: permanent failure'
+    end
+  end
+end

--- a/test/dummy/app/jobs/demo/rate_limited_job.rb
+++ b/test/dummy/app/jobs/demo/rate_limited_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Demo
+  # Runs its work through a bucket limiter so the Limiters widget shows live
+  # usage. OverLimit is swallowed here (the demo just wants the counters to
+  # move); in real code the limiter server middleware reschedules instead.
+  class RateLimitedJob
+    include Wurk::Job
+
+    def perform(*)
+      Demo::Workload.email_limiter.within_limit { sleep(rand * 0.01) }
+    rescue Wurk::Limiter::OverLimit
+      # Expected under load — the bucket is intentionally small.
+    end
+  end
+end

--- a/test/dummy/app/jobs/demo/report_job.rb
+++ b/test/dummy/app/jobs/demo/report_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Demo
+  # Target of the demo cron loops — firing it from the leader keeps the
+  # Cron/Periodic widget's "last fired" column moving.
+  class ReportJob
+    include Wurk::Job
+
+    def perform(*)
+      sleep(rand * 0.01)
+    end
+  end
+end

--- a/test/dummy/app/workloads/demo/workload.rb
+++ b/test/dummy/app/workloads/demo/workload.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+module Demo
+  # Generates realistic, self-healing demo traffic so every dashboard widget
+  # shows non-trivial values within ~30s of a cold start (issue #33).
+  #
+  # It's a feedback controller, not a fire-hose: each `tick!` tops the primary
+  # queue back up to a target backlog (so throughput stays steady as the worker
+  # drains it) and keeps the scheduled/retry/dead/batch/limiter/cron surfaces in
+  # a band. `ensure_seeded!` runs every tick, so a Redis flush or app restart
+  # self-heals within one interval — cron loops and limiters are re-registered
+  # and the queues refill on their own.
+  #
+  # Run it as its own process (fork-safe — no swarm here):
+  #   cd test/dummy && WURK_DEMO=1 bin/rails demo:workload
+  # The worker process drains what this enqueues.
+  class Workload
+    PRIMARY_QUEUE    = 'default'
+    SECONDARY_QUEUES = %w[high low].freeze
+    TARGET_BACKLOG   = 60   # primary-queue depth the controller maintains
+    SECONDARY_DEPTH  = 6    # keep high/low shallow but non-empty for the widget
+    SCHEDULED_TARGET = 20
+    RETRY_TARGET     = 12
+    DEAD_TARGET      = 25
+    BATCH_INTERVAL   = 12.0 # seconds between new demo batches
+    MAX_PER_TICK     = 200  # cap a single top-up so a flush doesn't spike
+
+    class << self
+      # Building a limiter registers it into `lmtr-list` (register: true by
+      # default), which is what makes it show up in the Limiters widget. The
+      # accessors memoize a handle for repeated use (e.g. Demo::RateLimitedJob
+      # in the worker); `build_*` constructs a fresh one so `ensure_seeded!` can
+      # re-register after a Redis flush. All handles point at the same
+      # Redis-backed limiter, keyed by name.
+      def email_limiter = @email_limiter ||= build_email_limiter
+      def api_limiter   = @api_limiter ||= build_api_limiter
+
+      def build_email_limiter = Wurk::Limiter.bucket('demo-emails', 60, :minute, wait_timeout: 0)
+      def build_api_limiter   = Wurk::Limiter.concurrent('demo-api', 5)
+    end
+
+    def initialize(logger: nil, interval: 1.0)
+      @logger = logger
+      @interval = interval
+      @stop = false
+      @last_batch_at = 0.0
+    end
+
+    def run
+      install_signal_traps
+      log "starting — backlog target #{TARGET_BACKLOG} on #{PRIMARY_QUEUE}, " \
+          "#{SECONDARY_QUEUES.join('/')} kept shallow"
+      until @stop
+        begin
+          tick!
+        rescue StandardError => e
+          log "tick error (continuing): #{e.class}: #{e.message}"
+        end
+        sleep @interval unless @stop
+      end
+      log 'stopped'
+    end
+
+    def stop
+      @stop = true
+    end
+
+    # One control step. Public and side-effect-explicit so a test can run it
+    # once and assert on the dashboard data it produced.
+    def tick!
+      ensure_seeded!
+      top_up_primary
+      top_up_secondary
+      top_up_scheduled
+      top_up_retries
+      top_up_dead
+      enqueue_rate_limited
+      roll_batch
+    end
+
+    # Idempotent (re)registration of cron loops + limiters. Cheap, run every
+    # tick, so the demo recovers within one interval of a Redis flush.
+    def ensure_seeded!
+      Wurk::Cron.register('demo report (minutely)', '* * * * *', 'Demo::ReportJob', [], queue: 'low')
+      Wurk::Cron.register('demo sweep (hourly)', '0 * * * *', 'Demo::ReportJob', [], queue: 'default')
+      self.class.build_email_limiter
+      self.class.build_api_limiter
+    end
+
+    private
+
+    def top_up_primary
+      deficit = TARGET_BACKLOG - Wurk::Queue.new(PRIMARY_QUEUE).size
+      return if deficit <= 0
+
+      enqueue_fast(PRIMARY_QUEUE, [deficit, MAX_PER_TICK].min)
+    end
+
+    def top_up_secondary
+      SECONDARY_QUEUES.each do |queue|
+        deficit = SECONDARY_DEPTH - Wurk::Queue.new(queue).size
+        enqueue_fast(queue, deficit) if deficit.positive?
+      end
+    end
+
+    def top_up_scheduled
+      deficit = SCHEDULED_TARGET - Wurk::ScheduledSet.new.size
+      return if deficit <= 0
+
+      [deficit, 5].min.times { Demo::FastJob.perform_in(rand(30..600)) }
+    end
+
+    def top_up_retries
+      return if Wurk::RetrySet.new.size >= RETRY_TARGET
+
+      3.times { Demo::FlakyJob.perform_async }
+    end
+
+    def top_up_dead
+      return if Wurk::DeadSet.new.size >= DEAD_TARGET
+
+      Demo::PoisonJob.perform_async
+    end
+
+    def enqueue_rate_limited
+      Demo::RateLimitedJob.perform_async
+    end
+
+    def roll_batch
+      now = monotonic
+      return if now - @last_batch_at < BATCH_INTERVAL
+
+      @last_batch_at = now
+      batch = Wurk::Batch.new
+      batch.description = "Demo export #{Time.now.strftime('%H:%M:%S')}"
+      batch.on(:success, 'Demo::BatchCallback')
+      batch.on(:complete, 'Demo::BatchCallback')
+      batch.jobs { rand(5..12).times { Demo::BatchChildJob.perform_async } }
+    end
+
+    def enqueue_fast(queue, count)
+      Demo::FastJob.set(queue: queue).perform_bulk(Array.new(count) { [] })
+    end
+
+    def monotonic
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    def install_signal_traps
+      %w[INT TERM].each { |sig| trap(sig) { stop } }
+    end
+
+    def log(message)
+      @logger&.info("[demo] #{message}")
+    end
+  end
+end

--- a/test/dummy/config/initializers/demo_workload.rb
+++ b/test/dummy/config/initializers/demo_workload.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Auto-start the demo workload generator in a background thread when WURK_DEMO=1.
+#
+# Gated to a non-forking process (WURK_DISABLED=1 — e.g. the web/dashboard
+# process): the generator holds a Redis connection, and a swarm fork must never
+# inherit a live socket (CLAUDE.md boot order). The worker swarm runs as its own
+# process and drains the traffic. For a dedicated process, use `rails demo:workload`.
+if ENV['WURK_DEMO'] == '1'
+  # Worker side: record per-job history so the dashboard's throughput/failures
+  # charts have data (the History middleware is opt-in). configure_server only
+  # fires in a worker/server process, so it's a no-op in the web process.
+  Wurk.configure_server do |config|
+    config.server_middleware.add(Wurk::Metrics::History)
+  end
+
+  # Web side (non-forking process — WURK_DISABLED=1): drive the traffic
+  # generator in a background thread. Gated off the swarm so the generator's
+  # Redis connection can never be inherited across a fork (CLAUDE.md boot order).
+  if ENV['WURK_DISABLED'] == '1' && !Rails.env.test?
+    Rails.application.config.after_initialize do
+      Thread.new do
+        Thread.current.name = 'demo-workload'
+        Demo::Workload.new(logger: Rails.logger).run
+      rescue StandardError => e
+        Rails.logger.error("[demo] workload thread crashed: #{e.class}: #{e.message}")
+      end
+    end
+  end
+end

--- a/test/dummy/lib/tasks/demo.rake
+++ b/test/dummy/lib/tasks/demo.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :demo do
+  desc 'Run the self-healing demo workload generator in the foreground (Ctrl-C to stop)'
+  task workload: :environment do
+    logger = Logger.new($stdout)
+    logger.formatter = ->(_severity, time, _progname, msg) { "#{time.strftime('%H:%M:%S')} #{msg}\n" }
+    Demo::Workload.new(logger: logger).run
+  end
+end

--- a/test/qa/demo_workload_driver.rb
+++ b/test/qa/demo_workload_driver.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+# Behavioral driver for #33 — the demo workload generator.
+#
+# Boots a REAL in-process Wurk worker (embedded mode: full middleware chain,
+# scheduled + cron pollers, metrics rollup) on an isolated Redis DB, runs the
+# Demo::Workload generator, and polls every dashboard surface until each shows
+# non-trivial values — proving the issue's "Done when": every widget has signal
+# within ~30s of a cold start. Prints PASS/FAIL and cleans up.
+#
+#   ruby test/qa/demo_workload_driver.rb
+#
+# Needs a local Redis (uses DB 15 so it never touches your real data).
+
+require 'pathname'
+ROOT = Pathname.new(__dir__).join('..', '..').expand_path
+$LOAD_PATH.unshift(ROOT.join('lib').to_s)
+require 'wurk'
+require 'logger'
+
+DEMO_APP = ROOT.join('test', 'dummy', 'app')
+Dir[DEMO_APP.join('jobs', 'demo', '*.rb').to_s].each { |f| require f }
+require DEMO_APP.join('workloads', 'demo', 'workload.rb').to_s
+
+URL = ENV.fetch('REDIS_URL', 'redis://localhost:6379/0').sub(%r{/\d+\z}, '/15')
+DEADLINE = Integer(ENV.fetch('WURK_DEMO_DEADLINE', '30')) # seconds
+
+# --- isolated config + worker ------------------------------------------------
+config = Wurk.configuration
+config.logger = Logger.new(IO::NULL)
+config.redis = { url: URL }
+config.queues = %w[default high low]
+config.concurrency = 5
+config[:cron_tick_interval]       = 0.5 # fire cron promptly within the window
+config[:scheduled_poll_interval]  = 0.5 # promote retries quickly
+config[:leader_ttl]               = 3
+config[:leader_renew_interval]    = 0.5
+config[:leader_follower_interval] = 0.5
+
+Wurk.redis { |c| c.call('FLUSHDB') }
+
+# Record per-job history so the throughput/failures charts have data (the
+# History middleware is opt-in; the demo turns it on — see the demo initializer).
+config.server_middleware.add(Wurk::Metrics::History)
+
+worker = Wurk.configure_embed { |c| c.concurrency = 5 }
+worker.run
+
+workload = Demo::Workload.new
+generator = Thread.new do
+  loop do
+    workload.tick!
+    sleep 0.4
+  rescue StandardError
+    sleep 0.4
+  end
+end
+
+# --- widget probes -----------------------------------------------------------
+def scan?(match)
+  cursor = '0'
+  loop do
+    cursor, keys = Wurk.redis { |c| c.call('SCAN', cursor, 'MATCH', match, 'COUNT', 200) }
+    return true unless keys.empty?
+    break if cursor == '0'
+  end
+  false
+end
+
+PROBES = {
+  'Dashboard: processed > 0' => -> { Wurk::Stats.new.processed.to_i.positive? },
+  'Dashboard: failed > 0' => -> { Wurk::Stats.new.failed.to_i.positive? },
+  'Queues: jobs enqueued' => -> { %w[default high low].sum { |q| Wurk::Queue.new(q).size }.positive? },
+  'Queues: >1 queue active' => -> { %w[default high low].count { |q| Wurk::Queue.new(q).size.positive? } > 1 },
+  'Scheduled: non-empty' => -> { Wurk::ScheduledSet.new.size.positive? },
+  'Retries: non-empty' => -> { Wurk::RetrySet.new.size.positive? },
+  'Dead: non-empty' => -> { Wurk::DeadSet.new.size.positive? },
+  'Batches: non-empty' => -> { Wurk::BatchSet.new.size.positive? },
+  'Limiters: demo-emails' => -> { Wurk.redis { |c| c.call('SISMEMBER', 'lmtr-list', 'demo-emails') } == 1 },
+  'Limiters: demo-api' => -> { Wurk.redis { |c| c.call('SISMEMBER', 'lmtr-list', 'demo-api') } == 1 },
+  'Cron: loops registered' => -> { Wurk::Cron::LoopSet.new.to_a.size >= 2 },
+  'Metrics: per-class buckets' => -> { scan?('j|*') }
+}.freeze
+
+results = {}
+started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+loop do
+  PROBES.each do |label, probe|
+    results[label] ||= begin
+      (probe.call ? true : nil)
+    rescue StandardError
+      nil
+    end
+  end
+  elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+  break if (results.size == PROBES.size && results.values.all?) || elapsed > DEADLINE
+
+  sleep 0.5
+end
+elapsed = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started).round(1)
+
+# Best-effort signals that depend on a clock boundary within the window.
+info = {
+  'Cron: fired at least once' => -> { Wurk::Cron::LoopSet.new.to_a.any?(&:last_fired_at) },
+  'Throughput chart (jr| rollup buckets)' => -> { scan?('jr|*') }
+}
+
+# --- teardown ----------------------------------------------------------------
+generator.kill
+worker.stop
+
+# --- report ------------------------------------------------------------------
+puts "\n#33 demo workload — every dashboard widget within #{DEADLINE}s (took #{elapsed}s)\n\n"
+failures = 0
+PROBES.each_key do |label|
+  ok = results[label]
+  failures += 1 unless ok
+  puts "  #{ok ? '✅ PASS' : '❌ FAIL'}  #{label}"
+end
+puts "\n  (informational — depend on a minute boundary in-window)"
+info.each { |label, probe| puts "  #{probe.call ? '•' : '◦'}  #{label}" }
+
+Wurk.redis { |c| c.call('FLUSHDB') }
+
+if failures.zero?
+  puts "\nALL PASS — demo is dashboard-ready."
+  exit 0
+else
+  puts "\n#{failures} FAILED"
+  exit 1
+end

--- a/test/unit/capsule_test.rb
+++ b/test/unit/capsule_test.rb
@@ -19,6 +19,33 @@ class CapsuleTest < Wurk::Test::UnitCase
     super
   end
 
+  # --- middleware binding (#69) ------------------------------------------
+
+  # The capsule must bind its chains via copy_for(self), not a bare dup, so
+  # middleware resolve config.redis_pool/redis/logger instead of hitting nil.
+  ProbeMiddleware = Class.new do
+    include Wurk::Middleware::ServerMiddleware
+
+    def call(*) = yield
+  end
+
+  def test_server_middleware_instances_are_bound_to_the_capsule
+    @config.server_middleware.add(ProbeMiddleware)
+
+    instance = @capsule.server_middleware.retrieve.find { |m| m.is_a?(ProbeMiddleware) }
+
+    refute_nil instance.config, 'server middleware config must not be nil'
+    assert_same @capsule, instance.config
+  end
+
+  def test_client_middleware_instances_are_bound_to_the_capsule
+    @config.client_middleware.add(ProbeMiddleware)
+
+    instance = @capsule.client_middleware.retrieve.find { |m| m.is_a?(ProbeMiddleware) }
+
+    assert_same @capsule, instance.config
+  end
+
   # --- defaults ----------------------------------------------------------
 
   def test_default_name_is_string

--- a/test/unit/demo_workload_test.rb
+++ b/test/unit/demo_workload_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Load the demo workload generator + its jobs straight from the dummy app
+# (no Rails boot needed — they only depend on Wurk).
+DEMO_APP = File.expand_path('../dummy/app', __dir__)
+Dir[File.join(DEMO_APP, 'jobs/demo/*.rb')].each { |f| require f }
+require File.join(DEMO_APP, 'workloads/demo/workload.rb')
+
+# Exercises the enqueue/seed side of the demo workload generator (#33) against an
+# isolated Redis DB: one `tick!` must light up every dashboard surface that is
+# observable without a running worker — queues, scheduled, batches, limiters,
+# cron — and the generator must be idempotent and self-heal after a flush. The
+# retry/dead/throughput surfaces need a real worker and are covered by
+# test/qa/demo_workload_driver.rb.
+class DemoWorkloadTest < Wurk::Test::UnitCase
+  DB = ENV.fetch('WURK_DEMO_TEST_DB', '15')
+
+  def setup
+    super
+    url = ENV.fetch('REDIS_URL', 'redis://localhost:6379/0').sub(%r{/\d+\z}, "/#{DB}")
+    @prev_config = Wurk.configuration
+    cfg = Wurk::Configuration.new
+    cfg.logger = Logger.new(IO::NULL)
+    cfg.redis = { url: url }
+    Wurk.instance_variable_set(:@configuration, cfg)
+    Wurk.redis { |c| c.call('FLUSHDB') }
+    @workload = Demo::Workload.new
+  end
+
+  def teardown
+    Wurk.redis { |c| c.call('FLUSHDB') }
+    Wurk.instance_variable_set(:@configuration, @prev_config)
+    super
+  end
+
+  def test_one_tick_fills_the_primary_and_secondary_queues
+    @workload.tick!
+
+    assert_operator Wurk::Queue.new('default').size, :>, 0
+    assert_operator(%w[high low].sum { |q| Wurk::Queue.new(q).size }, :>, 0)
+  end
+
+  def test_one_tick_schedules_future_jobs
+    @workload.tick!
+
+    assert_operator Wurk::ScheduledSet.new.size, :>, 0
+  end
+
+  def test_one_tick_creates_a_batch
+    @workload.tick!
+
+    assert_operator Wurk::BatchSet.new.size, :>, 0
+  end
+
+  def test_seeding_registers_both_limiters
+    @workload.ensure_seeded!
+
+    names = Wurk.redis { |c| c.call('SMEMBERS', 'lmtr-list') }
+
+    assert_includes names, 'demo-emails'
+    assert_includes names, 'demo-api'
+  end
+
+  def test_seeding_registers_cron_loops
+    @workload.ensure_seeded!
+
+    assert_operator Wurk::Cron::LoopSet.new.to_a.size, :>=, 2
+  end
+
+  def test_seeding_is_idempotent
+    5.times { @workload.ensure_seeded! }
+
+    # Deterministic lids + name-keyed limiters → no duplicates on re-seed.
+    assert_equal 2, Wurk::Cron::LoopSet.new.to_a.size
+    assert_equal(2, Wurk.redis { |c| c.call('SCARD', 'lmtr-list') })
+  end
+
+  def test_self_heals_after_a_redis_flush
+    @workload.tick!
+    Wurk.redis { |c| c.call('FLUSHDB') }
+
+    @workload.tick!
+
+    assert_operator Wurk::Queue.new('default').size, :>, 0
+    assert_includes Wurk.redis { |c| c.call('SMEMBERS', 'lmtr-list') }, 'demo-emails'
+  end
+end

--- a/test/unit/demo_workload_test.rb
+++ b/test/unit/demo_workload_test.rb
@@ -15,6 +15,15 @@ require File.join(DEMO_APP, 'workloads/demo/workload.rb')
 # retry/dead/throughput surfaces need a real worker and are covered by
 # test/qa/demo_workload_driver.rb.
 class DemoWorkloadTest < Wurk::Test::UnitCase
+  # Isolation here is by dedicated Redis DB, NOT by the per-test key namespace
+  # the rest of the suite uses. The generator and the Stats/Queue/Set classes it
+  # drives write fixed *global* keys (`queue:default`, `schedule`, `dead`,
+  # `lmtr-list`, the periodic set, …) that can't be prefixed, and the
+  # RedisNamespace helper is still a stub. So this class points the global config
+  # at its own DB (override with WURK_DEMO_TEST_DB) and FLUSHDB's it — no other
+  # suite test touches DB 15. For that reason it does NOT call `parallelize_me!`:
+  # FLUSHDB-based isolation is only safe with the tests run sequentially, which
+  # the per-class fork runner already guarantees.
   DB = ENV.fetch('WURK_DEMO_TEST_DB', '15')
 
   def setup


### PR DESCRIPTION
Closes #33. Also fixes a latent core bug it surfaced — #69.

The demo only sells if the dashboard actually moves. This adds a self-healing traffic generator so **every dashboard widget shows non-trivial values within ~30s of a cold start**.

## Scope (from #33)

- [x] Jobs exercising each feature: plain async, perform_in/at, a batch with callbacks, a periodic cron, a rate-limited job, fails+retries, ends-up-dead
- [x] A controller that maintains target throughput so charts always have signal
- [x] Self-resets if Redis is flushed or the app restarts
- [x] **Done when:** demo shows non-trivial values for every widget within 30s of cold start — the QA driver hits **12/12 widgets in ~10s**

## What's here

- **7 demo jobs** (`test/dummy/app/jobs/demo/`): `FastJob` (throughput), `FlakyJob` (retries, short backoff), `PoisonJob` (`retry: 0` → dead), `RateLimitedJob` (bucket limiter), `ReportJob` (cron target), `BatchChildJob` + `BatchCallback`.
- **`Demo::Workload`** (`test/dummy/app/workloads/demo/`): a feedback controller — each `tick!` tops the primary queue back to a target backlog (steady throughput as the worker drains), keeps scheduled/retry/dead/batch/limiter/cron in a band, and re-seeds every tick so a Redis flush or restart self-heals within one interval.
- **Two entry points**: `cd test/dummy && WURK_DEMO=1 bin/rails demo:workload` (dedicated foreground process) and a `WURK_DEMO=1` initializer that auto-starts it in a **fork-safe** (non-swarm) process and enables the `Metrics::History` middleware so the charts have data.
- **Tests**: unit tests for the enqueue/seed surfaces + idempotency + self-heal-after-flush; a QA driver that boots a real embedded worker and asserts all 12 widgets.

## The core bug this surfaced (#69) — first commit

The throughput/failures **charts never populated**. Root cause: `Wurk::Capsule` bound its middleware chains with a bare `.dup` instead of the purpose-built `copy_for(self)`, leaving the chain's `@config` **nil** — so *every* server middleware that reaches for `redis_pool`/`redis`/`logger` raised `NoMethodError` on nil, swallowed best-effort by the metrics recorder. Latent because no *default* middleware touches Redis, and `Metrics::History` was only ever tested via `.record`, never through a live chain. One-line fix + a capsule regression test. Kept as a **separate first commit** (`307f6f0`).

## Fork-safety note

The generator holds a Redis connection, so it must never run in a process about to fork the swarm (CLAUDE.md boot order). The initializer is gated to a non-forking process (`WURK_DISABLED=1`); the worker swarm runs separately and drains the traffic.

## Tests / verification

- `bin/rake test` → **1642 runs, 0 failures** · `test:parity` → 20 · `test:ecosystem` → all passed · rubocop clean
- `ruby test/qa/demo_workload_driver.rb` → **12/12 PASS in ~10s** (boots a real worker, checks every widget)

## Caveat

Two widgets depend on a **minute boundary** passing — cron firing (minutely schedules) and the cluster throughput **chart** (`jr|` rollup buckets, folded per minute). A 10s run doesn't hit them; they fill within ~1 minute. All per-class metric data (the chart's source) is present immediately. The QA driver marks these two as informational, not failures.

## How to test in prod

Run the worker and the generator as two processes against the demo Redis:

```bash
# worker (drains the demo queues; loads the demo job classes via the app)
cd test/dummy && bin/rails runner 'Wurk::Embedded' &   # or your exe/wurk worker

# generator
cd test/dummy && WURK_DEMO=1 bin/rails demo:workload
```

Open the dashboard — Dashboard/Queues/Retries/Scheduled/Dead/Batches/Limiters/Cron fill within seconds; the throughput chart fills within ~1 minute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed middleware chain binding so middleware can reliably access configured Redis, pools, and logging when run in a capsule.

* **New Features**
  * Added a demo workload generator, demo jobs (fast, flaky, poison, batch, rate‑limited, report) and a rake task to run it.
  * Optional initializer to auto-start the demo workload and a QA driver script for readiness checks.

* **Tests**
  * Added unit and QA tests validating middleware binding and the demo workload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->