### PR TITLE
Dashboard: job-detail modal overlays + reusable Modal system

### DIFF
--- a/app/controllers/wurk/api/serializers.rb
+++ b/app/controllers/wurk/api/serializers.rb
@@ -51,7 +51,8 @@ module Wurk
           at: entry.at.to_f,
           error_class: entry['error_class'],
           error_message: entry['error_message'],
-          retry_count: entry['retry_count']
+          retry_count: entry['retry_count'],
+          error_backtrace: entry.error_backtrace
         )
       end
 

--- a/frontend/src/components/JobDetailModal.tsx
+++ b/frontend/src/components/JobDetailModal.tsx
@@ -1,0 +1,87 @@
+import { type ReactNode } from 'react';
+import Modal from './Modal';
+import { t } from '../i18n';
+import { formatArgs, isoTime, relativeTime } from '../utils';
+
+// Union of the fields the various list endpoints expose for a job/entry
+// (queues · retries · scheduled · dead). All optional beyond jid/klass so one
+// component renders every source; missing fields are simply skipped.
+export interface JobEntry {
+  jid: string;
+  klass: string;
+  queue?: string;
+  args?: unknown;
+  enqueued_at?: number | null;
+  created_at?: number | null;
+  at?: number;
+  retry_count?: number;
+  error_class?: string;
+  error_message?: string;
+  error_backtrace?: string[] | null;
+}
+
+function Field({ label, children, mono }: { label: string; children: ReactNode; mono?: boolean }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      <span style={{ fontSize: 11, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+        {label}
+      </span>
+      <span style={{ fontSize: 13, fontFamily: mono ? 'ui-monospace, monospace' : undefined, wordBreak: 'break-word' }}>
+        {children}
+      </span>
+    </div>
+  );
+}
+
+interface JobDetailModalProps {
+  entry: JobEntry | null;
+  /** When the entry came from a failed set (retries/dead), show the at-field as "next retry" vs "scheduled". */
+  atLabel?: string;
+  onClose: () => void;
+}
+
+export default function JobDetailModal({ entry, atLabel, onClose }: JobDetailModalProps) {
+  return (
+    <Modal open={entry !== null} onClose={onClose} title={entry?.klass ?? t('job.detail')} width={680}>
+      {entry && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: '0.9rem' }}>
+            <Field label={t('job.class')}>{entry.klass}</Field>
+            {entry.queue && <Field label={t('job.queue')}>{entry.queue}</Field>}
+            <Field label={t('job.jid')} mono>{entry.jid}</Field>
+            {typeof entry.retry_count === 'number' && (
+              <Field label={t('job.retries')}>{entry.retry_count}</Field>
+            )}
+            {entry.enqueued_at != null && (
+              <Field label={t('job.enqueued')} mono>{isoTime(entry.enqueued_at)} ({relativeTime(entry.enqueued_at)})</Field>
+            )}
+            {entry.at != null && (
+              <Field label={atLabel ?? t('job.at')} mono>{isoTime(entry.at)} ({relativeTime(entry.at)})</Field>
+            )}
+          </div>
+
+          <Field label={t('job.args')} mono>
+            <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{formatArgs(entry.args)}</pre>
+          </Field>
+
+          {(entry.error_class || entry.error_message) && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+              <span style={{ fontSize: 11, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+                {t('job.error')}
+              </span>
+              <span style={{ fontSize: 13, color: 'var(--danger)', wordBreak: 'break-word' }}>
+                {entry.error_class}{entry.error_message ? `: ${entry.error_message}` : ''}
+              </span>
+            </div>
+          )}
+
+          {entry.error_backtrace && entry.error_backtrace.length > 0 && (
+            <Field label={t('job.backtrace')}>
+              <pre className="job-backtrace">{entry.error_backtrace.join('\n')}</pre>
+            </Field>
+          )}
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef, type ReactNode } from 'react';
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title: ReactNode;
+  children: ReactNode;
+  /** Optional footer (e.g. action buttons). */
+  footer?: ReactNode;
+  /** Max width of the dialog; defaults to a roomy detail width. */
+  width?: number;
+}
+
+// Reusable accessible dialog built on the native <dialog> element, so focus
+// trapping, Esc-to-close, and the top-layer/backdrop come from the platform.
+// We wire showModal()/close() to the `open` prop and surface close intents
+// (Esc, backdrop click, the ✕) through a single onClose.
+export default function Modal({ open, onClose, title, children, footer, width = 640 }: ModalProps) {
+  const ref = useRef<HTMLDialogElement>(null);
+  const titleId = useRef(`modal-title-${Math.random().toString(36).slice(2)}`).current;
+
+  useEffect(() => {
+    const dlg = ref.current;
+    if (!dlg) return;
+    if (open && !dlg.open) dlg.showModal();
+    else if (!open && dlg.open) dlg.close();
+  }, [open]);
+
+  // The native `cancel` event fires on Esc; route it through onClose so React
+  // state stays the source of truth (preventDefault stops the default close so
+  // we don't end up with dlg.open=false while the prop says open).
+  useEffect(() => {
+    const dlg = ref.current;
+    if (!dlg) return;
+    const onCancel = (e: Event) => {
+      e.preventDefault();
+      onClose();
+    };
+    dlg.addEventListener('cancel', onCancel);
+    return () => dlg.removeEventListener('cancel', onCancel);
+  }, [onClose]);
+
+  if (!open) return null;
+
+  return (
+    <dialog
+      ref={ref}
+      className="modal"
+      aria-labelledby={titleId}
+      // Backdrop click: the dialog element itself is the click target outside
+      // the inner content, so close only when the click lands on <dialog>.
+      onClick={(e) => {
+        if (e.target === ref.current) onClose();
+      }}
+    >
+      <div className="modal-panel" style={{ maxWidth: width }}>
+        <div className="modal-header">
+          <h2 id={titleId} className="modal-title">{title}</h2>
+          <button className="modal-close" onClick={onClose} aria-label="Close">
+            <i className="fa-solid fa-xmark" />
+          </button>
+        </div>
+        <div className="modal-body">{children}</div>
+        {footer && <div className="modal-footer">{footer}</div>}
+      </div>
+    </dialog>
+  );
+}

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -48,6 +48,18 @@
     "queues": "Queues",
     "hostname": "Hostname"
   },
