### PR TITLE
chore(demo): rework deploy-demo for ArgoCD Image Updater (no CI cluster creds)

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -2,13 +2,20 @@ name: deploy-demo
 
 # Manual-only deploy of the public demo (wurk.demo.developerz.ai).
 #
+# DEPLOY MODEL: this workflow only BUILDS + PUSHES the image. Infra deploys it
+# via the in-cluster ArgoCD Image Updater, which watches the GHCR `:latest` tag
+# (digest strategy) and syncs automatically — CI holds NO cluster credentials
+# (infra repo rule). There is no ArgoCD step here, and no ARGOCD_* secrets.
+#
 # WHO CAN RUN IT — three layers, only-the-org by construction:
 #   1. workflow_dispatch on a PUBLIC repo can only be triggered by users with
 #      *write* access (org members) — external forks/users cannot.
 #   2. the `authorize` job rejects anyone not in the DEMO_DEPLOYERS repo
 #      variable (comma-separated GitHub usernames).
-#   3. the `deploy` job targets the protected `demo` environment — add Required
-#      Reviewers there so a deploy waits for a named approver.
+#   3. the `build` job targets the protected `demo` environment — add Required
+#      Reviewers there so the build (which produces the deploy-triggering image
+#      digest) waits for a named approver. The gate sits on `build` precisely
+#      because the digest push IS the deploy trigger under Image Updater.
 # See docs/demo-deploy.md for the one-time setup and the infra requirements.
 
 on:
@@ -21,7 +28,7 @@ on:
 
 concurrency:
   group: deploy-demo
-  cancel-in-progress: false # never interrupt an in-flight deploy
+  cancel-in-progress: false # never interrupt an in-flight build
 
 # Least privilege at the workflow level; the build job opts into packages:write.
 permissions:
@@ -53,6 +60,12 @@ jobs:
   build:
     needs: authorize
     runs-on: ubuntu-latest
+    # The required-reviewer gate lives here: under the Image Updater model the
+    # pushed digest is the deploy trigger, so approval must pause the run BEFORE
+    # the image ships, not after.
+    environment:
+      name: demo
+      url: https://wurk.demo.developerz.ai
     permissions:
       contents: read
       packages: write # push the demo image to GHCR
