### PR TITLE
fix(web): Retries/Dead tab crash + demo read-only banner & hourly reset (#32)

### DIFF
--- a/app/controllers/wurk/api_controller.rb
+++ b/app/controllers/wurk/api_controller.rb
@@ -30,7 +30,8 @@ module Wurk
     # actions and show the read-only banner). Always a GET, so it stays
     # reachable while read-only mode blocks mutations.
     def meta
-      render json: { read_only: ::Wurk::Web.config.read_only? }
+      config = ::Wurk::Web.config
+      render json: { read_only: config.read_only?, read_only_message: config.read_only_message }
     end
 
     def stats

--- a/demo/config/initializers/wurk.rb
+++ b/demo/config/initializers/wurk.rb
@@ -6,7 +6,10 @@
 # pause/clear) returns 403 at the middleware layer, and the SPA hides the
 # destructive actions. WURK_WEB_READ_ONLY=1 in the image sets this too; doing it
 # here as well makes the demo read-only even if someone runs it without the env.
-Wurk::Web.configure { |c| c.read_only = true }
+Wurk::Web.configure do |c|
+  c.read_only = true
+  c.read_only_message = "This is a public demo — actions are disabled."
+end
 
 # Enterprise uniqueness — installs the client+server middleware so
 # `sidekiq_options unique_for:` (SendReceiptJob) actually de-dupes.

--- a/demo/k8s/demo-reset-cronjob.yaml
+++ b/demo/k8s/demo-reset-cronjob.yaml
@@ -1,0 +1,59 @@
+# Hourly state-cycle for the public demo (issue #32 — "Reset/seed task that
+# cycles state hourly so the demo never looks dead").
+#
+# The producer self-heals every tick, so the demo never goes empty — but a
+# single worker can't drain everything the producer tops up, so queue latency
+# creeps upward over hours. This CronJob flushes the demo Redis hourly; the
+# web pod's producer re-seeds a clean slate within one tick.
+#
+# Reference manifest for ../infrastructure — adjust namespace, secret/configmap
+# names, and imagePullSecret to match the web/worker deployments. `demo:reset`
+# is the rake task in demo/lib/tasks/demo.rake (FLUSHDB on the demo Redis).
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: wurk-demo-reset
+  namespace: wurk-demo
+spec:
+  schedule: "0 * * * *"          # top of every hour
+  concurrencyPolicy: Forbid       # never overlap a flush with the previous one
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 120
+      template:
+        spec:
+          restartPolicy: Never
+          # Same private image as the deployments; reuse the GHCR pull secret.
+          imagePullSecrets:
+            - name: ghcr-wurk-demo
+          containers:
+            - name: reset
+              image: ghcr.io/developerz-ai/wurk-demo:latest
+              # bin/demo-entrypoint's default branch execs "$@" from demo/.
+              args: ["bundle", "exec", "rails", "demo:reset"]
+              env:
+                # WURK_DISABLED keeps the railtie from forking a swarm in this
+                # one-shot pod; the task only needs Redis + a bootable Rails env.
+                - name: WURK_DISABLED
+                  value: "1"
+                - name: REDIS_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: wurk-demo
+                      key: REDIS_URL
+                - name: SECRET_KEY_BASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: wurk-demo
+                      key: SECRET_KEY_BASE
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  cpu: 250m
+                  memory: 256Mi

--- a/docs/demo-deploy.md
+++ b/docs/demo-deploy.md
@@ -18,7 +18,11 @@ One image (`Dockerfile`), two roles via `bin/demo-entrypoint`:
 
 Both connect to Redis via `REDIS_URL`. A reset/seed (the generator self-heals on
 a Redis flush) keeps the demo from ever looking dead — a flush of the demo Redis
-is enough; the generator re-seeds within one tick.
+is enough; the generator re-seeds within one tick. To stop queue latency from
+creeping up over hours (the single worker can't drain everything the producer
+tops up), an hourly `CronJob` flushes the demo Redis — reference manifest at
+[`demo/k8s/demo-reset-cronjob.yaml`](../demo/k8s/demo-reset-cronjob.yaml), which
+runs the `demo:reset` rake task.
 
 ```text
             ┌── web (puma)  ──► read-only dashboard + generator ──┐
@@ -68,6 +72,7 @@ What's needed to make `https://wurk.demo.developerz.ai` go live. Items marked
 - [ ] **DNS** — `wurk.demo.developerz.ai` → the cluster ingress / Traefik.
 - [ ] **Ingress (Traefik) + TLS** — route the host to the `web` Service, Let's Encrypt cert.
 - [ ] **Public rate-limit** — a Traefik rate-limit middleware on the ingress to discourage abuse.
+- [ ] **Hourly reset `CronJob`** — apply [`demo/k8s/demo-reset-cronjob.yaml`](../demo/k8s/demo-reset-cronjob.yaml) (`demo:reset` → FLUSHDB) so queue latency doesn't creep up over hours. Without it the demo stays alive but the `high`/`low` queues accumulate a multi-hour backlog.
 - [ ] **Resource limits + restart policy** — modest CPU/mem requests; pods must recover on restart with no manual step (the generator self-heals; no persistent state outside Redis).
 
 ### Decisions to confirm with infra

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,7 +45,7 @@ function ReadOnlyBanner() {
         letterSpacing: '0.01em',
       }}
     >
