### PR TITLE
test: unique Redis DB per parallel worker + widen periodic-leader window (closes #84, closes #73)

### DIFF
--- a/test/integration/periodic_leader_test.rb
+++ b/test/integration/periodic_leader_test.rb
@@ -24,8 +24,11 @@ end
 class PeriodicLeaderTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  ISOLATED_DB = 15
-  POLL_TIMEOUT = 20.0
+  # Ceiling only — wait_for_history returns the instant the loop fires, so a
+  # generous timeout costs nothing on the happy path and just absorbs the slow
+  # tail: under a loaded CI runner, forking + booting two swarm children and
+  # settling leader election can take well over 20s, which is what flaked #73.
+  POLL_TIMEOUT = 45.0
   POLL_INTERVAL = 0.1
 
   def setup

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,7 +27,14 @@ $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 # own DB. Tests that build a pool explicitly should use `Wurk::Test.redis_url`.
 module Wurk
   module Test
+    # Redis ships 16 logical DBs (0..15). DB 0 is never used (teardown FLUSHDB
+    # would wipe a developer's real data). Parallel workers take 1..14; DB 15 is
+    # reserved for tests that need a private fixed DB and touch un-prefixable
+    # global keys (see DemoWorkloadTest), so a worker is never assigned the same
+    # DB such a test flushes.
     REDIS_DATABASES = 15
+    WORKER_DATABASES = REDIS_DATABASES - 1 # 14 → DBs 1..14 for parallel workers
+    DEDICATED_DB = REDIS_DATABASES         # 15 → fixed-DB tests only
 
     class << self
       attr_accessor :redis_url
@@ -39,8 +46,19 @@ module Wurk
 
       # Point this process at its own DB. Updates ENV so fresh Configurations and
       # RedisPools pick it up, and caches the URL for explicit-pool tests.
+      #
+      # No modulo wrap: a `worker_index % WORKER_DATABASES` would silently map
+      # worker N back onto worker 0's DB, and that worker's startup FLUSHDB then
+      # wipes worker 0's keys mid-test (the #84/#73 flake class). The worker count
+      # is capped to WORKER_DATABASES below, so this raises only if that cap is
+      # ever bypassed — loud beats silent cross-contamination.
       def assign_redis_db(worker_index)
-        self.redis_url = redis_url_for_db((worker_index % REDIS_DATABASES) + 1)
+        if worker_index >= WORKER_DATABASES
+          raise "test worker #{worker_index} has no isolated Redis DB " \
+                "(only #{WORKER_DATABASES} for parallel workers); cap NCPU at #{WORKER_DATABASES}"
+        end
+
+        self.redis_url = redis_url_for_db(worker_index + 1)
         ENV["REDIS_URL"] = redis_url
       end
     end
@@ -57,6 +75,20 @@ require "wurk"
 Wurk.configuration.logger = Logger.new(IO::NULL)
 
 require "minitest/autorun"
+
+# minitest-parallel_fork forks ENV["NCPU"] workers (default 4) — and it forks
+# that many regardless of how many suites there are, so idle extra workers run
+# their startup FLUSHDB too. Each worker is isolated on its own Redis logical DB
+# (1..14; never 0, and 15 is reserved). More workers than DBs would collide and
+# a colliding worker's FLUSHDB would wipe a peer's keys mid-test — the root cause
+# of the #84 batch-TTL and #73 periodic-leader flakes. Cap the worker count to
+# the number of worker DBs so every worker gets a unique one. (CI leaves NCPU
+# unset → 4, so this is a no-op there; it only bites machines that set a high
+# NCPU for speed.)
+if (ENV["NCPU"] || "4").to_i > Wurk::Test::WORKER_DATABASES
+  ENV["NCPU"] = Wurk::Test::WORKER_DATABASES.to_s
+end
+
 require "minitest/parallel_fork" rescue nil
 
 # minitest-parallel_fork runs each test class in a forked worker, so the

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -85,9 +85,7 @@ require "minitest/autorun"
 # the number of worker DBs so every worker gets a unique one. (CI leaves NCPU
 # unset → 4, so this is a no-op there; it only bites machines that set a high
 # NCPU for speed.)
-if (ENV["NCPU"] || "4").to_i > Wurk::Test::WORKER_DATABASES
-  ENV["NCPU"] = Wurk::Test::WORKER_DATABASES.to_s
-end
+ENV["NCPU"] = Wurk::Test::WORKER_DATABASES.to_s if (ENV["NCPU"] || "4").to_i > Wurk::Test::WORKER_DATABASES
 
 require "minitest/parallel_fork" rescue nil
 

--- a/test/unit/demo_workload_test.rb
+++ b/test/unit/demo_workload_test.rb
@@ -20,11 +20,12 @@ class DemoWorkloadTest < Wurk::Test::UnitCase
   # drives write fixed *global* keys (`queue:default`, `schedule`, `dead`,
   # `lmtr-list`, the periodic set, …) that can't be prefixed, and the
   # RedisNamespace helper is still a stub. So this class points the global config
-  # at its own DB (override with WURK_DEMO_TEST_DB) and FLUSHDB's it — no other
-  # suite test touches DB 15. For that reason it does NOT call `parallelize_me!`:
-  # FLUSHDB-based isolation is only safe with the tests run sequentially, which
-  # the per-class fork runner already guarantees.
-  DB = ENV.fetch('WURK_DEMO_TEST_DB', '15')
+  # at the reserved DEDICATED_DB (15) and FLUSHDB's it — parallel workers are
+  # capped to DBs 1..14 (see test_helper), so no worker is ever assigned this DB.
+  # For that reason it does NOT call `parallelize_me!`: FLUSHDB-based isolation is
+  # only safe with the tests run sequentially, which the per-class fork runner
+  # already guarantees.
+  DB = ENV.fetch('WURK_DEMO_TEST_DB', Wurk::Test::DEDICATED_DB.to_s)
 
   def setup
     super


### PR DESCRIPTION
Closes #84. Closes #73. Both are test-isolation flakes, not product bugs.

## #84 — `BatchLifecycleTest` linger TTL `-2` (and the same "key vanished mid-test" class)
`minitest-parallel_fork` forks `ENV["NCPU"]` workers (default 4) — and forks *that many regardless of suite count*, so idle extra workers still run their startup `FLUSHDB`. `assign_redis_db` mapped workers to DBs with `worker % 15`, so on a machine with **>15 workers**, worker 15 wrapped back onto worker 0's DB (DB 1) and its startup `FLUSHDB` wiped worker 0's keys mid-test. The batch hash `b-<bid>` vanished, so `TTL` returned `-2`.

Reproduced deterministically with `NCPU=20 bin/rake test` → 7 TTL-class failures (e.g. `ClientTest`/`BatchLifecycleTest` TTL asserts). **0 failures across repeated runs after the fix.**

Fix:
- `assign_redis_db` no longer wraps — it **raises** if a worker has no isolated DB (loud beats silent cross-contamination).
- Cap the worker count to the number of worker DBs (**14**, DBs 1–14) so every worker gets a unique one.
- Reserve **DB 15** for fixed-DB tests (`DemoWorkloadTest`), which previously collided with worker 14 at exactly 15 workers.
- CI leaves `NCPU` unset (→4), so this is a **no-op on CI**; it hardens high-`NCPU`/contended local runs.

## #73 — `PeriodicLeaderTest#test_two_workers_fire_one_loop_exactly_once`
On a loaded CI runner, forking + booting two real swarm children and settling leader election can exceed the fixed **20s** ceiling, so the loop simply hadn't fired yet. `wait_for_history` returns the instant the loop fires, so widening `POLL_TIMEOUT` to **45s** only absorbs the slow tail and costs nothing on the happy path. (Removed the vestigial unused `ISOLATED_DB` constant.)

## Done when (from the issues)
- [x] #84: batch-linger TTL no longer reads `-2` under the parallel runner
- [x] #73: passes reliably across repeated runs (no single-leg flake)

## How to test in prod
These are test-isolation fixes; the operator-facing check is the suite under forced high parallelism:

```bash
# Before this PR: several TTL/state assertions fail (keys wiped by a colliding worker's FLUSHDB).
# After: clean — NCPU is clamped to 14 and each worker gets a unique DB.
NCPU=20 bin/rake test

# Default CI config (4 workers) — unaffected:
bin/rake test
```

## Local verification
- `NCPU=20 bin/rake test` — **4/4 runs clean** (was 7+ TTL-class failures before)
- `bin/rake test` (default 4 workers) — **2/2 runs clean**, 1904 runs, 0 failures
- `bin/rake test TEST=test/integration/periodic_leader_test.rb` — **4/4 runs clean**
- Test-only change — no `lib/` touched, coverage gate unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability to reduce intermittent failures in CI environments.
  * Enhanced test infrastructure to better support parallel test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->