### PR TITLE
fix: accept Sidekiq Pro initializer calls as drop-in no-ops (closes #78)

### DIFF
--- a/lib/wurk/compat.rb
+++ b/lib/wurk/compat.rb
@@ -18,7 +18,13 @@ module Sidekiq
   # Sidekiq::Enterprise::Crypto, …). Defined so downstream code can nest
   # classes under them — but `Sidekiq.pro?` / `Sidekiq.ent?` still return
   # `false` per docs/target/sidekiq-free.md §32 (Wurk advertises as free OSS).
-  module Pro; end
+  module Pro
+    # Sidekiq Pro mounts the dashboard at `Sidekiq::Pro::Web`; it's the same
+    # board as `Sidekiq::Web` here, so a Pro app's `mount Sidekiq::Pro::Web`
+    # drops in unchanged. `Wurk::Web` is already required by the time this file
+    # loads (lib/wurk.rb requires wurk/web before wurk/compat).
+    Web = Wurk::Web
+  end
 
   # Sidekiq Enterprise feature surface (`unique!`, `Crypto`, `Unique.locked?`).
   # Wurk ships these free; the namespace exists for drop-in compat.

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -204,6 +204,22 @@ module Wurk
       @options[:average_scheduled_poll_interval] = interval
     end
 
+    # --- Reliability (Sidekiq Pro drop-in no-ops) ------------------------
+
+    # Sidekiq Pro's opt-in toggles for reliable fetch and the reliable
+    # scheduler. Both are already the default in Wurk — the fetcher is always
+    # the reliable BLMOVE fetcher with orphan reclamation, and the scheduler is
+    # always atomic Lua — so these accept the call and do nothing. They exist
+    # only so a Pro initializer drops in unchanged instead of raising
+    # NoMethodError. Spec: docs/target/sidekiq-pro.md §3 (super_fetch).
+    def super_fetch!(*)
+      nil
+    end
+
+    def reliable_scheduler!(*)
+      nil
+    end
+
     # --- Periodic (Cron) registration ------------------------------------
 
     # Yields a Wurk::Cron::Manager so the host app can register periodic

--- a/test/unit/compat_aliases_test.rb
+++ b/test/unit/compat_aliases_test.rb
@@ -36,6 +36,13 @@ class CompatAliasesTest < Wurk::Test::UnitCase
     assert_kind_of Module, Sidekiq::Pro
   end
 
+  # A Pro app's `mount Sidekiq::Pro::Web` must drop in unchanged — it's the
+  # same dashboard as Sidekiq::Web here.
+  def test_pro_web_aliases_the_dashboard
+    assert_same Wurk::Web, Sidekiq::Pro::Web
+    assert_same Sidekiq::Web, Sidekiq::Pro::Web
+  end
+
   def test_enterprise_sentinel_defined
     assert(defined?(Sidekiq::Enterprise))
     assert_kind_of Module, Sidekiq::Enterprise

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -252,6 +252,19 @@ class ConfigurationTest < Wurk::Test::UnitCase
     assert_equal 1, other.error_handlers.size
   end
 
+  # --- Sidekiq Pro drop-in no-ops ---------------------------------------
+  # Reliable fetch + atomic scheduler are already the default, so these toggles
+  # do nothing — but a Pro initializer must drop in without NoMethodError.
+
+  def test_super_fetch_bang_is_a_noop
+    assert_nil @config.super_fetch!
+    assert_nil @config.super_fetch!(timeout: 3)
+  end
+
+  def test_reliable_scheduler_bang_is_a_noop
+    assert_nil @config.reliable_scheduler!
+  end
+
   def test_error_handlers_appends
     handler = ->(_ex, _ctx, _cfg) {}
     @config.error_handlers << handler


### PR DESCRIPTION
Closes #78. Surfaced while writing the migration guide (#42): a Sidekiq **Pro** app couldn't drop in over Wurk on a one-line gem swap — its initializer and dashboard mount raised at boot.

## Fix
- **`config.super_fetch!` / `config.reliable_scheduler!`** are now accepted **no-ops** on `Wurk::Configuration`. Both are already Wurk's default (the fetcher is always the reliable `BLMOVE` fetcher with orphan reclamation; the scheduler is always atomic Lua), so the toggles do nothing instead of `NoMethodError`. They accept any args (`super_fetch!(timeout: 3)`).
- **`Sidekiq::Pro::Web`** now aliases `Wurk::Web`, so `mount Sidekiq::Pro::Web` works (it's the same dashboard as `Sidekiq::Web`). `wurk/web` is required before `wurk/compat`, so the alias resolves at load.

## Done when (#78)
- [x] `config.super_fetch!` / `config.reliable_scheduler!` accepted no-ops (tested).
- [x] `Sidekiq::Pro::Web` resolves to `Wurk::Web` (tested).
- [ ] Update the `docs/migrate-from-sidekiq.md` caveats — **follow-up once #80 merges** (that doc only exists on the #42 branch; I'll update items 1–2 of its "known incompatibilities" after both land).

## Tests
- `configuration_test.rb`: `super_fetch!` / `reliable_scheduler!` return nil and accept args.
- `compat_aliases_test.rb`: `Sidekiq::Pro::Web` is the same object as `Wurk::Web` and `Sidekiq::Web`.
- Rubocop clean on touched files (one pre-existing offense in `configuration.rb#health_check` left untouched).

## How to test in prod
Drop wurk in over a Sidekiq Pro app whose initializer calls `config.super_fetch!` and whose routes `mount Sidekiq::Pro::Web` — boot now succeeds and the dashboard mounts, where before it raised `NoMethodError` / `NameError`.

```ruby
Sidekiq.configure_server { |c| c.super_fetch!; c.reliable_scheduler! }  # no longer raises
# config/routes.rb
mount Sidekiq::Pro::Web => "/sidekiq"                                    # resolves to the wurk dashboard
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Sidekiq Pro compatibility layer to prevent initialization errors when using Sidekiq Pro applications with Wurk.

* **Tests**
  * Added unit tests to verify Sidekiq Pro compatibility features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->