-      {t('readonly.banner')}
+      {meta.read_only_message || t('readonly.banner')}
     </div>
   );
 }

--- a/frontend/src/hooks/useMeta.ts
+++ b/frontend/src/hooks/useMeta.ts
@@ -2,6 +2,8 @@ import { useQuery } from '@tanstack/react-query';
 
 export interface Meta {
   read_only: boolean;
+  // Optional host-supplied banner copy; null → SPA uses its localized default.
+  read_only_message: string | null;
 }
 
 // Boot-time dashboard flags. Fetched once and cached forever — these only

--- a/frontend/src/pages/Dead.tsx
+++ b/frontend/src/pages/Dead.tsx
@@ -2,15 +2,16 @@ import { useQuery } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { Pagination } from '../components/Pagination';
 import { t } from '../i18n';
-import { relativeTime, truncate, formatArgs } from '../utils';
+import { relativeTime, truncate, formatArgs, isoTime } from '../utils';
 
 interface DeadEntry {
   jid: string;
-  class: string;
+  klass: string;
   args: unknown;
   error_class: string;
   error_message: string;
-  failed_at: number;
+  // `at` is the death epoch (the sorted-set score); see api/serializers.rb#sorted_entry.
+  at: number;
   score: number;
 }
 
@@ -75,14 +76,14 @@ export default function Dead() {
                       >
                         {truncate(entry.jid, 12)}
                       </td>
-                      <td style={{ fontWeight: 500 }}>{entry.class}</td>
+                      <td style={{ fontWeight: 500 }}>{entry.klass}</td>
                       <td title={argsStr}>{truncate(argsStr, 40)}</td>
                       <td title={entry.error_class} style={{ color: 'var(--danger)' }}>
                         {truncate(entry.error_class, 25)}
                       </td>
                       <td title={entry.error_message}>{truncate(entry.error_message, 40)}</td>
-                      <td title={new Date(entry.failed_at * 1000).toISOString()}>
-                        {relativeTime(entry.failed_at)}
+                      <td title={isoTime(entry.at)}>
+                        {relativeTime(entry.at)}
                       </td>
                     </tr>
                   );

--- a/frontend/src/pages/Retries.tsx
+++ b/frontend/src/pages/Retries.tsx
@@ -2,17 +2,16 @@ import { useQuery } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { Pagination } from '../components/Pagination';
 import { t } from '../i18n';
-import { relativeTime, truncate, formatArgs } from '../utils';
+import { relativeTime, truncate, formatArgs, isoTime } from '../utils';
 
 interface RetryEntry {
   jid: string;
-  class: string;
+  klass: string;
   args: unknown;
   error_class: string;
   error_message: string;
-  failed_at: number;
-  retry_at: number;
-  retried_at: number | null;
+  // `at` is the next-retry epoch (the sorted-set score); see api/serializers.rb#sorted_entry.
+  at: number;
   retry_count: number;
   score: number;
 }
