### PR TITLE
fix(demo): copy lib/wurk/version.rb into the SPA build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ WORKDIR /src
 COPY frontend/package.json frontend/package-lock.json ./frontend/
 RUN cd frontend && npm ci
 COPY frontend/ ./frontend/
+# vite.config.ts's wurk-manifest-generator plugin readFileSync's ../lib/wurk/version.rb
+# at build time, so the SPA stage needs it present (was missing → npm run build ENOENT).
+COPY lib/wurk/version.rb ./lib/wurk/version.rb
 RUN cd frontend && npm run build   # → /src/vendor/assets/dashboard
 
 # ---- Stage 2: Ruby runtime ----


### PR DESCRIPTION
## What

One-line Dockerfile fix so the demo image builds: copy `lib/wurk/version.rb` into the SPA build stage.

## Why

`docker build -f Dockerfile .` currently fails at the SPA step (`Dockerfile:18`, `cd frontend && npm run build`) with an `ENOENT`:

```
at readFileSync (node:fs)
at PluginContextImpl.writeBundle (frontend/vite.config.ts)
ERROR: process "/bin/sh -c cd frontend && npm run build" did not complete successfully: exit code: 1
```

Root cause: `frontend/vite.config.ts`'s `wurk-manifest-generator` plugin reads the gem version at build time —

```js
const versionFilePath = resolve(__dirname, "../lib/wurk/version.rb");
const versionContent = readFileSync(versionFilePath, "utf-8");
```

— but the SPA stage only `COPY frontend/`, so `lib/wurk/version.rb` isn't in the build context (`/src/lib/...` doesn't exist) and `readFileSync` throws before the existing `"0.0.1"` fallback is reached.

Surfaced during the infra verification build for `wurk.demo.developerz.ai` (the Dockerfile's own "the build still needs a verification pass with infra" note).

## Changes

- `Dockerfile`: add `COPY lib/wurk/version.rb ./lib/wurk/version.rb` to the SPA stage, before `npm run build`.

## Verification

- `docker build` now completes cleanly through both stages.
- The image boots in production (puma, `Environment: production`, runtime `uid=1000(wurk)`) and serves `GET /wurk` → `200` (Wurk dashboard) with a real Redis; `GET /` → `301` → `/wurk`.

## Follow-up (optional, not in this PR)

Wrap the `readFileSync` in `vite.config.ts` in a `try/catch` so a frontend-only build degrades to the existing `"0.0.1"` version fallback instead of hard-failing — defense-in-depth against the build context.
