### PR TITLE
test: real per-worker Redis isolation via dedicated logical DBs (closes #75)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Skip step 3 → leaked sockets in children. Skip step 5 → children corrupt eac
 ## Testing
 
 - **Minitest**, parallel runner. Each class opts in via `parallelize_me!`.
-- **Per-test Redis namespace** keyed to `PID:object_id`; cleaned in teardown. Required for parallel safety.
+- **Per-worker Redis DB isolation.** Each `minitest-parallel_fork` worker runs against its own Redis logical DB (1–15; never DB 0), assigned in `test_helper`'s `after_parallel_fork` hook; `teardown` runs `FLUSHDB` so each test gets a clean slate. Tests that build a pool explicitly use `Wurk::Test.redis_url`. Required for parallel safety — concurrent test classes never see each other's keys.
 - **Layers:** unit · engine (boots `test/dummy/`) · integration (real forks + real Redis) · parity (`test/parity/`, lifted from Sidekiq, SHA-pinned) · ecosystem (third-party gem suites run against Wurk) · benchmarks.
 - **Parity tests are oracles.** When Wurk diverges from a parity test, Wurk is wrong unless the divergence is explicitly documented as intentional.
 - **Never mock Redis** in integration or parity tests. Real Redis, unique namespace.

--- a/test/integration/graceful_shutdown_test.rb
+++ b/test/integration/graceful_shutdown_test.rb
@@ -34,7 +34,6 @@ end
 class GracefulShutdownTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  REDIS_URL = ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')
   POLL_TIMEOUT = 30.0
   POLL_INTERVAL = 0.1
   SHUTDOWN_TIMEOUT = 15
@@ -45,7 +44,7 @@ class GracefulShutdownTest < Wurk::Test::UnitCase
     @queue_name = "#{@ns}-q"
     @started_key = "#{@ns}-started"
     @done_key = "#{@ns}-done"
-    @observer = RedisClient.config(url: REDIS_URL).new_client
+    @observer = RedisClient.config(url: Wurk::Test.redis_url).new_client
   end
 
   def teardown
@@ -80,7 +79,7 @@ class GracefulShutdownTest < Wurk::Test::UnitCase
     config = build_config
     client = Wurk::Client.new(pool: capsule_pool(config), config: config)
     client.push('class' => GracefulShutdownSentinelWorker.name,
-                'args' => [REDIS_URL, @started_key, @done_key, sleep_seconds],
+                'args' => [Wurk::Test.redis_url, @started_key, @done_key, sleep_seconds],
                 'queue' => @queue_name)
   ensure
     config&.reset_redis_pools!

--- a/test/integration/limiter_stress_test.rb
+++ b/test/integration/limiter_stress_test.rb
@@ -9,7 +9,6 @@ require_relative '../test_helper'
 class LimiterStressTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  REDIS_URL = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
   THREADS = 50
   PER_THREAD = 20 # THREADS * PER_THREAD = 1000 acquires
 
@@ -18,7 +17,7 @@ class LimiterStressTest < Wurk::Test::UnitCase
     @suffix = "stress#{Process.pid}:#{object_id}"
     # A pool wide enough that 50 threads never starve on a connection (which
     # would surface as a pool timeout, not a limiter decision).
-    @pool = Wurk::RedisPool.new(size: THREADS + 8, url: REDIS_URL, timeout: 5, name: 'lstress')
+    @pool = Wurk::RedisPool.new(size: THREADS + 8, url: Wurk::Test.redis_url, timeout: 5, name: 'lstress')
     @pool.with { |c| Wurk::Lua::Loader.script_load_all(c) }
     Wurk::Limiter.reset_config!
     Wurk::Limiter.config.redis = @pool

--- a/test/integration/periodic_leader_test.rb
+++ b/test/integration/periodic_leader_test.rb
@@ -25,7 +25,6 @@ class PeriodicLeaderTest < Wurk::Test::UnitCase
   parallelize_me!
 
   ISOLATED_DB = 15
-  REDIS_URL = (ENV.fetch('REDIS_URL', 'redis://localhost:6379/0').sub(%r{/\d+\z}, '') + "/#{ISOLATED_DB}").freeze
   POLL_TIMEOUT = 20.0
   POLL_INTERVAL = 0.1
 
@@ -35,7 +34,7 @@ class PeriodicLeaderTest < Wurk::Test::UnitCase
     @queue = "#{@ns}-q"
     @config = Wurk::Configuration.new
     @config.logger = ::Logger.new(IO::NULL)
-    @config.redis = { url: REDIS_URL }
+    @config.redis = { url: Wurk::Test.redis_url }
     @config[:timeout] = 5
     # Tick fast so the due loop fires within the test window instead of after a
     # full minute; campaign/renew aggressively so a leader settles quickly.
@@ -43,7 +42,7 @@ class PeriodicLeaderTest < Wurk::Test::UnitCase
     @config[:leader_ttl] = 3
     @config[:leader_renew_interval] = 0.5
     @config[:leader_follower_interval] = 0.5
-    @observer = RedisClient.config(url: REDIS_URL).new_client
+    @observer = RedisClient.config(url: Wurk::Test.redis_url).new_client
     @observer.call('DEL', Wurk::Leader::DEFAULT_KEY)
     @lid = nil
   end

--- a/test/integration/reaper_kill9_test.rb
+++ b/test/integration/reaper_kill9_test.rb
@@ -35,7 +35,6 @@ end
 class ReaperKill9Test < Wurk::Test::UnitCase
   parallelize_me!
 
-  REDIS_URL     = ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')
   JOB_COUNT     = 1000
   CHILDREN      = 3
   CONCURRENCY   = 2
@@ -55,7 +54,7 @@ class ReaperKill9Test < Wurk::Test::UnitCase
     # Sweep aggressively so a kill -9 victim's stranded jobs are reclaimed
     # within ~1s instead of waiting out the 60s default.
     @config[:super_fetch_reaper_interval] = 1
-    @observer = RedisClient.config(url: REDIS_URL).new_client
+    @observer = RedisClient.config(url: Wurk::Test.redis_url).new_client
   end
 
   def teardown
@@ -102,7 +101,7 @@ class ReaperKill9Test < Wurk::Test::UnitCase
     client = Wurk::Client.new(pool: capsule_pool, config: @config)
     JOB_COUNT.times do |i|
       client.push('class' => ReaperKill9Worker.name,
-                  'args' => [REDIS_URL, @done_key, @exec_key, i.to_s],
+                  'args' => [Wurk::Test.redis_url, @done_key, @exec_key, i.to_s],
                   'queue' => @queue_name)
     end
   end

--- a/test/integration/rolling_restart_test.rb
+++ b/test/integration/rolling_restart_test.rb
@@ -26,7 +26,6 @@ end
 class RollingRestartTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  REDIS_URL = ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')
   POLL_TIMEOUT = 60.0
   POLL_INTERVAL = 0.1
   CHILD_COUNT = 2
@@ -37,7 +36,7 @@ class RollingRestartTest < Wurk::Test::UnitCase
     @ns = "rrestart-#{::Process.pid}-#{object_id}"
     @queue_name = "#{@ns}-q"
     @sentinel_prefix = "#{@ns}-sentinel"
-    @observer = RedisClient.config(url: REDIS_URL).new_client
+    @observer = RedisClient.config(url: Wurk::Test.redis_url).new_client
   end
 
   def teardown
@@ -139,7 +138,7 @@ class RollingRestartTest < Wurk::Test::UnitCase
     config = build_config
     client = Wurk::Client.new(pool: capsule_pool(config), config: config)
     jid = client.push('class' => RollingRestartIdleWorker.name,
-                      'args' => [REDIS_URL, @sentinel_prefix, 'placeholder'],
+                      'args' => [Wurk::Test.redis_url, @sentinel_prefix, 'placeholder'],
                       'queue' => @queue_name)
     # placeholder arg must equal jid so the worker stamps the right key
     repush_with_correct_jid(client, jid)
@@ -154,7 +153,7 @@ class RollingRestartTest < Wurk::Test::UnitCase
   def repush_with_correct_jid(client, jid)
     pop_existing(jid)
     client.push('class' => RollingRestartIdleWorker.name,
-                'args' => [REDIS_URL, @sentinel_prefix, jid],
+                'args' => [Wurk::Test.redis_url, @sentinel_prefix, jid],
                 'queue' => @queue_name,
                 'jid' => jid)
   end

--- a/test/integration/scheduled_promotion_test.rb
+++ b/test/integration/scheduled_promotion_test.rb
@@ -40,7 +40,6 @@ end
 class ScheduledPromotionTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  REDIS_URL = ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')
   POLL_TIMEOUT = 15.0
   POLL_INTERVAL = 0.1
   SCHEDULE_DELAY = 1.0
@@ -66,7 +65,7 @@ class ScheduledPromotionTest < Wurk::Test::UnitCase
     # (not a global-constant mutation) so it can't race other parallel tests'
     # pollers into draining the shared retry/schedule sets.
     @config[:scheduler_initial_wait] = 0.1
-    @observer_pool = RedisClient.config(url: REDIS_URL).new_client
+    @observer_pool = RedisClient.config(url: Wurk::Test.redis_url).new_client
   end
 
   def teardown
@@ -121,7 +120,7 @@ class ScheduledPromotionTest < Wurk::Test::UnitCase
     target_at = ::Process.clock_gettime(::Process::CLOCK_REALTIME) + delay
     job = {
       'class' => ScheduledPromotionSentinelWorker.name,
-      'args' => [REDIS_URL, @sentinel_key],
+      'args' => [Wurk::Test.redis_url, @sentinel_key],
       'queue' => @queue_name,
       'jid' => SecureRandom.hex(12),
       'retry' => true

--- a/test/integration/swarm_boot_test.rb
+++ b/test/integration/swarm_boot_test.rb
@@ -27,7 +27,6 @@ end
 class SwarmBootTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  REDIS_URL = ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')
   POLL_TIMEOUT = 15.0
   POLL_INTERVAL = 0.1
 
@@ -39,7 +38,7 @@ class SwarmBootTest < Wurk::Test::UnitCase
     @config = Wurk::Configuration.new
     @config.logger = ::Logger.new(IO::NULL)
     @config[:timeout] = 5
-    @observer_pool = RedisClient.config(url: REDIS_URL).new_client
+    @observer_pool = RedisClient.config(url: Wurk::Test.redis_url).new_client
   end
 
   def teardown
@@ -99,7 +98,7 @@ class SwarmBootTest < Wurk::Test::UnitCase
   def push_sentinel_job
     client = Wurk::Client.new(pool: capsule_pool, config: @config)
     client.push('class' => SwarmBootSentinelWorker.name,
-                'args' => [REDIS_URL, @sentinel_key],
+                'args' => [Wurk::Test.redis_url, @sentinel_key],
                 'queue' => @queue_name)
   end
 

--- a/test/support/redis_namespace.rb
+++ b/test/support/redis_namespace.rb
@@ -1,17 +1,18 @@
 # frozen_string_literal: true
 
-# Per-test Redis namespace isolation. Required for parallel test safety.
-# Each test gets a unique key prefix keyed to PID + object_id, and the
-# namespace is wiped in teardown. See docs/idea/11-testing-ci.md.
+# Per-test Redis isolation. Each minitest-parallel_fork worker runs against its
+# own Redis logical DB (assigned in test_helper's after_parallel_fork hook), so
+# concurrent test *classes* never see each other's keys. Within a worker, classes
+# run sequentially, so wiping the worker's DB after every test gives each test a
+# clean slate without affecting any other worker. Workers never touch DB 0.
 module RedisNamespace
-  def setup
-    super
-    @wurk_test_namespace = "wurktest:#{Process.pid}:#{object_id}:"
-    # TODO: scope Wurk.redis to use this prefix during the test
-  end
-
   def teardown
-    # TODO: SCAN + DEL all keys under @wurk_test_namespace
+    Wurk.redis { |conn| conn.call('FLUSHDB') }
+  rescue StandardError
+    # A test may have torn down or swapped the global pool; isolation for the
+    # *next* test is still covered by the worker-start flush + its own teardown.
+    nil
+  ensure
     super
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,37 @@ end
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 
+# --- Per-worker Redis DB isolation -----------------------------------------
+# Tests must never touch the base Redis DB (0): teardown runs FLUSHDB, which
+# would wipe a developer's real data. Each minitest-parallel_fork worker instead
+# gets its own logical DB (Redis ships 16; we use 1..15) so concurrent test
+# classes never see each other's keys. The baseline below (DB 1) covers the
+# parent / serial (un-forked) run; after_parallel_fork bumps each worker to its
+# own DB. Tests that build a pool explicitly should use `Wurk::Test.redis_url`.
+module Wurk
+  module Test
+    REDIS_DATABASES = 15
+
+    class << self
+      attr_accessor :redis_url
+
+      def redis_url_for_db(database)
+        base = ENV["REDIS_URL"] || "redis://localhost:6379/0"
+        base.match?(%r{/\d+\z}) ? base.sub(%r{/\d+\z}, "/#{database}") : "#{base}/#{database}"
+      end
+
+      # Point this process at its own DB. Updates ENV so fresh Configurations and
+      # RedisPools pick it up, and caches the URL for explicit-pool tests.
+      def assign_redis_db(worker_index)
+        self.redis_url = redis_url_for_db((worker_index % REDIS_DATABASES) + 1)
+        ENV["REDIS_URL"] = redis_url
+      end
+    end
+  end
+end
+
+Wurk::Test.assign_redis_db(0) # serial/parent baseline (DB 1), before Wurk loads
+
 require "wurk"
 
 # Silence the global configuration's logger so default ERROR_HANDLER doesn't
@@ -35,11 +66,18 @@ require "minitest/parallel_fork" rescue nil
 # the parent then merges them all. Process.waitall before the parent's at-exit
 # merge guarantees every worker has finished writing first. Hooking the gem's
 # own fork callback (not Process._fork) leaves the swarm's real forks alone.
-if ENV["COVERAGE"] && defined?(SimpleCov) && Minitest.respond_to?(:after_parallel_fork)
+# Each forked worker gets its own Redis DB (isolation) and, under COVERAGE, its
+# own SimpleCov resultset. parallel_fork keeps a single after_parallel_fork
+# block, so both concerns share one hook.
+if Minitest.respond_to?(:after_parallel_fork)
   Minitest.after_parallel_fork do |worker|
-    SimpleCov.at_fork.call("worker-#{worker}")
+    Wurk::Test.assign_redis_db(worker)
+    Wurk.configuration.redis = { url: Wurk::Test.redis_url }
+    Wurk.configuration.reset_redis_pools!
+    Wurk.redis { |c| c.call("FLUSHDB") }
+    SimpleCov.at_fork.call("worker-#{worker}") if ENV["COVERAGE"] && defined?(SimpleCov)
   end
-  Minitest.after_run { Process.waitall }
+  Minitest.after_run { Process.waitall } if ENV["COVERAGE"] && defined?(SimpleCov)
 end
 
 require_relative "support/redis_namespace"

--- a/test/unit/cron_test.rb
+++ b/test/unit/cron_test.rb
@@ -6,7 +6,6 @@ require 'tzinfo'
 class CronTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  REDIS_URL = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
 
   # Workers used by ConfigTester resolution checks. Bodies stay empty —
   # the test only needs the constant to resolve, not actual perform logic.

--- a/test/unit/encryption_test.rb
+++ b/test/unit/encryption_test.rb
@@ -548,10 +548,10 @@ class EncryptionTest < Wurk::Test::UnitCase
     end
   end
 
-  # The DEAD/RETRY sets are shared across the suite (per-test Redis namespacing
-  # is still a stub — see test/support/redis_namespace.rb), and processor_test
-  # intentionally routes malformed, non-JSON payloads to DEAD. Skip a neighbor's
-  # poison entry rather than letting JSON.parse blow up while scanning for ours.
+  # Per-worker Redis DB isolation (test_helper) means this test no longer shares
+  # the DEAD/RETRY sets with other classes. Kept as belt-and-suspenders: this
+  # test still writes intentionally-malformed envelopes, so tolerate a non-JSON
+  # member rather than letting JSON.parse blow up while scanning for ours.
   def jid_of(member)
     JSON.parse(member)['jid']
   rescue JSON::ParserError

--- a/test/unit/limiter_bucket_test.rb
+++ b/test/unit/limiter_bucket_test.rb
@@ -5,12 +5,11 @@ require_relative '../test_helper'
 class LimiterBucketTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  REDIS_URL = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
 
   def setup
     super
     @suffix = "bk#{Process.pid}#{object_id}"
-    @pool = Wurk::RedisPool.new(size: 2, url: REDIS_URL, timeout: 2, name: 'bkp')
+    @pool = Wurk::RedisPool.new(size: 2, url: Wurk::Test.redis_url, timeout: 2, name: 'bkp')
     @pool.with { |c| Wurk::Lua::Loader.script_load_all(c) }
     Wurk::Limiter.reset_config!
     Wurk::Limiter.config.redis = @pool

--- a/test/unit/limiter_concurrent_test.rb
+++ b/test/unit/limiter_concurrent_test.rb
@@ -5,12 +5,11 @@ require_relative '../test_helper'
 class LimiterConcurrentTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  REDIS_URL = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
 
   def setup
     super
     @suffix = "cc#{Process.pid}#{object_id}"
-    @pool = Wurk::RedisPool.new(size: 4, url: REDIS_URL, timeout: 2, name: 'ccp')
+    @pool = Wurk::RedisPool.new(size: 4, url: Wurk::Test.redis_url, timeout: 2, name: 'ccp')
     @pool.with { |c| Wurk::Lua::Loader.script_load_all(c) }
     Wurk::Limiter.reset_config!
     Wurk::Limiter.config.redis = @pool

--- a/test/unit/limiter_leaky_test.rb
+++ b/test/unit/limiter_leaky_test.rb
@@ -5,12 +5,11 @@ require_relative '../test_helper'
 class LimiterLeakyTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  REDIS_URL = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
 
   def setup
     super
     @suffix = "lk#{Process.pid}#{object_id}"
-    @pool = Wurk::RedisPool.new(size: 2, url: REDIS_URL, timeout: 2, name: 'lkp')
+    @pool = Wurk::RedisPool.new(size: 2, url: Wurk::Test.redis_url, timeout: 2, name: 'lkp')
     @pool.with { |c| Wurk::Lua::Loader.script_load_all(c) }
     Wurk::Limiter.reset_config!
     Wurk::Limiter.config.redis = @pool

--- a/test/unit/limiter_points_test.rb
+++ b/test/unit/limiter_points_test.rb
@@ -5,12 +5,11 @@ require_relative '../test_helper'
 class LimiterPointsTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  REDIS_URL = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
 
   def setup
     super
     @suffix = "pt#{Process.pid}#{object_id}"
-    @pool = Wurk::RedisPool.new(size: 2, url: REDIS_URL, timeout: 2, name: 'ptp')
+    @pool = Wurk::RedisPool.new(size: 2, url: Wurk::Test.redis_url, timeout: 2, name: 'ptp')
     @pool.with { |c| Wurk::Lua::Loader.script_load_all(c) }
     Wurk::Limiter.reset_config!
     Wurk::Limiter.config.redis = @pool

--- a/test/unit/limiter_test.rb
+++ b/test/unit/limiter_test.rb
@@ -5,12 +5,11 @@ require_relative '../test_helper'
 class LimiterTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  REDIS_URL = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
 
   def setup
     super
     @suffix = "ltest#{Process.pid}#{object_id}"
-    @pool = Wurk::RedisPool.new(size: 1, url: REDIS_URL, timeout: 2, name: 'ltop')
+    @pool = Wurk::RedisPool.new(size: 1, url: Wurk::Test.redis_url, timeout: 2, name: 'ltop')
     @pool.with { |c| Wurk::Lua::Loader.script_load_all(c) }
     Wurk::Limiter.reset_config!
     Wurk::Limiter.config.redis = @pool

--- a/test/unit/limiter_window_test.rb
+++ b/test/unit/limiter_window_test.rb
@@ -5,12 +5,11 @@ require_relative '../test_helper'
 class LimiterWindowTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  REDIS_URL = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
 
   def setup
     super
     @suffix = "wn#{Process.pid}#{object_id}"
-    @pool = Wurk::RedisPool.new(size: 2, url: REDIS_URL, timeout: 2, name: 'wnp')
+    @pool = Wurk::RedisPool.new(size: 2, url: Wurk::Test.redis_url, timeout: 2, name: 'wnp')
     @pool.with { |c| Wurk::Lua::Loader.script_load_all(c) }
     Wurk::Limiter.reset_config!
     Wurk::Limiter.config.redis = @pool

--- a/test/unit/lua_loader_test.rb
+++ b/test/unit/lua_loader_test.rb
@@ -5,11 +5,10 @@ require_relative '../test_helper'
 class LuaLoaderTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  REDIS_URL = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
 
   def setup
     super
-    @pool = Wurk::RedisPool.new(size: 1, url: REDIS_URL, timeout: 2, name: 'loader-test')
+    @pool = Wurk::RedisPool.new(size: 1, url: Wurk::Test.redis_url, timeout: 2, name: 'loader-test')
     @ns   = "loadertest:#{Process.pid}:#{object_id}"
   end
 

--- a/test/unit/lua_test.rb
+++ b/test/unit/lua_test.rb
@@ -5,11 +5,10 @@ require_relative '../test_helper'
 class LuaTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  REDIS_URL = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
 
   def setup
     super
-    @pool = Wurk::RedisPool.new(size: 1, url: REDIS_URL, timeout: 2, name: 'lua-test')
+    @pool = Wurk::RedisPool.new(size: 1, url: Wurk::Test.redis_url, timeout: 2, name: 'lua-test')
     @ns   = "luatest:#{Process.pid}:#{object_id}"
     @pool.with { |c| Wurk::Lua::Loader.script_load_all(c) }
   end

--- a/test/unit/redis_pool_test.rb
+++ b/test/unit/redis_pool_test.rb
@@ -5,7 +5,6 @@ require_relative '../test_helper'
 class RedisPoolTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  REDIS_URL = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
 
   def teardown
     @pool&.disconnect!
@@ -18,15 +17,15 @@ class RedisPoolTest < Wurk::Test::UnitCase
   # --- happy path (real Redis) ---
 
   def test_initialize_stores_size
-    @pool = Wurk::RedisPool.new(size: 4, url: REDIS_URL, timeout: 2, name: 'primary')
+    @pool = Wurk::RedisPool.new(size: 4, url: Wurk::Test.redis_url, timeout: 2, name: 'primary')
 
     assert_equal 4, @pool.size
   end
 
   def test_initialize_stores_url_timeout_and_name
-    @pool = Wurk::RedisPool.new(size: 1, url: REDIS_URL, timeout: 2, name: 'primary')
+    @pool = Wurk::RedisPool.new(size: 1, url: Wurk::Test.redis_url, timeout: 2, name: 'primary')
 
-    assert_equal REDIS_URL, @pool.url
+    assert_equal Wurk::Test.redis_url, @pool.url
     assert_equal 2, @pool.timeout
     assert_equal 'primary', @pool.name
   end
@@ -147,11 +146,11 @@ class RedisPoolTest < Wurk::Test::UnitCase
   private
 
   def build_pool(size: 1, timeout: 1, name: 'test')
-    Wurk::RedisPool.new(size: size, url: REDIS_URL, timeout: timeout, name: name)
+    Wurk::RedisPool.new(size: size, url: Wurk::Test.redis_url, timeout: timeout, name: name)
   end
 
   def pool_wrapping(conn)
-    pool = Wurk::RedisPool.new(size: 1, url: REDIS_URL, timeout: 1, name: 'fake')
+    pool = Wurk::RedisPool.new(size: 1, url: Wurk::Test.redis_url, timeout: 1, name: 'fake')
     pool.instance_variable_set(:@pool, FakePool.new(conn))
     pool
   end

--- a/test/unit/unique_test.rb
+++ b/test/unit/unique_test.rb
@@ -8,7 +8,6 @@ class UniqueTest < Wurk::Test::UnitCase
   # the global config. Running in parallel would let one test's `enable!`
   # leak into another's "should be a no-op" assertion.
 
-  REDIS_URL = ENV['REDIS_URL'] || 'redis://localhost:6379/0'
 
   ENABLE_MUTEX = ::Mutex.new
 


### PR DESCRIPTION
Closes #75 — the test-isolation root cause behind the rotating CI flakes (worked around in #68, surfaced repeatedly since).

## Problem
`RedisNamespace` was a stub: every test shared one Redis keyspace. Test *classes* run concurrently in `minitest-parallel_fork` workers, so any test scanning a global set (`DEAD`/`RETRY`/`processes`/`periodic`) could see another class's data — e.g. `processor_test` routes intentionally-malformed payloads to `DEAD` while `encryption_test`/`api_endpoints` scan it.

## Approach — DB-per-worker + flushdb
Per your pick, Redis's native isolation primitive (no fragile key-rewriting):
- Each parallel_fork worker is pinned to its **own logical DB (1–15; never DB 0)** in `test_helper`'s `after_parallel_fork` hook, which also resets the global config's pools to that DB. Serial/parent runs use a DB-1 baseline set *before* Wurk loads. `Wurk::Test.redis_url` exposes the worker URL.
- `RedisNamespace#teardown` runs `FLUSHDB` on the worker's DB so each sequential test in a worker starts clean — safe because workers never share a DB.
- Converted the ~18 tests that captured `REDIS_URL` at parent-load (which would pin them to one DB and collide) to call `Wurk::Test.redis_url` at runtime — **including the integration tests that pass the URL to forked swarm children** (so children connect to the worker's DB too).
- `encryption_test`'s `jid_of` skip kept as **documented belt-and-suspenders** (per the issue's option), its stale "namespacing is a stub" comment corrected. CLAUDE.md Testing section updated to describe the real mechanism.

No production code changed — pools already resolve their URL from `config.redis_config`.

## Done when (#75)
- [x] `RedisNamespace` actually isolates per worker (DB-per-worker, cleaner than a key prefix).
- [x] `teardown` wipes the worker's keyspace (`FLUSHDB`).
- [x] Tests that scan global sets no longer observe other tests' entries.
- [x] The #68 `jid_of` skip is kept as documented belt-and-suspenders.

## Verification
- **Full suite (unit + integration + engine) run 3× back-to-back → 0 failures each.** Before this, 1–3 rotating flakes per run (`ReaperKill9`, `ApiEndpoints` pagination, `encryption`). 1661 runs.
- Converted unit + integration tests spot-checked individually (limiter/lua/redis_pool/cron/unique/reaper) — all green.

## ⚠️ Note for runners
Tests now `FLUSHDB` Redis logical DBs **1–15** (never DB 0). Point the suite at a disposable Redis (same assumption Sidekiq's own suite and our `test/qa` drivers already make).

## How to test in prod
N/A (test-infra only). To see it work: `for i in 1 2 3; do bin/rake test; done` → 0 failures every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test infrastructure with enhanced Redis isolation for parallel test workers, ensuring more reliable and deterministic test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->