@@ -72,15 +71,15 @@ export default function Retries() {
                   const argsStr = formatArgs(entry.args);
                   return (
                     <tr key={entry.jid}>
-                      <td style={{ fontWeight: 500 }}>{entry.class}</td>
+                      <td style={{ fontWeight: 500 }}>{entry.klass}</td>
                       <td title={argsStr}>{truncate(argsStr, 40)}</td>
                       <td title={entry.error_class} style={{ color: 'var(--danger)' }}>
                         {truncate(entry.error_class, 30)}
                       </td>
                       <td title={entry.error_message}>{truncate(entry.error_message, 50)}</td>
                       <td style={{ color: 'var(--warning)' }}>{entry.retry_count}</td>
-                      <td title={new Date(entry.retry_at * 1000).toISOString()}>
-                        {relativeTime(entry.retry_at)}
+                      <td title={isoTime(entry.at)}>
+                        {relativeTime(entry.at)}
                       </td>
                     </tr>
                   );

--- a/frontend/src/pages/Scheduled.tsx
+++ b/frontend/src/pages/Scheduled.tsx
@@ -2,11 +2,11 @@ import { useQuery } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { Pagination } from '../components/Pagination';
 import { t } from '../i18n';
-import { relativeTime, truncate, formatArgs } from '../utils';
+import { relativeTime, truncate, formatArgs, isoTime } from '../utils';
 
 interface ScheduledEntry {
   jid: string;
-  class: string;
+  klass: string;
   args: unknown;
   score: number;
   at: number;
@@ -71,9 +71,9 @@ export default function Scheduled() {
                       >
                         {truncate(entry.jid, 12)}
                       </td>
-                      <td style={{ fontWeight: 500 }}>{entry.class}</td>
+                      <td style={{ fontWeight: 500 }}>{entry.klass}</td>
                       <td title={argsStr}>{truncate(argsStr, 60)}</td>
-                      <td title={new Date(entry.at * 1000).toISOString()}>
+                      <td title={isoTime(entry.at)}>
                         {relativeTime(entry.at)}
                       </td>
                     </tr>

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,4 +1,8 @@
 export function relativeTime(epochSeconds: number): string {
+  // Sorted-set entries can arrive without a usable timestamp; guard so a bad
+  // value renders a dash instead of "NaNs ago".
+  if (!Number.isFinite(epochSeconds)) return '—';
+
   const now = Date.now() / 1000;
   const diff = now - epochSeconds;
   const absDiff = Math.abs(diff);
@@ -16,6 +20,15 @@ export function relativeTime(epochSeconds: number): string {
   }
 
   return future ? `${value} from now` : `${value} ago`;
+}
+
+// ISO timestamp for hover titles. `new Date(NaN).toISOString()` throws a
+// RangeError that unmounts the whole table; returning '' keeps the cell safe
+// when the epoch is missing or non-numeric.
+export function isoTime(epochSeconds: number): string {
+  const ms = epochSeconds * 1000;
+  if (!Number.isFinite(ms)) return '';
+  return new Date(ms).toISOString();
 }
 
 export function truncate(s: string, max = 80): string {

--- a/lib/wurk/web/config.rb
+++ b/lib/wurk/web/config.rb
@@ -37,9 +37,16 @@ module Wurk
       def initialize
         @authorization = nil
         @read_only = env_read_only?
+        @read_only_message = nil
         @middlewares = []
         @rack_app = nil
       end
+
+      # Optional banner copy shown by the dashboard in read-only mode. Nil →
+      # the SPA falls back to its localized default ("Read-only mode"). Lets a
+      # host explain *why* it's read-only — e.g. the public demo sets
+      # "This is a public demo — actions are disabled."
+      attr_accessor :read_only_message
 
       # Registers a `(env, method, path) -> truthy/falsey` block. Re-calling
       # overwrites; the spec exposes a single hook, not a chain.
@@ -88,6 +95,7 @@ module Wurk
       def reset!
         @authorization = nil
         @read_only = env_read_only?
+        @read_only_message = nil
         @middlewares = []
         @rack_app = nil
       end

--- a/test/engine/web_authorization_test.rb
+++ b/test/engine/web_authorization_test.rb
@@ -91,7 +91,9 @@ class WebAuthorizationTest < Wurk::Test::EngineCase
     get '/wurk/api/meta'
 
     assert_equal 200, last_response.status
-    assert_equal false, JSON.parse(last_response.body)['read_only']
+    body = JSON.parse(last_response.body)
+    assert_equal false, body['read_only']
+    assert_nil body['read_only_message']
   end
 
   def test_meta_reports_read_only_when_enabled
@@ -101,5 +103,18 @@ class WebAuthorizationTest < Wurk::Test::EngineCase
 
     assert_equal 200, last_response.status
     assert_equal true, JSON.parse(last_response.body)['read_only']
+  end
+
+  def test_meta_includes_read_only_message_when_set
+    Wurk::Web.configure do |c|
+      c.read_only = true
+      c.read_only_message = 'This is a public demo — actions are disabled.'
+    end
+
+    get '/wurk/api/meta'
+
+    assert_equal 200, last_response.status
+    assert_equal 'This is a public demo — actions are disabled.',
+                 JSON.parse(last_response.body)['read_only_message']
   end
 end

--- a/test/unit/web_config_test.rb
+++ b/test/unit/web_config_test.rb
@@ -105,6 +105,23 @@ class WebConfigTest < Wurk::Test::UnitCase
     refute Wurk::Web.config.read_only?
   end
 
+  def test_read_only_message_defaults_nil
+    assert_nil Wurk::Web.config.read_only_message
+  end
+
+  def test_read_only_message_is_configurable
+    Wurk::Web.configure { |c| c.read_only_message = 'public demo — actions disabled' }
+
+    assert_equal 'public demo — actions disabled', Wurk::Web.config.read_only_message
+  end
+
+  def test_reset_clears_read_only_message
+    Wurk::Web.configure { |c| c.read_only_message = 'x' }
+    Wurk::Web.reset_config!
+
+    assert_nil Wurk::Web.config.read_only_message
+  end
+
   def test_read_only_writer_coerces_to_boolean
     Wurk::Web.configure { |c| c.read_only = 'yes' }
 


### PR DESCRIPTION
Demo-polish + a real dashboard bug surfaced while verifying the live demo for #32.

## What & why

### 1. Fix the Retries/Dead tab crash (general bug — affects all users)
`Retries.tsx` read `entry.retry_at` and `Dead.tsx` read `entry.failed_at`, but the API serializer (`api/serializers.rb#sorted_entry`) emits **`at`** (the sorted-set score) and **`klass`** — not those names. So the time field was `undefined`, and `new Date(undefined * 1000).toISOString()` threw a **`RangeError: Invalid time value`** that unmounted the whole tab (reported live from the Retries tab). The class column was also empty on all three sorted-set pages (`class` vs `klass`).

- Align `Retries` / `Dead` / `Scheduled` with the real payload (`klass`, `at`).
- Add `isoTime()` (returns `''` on a non-finite epoch) for the hover titles, and guard `relativeTime()` to render `—` instead of crashing — defense-in-depth so a missing timestamp can never take a tab down again.

### 2. Public-demo read-only banner copy
The banner existed but said the generic "Read-only mode". Added a **host-overridable** `Wurk::Web.config.read_only_message`, surfaced in `/api/meta` and rendered by the banner (falls back to the localized default when unset). The demo sets *"This is a public demo — actions are disabled."* — satisfying #32's banner requirement without changing copy for other read-only deployments.

### 3. Hourly reset CronJob (so the demo never looks neglected)
The producer self-heals so the demo never goes empty, but a single worker can't drain everything it tops up — live `high`/`low` queue latency had crept to **~6 hours**. Added [`demo/k8s/demo-reset-cronjob.yaml`](../blob/fix/32-demo-banner-cron-retries-crash/demo/k8s/demo-reset-cronjob.yaml) (`demo:reset` → FLUSHDB, hourly) as a copy-paste reference for `../infrastructure`, wired into `docs/demo-deploy.md`.

## Tests
- `test/unit/web_config_test.rb` — `read_only_message` default-nil, configurable, cleared on reset.
- `test/engine/web_authorization_test.rb` — `/api/meta` includes `read_only_message`.
- Full suite green (1908 runs, 0 failures), parity green (20 runs), frontend `tsc --noEmit` + `vite build` clean.

## Follow-up filed separately
The live demo's rate-limited workload is failing 100% because the limiter Lua script accesses an undeclared key on **Dragonfly** (the demo's Redis) — see the linked issue. Out of scope here; it's why the demo shows 44k retries / 427k failures.

## How to test in prod
It's the dashboard SPA + a config flag. After deploy: open the **Retries** and **Dead** tabs (they render instead of white-screening), confirm the **class** column is populated, and confirm the read-only banner reads "This is a public demo — actions are disabled." Apply `demo/k8s/demo-reset-cronjob.yaml` to cap queue-latency growth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configurable custom messages now display in the read-only mode banner.
  * Demo environment automatically resets hourly to manage queue state.

* **Improvements**
  * Enhanced timestamp handling and validation across task management pages.
  * Better null-value handling in time display utilities.

* **Documentation**
  * Updated demo deployment guide with reset mechanism details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/developerz-ai/wurk/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->