### PR TITLE
chore(release): v1.0.0-rc1 — first OIDC-published release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Wurk are recorded here. Format: [Keep a Changelog](https:
 
 ## [Unreleased]
 
+## [1.0.0.rc1] - 2026-06-02
+
+First v1.0.0 release candidate, and the first gem published through the keyless
+(OIDC trusted publishing) release pipeline.
+
 ### Added
 - `Sidekiq::Testing` drop-in: `inline!` / `fake!` / `disable!` (global or block-scoped), the in-memory `Sidekiq::Queues` store, and the `Worker`/`Job` test helpers (`.jobs`, `.clear`, `.drain`, `.perform_one`, `.process_job`, `.drain_all`, `.clear_all`) + `Sidekiq::EmptyQueueError`.
 
@@ -71,7 +76,8 @@ First public (pre-1.0) release. Wurk is a 100% API-compatible drop-in replacemen
 - ActiveJob adapter, `IterableJob`, embedded mode, and a standalone `exe/wurk` runner.
 - Sidekiq client/server middleware contract; third-party ecosystem suites (sidekiq-cron, sidekiq-unique-jobs, sidekiq-scheduler, sidekiq-status, sidekiq-failures, sidekiq-throttled) pass against Wurk.
 
-[Unreleased]: https://github.com/developerz-ai/wurk/compare/v0.0.5...HEAD
+[Unreleased]: https://github.com/developerz-ai/wurk/compare/v1.0.0-rc1...HEAD
+[1.0.0.rc1]: https://github.com/developerz-ai/wurk/compare/v0.0.5...v1.0.0-rc1
 [0.0.5]: https://github.com/developerz-ai/wurk/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/developerz-ai/wurk/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/developerz-ai/wurk/compare/v0.0.2...v0.0.3

--- a/lib/wurk/version.rb
+++ b/lib/wurk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wurk
-  VERSION = "0.0.5"
+  VERSION = "1.0.0.rc1"
 end


### PR DESCRIPTION
Cuts the **v1.0.0-rc1** release candidate so the keyless trusted-publishing pipeline from #28 can be proven end-to-end. Depends on #76 (merged).

## Changes
- `lib/wurk/version.rb`: `0.0.5` → `1.0.0.rc1` (gem dot-form; the git tag will be `v1.0.0-rc1`).
- `CHANGELOG.md`: promote `[Unreleased]` into `## [1.0.0.rc1] - 2026-06-02` + compare-link footnotes.

## Verified locally
- ✅ `release:package` builds `wurk-1.0.0.rc1.gem` with the dashboard bundle (html/manifest/js/css) **inside** it.
- ✅ `bin/changelog-section 1.0.0.rc1` returns the new section (becomes the GitHub Release notes).
- ✅ tag↔version gate: `GITHUB_REF_NAME=v1.0.0-rc1` ↔ `Wurk::VERSION 1.0.0.rc1` passes.

## How to test in prod (after merge — closes #28)
```bash
git checkout main && git pull
git tag v1.0.0-rc1
git push origin v1.0.0-rc1

# watch it publish, keyless, end-to-end
gh run watch "$(gh run list --workflow release --limit 1 --json databaseId --jq '.[0].databaseId')"

# confirm: prerelease on rubygems with assets baked in + a GitHub Release
gem fetch wurk --version 1.0.0.rc1 --prerelease
gem unpack wurk-1.0.0.rc1.gem && ls wurk-1.0.0.rc1/vendor/assets/dashboard/
gh release view v1.0.0-rc1
```
A successful publish here is the literal "Done when" for #28 — close it once green.

> ⚠️ Pre-merge sanity: confirm the rubygems.org Trusted Publisher for `wurk` targets workflow `release.yml` on `developerz-ai/wurk`, or the OIDC `gem push` will fail. (Manager confirmed OIDC is set up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to `1.0.0.rc1`, marking the first release candidate for v1.0.0.

* **Documentation**
  * Updated CHANGELOG with release candidate details and updated version comparison links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->