### PR TITLE
docs: polish README for RubyGems landing + CONTRIBUTING/SECURITY/templates (closes #30)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: Bug report
+description: Something in Wurk doesn't work as expected (or differs from Sidekiq).
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. For security vulnerabilities, use the
+        [private advisory form](https://github.com/developerz-ai/wurk/security/advisories/new)
+        instead of a public issue.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you observe, and what did you expect instead?
+      placeholder: Enqueuing X with Wurk did Y; with Sidekiq it does Z.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: A minimal job class + the calls that trigger it, ideally runnable.
+      render: ruby
+    validations:
+      required: true
+  - type: input
+    id: wurk-version
+    attributes:
+      label: Wurk version
+      placeholder: "1.0.0"
+    validations:
+      required: true
+  - type: input
+    id: ruby-redis
+    attributes:
+      label: Ruby / Redis / Rails versions
+      placeholder: "ruby 3.4.1, redis 7.4, rails 8.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: drop-in
+    attributes:
+      label: Is this a drop-in compatibility difference from Sidekiq?
+      description: i.e. the same code behaves differently on Sidekiq vs Wurk.
+      options:
+        - "No / not sure"
+        - "Yes — Sidekiq does it differently"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/developerz-ai/wurk/security/advisories/new
+    about: Report security issues privately, not as a public issue.
+  - name: Question or discussion
+    url: https://github.com/developerz-ai/wurk/discussions
+    about: Usage questions, ideas, and general discussion.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,29 @@
+name: Feature request
+description: Suggest a capability or a Sidekiq surface Wurk should cover.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: The use case, not just the feature. What can't you do today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: API sketch, behavior, or the Sidekiq feature it should match.
+    validations:
+      required: true
+  - type: input
+    id: sidekiq-parity
+    attributes:
+      label: Sidekiq parity reference (if any)
+      description: Link or section in docs/target/sidekiq-{free,pro,ent}.md this maps to.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!-- Thanks for contributing to Wurk! Keep PRs focused. -->
+
+## What & why
+
+<!-- What does this change, and what problem does it solve? Link the issue: Closes #123 -->
+
+## Checklist
+
+- [ ] Tests added/updated at the right layer (unit · engine · integration · parity)
+- [ ] `bin/rake test`, `bin/rake test:parity`, and `bundle exec rubocop` pass locally
+- [ ] No Redis key, JSON field, or sorted-set score format changed (wire-compat is sacred)
+- [ ] Public Sidekiq surface still matches `docs/target/sidekiq-{free,pro,ent}.md`
+- [ ] Coverage on `lib/` stays ≥ 90%
+
+## How to test in prod
+
+<!-- Copy-paste operator commands a maintainer can run to verify this in a real deploy. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to Wurk
+
+Thanks for helping make Wurk better. This guide covers local setup, the test
+layers, and the conventions a change has to follow to merge.
+
+## Setup
+
+```sh
+git clone https://github.com/developerz-ai/wurk
+cd wurk
+bundle install
+```
+
+You'll need a local **Redis ≥ 7.0** running (tests use real Redis, never a mock).
+Node is only needed if you touch the dashboard frontend (`frontend/`); the
+precompiled bundle is committed under `vendor/assets/`.
+
+## Running the tests
+
+| Task | Command |
+|---|---|
+| Full suite (parallel) | `bin/rake test` |
+| A single file | `bin/rake test TEST=test/path/to/file_test.rb` |
+| A single test by name | `bin/rake test TEST=test/foo_test.rb TESTOPTS="--name=/pattern/"` |
+| Parity suite (oracles lifted from Sidekiq) | `bin/rake test:parity` |
+| Ecosystem compatibility | `bin/rake test:ecosystem` |
+| Coverage gate | `COVERAGE=1 bin/rake test` |
+| Benchmarks | `bin/rake bench` |
+| Lint | `bundle exec rubocop` |
+
+Test layers:
+
+- **unit** — plain Ruby classes in isolation.
+- **engine** — boots the dummy Rails app in `test/dummy/`.
+- **integration** — real forks + real Redis.
+- **parity** (`test/parity/`) — tests lifted from upstream Sidekiq, SHA-pinned.
+  These are **oracles**: if Wurk diverges, Wurk is wrong unless the divergence
+  is explicitly documented as intentional.
+- **ecosystem** — third-party Sidekiq gem suites run against Wurk.
+
+Never mock Redis in integration or parity tests. Each test uses a unique Redis
+key namespace so the parallel runner stays safe.
+
+## Conventions
+
+These are non-negotiable — they're what keep Wurk a true drop-in:
+
+- **Wire-compat is sacred.** Never change a Redis key, JSON field, or
+  sorted-set score format. If an optimization would break compatibility, drop
+  the optimization.
+- **SOLID, especially SRP.** One reason to change per class — Manager owns
+  lifecycle, Fetcher owns the Redis pop, Processor owns middleware + perform,
+  Client owns enqueue.
+- **Match the spec.** Any public Sidekiq surface must match
+  `docs/target/sidekiq-{free,pro,ent}.md` exactly.
+- **Frozen string literals everywhere**; per-fork Redis pools (never share a
+  socket across a fork).
+- **Comments explain non-obvious _why_**, never restate the code.
+- **Coverage**: line coverage on `lib/` must stay ≥ 90% (the gate blocks PRs
+  below it). Branch coverage is tracked and ratcheting toward 90%.
+
+## Pull requests
+
+1. Branch off `main`.
+2. Keep the change focused; add tests at the right layer.
+3. Run `bin/rake test`, `test:parity`, `test:ecosystem`, and `rubocop` locally.
+4. Open the PR — CI runs the matrix (Ruby 3.2/3.3/3.4 × Rails 7.2/8.0), the
+   coverage gate, the parity job, and benchmarks. The bench bot comments
+   per-benchmark deltas; a real regression fails the check.
+5. Don't `--no-verify` past a failing hook — fix the hook.
+
+By contributing you agree your work is licensed under the project's
+[MIT License](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ These are non-negotiable — they're what keep Wurk a true drop-in:
 
 1. Branch off `main`.
 2. Keep the change focused; add tests at the right layer.
-3. Run `bin/rake test`, `test:parity`, `test:ecosystem`, and `rubocop` locally.
+3. Run `bin/rake test`, `bin/rake test:parity`, `bin/rake test:ecosystem`, and `bundle exec rubocop` locally.
 4. Open the PR — CI runs the matrix (Ruby 3.2/3.3/3.4 × Rails 7.2/8.0), the
    coverage gate, the parity job, and benchmarks. The bench bot comments
    per-benchmark deltas; a real regression fails the check.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Gem Version](https://img.shields.io/gem/v/wurk.svg)](https://rubygems.org/gems/wurk)
 [![CI](https://github.com/developerz-ai/wurk/actions/workflows/test.yml/badge.svg)](https://github.com/developerz-ai/wurk/actions/workflows/test.yml)
-[![Coverage](https://img.shields.io/badge/coverage-line%20%E2%89%A590%25-brightgreen.svg)](https://github.com/developerz-ai/wurk/actions/workflows/test.yml)
+[![Coverage gate](https://img.shields.io/badge/coverage%20gate-line%20%E2%89%A590%25-brightgreen.svg)](https://github.com/developerz-ai/wurk/actions/workflows/test.yml)
 [![Ruby](https://img.shields.io/badge/ruby-%E2%89%A5%203.2-CC342D.svg)](https://www.ruby-lang.org)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
@@ -126,7 +126,7 @@ Knobs: `health_check(port:, bind: "0.0.0.0", ready_window: 30)`. In swarm mode o
 + gem "wurk"
 ```
 
-`bundle install && restart`. Wurk reads and writes the same Redis schema, so a rolling deploy can run Sidekiq and Wurk against the same Redis during the cutover. Third-party gems (sidekiq-cron, sidekiq-unique-jobs, sidekiq-scheduler, sidekiq-status, sidekiq-failures, sidekiq-throttled, …) pass their own suites against Wurk.
+`bundle install && restart`. Wurk reads and writes the same Redis schema, so a rolling deploy can run Sidekiq and Wurk against the same Redis during the cutover. Third-party gems (sidekiq-cron, sidekiq-unique-jobs, sidekiq-scheduler, sidekiq-status, sidekiq-failures, sidekiq-throttled, …) are exercised by running their own upstream suites against Wurk in the [`ecosystem` CI job](https://github.com/developerz-ai/wurk/blob/main/.github/workflows/ecosystem.yml) (see [`test/ecosystem/`](https://github.com/developerz-ai/wurk/tree/main/test/ecosystem)).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,87 +1,108 @@
 # Wurk ⚡
 
-**100% drop-in replacement for Sidekiq + Sidekiq Pro + Sidekiq Enterprise. Free forever. Faster.** 🚀
+**A 100% drop-in replacement for Sidekiq + Sidekiq Pro + Sidekiq Enterprise. Free forever. Faster.**
 
-Wire-compatible: same Redis keys, same job JSON, same Ruby DSL. Swap one gem line — existing jobs, batches, limiters, cron entries, and Redis data keep working untouched.
+[![Gem Version](https://img.shields.io/gem/v/wurk.svg)](https://rubygems.org/gems/wurk)
+[![CI](https://github.com/developerz-ai/wurk/actions/workflows/test.yml/badge.svg)](https://github.com/developerz-ai/wurk/actions/workflows/test.yml)
+[![Coverage](https://img.shields.io/badge/coverage-line%20%E2%89%A590%25-brightgreen.svg)](https://github.com/developerz-ai/wurk/actions/workflows/test.yml)
+[![Ruby](https://img.shields.io/badge/ruby-%E2%89%A5%203.2-CC342D.svg)](https://www.ruby-lang.org)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
----
+Wurk is wire-compatible with Sidekiq — same Redis keys, same job JSON, same Ruby DSL. Swap one line in your `Gemfile` and your existing jobs, batches, limiters, cron entries, and live Redis data keep working untouched. The Pro and Enterprise feature sets ship in the same free gem, with no license check and no tiers.
 
-## 🏛️ The three pillars
+## Install
 
-| Pillar | What it means |
-|---|---|
-| 🔌 **100% drop-in** | Same Redis schema, same job JSON, same Ruby DSL. Third-party Sidekiq gems work unchanged. |
-| 🆓 **Free** | Pro + Ent feature parity in the same gem. No tiers. No license check. No env-flag gates. |
-| ⚡ **Faster** | Fork-based real parallelism. Every release benchmarked vs Sidekiq. >5% regression blocks merge. |
+```ruby
+# Gemfile
+gem "wurk"
+```
 
----
+```diff
+# ...or drop in over an existing Sidekiq stack — delete these, add one line:
+- gem "sidekiq"
+- gem "sidekiq-pro", source: "https://gems.contribsys.com/"
+- gem "sidekiq-ent", source: "https://enterprise.contribsys.com/"
++ gem "wurk"
+```
 
-## ✨ What's in the box
+`bundle install && restart`. That's it — `Sidekiq::Worker`, `Sidekiq::Batch`, `Sidekiq::Limiter`, `Sidekiq.configure_server`, and friends all resolve to Wurk.
 
-- 🎁 **Sidekiq OSS parity** — `Sidekiq::Worker`, `Sidekiq::Job`, queues, retry/scheduled/dead sets, middleware chain, stats, heartbeat, web UI.
-- 💎 **Sidekiq Pro parity** — reliable BLMOVE fetch, batches + callbacks, queue pause/resume, Redis-outage client buffer, statsd, Lua bulk path, web search.
-- 🏢 **Sidekiq Enterprise parity** — rate limiters (concurrent/window/bucket), periodic jobs, leader election, unique jobs, AES-256-GCM encryption with rotation, historical metrics, multi-process swarm, rolling restarts.
-- 🛠️ **Wurk extras** — worker topology DSL, mountable Rails engine, precompiled React dashboard (no Node needed by consumers), AI dashboard panes (anomaly detection, NL queries, backlog forecasting).
+## Feature matrix
 
----
+Everything below is in the one free gem. The "Sidekiq tier" column is only there to show what you'd otherwise pay for.
 
-## 🚧 Status
+| Area | What you get | Sidekiq tier |
+|---|---|---|
+| **Runtime** | Fork-based real parallelism, reliable `BLMOVE` fetch, PID supervision, rolling restarts, graceful drain, scheduled/retry pollers | OSS + Pro |
+| **Batches** | `Sidekiq::Batch` with `on(:success/:complete/:death)` callbacks, nested batches, progress | Pro |
+| **Limiters** | Concurrent, bucket, window, leaky, and points rate limiters via `Sidekiq::Limiter` | Enterprise |
+| **Periodic** | Cron/periodic jobs, leader-elected so each tick fires exactly once across the cluster | Enterprise |
+| **Encryption** | Transparent AES-256-GCM job-argument encryption with zero-downtime key rotation | Enterprise |
+| **Dashboard** | Mountable Rails engine, precompiled React SPA (no Node needed), live SSE, charts, host-app auth hook | OSS + Pro/Ent |
 
-**Skeleton stage.** Directory layout, stub classes, scripts, dummy app, CI, frontend scaffold — all wired. Implementation lands per `docs/idea/` and `docs/target/sidekiq-{free,pro,ent}.md`.
+Plus Wurk extras: a worker topology DSL, a Kubernetes liveness/readiness listener, and opt-in AI dashboard panes (anomaly detection, NL queries, backlog forecasting).
 
----
+## Documentation
 
-## 📋 Requirements
+- **[Getting started & architecture](https://github.com/developerz-ai/wurk/blob/main/docs/idea/01-overview.md)** — how the swarm, manager, fetcher, and processor fit together.
+- **[Migrating from Sidekiq](#migrating-from-sidekiq)** — the one-line swap and what to expect.
+- **API reference (parity specs):** [Sidekiq OSS](https://github.com/developerz-ai/wurk/blob/main/docs/target/sidekiq-free.md) · [Pro](https://github.com/developerz-ai/wurk/blob/main/docs/target/sidekiq-pro.md) · [Enterprise](https://github.com/developerz-ai/wurk/blob/main/docs/target/sidekiq-ent.md) — the authoritative surface Wurk matches exactly.
+- **[Securing the dashboard](https://github.com/developerz-ai/wurk/blob/main/docs/dashboard.md)** · **[Metrics history](https://github.com/developerz-ai/wurk/blob/main/docs/metrics-history.md)**
+- **Live demo:** [wurk.demo.developerz.ai](https://wurk.demo.developerz.ai)
+
+## Requirements
 
 | Component | Minimum |
 |---|---|
-| Ruby   | `>= 3.2.0` |
-| Redis  | `>= 7.0.0` (uses `ZRANGE ... REV` introduced in 6.2 and other 7.x server features) |
+| Ruby | `>= 3.2.0` |
+| Redis | `>= 7.0.0` |
 
-JRuby / TruffleRuby / Windows fall back to threads-only mode (no fork) — behaviorally equivalent to stock Sidekiq.
+JRuby, TruffleRuby, and Windows fall back to threads-only mode (no fork) — behaviorally equivalent to stock Sidekiq.
 
----
+## The dashboard
 
-## 🏃 Quick start
+Mount the engine wherever you like:
 
-```sh
-bundle install
-bin/rake test             # expect skipped tests until implementations land
-bin/rake bench            # bench/*.rb stubs
-cd test/dummy && bin/rails s
+```ruby
+# config/routes.rb
+mount Wurk::Engine => "/wurk"
 ```
 
----
+The precompiled SPA ships inside the gem, so consumers never run Node. Gate it behind your app's auth with one line — see **[Securing the dashboard](https://github.com/developerz-ai/wurk/blob/main/docs/dashboard.md)** for Devise/Warden/Sorcery recipes:
 
-## 📁 Layout
+```ruby
+Wurk::Web.use(Rack::Auth::Basic, "Wurk") { |user, pass| user == ENV["WURK_USER"] && pass == ENV["WURK_PASS"] }
+```
 
-| Path | What lives there |
-|---|---|
-| `lib/wurk/` | 🧩 Core — swarm, manager, fetcher, processor, client, middleware, batch, limiter, cron, … |
-| `lib/wurk/engine.rb` | 🚂 Rails engine (mount point, asset path) |
-| `app/` · `config/` | 🎨 Dashboard controllers + routes + locales |
-| `exe/wurk` | 🏃 Standalone runner |
-| `vendor/assets/dashboard/` | 📦 Precompiled SPA bundle (built at release) |
-| `frontend/` | ⚛️ React + Vite source for the dashboard |
-| `test/dummy/` | 🧪 Embedded Rails app for engine tests |
-| `test/{unit,integration,engine}/` | ✅ Layered Minitest suites |
-| `test/parity/` | 🎯 Sidekiq tests lifted as oracles (SHA-pinned) |
-| `test/ecosystem/` | 🌍 Third-party Sidekiq gem suites run against Wurk |
-| `bench/` | 📊 Throughput / latency / memory benchmarks |
-| `docs/idea/` | 💡 Design notes |
-| `docs/target/` | 📜 Sidekiq surface specs — the authoritative spec |
+Ship a viewer-only board (e.g. a public demo) with no auth code at all by setting `WURK_WEB_READ_ONLY=1` — every mutating request returns 403 and the SPA hides destructive actions.
 
----
+## Encryption
 
-## 📜 Spec-driven
+A drop-in for `Sidekiq::Enterprise::Crypto`. It encrypts the **last** positional argument of a job with AES-256-GCM — the client middleware seals it on push, the server middleware opens it before `perform`. Earlier args stay plaintext so you can still triage on `user_id`.
 
-Anything implemented here MUST match `docs/target/sidekiq-{free,pro,ent}.md` exactly. Parity tests are oracles — if Wurk diverges, Wurk is wrong unless the divergence is documented.
+```ruby
+# config/initializers/wurk.rb — point at any key source (file, ENV, KMS)
+Sidekiq::Enterprise::Crypto.enable(active_version: 1) do |version|
+  File.binread("config/crypto/secret.#{Rails.env}.#{version}.key") # exactly 32 bytes
+end
+```
 
----
+```ruby
+class ChargeCardJob
+  include Sidekiq::Job
+  sidekiq_options encrypt: true
 
-## 🩺 Kubernetes probes
+  def perform(user_id, secret_bag) # secret_bag arrives already decrypted
+    Payments.charge(user_id, secret_bag["pan"], secret_bag["cvv"])
+  end
+end
+```
 
-Opt in to a thin HTTP listener for liveness/readiness probes:
+Keys rotate without downtime — keep every still-in-flight version resolvable so old jobs decrypt, then bump `active_version`. A job that can't be decrypted (key rotated away, corrupt ciphertext) goes **straight to the dead set in under a second** rather than crash-looping through 25 retries, with the still-encrypted payload preserved for replay. The dashboard renders encrypted args as `"<encrypted>"`; cleartext is never written to Redis.
+
+## Kubernetes probes
+
+Opt in to a thin HTTP listener for liveness/readiness:
 
 ```ruby
 Wurk.configure_server do |config|
@@ -89,132 +110,28 @@ Wurk.configure_server do |config|
 end
 ```
 
-Endpoints (off by default; only start when `health_check` is configured):
+| Path | Meaning |
+|---|---|
+| `/live` | 200 while the Launcher is running; 503 once `stop`/`quiet` is called. |
+| `/ready` | 200 only when Redis is reachable **and** the heartbeat fired within `ready_window` (default 30s); 503 otherwise. |
 
-| Path     | Meaning                                                                 |
-|----------|-------------------------------------------------------------------------|
-| `/live`  | 200 while the Launcher is running. 503 once `stop` / `quiet` is called. |
-| `/ready` | 200 only when Redis is reachable **and** the heartbeat fired within the last 30s (configurable). 503 otherwise. |
+Knobs: `health_check(port:, bind: "0.0.0.0", ready_window: 30)`. In swarm mode only the first child to `start` binds the port.
 
-Example k8s `Deployment` spec:
-
-```yaml
-spec:
-  template:
-    spec:
-      containers:
-        - name: wurk
-          image: myorg/myapp:latest
-          ports:
-            - containerPort: 7433
-              name: health
-          livenessProbe:
-            httpGet:
-              path: /live
-              port: health
-            periodSeconds: 10
-            failureThreshold: 3
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: health
-            periodSeconds: 5
-            failureThreshold: 2
-```
-
-Knobs: `health_check(port:, bind: '0.0.0.0', ready_window: 30)`. In swarm mode only the first child to call `start` binds the port; the rest log a warning and skip — drive your supervisor topology accordingly.
-
----
-
-## 🚀 Deployment
-
-### Read-only dashboard
-
-Ship a viewer-only dashboard (e.g. a public demo, or a shared read-only board) without bolting on your own auth. When read-only mode is on, every mutating request to the mounted dashboard (retry, kill, requeue, delete, pause/resume, clear) returns **403**, the SPA hides destructive actions, and a **"Read-only mode"** banner makes it unambiguous. Reads (GET) keep working.
-
-Enable it either way:
-
-```sh
-# Simplest — works in every process, including the web server.
-WURK_WEB_READ_ONLY=1
-```
-
-```ruby
-# Or in a Rails initializer (config/initializers/wurk.rb):
-Wurk::Web.configure { |c| c.read_only = true }
-```
-
-> The dashboard runs in your **web** process (Puma), not the worker — so set the flag there. The env var is read by every process, which is why it's the easiest option. `Wurk.configuration.web.read_only = true` reaches the same setting — `config.web` delegates to the `Wurk::Web` config singleton.
-
-Default is read/write — nothing changes unless you opt in.
-
----
-
-## 🔐 Encryption
-
-Drop-in for Sidekiq Enterprise's `Sidekiq::Enterprise::Crypto`. Encrypts the **last** positional argument of a job with AES-256-GCM, transparently — the client middleware seals it on push, the server middleware opens it before `perform` runs. Earlier args stay plaintext so you can still triage on `user_id` / `object_id`.
-
-**Enable it** in `config/initializers/wurk.rb`, pointing at your key source (file, ENV, KMS — anything that maps an integer version to a 32-byte key):
-
-```ruby
-Sidekiq::Enterprise::Crypto.enable(active_version: 1) do |version|
-  File.binread("config/crypto/secret.#{Rails.env}.#{version}.key") # exactly 32 bytes
-end
-```
-
-**Opt a job in** — and make sure `perform` takes at least two args (pass `nil` first if there's no cleartext):
-
-```ruby
-class ChargeCardJob
-  include Sidekiq::Job
-  sidekiq_options encrypt: true
-
-  def perform(user_id, secret_bag)   # secret_bag arrives already decrypted
-    Payments.charge(user_id, secret_bag["pan"], secret_bag["cvv"])
-  end
-end
-```
-
-The dashboard renders the encrypted arg as `"<encrypted>"`; it's never written to Redis in cleartext.
-
-### Key rotation
-
-Keys rotate without downtime. The resolver block **must keep returning every still-in-flight version**, not just the active one, so jobs enqueued under the old key still decrypt:
-
-```ruby
-KEYS = {
-  1 => File.binread("config/crypto/secret.production.1.key"),
-  2 => File.binread("config/crypto/secret.production.2.key"),
-}
-
-# Step 1: ship the new key file + resolver that knows both versions, active still 1.
-Sidekiq::Enterprise::Crypto.enable(active_version: 1) { |v| KEYS.fetch(v) }
-
-# Step 2: once every process has the new key, bump active_version → 2 and redeploy.
-Sidekiq::Enterprise::Crypto.enable(active_version: 2) { |v| KEYS.fetch(v) }
-```
-
-New pushes encrypt under v2; v1 jobs already in the queue keep decrypting with the v1 key. Keep the old key around until you're sure no v1 jobs remain (queues, retries, scheduled set).
-
-### Graceful failure
-
-If a job can't be decrypted — the key was rotated away, or the ciphertext is corrupt — retrying is pointless (the key won't come back), so Wurk **does not** crash-loop it through 25 retries. Instead the job goes **straight to the dead set in under a second**, with `error_class` set to `Wurk::Encryption::DecryptionError` and `error_message` prefixed `encryption_error:` (both visible in the dashboard's Dead tab); the `jobs.encryption_error` statsd counter increments, and your death handlers fire so you can alert on a rotation gap. The still-encrypted payload is preserved on the dead record; fix the key and replay it from the dashboard.
-
----
-
-## 🤝 Migration
+## Migrating from Sidekiq
 
 ```diff
 - gem "sidekiq"
-- gem "sidekiq-pro",        source: "https://gems.contribsys.com/"
-- gem "sidekiq-ent",        source: "https://enterprise.contribsys.com/"
+- gem "sidekiq-pro", source: "https://gems.contribsys.com/"
+- gem "sidekiq-ent", source: "https://enterprise.contribsys.com/"
 + gem "wurk"
 ```
 
-Then: `bundle install && restart`. That's it. ✨
+`bundle install && restart`. Wurk reads and writes the same Redis schema, so a rolling deploy can run Sidekiq and Wurk against the same Redis during the cutover. Third-party gems (sidekiq-cron, sidekiq-unique-jobs, sidekiq-scheduler, sidekiq-status, sidekiq-failures, sidekiq-throttled, …) pass their own suites against Wurk.
 
----
+## Contributing
 
-## 📄 License
+Issues and pull requests are welcome — see **[CONTRIBUTING.md](https://github.com/developerz-ai/wurk/blob/main/CONTRIBUTING.md)** for the dev setup, test layers, and conventions, and **[SECURITY.md](https://github.com/developerz-ai/wurk/blob/main/SECURITY.md)** to report a vulnerability.
 
-MIT. See `LICENSE`.
+## License
+
+MIT. See [LICENSE](https://github.com/developerz-ai/wurk/blob/main/LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported versions
+
+Wurk follows semantic versioning. Security fixes land on the latest minor
+release line.
+
+| Version | Supported |
+|---|---|
+| 1.x | ✅ |
+| < 1.0 | ❌ |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Report privately through GitHub's
+[**Report a vulnerability**](https://github.com/developerz-ai/wurk/security/advisories/new)
+form (Security → Advisories). This opens a private advisory only the
+maintainers can see.
+
+Please include:
+
+- a description of the issue and its impact,
+- the affected version(s),
+- steps to reproduce or a proof of concept,
+- any suggested remediation.
+
+## What to expect
+
+- **Acknowledgement** within 3 business days.
+- An initial assessment and severity within 7 days.
+- Coordinated disclosure: we'll agree on a timeline with you, ship a patched
+  release, and credit you in the advisory and `CHANGELOG.md` unless you prefer
+  to remain anonymous.
+
+Because Wurk is wire-compatible with Sidekiq and runs your job code with access
+to Redis, reports about deserialization, the dashboard's auth surface, or
+argument encryption are especially welcome.

--- a/wurk.gemspec
+++ b/wurk.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.2.0"
 
-  spec.metadata["homepage_uri"]      = spec.homepage
   spec.metadata["source_code_uri"]   = spec.homepage
+  spec.metadata["documentation_uri"] = "#{spec.homepage}/tree/main/docs"
   spec.metadata["changelog_uri"]     = "#{spec.homepage}/blob/main/CHANGELOG.md"
   spec.metadata["bug_tracker_uri"]   = "#{spec.homepage}/issues"
   spec.metadata["rubygems_mfa_required"] = "true"
@@ -29,6 +29,8 @@ Gem::Specification.new do |spec|
     "vendor/assets/**/*",
     "README.md",
     "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "SECURITY.md",
     "LICENSE"
   ]
 
@@ -36,8 +38,11 @@ Gem::Specification.new do |spec|
   spec.executables = ["wurk"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "redis-client", ">= 0.22"
-  spec.add_dependency "connection_pool", ">= 2.4"
-  spec.add_dependency "rack", ">= 2.2"
-  spec.add_dependency "concurrent-ruby", ">= 1.2"
+  # Bounded ranges (not pessimistic `~>`) where a newer major is already in
+  # use: connection_pool 3.x and rack 3.x (Rails 7.1+/8) must both be allowed,
+  # so cap at the *next* untested major rather than the current one.
+  spec.add_dependency "redis-client", "~> 0.22"
+  spec.add_dependency "connection_pool", ">= 2.4", "< 4"
+  spec.add_dependency "rack", ">= 2.2", "< 4"
+  spec.add_dependency "concurrent-ruby", "~> 1.2"
 end


### PR DESCRIPTION
Closes #30. Makes the README — the RubyGems landing page — the strongest possible first impression, and adds the standard OSS meta files.

## Scope (from #30)

- [x] Trim emoji (now 1) + add badges (gem version, CI, coverage, Ruby, license)
- [x] One-line install + one-line drop-in swap up top
- [x] Feature matrix table (Runtime / Batches / Limiters / Periodic / Encryption / Dashboard)
- [x] Link out: getting-started, migration, API reference, demo site
- [x] Add CONTRIBUTING.md, SECURITY.md, GitHub issue + PR templates

## What changed

- **README**: rewritten — badges, `## Install` first (gem line + Sidekiq-swap diff), feature matrix mapping each area to the Sidekiq tier you'd otherwise pay for, a Documentation section (absolute GitHub URLs so links resolve from the RubyGems page), de-emoji'd sections, and the stale "skeleton stage / expect skipped tests / stubs" claims removed (this is v1.0.0).
- **CONTRIBUTING.md**: setup, the test layers (unit/engine/integration/parity/ecosystem), and the non-negotiable conventions (wire-compat, SRP, spec-match, coverage gate).
- **SECURITY.md**: supported versions + private vulnerability reporting via GitHub advisories.
- **Templates**: `.github/ISSUE_TEMPLATE/{bug_report,feature_request,config}.yml` + `PULL_REQUEST_TEMPLATE.md`.
- **gemspec**: added `documentation_uri`, ship CONTRIBUTING/SECURITY in the gem, and made `gem build` **warning-free** — dropped the redundant `homepage_uri`, and bounded the open-ended deps. `rack` and `connection_pool` are kept as `>= …, < 4` ranges (not the `~>` rubygems suggested) so they still span the 3.x majors that Rails 8 and the current lock use — `~> 2.4` would have downgraded connection_pool 3.0.2.

## Done when — verified

`gem build wurk.gemspec` → **Successfully built `wurk-1.0.0.gem`, with no warnings**. README is valid markdown; internal links are absolute so they render on the RubyGems page.

## How to test in prod

```bash
gem build wurk.gemspec   # clean build, no warnings
# Then preview README.md on GitHub / the RubyGems dashboard after publish.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Streamlined README with drop-in replacement focus and feature matrix.
  * Added a comprehensive contribution guide and a security policy for vulnerability reporting.
* **New Features**
  * Added structured GitHub issue templates for bug reports and feature requests.
  * Added a pull request template with contributor guidelines and checklist.
* **Chores**
  * Tightened gem dependency constraints for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->