@@ -77,39 +90,3 @@ jobs:
             ${{ env.IMAGE }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: demo
-      url: https://wurk.demo.developerz.ai
-    steps:
-      # GitOps via ArgoCD: point the demo Application at the freshly-built image
-      # and sync. Requires the ARGOCD_SERVER + ARGOCD_AUTH_TOKEN secrets and an
-      # ArgoCD Application named `wurk-demo` (see docs/demo-deploy.md). If infra
-      # prefers ArgoCD Image Updater or a manifest bump in ../infrastructure,
-      # replace this step per that decision — the gating above is unchanged.
-      - name: Sync ArgoCD app
-        env:
-          ARGOCD_SERVER: ${{ secrets.ARGOCD_SERVER }}
-          ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
-          # Pin to the ArgoCD server's version; the CLI is fetched from the
-          # official release (not the server) and checksum-verified.
-          ARGOCD_VERSION: v2.13.1
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          if [ -z "${ARGOCD_SERVER:-}" ] || [ -z "${ARGOCD_AUTH_TOKEN:-}" ]; then
-            echo "::error::ARGOCD_SERVER / ARGOCD_AUTH_TOKEN not set — see docs/demo-deploy.md (Infra requirements)."
-            exit 1
-          fi
-          base="https://github.com/argoproj/argo-cd/releases/download/${ARGOCD_VERSION}"
-          curl -fsSL -o argocd "${base}/argocd-linux-amd64"
-          curl -fsSL -o cli_checksums.txt "${base}/cli_checksums.txt"
-          want=$(grep ' argocd-linux-amd64$' cli_checksums.txt | awk '{print $1}')
-          echo "${want}  argocd" | sha256sum -c -
-          chmod +x argocd && sudo mv argocd /usr/local/bin/argocd
-          argocd app set wurk-demo --grpc-web -p image.tag="$IMAGE_TAG"
-          argocd app sync wurk-demo --grpc-web --timeout 300
-          argocd app wait wurk-demo --grpc-web --health --timeout 300

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: Git ref (branch / tag / SHA) to build and deploy
+        description: Git ref (branch / tag / SHA) to build and push (Image Updater deploys it)
         required: false
         default: main
 

--- a/docs/demo-deploy.md
+++ b/docs/demo-deploy.md
@@ -28,15 +28,19 @@ internet ──►│                                                     ├─
 
 ## Deploy: who can trigger it
 
-`.github/workflows/deploy-demo.yml` is **manual only** (`workflow_dispatch`) and
-gated three ways so only the org can deploy:
+`.github/workflows/deploy-demo.yml` **builds and pushes the image only** — it
+holds no cluster credentials. The in-cluster **ArgoCD Image Updater** watches the
+GHCR `:latest` digest and syncs the deployment automatically; the pushed digest
+*is* the deploy trigger. The workflow is **manual only** (`workflow_dispatch`) and
+gated three ways so only the org can ship an image:
 
 1. **Public repo + `workflow_dispatch`** → only users with *write* access (org
    members) can trigger it; external forks cannot.
 2. **`DEMO_DEPLOYERS` repo variable** (comma-separated GitHub usernames) → the
    `authorize` job rejects anyone not listed.
-3. **Protected `demo` environment** → add Required Reviewers so a deploy waits
-   for a named approver.
+3. **Protected `demo` environment** → add Required Reviewers. The gate sits on the
+   `build` job (not a separate deploy job) because the digest push is what
+   triggers the deploy, so approval must pause the run *before* the image ships.
 
 ### One-time GitHub setup (repo admin)
 
@@ -44,13 +48,9 @@ gated three ways so only the org can deploy:
   `DEMO_DEPLOYERS` = e.g. `sebyx07,din-handle,ivann-handle`.
 - **Settings → Environments → `demo`:** create it, add the deployer(s) as
   *Required reviewers*, and (optionally) restrict the deployment branch to `main`.
-- **Secrets** (Environment or repo): `ARGOCD_SERVER`, `ARGOCD_AUTH_TOKEN`
-  (see below). The image push uses the built-in `GITHUB_TOKEN` (GHCR) — no extra
-  registry secret needed.
 
-The deploy step does ArgoCD `app set image.tag` + `app sync`. If infra prefers
-ArgoCD Image Updater or a manifest bump in `../infrastructure`, swap that one
-step — the gating above is independent of the deploy mechanism.
+No `ARGOCD_*` secrets are needed — CI never talks to the cluster. The image push
+uses the built-in `GITHUB_TOKEN` (GHCR), so no registry secret is required either.
 
 ## ✅ Infra requirements (for the infra team)
 
@@ -63,8 +63,8 @@ What's needed to make `https://wurk.demo.developerz.ai` go live. Items marked
 - [ ] **Redis** — a small managed/in-cluster Redis (7.x) reachable from both pods, exposed as `REDIS_URL`. Demo data only; safe to flush.
 - [ ] **`SECRET_KEY_BASE`** — a strong random value injected at runtime (k8s secret) so the Rails app boots in production. Not baked into the image.
 - [ ] **GHCR pull access** — an `imagePullSecret` (or public package) so the cluster can pull `ghcr.io/developerz-ai/wurk-demo`.
-- [ ] **ArgoCD Application `wurk-demo`** in `../infrastructure` — Deployments for `web` (cmd `web`) and `worker` (cmd `worker`), a Service, and the Redis dependency. Parameterize `image.tag` so the deploy step can set it.
-- [ ] **ArgoCD API access for CI** — `ARGOCD_SERVER` (host) + `ARGOCD_AUTH_TOKEN` (a deploy-scoped account/token that can `sync` only `wurk-demo`), added as GitHub secrets.
+- [ ] **ArgoCD Application `wurk-demo`** in `../infrastructure` — Deployments for `web` (cmd `web`) and `worker` (cmd `worker`), a Service, and the Redis dependency.
+- [ ] **ArgoCD Image Updater** watching `ghcr.io/developerz-ai/wurk-demo:latest` (digest strategy) so a pushed image auto-syncs. CI holds no cluster credentials, so there are no `ARGOCD_*` secrets.
 - [ ] **DNS** — `wurk.demo.developerz.ai` → the cluster ingress / Traefik.
 - [ ] **Ingress (Traefik) + TLS** — route the host to the `web` Service, Let's Encrypt cert.
 - [ ] **Public rate-limit** — a Traefik rate-limit middleware on the ingress to discourage abuse.
@@ -72,9 +72,6 @@ What's needed to make `https://wurk.demo.developerz.ai` go live. Items marked
 
 ### Decisions to confirm with infra
 
-- **Deploy mechanism:** ArgoCD `app sync` from CI (current scaffold) vs. ArgoCD
-  Image Updater (no CI deploy step) vs. image-tag bump committed to
-  `../infrastructure`. This determines which secrets the workflow needs.
 - **Redis sizing / persistence:** demo can run on an ephemeral Redis (a restart
   just empties it; the generator refills). Confirm whether infra wants
   persistence at all.


### PR DESCRIPTION
## What

Rework `deploy-demo.yml` for the **ArgoCD Image Updater** deploy model agreed on the infra side (`developerz-ai/infrastructure#111`): CI only builds + pushes the image; the in-cluster Image Updater deploys it. Removes the CI ArgoCD step and the cluster credentials it needed.

## Why

Infra deploys `wurk.demo.developerz.ai` via the in-cluster ArgoCD Image Updater, which watches the GHCR `:latest` tag (digest strategy) and auto-syncs. This follows the infra repo rule **"CI holds NO cluster credentials — the handoff is image-only"** (reinforced after a shared-token incident on 2026-05-27). A CI `argocd app sync` step would require a standing `ARGOCD_AUTH_TOKEN` in this repo, which that rule exists to avoid.

## Changes

- **Delete the `deploy` job** (ArgoCD CLI `app set` / `sync` / `wait`) entirely.
- **Move the protected `demo` environment** (Required Reviewers) onto the **`build`** job. Under Image Updater the pushed image digest *is* the deploy trigger, so the reviewer gate must pause the run **before** the image ships — putting it on a downstream job would let `build` push an unreviewed `:latest` first.
- **Keep** the `authorize` job and `build: needs: authorize` unchanged (the `DEMO_DEPLOYERS` allowlist layer).
- **Drop** the now-unused `ARGOCD_SERVER` / `ARGOCD_AUTH_TOKEN` secrets.

Resulting shape: `authorize` → `build` (gated by `environment: demo`). No `deploy` job.

The org-only deploy gate is preserved end-to-end: only the gated build can produce a new `:latest` digest, and the Image Updater only acts on that digest.

## Verification

- `deploy-demo.yml` parses as valid YAML; jobs are exactly `authorize` → `build`; `environment: demo` is on `build`; no `ARGOCD*` references remain; `packages: write` retained on `build`.
- Pairs with the infra stack (`infrastructure#111`): Application annotated for Image Updater (`image-list app=ghcr.io/developerz-ai/wurk-demo`, `update-strategy: digest`, `allow-tags: ^latest$`, `write-back-target: kustomization`), GHCR added to the in-cluster Image Updater registry config.

## Follow-up (repo settings, needs repo admin)

- Set `DEMO_DEPLOYERS` repo variable (`sebyx07,<din>,ivndev001`).
- Create the `demo` environment with Required Reviewers.
- Make `ghcr.io/developerz-ai/wurk-demo` public (or supply a GHCR pull secret).

Companion build fix: #85 (the demo image doesn't build from main without it).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now builds and pushes images but pauses for manual approval before the push that triggers deployment.
  * Deployment is handled externally by an in-cluster image updater; CI no longer performs direct sync operations or holds deployment credentials.

* **Documentation**
  * Updated deploy docs to describe image-push–only CI, manual trigger workflow, approval gating, and external image-updater deployment flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->