### PR TITLE
feat(demo): throttle producer to light load (~1–2 jobs/10s) (#127)

### DIFF
--- a/demo/app/workloads/demo_producer.rb
+++ b/demo/app/workloads/demo_producer.rb
@@ -1,34 +1,38 @@
 # frozen_string_literal: true
 
-# Generates continuous, self-healing demo traffic so every dashboard surface
-# shows live data within ~30s of a cold start — and never looks dead.
+# Generates light, self-healing demo traffic so every dashboard surface shows
+# live data — and never looks dead — without taxing the public demo server.
 #
-# It's a feedback controller: each tick tops the primary queue back up to a
-# target backlog (steady throughput as the worker drains) and keeps the
-# scheduled / retry / dead / batch / limiter / cron surfaces in a band.
-# `ensure_seeded!` runs every tick, so a Redis flush or restart self-heals
-# within one interval.
+# It's a feedback controller: each tick tops shallow target bands back up as the
+# worker drains, and keeps the scheduled / retry / dead / batch / limiter / cron
+# surfaces populated. `ensure_seeded!` runs every tick, so a Redis flush or
+# restart self-heals within one interval.
+#
+# Tuned for a public demo: a ~10s tick with shallow targets means only a trickle
+# of jobs (≈1–2 / 10s in steady state), enough to keep every widget live. Tune
+# the cadence at runtime with DEMO_PRODUCER_INTERVAL (seconds) — no rebuild.
 #
 # Run as its own process:  cd demo && WURK_DEMO=1 bin/rails demo:workload
 class DemoProducer
   PRIMARY_QUEUE    = "default"
   SECONDARY_QUEUES = %w[high low].freeze
-  TARGET_BACKLOG   = 60
-  SECONDARY_DEPTH  = 6
-  SCHEDULED_TARGET = 20
-  RETRY_TARGET     = 12
-  DEAD_TARGET      = 25
-  BATCH_INTERVAL   = 12.0
-  MAX_PER_TICK     = 200
+  DEFAULT_INTERVAL = 10.0
+  TARGET_BACKLOG   = 6
+  SECONDARY_DEPTH  = 2
+  SCHEDULED_TARGET = 5
+  RETRY_TARGET     = 4
+  DEAD_TARGET      = 6
+  BATCH_INTERVAL   = 60.0
+  MAX_PER_TICK     = 5
 
   class << self
     def api_limiter = @api_limiter ||= build_api_limiter
     def build_api_limiter = Wurk::Limiter.bucket("demo-api", 60, :minute, wait_timeout: 0)
   end
 
-  def initialize(logger: nil, interval: 1.0)
+  def initialize(logger: nil, interval: nil)
     @logger = logger
-    @interval = interval
+    @interval = interval || (ENV["DEMO_PRODUCER_INTERVAL"]&.to_f&.nonzero?) || DEFAULT_INTERVAL
     @stop = false
     @last_batch_at = 0.0
   end


### PR DESCRIPTION
Phase 1 of the **Dashboard & demo revamp** (milestone #4). Closes #127.

## Why
The public demo's `DemoProducer` ticked every **1s** and topped up deep backlogs (`TARGET_BACKLOG=60`, `MAX_PER_TICK=200`) — constant heavy load on the demo server. This drops it to a light cadence so the demo stays alive without taxing the box.

## What
`demo/app/workloads/demo_producer.rb`:
- tick interval **1s → 10s** (runtime-tunable via `DEMO_PRODUCER_INTERVAL` — no rebuild)
- shallow targets: `TARGET_BACKLOG` 60→6 · `SECONDARY_DEPTH` 6→2 · `SCHEDULED_TARGET` 20→5 · `RETRY_TARGET` 12→4 · `DEAD_TARGET` 25→6 · `MAX_PER_TICK` 200→5 · `BATCH_INTERVAL` 12→60s

Steady state ≈ 1–2 jobs / 10s, with every surface (queues/scheduled/retries/dead/batches/cron/limiters) still populated so nothing looks dead. The hourly reset CronJob (infra #130) keeps totals bounded.

## Scope / tests
Only touches the public demo app (`demo/`). The `demo_workload_test` covers the **dummy** app's workload (`test/dummy/...`), which is unchanged — still green (7 runs, 0 failures). The public demo producer has no unit harness (it lives in the separate `demo/` Rails app).

## How to test in prod
On the live demo, queue depths stay shallow and churn slowly (~10s) instead of constantly refilling to 60; load on the pod drops accordingly. Set `DEMO_PRODUCER_INTERVAL` to retune without a rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated demo producer to tick at a faster cadence (~10 seconds) with reduced queue targets for lighter-weight demonstrations.
  * Added environment variable configuration support for runtime interval customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->