### PR TITLE
fix(demo): populate the Metrics tab — register Metrics::History on the worker

### DIFF
--- a/demo/config/initializers/wurk.rb
+++ b/demo/config/initializers/wurk.rb
@@ -15,11 +15,18 @@ end
 # `sidekiq_options unique_for:` (SendReceiptJob) actually de-dupes.
 Sidekiq::Enterprise.unique!
 
-# Worker side: record per-job history so the throughput/failures charts have
-# data (the History middleware is opt-in). Only fires in a worker/server process.
+# Worker side: record per-job history so the Metrics throughput/failure charts
+# have data (the History middleware is opt-in).
+#
+# Add it DIRECTLY to the server-middleware chain, not via `Wurk.configure_server`:
+# that block only runs when `Wurk.configuration.server?` is true, but the demo
+# worker boots via `bin/rails runner 'Wurk::Swarm.new…supervise'` where the
+# initializer runs with server? == false, so the block was silently skipped and
+# Metrics stayed empty (see #100). The swarm forks AFTER this initializer, so the
+# children inherit the chain.
 if ENV["WURK_DEMO"] == "1"
-  Wurk.configure_server do |config|
-    config.server_middleware.add(Wurk::Metrics::History)
+  unless Wurk.configuration.server_middleware.exists?(Wurk::Metrics::History)
+    Wurk.configuration.server_middleware.add(Wurk::Metrics::History)
   end
 
   # Web side (non-forking process): run the traffic producer in a background


### PR DESCRIPTION
The live demo's **Metrics tab is empty** even though jobs are processing (`stat:processed` climbs). Root cause + fix below.

## Root cause
`Wurk::Configuration#configure_server` yields its block **only when `server?` is true**, and runs it inline (it doesn't store it). The demo worker boots via `bin/rails runner 'Wurk::Swarm.new…boot.supervise'` — the railtie is skipped (`WURK_DISABLED=1`) and the swarm is started manually. When the Rails initializer runs, `Wurk.configuration.server?` is **false**, so:

```ruby
Wurk.configure_server { |c| c.server_middleware.add(Wurk::Metrics::History) }  # block never yields → no-op
```

So `Metrics::History` never lands on the chain → no per-class history written → `/api/metrics` `top_jobs: []` and `/api/history` empty. (Same spirit as #100.)

## Fix
Add `Metrics::History` **directly** to `Wurk.configuration.server_middleware` (idempotent, mirrors `Encryption`'s server-middleware registration). The swarm forks *after* this initializer, so children inherit the chain and record history.

## Verification
- Local showcase harness (`test/qa/demo_showcase_check.rb`) already records metrics with a direct add (`top_jobs: 8`).
- After deploy: `curl .../wurk/api/metrics?minutes=60` → `top_jobs` non-empty; Metrics tab shows the throughput/failure charts + per-job table.

## How to test in prod
After the demo redeploys, open `https://<demo-host>/wurk` → **Metrics** → throughput/failure charts + top-jobs table populate within a minute or two of traffic.

Relates to #100.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured the demo environment's web UI as read-only with user-friendly messaging explaining disabled actions.
  * Improved background job processing reliability in demo mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->