+  "job": {
+    "detail": "Job detail",
+    "class": "Class",
+    "queue": "Queue",
+    "jid": "JID",
+    "retries": "Retries",
+    "enqueued": "Enqueued",
+    "at": "Scheduled",
+    "args": "Arguments",
+    "error": "Error",
+    "backtrace": "Backtrace"
+  },
   "actions": {
     "retry": "Retry",
     "delete": "Delete",

--- a/frontend/src/pages/Dead.tsx
+++ b/frontend/src/pages/Dead.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 import { Pagination } from '../components/Pagination';
 import { t } from '../i18n';
 import { relativeTime, truncate, formatArgs, isoTime } from '../utils';
+import JobDetailModal, { type JobEntry } from '../components/JobDetailModal';
 
 interface DeadEntry {
   jid: string;
@@ -13,6 +14,9 @@ interface DeadEntry {
   // `at` is the death epoch (the sorted-set score); see api/serializers.rb#sorted_entry.
   at: number;
   score: number;
+  queue?: string;
+  enqueued_at?: number | null;
+  error_backtrace?: string[] | null;
 }
 
 interface DeadResponse {
@@ -26,6 +30,7 @@ const PAGE_SIZE = 25;
 
 export default function Dead() {
   const [page, setPage] = useState(1);
+  const [selected, setSelected] = useState<JobEntry | null>(null);
 
   useEffect(() => {
     document.title = `${t('nav.dead')} — Wurk`;
@@ -69,7 +74,7 @@ export default function Dead() {
                 {data.entries.map((entry) => {
                   const argsStr = formatArgs(entry.args);
                   return (
-                    <tr key={entry.jid}>
+                    <tr key={entry.jid} className="row-clickable" onClick={() => setSelected(entry)}>
                       <td
                         title={entry.jid}
                         style={{ fontFamily: 'monospace', fontSize: 12, color: 'var(--text-muted)' }}
@@ -94,6 +99,7 @@ export default function Dead() {
           <Pagination page={page} total={data.total} count={PAGE_SIZE} onChange={setPage} />
         </>
       )}
+      <JobDetailModal entry={selected} atLabel={t('table.failed_at')} onClose={() => setSelected(null)} />
     </div>
   );
 }

--- a/frontend/src/pages/Queues.tsx
+++ b/frontend/src/pages/Queues.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 import { Pagination } from '../components/Pagination';
 import { t } from '../i18n';
 import { relativeTime, truncate, formatArgs } from '../utils';
+import JobDetailModal, { type JobEntry } from '../components/JobDetailModal';
 
 interface QueueSummary {
   name: string;
@@ -34,6 +35,7 @@ const PAGE_SIZE = 25;
 
 function QueueJobs({ name }: { name: string }) {
   const [page, setPage] = useState(1);
+  const [selected, setSelected] = useState<JobEntry | null>(null);
 
   const { data, isLoading, isError } = useQuery<QueueDetail>({
     queryKey: ['queue', name, page],
@@ -73,7 +75,11 @@ function QueueJobs({ name }: { name: string }) {
                 {data.jobs.map((job) => {
                   const argsStr = formatArgs(job.args);
                   return (
-                    <tr key={job.jid}>
+                    <tr
+                      key={job.jid}
+                      className="row-clickable"
+                      onClick={() => setSelected({ jid: job.jid, klass: job.class, args: job.args, queue: name, enqueued_at: job.enqueued_at })}
+                    >
                       <td title={job.jid} style={{ fontFamily: 'monospace', fontSize: 12, color: 'var(--text-muted)' }}>
                         {truncate(job.jid, 12)}
                       </td>
@@ -89,6 +95,7 @@ function QueueJobs({ name }: { name: string }) {
           <Pagination page={page} total={data.size} count={PAGE_SIZE} onChange={setPage} />
         </>
       )}
+      <JobDetailModal entry={selected} onClose={() => setSelected(null)} />
     </div>
   );
 }

--- a/frontend/src/pages/Retries.tsx
+++ b/frontend/src/pages/Retries.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 import { Pagination } from '../components/Pagination';
 import { t } from '../i18n';
 import { relativeTime, truncate, formatArgs, isoTime } from '../utils';
+import JobDetailModal, { type JobEntry } from '../components/JobDetailModal';
 
 interface RetryEntry {
   jid: string;
@@ -14,6 +15,9 @@ interface RetryEntry {
   at: number;
   retry_count: number;
   score: number;
+  queue?: string;
+  enqueued_at?: number | null;
+  error_backtrace?: string[] | null;
 }
 
 interface RetriesResponse {
@@ -27,6 +31,7 @@ const PAGE_SIZE = 25;
 
 export default function Retries() {
   const [page, setPage] = useState(1);
+  const [selected, setSelected] = useState<JobEntry | null>(null);
 
   useEffect(() => {
     document.title = `${t('nav.retries')} — Wurk`;
@@ -70,7 +75,7 @@ export default function Retries() {
                 {data.entries.map((entry) => {
                   const argsStr = formatArgs(entry.args);
                   return (
-                    <tr key={entry.jid}>
+                    <tr key={entry.jid} className="row-clickable" onClick={() => setSelected(entry)}>
                       <td style={{ fontWeight: 500 }}>{entry.klass}</td>
                       <td title={argsStr}>{truncate(argsStr, 40)}</td>
                       <td title={entry.error_class} style={{ color: 'var(--danger)' }}>
@@ -90,6 +95,7 @@ export default function Retries() {
           <Pagination page={page} total={data.total} count={PAGE_SIZE} onChange={setPage} />
         </>
       )}
+      <JobDetailModal entry={selected} atLabel={t('table.retry_at')} onClose={() => setSelected(null)} />
     </div>
   );
 }

--- a/frontend/src/pages/Scheduled.tsx
+++ b/frontend/src/pages/Scheduled.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 import { Pagination } from '../components/Pagination';
 import { t } from '../i18n';
 import { relativeTime, truncate, formatArgs, isoTime } from '../utils';
+import JobDetailModal, { type JobEntry } from '../components/JobDetailModal';
 
 interface ScheduledEntry {
   jid: string;
@@ -10,6 +11,8 @@ interface ScheduledEntry {
   args: unknown;
   score: number;
   at: number;
+  queue?: string;
+  enqueued_at?: number | null;
 }
 
 interface ScheduledResponse {
@@ -23,6 +26,7 @@ const PAGE_SIZE = 25;
 
 export default function Scheduled() {
   const [page, setPage] = useState(1);
+  const [selected, setSelected] = useState<JobEntry | null>(null);
 
   useEffect(() => {
     document.title = `${t('nav.scheduled')} — Wurk`;
@@ -64,7 +68,7 @@ export default function Scheduled() {
                 {data.entries.map((entry) => {
                   const argsStr = formatArgs(entry.args);
                   return (
-                    <tr key={entry.jid}>
+                    <tr key={entry.jid} className="row-clickable" onClick={() => setSelected(entry)}>
                       <td
                         title={entry.jid}
                         style={{ fontFamily: 'monospace', fontSize: 12, color: 'var(--text-muted)' }}
@@ -85,6 +89,7 @@ export default function Scheduled() {
           <Pagination page={page} total={data.total} count={PAGE_SIZE} onChange={setPage} />
         </>
       )}
+      <JobDetailModal entry={selected} atLabel={t('table.scheduled_at')} onClose={() => setSelected(null)} />
     </div>
   );
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -413,3 +413,99 @@ tbody tr:last-child td {
 .wurk-nav {
   border-right: 1px solid var(--border) !important;
 }
+
+/* ── Modal (native <dialog>) ───────────────────────────────────────────────*/
+.modal {
+  border: none;
+  background: transparent;
+  padding: 0;
+  max-width: 92vw;
+  max-height: 88vh;
+  color: var(--text);
+  overflow: visible;
+}
+
+.modal::backdrop {
+  background: oklch(0 0 0 / 0.55);
+  -webkit-backdrop-filter: blur(2px);
+  backdrop-filter: blur(2px);
+}
+
+.modal-panel {
+  width: 92vw;
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  box-shadow: 0 20px 60px oklch(0 0 0 / 0.5);
+  display: flex;
+  flex-direction: column;
+  max-height: 88vh;
+  overflow: hidden;
+  animation: modal-in 0.14s ease;
+}
+
+@keyframes modal-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem 1.1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.modal-title {
+  font-size: 15px;
+  font-weight: 600;
+  font-family: ui-monospace, monospace;
+  word-break: break-all;
+}
+
+.modal-close {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  font-size: 16px;
+  padding: 4px 7px;
+  border-radius: 7px;
+  transition: color 0.15s, background 0.15s;
+}
+
+.modal-close:hover {
+  color: var(--text);
+  background: var(--surface-hover);
+}
+
+.modal-body {
+  padding: 1.1rem;
+  overflow-y: auto;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding: 0.8rem 1.1rem;
+  border-top: 1px solid var(--border);
+}
+
+.job-backtrace {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  background: var(--color-base-100);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.7rem 0.85rem;
+  max-height: 320px;
+  overflow: auto;
+  white-space: pre;
+}
+
+/* Clickable list rows that open a detail modal. */
+.row-clickable { cursor: pointer; }
+.row-clickable:hover td { background: var(--accent-soft); }


### PR DESCRIPTION
Adds a reusable modal/dialog system and uses it for click-to-open job detail. Closes #131, closes #132.

## #131 — reusable Modal
Accessible dialog built on the native `<dialog>` element, so focus-trap, Esc, and the top-layer backdrop come from the platform. Adds backdrop-click + ✕ close and ARIA labelling; slate-themed to match the dark dashboard. Built to host action buttons later.

## #132 — job-detail overlays
`JobDetailModal` renders an entry's full context — class · queue · jid · args · error class+message · **backtrace** · retry count · timestamps — wired as a click-to-open overlay from the **Retries, Dead, Scheduled, and Queues** list rows. One component handles every list's entry shape (fields are conditional). Rows get a pointer cursor + hover highlight.

## API
Exposes `error_backtrace` (already decoded by `JobRecord`) on the failed-entry serializer so the overlay can show the stack.

## Scope
Detail as **overlays**, not routes (chosen UX). No mutating actions here — retry/kill/delete + their confirm dialogs land with **#102** (the Modal is built to host them); the public demo is read-only regardless.

## Verification
`tsc` clean · `vite build` clean · `en.json` valid · engine API test 26/0 (serializer change safe).

## How to test in prod
Once a demo image with this is deployed, on `https://<demo-host>/wurk`:
- Open **Dead** or **Retries** → **click any row** → detail modal opens with error + backtrace.
- Close via ✕ / Esc / backdrop click. Scheduled + Queues rows open too (no error section, as those jobs haven't failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)