### PR TITLE
Dashboard + site polish: branded hero, per-tab headers, modal motion, search fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 <div align="center">
 
+[![Live Demo](https://img.shields.io/badge/live%20demo-wurk.demo.developerz.ai-22c55e?logo=googlechrome&logoColor=white)](https://wurk.demo.developerz.ai/wurk)
 [![Gem Version](https://img.shields.io/gem/v/wurk.svg)](https://rubygems.org/gems/wurk)
 [![CI](https://github.com/developerz-ai/wurk/actions/workflows/test.yml/badge.svg)](https://github.com/developerz-ai/wurk/actions/workflows/test.yml)
 [![Coverage gate](https://img.shields.io/badge/coverage%20gate-line%20%E2%89%A590%25-brightgreen.svg)](https://github.com/developerz-ai/wurk/actions/workflows/test.yml)

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -13,65 +13,87 @@
   <meta property="og:image" content="https://developerz-ai.github.io/wurk/wurk-logo.png">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:image" content="https://developerz-ai.github.io/wurk/wurk-logo.png">
+  <meta name="theme-color" content="#0d1117">
+  <meta name="color-scheme" content="dark">
   <link rel="icon" type="image/png" href="wurk-logo.png">
+  <!-- Set early so scroll-reveal elements start hidden only when JS can reveal them (no-JS = visible). -->
+  <script>document.documentElement.classList.add('js');</script>
   <style>
+    /* Slate palette — matches the Wurk dashboard (GitHub dark-dimmed lineage). */
     :root {
-      --bg: #0b0e14; --panel: #131722; --line: #232838; --fg: #e6e9f0;
-      --muted: #9aa4b2; --accent: #7c9cff; --accent2: #57e6c3; --code: #0e121b;
+      --bg: #0d1117; --panel: #161b22; --panel-2: #21262d;
+      --line: rgba(255,255,255,0.08); --line-strong: #30363d;
+      --fg: #e6edf3; --muted: #8b949e;
+      --accent: #ffffff; --success: #3fb950; --danger: #e5534b; --warning: #d29922;
+      --code: #0d1117; --radius: 10px;
     }
     * { box-sizing: border-box; }
     html { scroll-behavior: smooth; }
     body {
       margin: 0; background: var(--bg); color: var(--fg);
-      font: 16px/1.6 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
-      -webkit-font-smoothing: antialiased;
+      font: 16px/1.6 system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility;
     }
-    a { color: var(--accent); text-decoration: none; }
-    a:hover { text-decoration: underline; }
+    a { color: var(--fg); text-decoration: none; }
+    a:hover { text-decoration: underline; text-underline-offset: 2px; }
     .wrap { max-width: 960px; margin: 0 auto; padding: 0 20px; }
     code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
     pre {
-      background: var(--code); border: 1px solid var(--line); border-radius: 10px;
-      padding: 16px 18px; overflow-x: auto; font-size: 14px; line-height: 1.55;
+      background: var(--code); border: 1px solid var(--line-strong); border-radius: var(--radius);
+      padding: 16px 18px; overflow-x: auto; font-size: 14px; line-height: 1.6;
     }
-    .add { color: var(--accent2); } .del { color: #ff7b86; } .cmt { color: var(--muted); }
+    .add { color: var(--success); } .del { color: var(--danger); } .cmt { color: var(--muted); }
 
-    header { border-bottom: 1px solid var(--line); }
-    nav { display: flex; align-items: center; gap: 20px; padding: 16px 0; }
-    nav .brand { font-weight: 700; font-size: 18px; }
+    /* ── Header ── */
+    header { border-bottom: 1px solid var(--line); position: sticky; top: 0; z-index: 10;
+      background: color-mix(in oklch, var(--bg) 88%, transparent);
+      -webkit-backdrop-filter: blur(8px); backdrop-filter: blur(8px); }
+    nav { display: flex; align-items: center; gap: 20px; padding: 14px 0; }
+    nav .brand { font-weight: 800; font-size: 18px; letter-spacing: -0.02em; }
     nav .spacer { flex: 1; }
     nav a.navlink { color: var(--muted); font-size: 14px; }
     nav a.navlink:hover { color: var(--fg); text-decoration: none; }
 
-    .hero { padding: 72px 0 56px; text-align: center; }
-    .hero h1 { font-size: 52px; line-height: 1.05; margin: 0 0 16px; letter-spacing: -1px; }
-    .hero h1 .grad {
-      background: linear-gradient(90deg, var(--accent), var(--accent2));
-      -webkit-background-clip: text; background-clip: text; color: transparent;
+    /* ── Hero ── */
+    .hero { padding: 64px 0 52px; text-align: center; animation: fade-up .5s ease both; }
+    .hero__logo {
+      height: 188px; width: auto; display: block; margin: 0 auto 18px;
+      filter: drop-shadow(0 14px 26px rgba(0,0,0,0.55));
+      animation: float 5s ease-in-out infinite;
     }
-    .hero p.lede { font-size: 20px; color: var(--muted); max-width: 720px; margin: 0 auto 28px; }
+    .hero h1 { font-size: 60px; line-height: 1; margin: 0; letter-spacing: -0.03em; font-weight: 800; }
+    .hero .strapline { font-size: 20px; font-weight: 600; margin: 14px 0 0; }
+    .hero .lede { font-size: 18px; color: var(--muted); max-width: 680px; margin: 12px auto 28px; }
     .cta { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; margin-bottom: 28px; }
     .btn {
-      display: inline-block; padding: 11px 20px; border-radius: 9px; font-weight: 600; font-size: 15px;
-      border: 1px solid var(--line);
+      display: inline-flex; align-items: center; gap: 0.45rem;
+      padding: 11px 20px; border-radius: var(--radius); font-weight: 600; font-size: 15px;
+      border: 1px solid var(--line-strong); transition: background .15s, border-color .15s, transform .05s;
     }
-    .btn.primary { background: var(--accent); color: #0b0e14; border-color: var(--accent); }
-    .btn.primary:hover { text-decoration: none; filter: brightness(1.07); }
+    .btn:hover { text-decoration: none; }
+    .btn:active { transform: translateY(1px); }
+    .btn.primary { background: var(--accent); color: #0d1117; border-color: var(--accent); }
+    .btn.primary:hover { filter: brightness(0.94); }
     .btn.ghost { background: var(--panel); color: var(--fg); }
-    .btn.ghost:hover { text-decoration: none; border-color: var(--accent); }
+    .btn.ghost:hover { border-color: var(--accent); background: var(--panel-2); }
     .install { max-width: 560px; margin: 0 auto; text-align: left; }
 
+    /* ── Sections ── */
     section { padding: 48px 0; border-top: 1px solid var(--line); }
-    h2 { font-size: 28px; margin: 0 0 24px; letter-spacing: -0.5px; }
+    h2 { font-size: 28px; margin: 0 0 24px; letter-spacing: -0.02em; font-weight: 800; }
     .pillars { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
-    .pillar { background: var(--panel); border: 1px solid var(--line); border-radius: 12px; padding: 20px; }
+    .pillar { background: var(--panel); border: 1px solid var(--line); border-radius: 12px; padding: 20px;
+      box-shadow: 0 1px 2px rgba(0,0,0,0.4); transition: transform .15s ease, border-color .15s ease; }
+    .pillar:hover { transform: translateY(-2px); border-color: var(--line-strong); }
     .pillar h3 { margin: 0 0 8px; font-size: 17px; }
     .pillar p { margin: 0; color: var(--muted); font-size: 14px; }
 
-    table { width: 100%; border-collapse: collapse; font-size: 14px; }
+    table { width: 100%; border-collapse: collapse; font-size: 14px;
+      background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius); overflow: hidden; }
     th, td { text-align: left; padding: 12px 14px; border-bottom: 1px solid var(--line); vertical-align: top; }
-    th { color: var(--muted); font-weight: 600; }
-    td .tier { color: var(--accent2); white-space: nowrap; }
+    tr:last-child td { border-bottom: none; }
+    th { color: var(--muted); font-weight: 600; text-transform: uppercase; font-size: 11px; letter-spacing: 0.05em; }
+    td .tier { color: var(--muted); white-space: nowrap; font-variant: small-caps; }
 
     .two { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
     .two h3 { font-size: 16px; margin: 0 0 10px; }
@@ -79,9 +101,23 @@
     footer { border-top: 1px solid var(--line); padding: 32px 0 48px; color: var(--muted); font-size: 14px; }
     footer a { color: var(--muted); } footer a:hover { color: var(--fg); }
 
+    /* ── Motion ── */
+    @keyframes fade-up { from { opacity: 0; transform: translateY(14px); } to { opacity: 1; transform: translateY(0); } }
+    @keyframes float { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-8px); } }
+    .js .reveal { opacity: 0; transform: translateY(18px); }
+    .reveal.in { opacity: 1; transform: none; transition: opacity .5s ease, transform .5s ease; }
+
     @media (max-width: 720px) {
-      .hero h1 { font-size: 38px; } .pillars, .two { grid-template-columns: 1fr; }
+      .hero { padding: 40px 0 36px; }
+      .hero__logo { height: 150px; }
+      .hero h1 { font-size: 42px; }
+      .pillars, .two { grid-template-columns: 1fr; }
       nav .navlink.hide { display: none; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .hero, .hero__logo { animation: none; }
+      .js .reveal { opacity: 1; transform: none; }
+      .pillar { transition: none; }
     }
   </style>
 </head>
@@ -94,6 +130,7 @@
         <a class="navlink hide" href="#features">Features</a>
         <a class="navlink hide" href="#install">Install</a>
         <a class="navlink hide" href="#migrate">Migrate</a>
+        <a class="navlink" href="https://wurk.demo.developerz.ai/wurk">Live demo</a>
         <a class="navlink" href="https://github.com/developerz-ai/wurk/wiki">Docs</a>
         <a class="navlink" href="https://github.com/developerz-ai/wurk">GitHub</a>
       </nav>
@@ -103,14 +140,15 @@
   <main>
     <div class="wrap">
       <section class="hero" style="border-top:none">
-        <h1>A free, faster,<br><span class="grad">100% drop-in</span> Sidekiq replacement</h1>
+        <img class="hero__logo" src="wurk-logo.png" alt="Wurk — an orc ready to work">
+        <h1>Wurk ⚡</h1>
+        <p class="strapline">Wurk, wurk. 🪓 Ready to work. Zug zug.</p>
         <p class="lede">
-          Same Redis keys, same job JSON, same Ruby DSL. Swap one line in your Gemfile and your
-          existing jobs, batches, limiters, and cron keep working — with Pro + Enterprise feature
-          parity in one free gem.
+          A 100% drop-in replacement for Sidekiq + Sidekiq Pro + Sidekiq Enterprise.
+          Free forever. Faster.
         </p>
         <div class="cta">
-          <a class="btn primary" href="https://wurk.demo.developerz.ai">View the live demo →</a>
+          <a class="btn primary" href="https://wurk.demo.developerz.ai/wurk">View the live demo →</a>
           <a class="btn ghost" href="https://rubygems.org/gems/wurk">Get the gem</a>
           <a class="btn ghost" href="https://github.com/developerz-ai/wurk">GitHub</a>
         </div>
@@ -120,7 +158,7 @@ gem <span class="add">"wurk"</span></pre>
         </div>
       </section>
 
-      <section id="pillars" style="border-top:none">
+      <section id="pillars" class="reveal" style="border-top:none">
         <div class="pillars">
           <div class="pillar">
             <h3>🔌 100% drop-in</h3>
@@ -137,7 +175,7 @@ gem <span class="add">"wurk"</span></pre>
         </div>
       </section>
 
-      <section id="features">
+      <section id="features" class="reveal">
         <h2>Everything, in one free gem</h2>
         <table>
           <thead><tr><th>Area</th><th>What you get</th><th>Sidekiq tier</th></tr></thead>
@@ -147,12 +185,24 @@ gem <span class="add">"wurk"</span></pre>
             <tr><td><b>Limiters</b></td><td>Concurrent, bucket, window, leaky, points rate limiters</td><td><span class="tier">Enterprise</span></td></tr>
             <tr><td><b>Periodic</b></td><td>Cron jobs, leader-elected so each tick fires exactly once</td><td><span class="tier">Enterprise</span></td></tr>
             <tr><td><b>Encryption</b></td><td>AES-256-GCM argument encryption with zero-downtime key rotation</td><td><span class="tier">Enterprise</span></td></tr>
-            <tr><td><b>Dashboard</b></td><td>Mountable Rails engine, precompiled React SPA (no Node), live charts</td><td><span class="tier">OSS + Pro/Ent</span></td></tr>
+            <tr><td><b>Dashboard</b></td><td>Mountable Rails engine, precompiled React SPA (no Node), live charts, job-detail modals</td><td><span class="tier">OSS + Pro/Ent</span></td></tr>
           </tbody>
         </table>
       </section>
 
-      <section id="install">
+      <section id="dashboard" class="reveal">
+        <h2>A dashboard you'll actually want open</h2>
+        <p style="color:var(--muted);max-width:720px">
+          Dark, fast, and mobile-first — a precompiled React SPA that ships inside the gem (consumers
+          never run Node). Live queues, retries, scheduled, dead, busy workers, batches, limiters, cron,
+          and throughput/failure metrics. Click any job for its full args, error, and backtrace.
+        </p>
+        <p style="margin-top:18px">
+          <a class="btn primary" href="https://wurk.demo.developerz.ai/wurk">Open the live demo →</a>
+        </p>
+      </section>
+
+      <section id="install" class="reveal">
         <h2>Install</h2>
         <div class="two">
           <div>
@@ -171,7 +221,7 @@ mount Wurk::Engine =&gt; <span class="add">"/wurk"</span></pre>
         </div>
       </section>
 
-      <section id="migrate">
+      <section id="migrate" class="reveal">
         <h2>Migrating from Sidekiq</h2>
         <p style="color:var(--muted);max-width:720px">
           Wurk reads and writes the same Redis schema, so a rolling deploy can run Sidekiq and Wurk
@@ -193,10 +243,27 @@ mount Wurk::Engine =&gt; <span class="add">"/wurk"</span></pre>
         <a href="https://github.com/developerz-ai/wurk">GitHub</a> ·
         <a href="https://rubygems.org/gems/wurk">RubyGems</a> ·
         <a href="https://github.com/developerz-ai/wurk/wiki">Docs</a> ·
-        <a href="https://wurk.demo.developerz.ai">Live demo</a>
+        <a href="https://wurk.demo.developerz.ai/wurk">Live demo</a>
       </p>
       <p>Wurk is a clean-room reimplementation of the Sidekiq <b>API</b> — MIT licensed. Sidekiq is a trademark of Contributed Systems LLC; Wurk is not affiliated with or endorsed by it.</p>
     </div>
   </footer>
+
+  <script>
+    // Progressive scroll-reveal: fade sections up as they enter the viewport.
+    (function () {
+      var els = document.querySelectorAll('.reveal');
+      if (!('IntersectionObserver' in window)) {
+        els.forEach(function (el) { el.classList.add('in'); });
+        return;
+      }
+      var io = new IntersectionObserver(function (entries) {
+        entries.forEach(function (e) {
+          if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); }
+        });
+      }, { threshold: 0.12 });
+      els.forEach(function (el) { io.observe(el); });
+    })();
+  </script>
 </body>
 </html>

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -11,13 +11,19 @@ interface ModalProps {
   width?: number;
 }
 
-// Reusable accessible dialog built on the native <dialog> element, so focus
-// trapping, Esc-to-close, and the top-layer/backdrop come from the platform.
-// We wire showModal()/close() to the `open` prop and surface close intents
-// (Esc, backdrop click, the ✕) through a single onClose.
+// Reusable accessible dialog on the native <dialog> element — focus trapping,
+// Esc-to-close, and the top-layer/backdrop come from the platform. The dialog
+// stays mounted (not conditionally rendered) and is driven by showModal()/close(),
+// so enter AND exit animate via CSS (@starting-style + allow-discrete in styles.css).
 export default function Modal({ open, onClose, title, children, footer, width = 640 }: ModalProps) {
   const ref = useRef<HTMLDialogElement>(null);
   const titleId = useRef(`modal-title-${Math.random().toString(36).slice(2)}`).current;
+
+  // Hold the last content + title so the panel isn't blank while it animates out
+  // (consumers typically clear their data the moment `open` flips false).
+  const held = useRef<{ title: ReactNode; children: ReactNode }>({ title, children });
+  if (open) held.current = { title, children };
+  const shown = open ? { title, children } : held.current;
 
   useEffect(() => {
     const dlg = ref.current;
@@ -26,9 +32,8 @@ export default function Modal({ open, onClose, title, children, footer, width = 
     else if (!open && dlg.open) dlg.close();
   }, [open]);
 
-  // The native `cancel` event fires on Esc; route it through onClose so React
-  // state stays the source of truth (preventDefault stops the default close so
-  // we don't end up with dlg.open=false while the prop says open).
+  // Esc fires the native `cancel`; route it through onClose so React state stays
+  // the source of truth.
   useEffect(() => {
     const dlg = ref.current;
     if (!dlg) return;
@@ -40,27 +45,25 @@ export default function Modal({ open, onClose, title, children, footer, width = 
     return () => dlg.removeEventListener('cancel', onCancel);
   }, [onClose]);
 
-  if (!open) return null;
-
   return (
     <dialog
       ref={ref}
       className="modal"
       aria-labelledby={titleId}
-      // Backdrop click: the dialog element itself is the click target outside
-      // the inner content, so close only when the click lands on <dialog>.
+      // Close only when the click lands on the <dialog> itself (the backdrop area),
+      // not the panel inside it.
       onClick={(e) => {
         if (e.target === ref.current) onClose();
       }}
     >
       <div className="modal-panel" style={{ maxWidth: width }}>
         <div className="modal-header">
-          <h2 id={titleId} className="modal-title">{title}</h2>
+          <h2 id={titleId} className="modal-title">{shown.title}</h2>
           <button className="modal-close" onClick={onClose} aria-label="Close">
             <i className="fa-solid fa-xmark" />
           </button>
         </div>
-        <div className="modal-body">{children}</div>
+        <div className="modal-body">{shown.children}</div>
         {footer && <div className="modal-footer">{footer}</div>}
       </div>
     </dialog>

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -1,6 +1,5 @@
 import { NavLink } from 'react-router-dom';
 import { t } from '../i18n';
-import logoUrl from '../assets/wurk-logo.png';
 
 interface NavProps {
   open: boolean;
@@ -67,19 +66,7 @@ export default function Nav({ open, onClose }: NavProps) {
               gap: '0.55rem',
             }}
           >
-            <img
-              src={logoUrl}
-              alt=""
-              style={{
-                width: 68,
-                height: 68,
-                borderRadius: 12,
-                objectFit: 'cover',
-                objectPosition: 'top',
-                display: 'block',
-                border: '1px solid var(--border)',
-              }}
-            />
+            <i className="fa-solid fa-bolt" style={{ fontSize: 16, color: 'var(--accent)' }} />
             Wurk
           </span>
         </div>

--- a/frontend/src/components/PageHeader.tsx
+++ b/frontend/src/components/PageHeader.tsx
@@ -1,0 +1,27 @@
+import { type ReactNode } from 'react';
+
+interface PageHeaderProps {
+  /** Font Awesome solid icon class, e.g. `fa-layer-group` (matches the nav). */
+  icon: string;
+  title: string;
+  summary: string;
+  /** Optional right-aligned slot — typically the count badge. */
+  children?: ReactNode;
+}
+
+// Consistent header for each tab page: the tab's icon, its title, and a one-line
+// summary of what the page shows. Keeps every page oriented and on-brand.
+export function PageHeader({ icon, title, summary, children }: PageHeaderProps) {
+  return (
+    <div className="page-header">
+      <span className="page-header__icon">
+        <i className={`fa-solid ${icon}`} />
+      </span>
+      <div className="page-header__text">
+        <h1 className="page-header__title">{title}</h1>
+        <p className="page-header__summary">{summary}</p>
+      </div>
+      {children != null && <div className="page-header__aside">{children}</div>}
+    </div>
+  );
+}

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -24,7 +24,11 @@
     "processes": "Processes",
     "latency": "Latency",
     "live": "Live",
-    "paused": "Paused"
+    "paused": "Paused",
+    "strapline": "Wurk, wurk. 🪓 Ready to work. Zug zug.",
+    "tagline": "A 100% drop-in replacement for Sidekiq + Sidekiq Pro + Sidekiq Enterprise. Free forever. Faster.",
+    "install": "Install",
+    "docs": "Documentation"
   },
   "table": {
     "class": "Class",
@@ -48,6 +52,18 @@
     "queues": "Queues",
     "hostname": "Hostname"
   },
+  "summaries": {
+    "queues": "Active queues with their depth and latency — click a queue to inspect its jobs.",
+    "retries": "Jobs that raised an error and are scheduled to run again — click one for the error and backtrace.",
+    "scheduled": "Jobs enqueued to run at a future time.",
+    "dead": "Jobs that exhausted every retry — click one to inspect the failure.",
+    "busy": "Live worker processes and the jobs they're currently running.",
+    "batches": "Batched jobs and their progress, successes, and failures.",
+    "limiters": "Rate limiters and their current usage.",
+    "cron": "Periodic (cron) jobs with their schedule and last run.",
+    "metrics": "Throughput and failure history, with per-job execution stats.",
+    "search": "Find a job across retries, scheduled, and dead by JID or class name."
+  },
   "job": {
     "detail": "Job detail",
     "class": "Class",
@@ -59,6 +75,11 @@
     "args": "Arguments",
     "error": "Error",
     "backtrace": "Backtrace"
+  },
+  "search": {
+    "emptyTitle": "Search for a job",
+    "emptyHint": "Enter a JID or class name (2+ characters) and hit Search. Results span retries, scheduled, and dead jobs.",
+    "try": "Try:"
   },
   "actions": {
     "retry": "Retry",

--- a/frontend/src/pages/Batches.tsx
+++ b/frontend/src/pages/Batches.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { Pagination } from '../components/Pagination';
 import { t } from '../i18n';
+import { PageHeader } from '../components/PageHeader';
 import { relativeTime, truncate } from '../utils';
 
 interface Batch {
@@ -45,10 +46,9 @@ export default function Batches() {
 
   return (
     <div>
-      <div className="section-header">
-        <h1 className="page-title" style={{ margin: 0 }}>{t('nav.batches')}</h1>
-        <span className="badge badge-accent" style={{ marginLeft: 'auto' }}>{data.total.toLocaleString()}</span>
-      </div>
+      <PageHeader icon="fa-table-cells-large" title={t('nav.batches')} summary={t('summaries.batches')}>
+        <span className="badge badge-accent">{data.total.toLocaleString()}</span>
+      </PageHeader>
 
       {data.batches.length === 0 ? (
         <div className="empty-state">{t('common.empty')}</div>

--- a/frontend/src/pages/Busy.tsx
+++ b/frontend/src/pages/Busy.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { t } from '../i18n';
+import { PageHeader } from '../components/PageHeader';
 import { relativeTime } from '../utils';
 
 interface Process {
@@ -29,12 +30,11 @@ export default function Busy() {
 
   return (
     <div>
-      <div className="section-header">
-        <h1 className="page-title" style={{ margin: 0 }}>{t('nav.busy')}</h1>
-        <span className="badge badge-muted" style={{ marginLeft: 'auto' }}>
+      <PageHeader icon="fa-gears" title={t('nav.busy')} summary={t('summaries.busy')}>
+        <span className="badge badge-muted">
           {data.length} {t('dashboard.processes').toLowerCase()}
         </span>
-      </div>
+      </PageHeader>
 
       {data.length === 0 ? (
         <div className="empty-state">{t('common.empty')}</div>
@@ -42,7 +42,7 @@ export default function Busy() {
         <div
           style={{
             display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(min(100%, 320px), 1fr))',
             gap: '1rem',
           }}
         >

--- a/frontend/src/pages/Cron.tsx
+++ b/frontend/src/pages/Cron.tsx
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { t } from '../i18n';
+import { PageHeader } from '../components/PageHeader';
 import { relativeTime, truncate } from '../utils';
 import { useMeta } from '../hooks/useMeta';
 
@@ -51,10 +52,9 @@ export default function Cron() {
 
   return (
     <div>
-      <div className="section-header">
-        <h1 className="page-title" style={{ margin: 0 }}>{t('nav.cron')}</h1>
-        <span className="badge badge-muted" style={{ marginLeft: 'auto' }}>{data.length}</span>
-      </div>
+      <PageHeader icon="fa-stopwatch" title={t('nav.cron')} summary={t('summaries.cron')}>
+        <span className="badge badge-muted">{data.length}</span>
+      </PageHeader>
 
       {data.length === 0 ? (
         <div className="empty-state">{t('common.empty')}</div>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import { StatCard } from '../components/StatCard';
 import { t } from '../i18n';
 import type { StatsSnapshot } from '../hooks/useSSE';
 import { relativeTime } from '../utils';
+import logoUrl from '../assets/wurk-logo.png';
 
 interface StatsData {
   processed: number;
@@ -69,19 +70,34 @@ export default function Dashboard({ sse }: DashboardProps) {
 
   return (
     <div>
-      <div className="section-header" style={{ marginBottom: '1.25rem' }}>
-        <h1 className="page-title" style={{ margin: 0 }}>{t('nav.dashboard')}</h1>
-        {sse.connected && (
-          <span style={{ display: 'flex', alignItems: 'center', gap: '0.375rem', fontSize: 12, color: 'var(--success)' }}>
-            <span className="live-dot" />
-            {t('dashboard.live')}
-          </span>
-        )}
-        {sse.stats?.at && (
-          <span style={{ fontSize: 12, color: 'var(--text-muted)', marginLeft: 'auto' }}>
-            {relativeTime(sse.stats.at)}
-          </span>
-        )}
+      <div className="dash-hero">
+        <div className="dash-hero__mark">
+          <img src={logoUrl} alt="Wurk" />
+        </div>
+        <div className="dash-hero__body">
+          <h1 className="dash-hero__title">Wurk ⚡</h1>
+          <p className="dash-hero__strapline">{t('dashboard.strapline')}</p>
+          <p className="dash-hero__tagline">{t('dashboard.tagline')}</p>
+          <div className="dash-hero__actions">
+            <a className="btn btn-accent" href="https://developerz-ai.github.io/wurk/" target="_blank" rel="noreferrer">
+              <i className="fa-solid fa-download" /> {t('dashboard.install')}
+            </a>
+            <a className="btn" href="https://github.com/developerz-ai/wurk/wiki" target="_blank" rel="noreferrer">
+              <i className="fa-solid fa-book" /> {t('dashboard.docs')}
+            </a>
+          </div>
+        </div>
+        <div className="dash-hero__status">
+          {sse.connected && (
+            <span className="dash-hero__live">
+              <span className="live-dot" />
+              {t('dashboard.live')}
+            </span>
+          )}
+          {sse.stats?.at && (
+            <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>{relativeTime(sse.stats.at)}</span>
+          )}
+        </div>
       </div>
 
       <div

--- a/frontend/src/pages/Dead.tsx
+++ b/frontend/src/pages/Dead.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { Pagination } from '../components/Pagination';
 import { t } from '../i18n';
+import { PageHeader } from '../components/PageHeader';
 import { relativeTime, truncate, formatArgs, isoTime } from '../utils';
 import JobDetailModal, { type JobEntry } from '../components/JobDetailModal';
 
@@ -49,10 +50,9 @@ export default function Dead() {
 
   return (
     <div>
-      <div className="section-header">
-        <h1 className="page-title" style={{ margin: 0 }}>{t('nav.dead')}</h1>
-        <span className="badge badge-danger" style={{ marginLeft: 'auto' }}>{data.total.toLocaleString()}</span>
-      </div>
+      <PageHeader icon="fa-skull" title={t('nav.dead')} summary={t('summaries.dead')}>
+        <span className="badge badge-danger">{data.total.toLocaleString()}</span>
+      </PageHeader>
 
       {data.entries.length === 0 ? (
         <div className="empty-state">{t('common.empty')}</div>

--- a/frontend/src/pages/Limiters.tsx
+++ b/frontend/src/pages/Limiters.tsx
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { Pagination } from '../components/Pagination';
 import { t } from '../i18n';
+import { PageHeader } from '../components/PageHeader';
 import { useMeta } from '../hooks/useMeta';
 
 // Uniform live status every limiter type reports (Wurk::Limiter#status).
@@ -65,10 +66,9 @@ export default function Limiters() {
 
   return (
     <div>
-      <div className="section-header">
-        <h1 className="page-title" style={{ margin: 0 }}>{t('nav.limiters')}</h1>
-        <span className="badge badge-muted" style={{ marginLeft: 'auto' }}>{data.total.toLocaleString()}</span>
-      </div>
+      <PageHeader icon="fa-gauge" title={t('nav.limiters')} summary={t('summaries.limiters')}>
+        <span className="badge badge-muted">{data.total.toLocaleString()}</span>
+      </PageHeader>
 
       {data.limiters.length === 0 ? (
         <div className="empty-state">{t('common.empty')}</div>

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -12,6 +12,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { t } from '../i18n';
+import { PageHeader } from '../components/PageHeader';
 import { truncate } from '../utils';
 
 // Matches Wurk::Api::Serializers.metric_row — processed (successes), failed,
@@ -143,9 +144,8 @@ export default function Metrics() {
 
   return (
     <div>
-      <div className="section-header">
-        <h1 className="page-title" style={{ margin: 0 }}>{t('nav.metrics')}</h1>
-        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+      <PageHeader icon="fa-chart-line" title={t('nav.metrics')} summary={t('summaries.metrics')}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
           <span style={{ fontSize: 13, color: 'var(--text-muted)' }}>Last</span>
           <select
             className="select"
@@ -159,7 +159,7 @@ export default function Metrics() {
             ))}
           </select>
         </div>
-      </div>
+      </PageHeader>
 
       <HistoryCharts />
 

--- a/frontend/src/pages/Queues.tsx
+++ b/frontend/src/pages/Queues.tsx
@@ -2,8 +2,10 @@ import { useQuery } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { Pagination } from '../components/Pagination';
 import { t } from '../i18n';
+import { PageHeader } from '../components/PageHeader';
 import { relativeTime, truncate, formatArgs } from '../utils';
 import JobDetailModal, { type JobEntry } from '../components/JobDetailModal';
+import Modal from '../components/Modal';
 
 interface QueueSummary {
   name: string;
@@ -118,65 +120,49 @@ export default function Queues() {
 
   return (
     <div>
-      <h1 className="page-title">{t('nav.queues')}</h1>
+      <PageHeader icon="fa-layer-group" title={t('nav.queues')} summary={t('summaries.queues')} />
 
-      <div style={{ display: 'grid', gridTemplateColumns: selectedQueue ? '280px 1fr' : '1fr', gap: '1.5rem' }}>
-        <div>
-          {data.length === 0 ? (
-            <div className="empty-state">{t('common.empty')}</div>
-          ) : (
-            <div className="table-wrapper">
-              <table>
-                <thead>
-                  <tr>
-                    <th>Name</th>
-                    <th>{t('table.size')}</th>
-                    <th>{t('table.latency')}</th>
-                    <th>{t('table.status')}</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {data.map((q) => (
-                    <tr
-                      key={q.name}
-                      onClick={() => setSelectedQueue(q.name === selectedQueue ? null : q.name)}
-                      style={{
-                        cursor: 'pointer',
-                        background: q.name === selectedQueue ? 'rgba(124,106,247,0.08)' : undefined,
-                      }}
-                    >
-                      <td style={{ fontWeight: 500, color: q.name === selectedQueue ? 'var(--accent)' : undefined }}>
-                        {q.name}
-                      </td>
-                      <td>{q.size.toLocaleString()}</td>
-                      <td>{q.latency.toFixed(3)}s</td>
-                      <td>
-                        {q.paused ? (
-                          <span className="badge badge-warning">{t('dashboard.paused')}</span>
-                        ) : (
-                          <span className="badge badge-success">Active</span>
-                        )}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
+      {data.length === 0 ? (
+        <div className="empty-state">{t('common.empty')}</div>
+      ) : (
+        <div className="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>{t('table.size')}</th>
+                <th>{t('table.latency')}</th>
+                <th>{t('table.status')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.map((q) => (
+                <tr key={q.name} className="row-clickable" onClick={() => setSelectedQueue(q.name)}>
+                  <td style={{ fontWeight: 500 }}>{q.name}</td>
+                  <td>{q.size.toLocaleString()}</td>
+                  <td>{q.latency.toFixed(3)}s</td>
+                  <td>
+                    {q.paused ? (
+                      <span className="badge badge-warning">{t('dashboard.paused')}</span>
+                    ) : (
+                      <span className="badge badge-success">Active</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
+      )}
 
-        {selectedQueue && (
-          <div>
-            <div className="section-header">
-              <h2 className="section-title">{selectedQueue}</h2>
-              <button className="btn" onClick={() => setSelectedQueue(null)} style={{ marginLeft: 'auto' }}>
-                ✕
-              </button>
-            </div>
-            <QueueJobs name={selectedQueue} />
-          </div>
-        )}
-      </div>
+      <Modal
+        open={selectedQueue !== null}
+        onClose={() => setSelectedQueue(null)}
+        title={selectedQueue ?? ''}
+        width={780}
+      >
+        {selectedQueue && <QueueJobs name={selectedQueue} />}
+      </Modal>
     </div>
   );
 }

--- a/frontend/src/pages/Retries.tsx
+++ b/frontend/src/pages/Retries.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { Pagination } from '../components/Pagination';
 import { t } from '../i18n';
+import { PageHeader } from '../components/PageHeader';
 import { relativeTime, truncate, formatArgs, isoTime } from '../utils';
 import JobDetailModal, { type JobEntry } from '../components/JobDetailModal';
 
@@ -50,10 +51,9 @@ export default function Retries() {
 
   return (
     <div>
-      <div className="section-header">
-        <h1 className="page-title" style={{ margin: 0 }}>{t('nav.retries')}</h1>
-        <span className="badge badge-warning" style={{ marginLeft: 'auto' }}>{data.total.toLocaleString()}</span>
-      </div>
+      <PageHeader icon="fa-rotate-right" title={t('nav.retries')} summary={t('summaries.retries')}>
+        <span className="badge badge-warning">{data.total.toLocaleString()}</span>
+      </PageHeader>
 
       {data.entries.length === 0 ? (
         <div className="empty-state">{t('common.empty')}</div>

--- a/frontend/src/pages/Scheduled.tsx
+++ b/frontend/src/pages/Scheduled.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { Pagination } from '../components/Pagination';
 import { t } from '../i18n';
+import { PageHeader } from '../components/PageHeader';
 import { relativeTime, truncate, formatArgs, isoTime } from '../utils';
 import JobDetailModal, { type JobEntry } from '../components/JobDetailModal';
 
@@ -45,10 +46,9 @@ export default function Scheduled() {
 
   return (
     <div>
-      <div className="section-header">
-        <h1 className="page-title" style={{ margin: 0 }}>{t('nav.scheduled')}</h1>
-        <span className="badge badge-accent" style={{ marginLeft: 'auto' }}>{data.total.toLocaleString()}</span>
-      </div>
+      <PageHeader icon="fa-clock" title={t('nav.scheduled')} summary={t('summaries.scheduled')}>
+        <span className="badge badge-accent">{data.total.toLocaleString()}</span>
+      </PageHeader>
 
       {data.entries.length === 0 ? (
         <div className="empty-state">{t('common.empty')}</div>

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -1,11 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { t } from '../i18n';
+import { PageHeader } from '../components/PageHeader';
 import { relativeTime, truncate, formatArgs } from '../utils';
 
 interface RetryEntry {
   jid: string;
-  class: string;
+  klass: string;
   args: unknown;
   error_class: string;
   error_message: string;
@@ -18,7 +19,7 @@ interface RetryEntry {
 
 interface ScheduledEntry {
   jid: string;
-  class: string;
+  klass: string;
   args: unknown;
   score: number;
   at: number;
@@ -26,7 +27,7 @@ interface ScheduledEntry {
 
 interface DeadEntry {
   jid: string;
-  class: string;
+  klass: string;
   args: unknown;
   error_class: string;
   error_message: string;
@@ -57,7 +58,7 @@ interface DeadResponse {
 
 function matches(term: string, jid: string, cls: string): boolean {
   const q = term.toLowerCase();
-  return jid.toLowerCase().includes(q) || cls.toLowerCase().includes(q);
+  return (jid ?? '').toLowerCase().includes(q) || (cls ?? '').toLowerCase().includes(q);
 }
 
 export default function Search() {
@@ -95,19 +96,42 @@ export default function Search() {
     enabled: submitted.length >= 2,
   });
 
+  // Live sample of job classes for the empty-state suggestion chips — derived
+  // from real data so it works for any app, not hardcoded to the demo.
+  const { data: sample } = useQuery<Array<{ entries?: Array<{ klass?: string }> }>>({
+    queryKey: ['search-suggest'],
+    queryFn: () =>
+      Promise.all(
+        ['/wurk/api/retries?page=0&count=10', '/wurk/api/dead?page=0&count=10'].map((u) =>
+          fetch(u).then((r) => r.json())
+        )
+      ),
+    staleTime: 30000,
+  });
+  const suggestions = Array.from(
+    new Set(
+      (sample ?? []).flatMap((s) => (s.entries ?? []).map((e) => e.klass)).filter(Boolean) as string[]
+    )
+  ).slice(0, 5);
+
+  const runSearch = (term: string) => {
+    setQuery(term);
+    setSubmitted(term);
+  };
+
   const filteredRetries =
     submitted.length >= 2
-      ? (retries?.entries ?? []).filter((e) => matches(submitted, e.jid, e.class))
+      ? (retries?.entries ?? []).filter((e) => matches(submitted, e.jid, e.klass))
       : [];
 
   const filteredScheduled =
     submitted.length >= 2
-      ? (scheduled?.entries ?? []).filter((e) => matches(submitted, e.jid, e.class))
+      ? (scheduled?.entries ?? []).filter((e) => matches(submitted, e.jid, e.klass))
       : [];
 
   const filteredDead =
     submitted.length >= 2
-      ? (dead?.entries ?? []).filter((e) => matches(submitted, e.jid, e.class))
+      ? (dead?.entries ?? []).filter((e) => matches(submitted, e.jid, e.klass))
       : [];
 
   const handleSearch = (e: React.FormEvent) => {
@@ -119,7 +143,7 @@ export default function Search() {
 
   return (
     <div>
-      <h1 className="page-title">{t('nav.search')}</h1>
+      <PageHeader icon="fa-magnifying-glass" title={t('nav.search')} summary={t('summaries.search')} />
 
       <form onSubmit={handleSearch} style={{ display: 'flex', gap: '0.75rem', marginBottom: '2rem' }}>
         <input
@@ -134,6 +158,24 @@ export default function Search() {
           {t('actions.search')}
         </button>
       </form>
+
+      {submitted.length < 2 && (
+        <div className="search-empty">
+          <div className="search-empty__icon"><i className="fa-solid fa-magnifying-glass" /></div>
+          <p className="search-empty__title">{t('search.emptyTitle')}</p>
+          <p className="search-empty__hint">{t('search.emptyHint')}</p>
+          {suggestions.length > 0 && (
+            <div className="search-empty__chips">
+              <span className="search-empty__chips-label">{t('search.try')}</span>
+              {suggestions.map((s) => (
+                <button key={s} type="button" className="chip" onClick={() => runSearch(s)}>
+                  {s}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
 
       {submitted.length >= 2 && (
         <div style={{ marginBottom: '0.75rem', color: 'var(--text-muted)', fontSize: 13 }}>
@@ -166,7 +208,7 @@ export default function Search() {
                       <td title={entry.jid} style={{ fontFamily: 'monospace', fontSize: 12, color: 'var(--text-muted)' }}>
                         {truncate(entry.jid, 12)}
                       </td>
-                      <td style={{ fontWeight: 500 }}>{entry.class}</td>
+                      <td style={{ fontWeight: 500 }}>{entry.klass}</td>
                       <td title={argsStr}>{truncate(argsStr, 40)}</td>
                       <td title={entry.error_class} style={{ color: 'var(--danger)' }}>
                         {truncate(entry.error_class, 25)}
@@ -205,7 +247,7 @@ export default function Search() {
                       <td title={entry.jid} style={{ fontFamily: 'monospace', fontSize: 12, color: 'var(--text-muted)' }}>
                         {truncate(entry.jid, 12)}
                       </td>
-                      <td style={{ fontWeight: 500 }}>{entry.class}</td>
+                      <td style={{ fontWeight: 500 }}>{entry.klass}</td>
                       <td title={argsStr}>{truncate(argsStr, 60)}</td>
                       <td>{relativeTime(entry.at)}</td>
                     </tr>
@@ -241,7 +283,7 @@ export default function Search() {
                       <td title={entry.jid} style={{ fontFamily: 'monospace', fontSize: 12, color: 'var(--text-muted)' }}>
                         {truncate(entry.jid, 12)}
                       </td>
-                      <td style={{ fontWeight: 500 }}>{entry.class}</td>
+                      <td style={{ fontWeight: 500 }}>{entry.klass}</td>
                       <td title={argsStr}>{truncate(argsStr, 40)}</td>
                       <td title={entry.error_class} style={{ color: 'var(--danger)' }}>
                         {truncate(entry.error_class, 25)}

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -301,12 +301,6 @@ export default function Search() {
       {submitted.length >= 2 && totalResults === 0 && (
         <div className="empty-state">{t('common.empty')}</div>
       )}
-
-      {submitted.length < 2 && (
-        <div className="empty-state" style={{ color: 'var(--text-muted)' }}>
-          Enter at least 2 characters to search across retries, scheduled, and dead jobs.
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -157,6 +157,10 @@ tbody tr:last-child td {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
+  /* Gentle entrance, same fade-up as the page header (slightly delayed so the
+     header leads and the table follows). Runs once on mount, not on refetch. */
+  animation: fade-up 0.35s ease both;
+  animation-delay: 0.05s;
 }
 
 /* Interactive stat cards: a subtle border + lift on hover, no glow. */
@@ -419,16 +423,58 @@ tbody tr:last-child td {
   border: none;
   background: transparent;
   padding: 0;
+  /* The global `* { margin: 0 }` reset breaks the native dialog's auto-margin
+     centering, so centre explicitly with a fixed transform — robust in both
+     axes regardless of the reset. */
+  margin: 0;
+  position: fixed;
+  top: 50%;
+  left: 50%;
   max-width: 92vw;
   max-height: 88vh;
   color: var(--text);
   overflow: visible;
+  /* Closed/exit state — animates BOTH ways. allow-discrete keeps the dialog in
+     the top layer through the exit transition (the "animation back"). */
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(0.95);
+  transition:
+    opacity 0.22s ease,
+    transform 0.24s cubic-bezier(0.16, 1, 0.3, 1),
+    overlay 0.24s ease allow-discrete,
+    display 0.24s ease allow-discrete;
+}
+
+.modal[open] {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+/* Entry: start from the closed state when [open] first applies. */
+@starting-style {
+  .modal[open] {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.95);
+  }
 }
 
 .modal::backdrop {
-  background: oklch(0 0 0 / 0.55);
-  -webkit-backdrop-filter: blur(2px);
-  backdrop-filter: blur(2px);
+  /* Dim + blur the page so focus lands on the modal and its contents stay
+     readable. Fades in/out with the dialog (allow-discrete). */
+  background: oklch(0 0 0 / 0.58);
+  -webkit-backdrop-filter: blur(6px) saturate(75%);
+  backdrop-filter: blur(6px) saturate(75%);
+  opacity: 0;
+  transition:
+    opacity 0.22s ease,
+    overlay 0.22s ease allow-discrete,
+    display 0.22s ease allow-discrete;
+}
+
+.modal[open]::backdrop { opacity: 1; }
+
+@starting-style {
+  .modal[open]::backdrop { opacity: 0; }
 }
 
 .modal-panel {
@@ -441,12 +487,6 @@ tbody tr:last-child td {
   flex-direction: column;
   max-height: 88vh;
   overflow: hidden;
-  animation: modal-in 0.14s ease;
-}
-
-@keyframes modal-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
 }
 
 .modal-header {
@@ -509,3 +549,267 @@ tbody tr:last-child td {
 /* Clickable list rows that open a detail modal. */
 .row-clickable { cursor: pointer; }
 .row-clickable:hover td { background: var(--accent-soft); }
+
+/* Lowkey "clickable" hint: a faint chevron at the row's end, just present enough
+   to read as interactive at rest, brightening + nudging right on hover. */
+.row-clickable td:last-child {
+  position: relative;
+  padding-right: 1.85rem;
+}
+.row-clickable td:last-child::after {
+  content: '\203A'; /* › */
+  position: absolute;
+  right: 0.8rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 15px;
+  line-height: 1;
+  color: var(--text-muted);
+  opacity: 0.28;
+  transition: opacity 0.15s ease, transform 0.15s ease, color 0.15s ease;
+}
+.row-clickable:hover td:last-child::after {
+  opacity: 0.9;
+  color: var(--accent);
+  transform: translateY(-50%) translateX(3px);
+}
+@media (prefers-reduced-motion: reduce) {
+  .row-clickable td:last-child::after { transition: none; }
+}
+
+/* ── Dashboard hero (mascot banner) ────────────────────────────────────────*/
+.dash-hero {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.5rem;
+  padding: 1.6rem 1.5rem 1.7rem;
+  margin-bottom: 1.5rem;
+  background:
+    radial-gradient(70% 120% at 50% 100%, color-mix(in oklch, var(--success) 13%, transparent), transparent 60%),
+    linear-gradient(180deg, var(--surface-hover), var(--surface));
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+/* The mascot stands centred in the banner: full body, soft shadow. */
+.dash-hero__mark {
+  display: grid;
+  place-items: center;
+}
+
+.dash-hero__mark img {
+  height: 200px;
+  width: auto;
+  object-fit: contain;
+  display: block;
+  filter: drop-shadow(0 12px 22px oklch(0 0 0 / 0.55));
+}
+
+.dash-hero__body { min-width: 0; max-width: 640px; }
+
+/* Three clear hierarchy levels: title (largest/brightest) → strapline (medium
+   emphasis) → tagline (smallest/muted). */
+.dash-hero__title {
+  font-size: 42px;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  line-height: 1.05;
+  color: var(--text);
+}
+
+.dash-hero__strapline {
+  margin-top: 0.55rem;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.dash-hero__tagline {
+  margin-top: 0.55rem;
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+/* Live/updated status floats top-right so the brand column stays centred. */
+.dash-hero__status {
+  position: absolute;
+  top: 0.9rem;
+  right: 1.1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.dash-hero__live {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 12px;
+  color: var(--success);
+}
+
+@media (max-width: 560px) {
+  .dash-hero { padding: 1.25rem 1rem 1.4rem; }
+  .dash-hero__mark img { height: 150px; }
+  .dash-hero__title { font-size: 32px; }
+  .dash-hero__strapline { font-size: 16px; }
+  .dash-hero__tagline { font-size: 14px; }
+  /* The absolute status can crowd the centred title on narrow screens — drop it
+     back into the flow, centred under the brand. */
+  .dash-hero__status {
+    position: static;
+    margin-top: 0.4rem;
+    justify-content: center;
+  }
+}
+
+/* ── Page header (per-tab icon + summary) ──────────────────────────────────*/
+.page-header {
+  display: flex;
+  align-items: center;
+  gap: 0.95rem;
+  margin-bottom: 1.5rem;
+  animation: fade-up 0.3s ease both;
+}
+
+.page-header__icon {
+  flex: none;
+  width: 44px;
+  height: 44px;
+  border-radius: 11px;
+  display: grid;
+  place-items: center;
+  background: var(--surface-strong);
+  border: 1px solid var(--border-strong);
+  color: var(--accent);
+  font-size: 18px;
+  transition: transform 0.18s ease, border-color 0.18s ease;
+}
+
+.page-header:hover .page-header__icon {
+  transform: translateY(-1px);
+  border-color: color-mix(in oklch, var(--accent) 40%, var(--border-strong));
+}
+
+.page-header__text { min-width: 0; }
+
+.page-header__title {
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+}
+
+.page-header__summary {
+  margin-top: 3px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.page-header__aside { margin-left: auto; align-self: center; }
+
+@media (max-width: 560px) {
+  .page-header__summary { font-size: 12px; }
+  .page-header__icon { width: 38px; height: 38px; font-size: 16px; }
+}
+
+/* ── Motion (tasteful; honours reduced-motion) ─────────────────────────────*/
+@keyframes fade-up {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.dash-hero { animation: fade-up 0.35s ease both; }
+
+/* The mascot gently floats in its banner. */
+@keyframes float {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-7px); }
+}
+.dash-hero__mark img { animation: float 5s ease-in-out infinite; }
+
+@media (prefers-reduced-motion: reduce) {
+  .page-header,
+  .dash-hero,
+  .table-wrapper { animation: none; }
+  .dash-hero__mark img { animation: none; }
+  .card--stat { transition: none; }
+  .modal,
+  .modal::backdrop { transition: none; }
+}
+
+/* Hero quick-link buttons (install / docs). */
+.dash-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.6rem;
+  margin-top: 1.05rem;
+}
+.dash-hero__actions .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+.dash-hero__actions .btn:hover { text-decoration: none; }
+
+/* ── Search empty state (sample chips) ─────────────────────────────────────*/
+.search-empty {
+  text-align: center;
+  padding: 2.5rem 1.5rem 3rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  animation: fade-up 0.3s ease both;
+}
+.search-empty__icon {
+  width: 52px;
+  height: 52px;
+  margin: 0 auto 0.9rem;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  background: var(--surface-strong);
+  border: 1px solid var(--border-strong);
+  color: var(--text-muted);
+  font-size: 20px;
+}
+.search-empty__title { font-size: 16px; font-weight: 600; }
+.search-empty__hint {
+  margin: 0.4rem auto 0;
+  max-width: 460px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+.search-empty__chips {
+  margin-top: 1.1rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+.search-empty__chips-label { font-size: 12px; color: var(--text-muted); }
+
+.chip {
+  background: var(--surface-strong);
+  border: 1px solid var(--border-strong);
+  color: var(--text);
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  transition: border-color 0.15s, background 0.15s, color 0.15s, transform 0.05s;
+}
+.chip:hover {
+  border-color: var(--accent);
+  background: var(--surface-hover);
+}
+.chip:active { transform: translateY(1px); }


### PR DESCRIPTION
A cohesive UX polish pass over the dashboard, plus a matching reskin of the GitHub Pages marketing site so the **site, dashboard, and README share one look**. Builds on the merged revamp (#128–#132).

## Dashboard (`/wurk`)
- **Branded hero** — orc logo moved out of the nav (now a clean `⚡ Wurk` wordmark) into a **centered hero**: `Wurk ⚡` + *"Wurk, wurk. 🪓 Ready to work. Zug zug."* + the drop-in tagline, with **Install** (→ GH Pages) and **Documentation** (→ Wiki) quick links. Logo gently floats.
- **Per-tab headers** — every main page leads with its **icon + one-line summary** (new `PageHeader` component + i18n `summaries`).
- **Modal** — centered (fixed transform), with **enter *and* exit animation** + a dimmed, **6px-blurred backdrop** so content stands out. Native `<dialog>` + `@starting-style` + `allow-discrete`; kept mounted so it animates out and holds content through the exit; degrades gracefully; `prefers-reduced-motion`-safe.
- **Search fix** — filtered on `e.class` but the API field is `klass` → class-name search matched nothing and could throw. Now uses `klass` + a crash-proof `matches()`, plus a polished empty state with **live sample chips** (real job classes).
- **Queues** — clicking a queue opens its jobs in a **modal** instead of a confusing split-pane.
- **Lowkey clickable rows** — a faint `›` chevron that brightens + nudges on hover.
- **Motion** — fade-up entrances on hero, page headers, and tables; all reduced-motion-safe.
- **Mobile** — responsive hero; Busy grid `minmax(min(100%, 320px), 1fr)` fix.

## GitHub Pages site (`docs/site/index.html`)
Reskinned to the same **slate theme** — orc hero, `Wurk ⚡` branding, monochrome buttons, **fade-up + scroll-reveal** animations, sticky blurred header, hover-lift pillars; added a dashboard section; demo links point to `/wurk`.

## README
Prominent **Live Demo** badge at the top.

## Notes
- **Source-only** — the dashboard bundle (`vendor/assets/`) is gitignored and rebuilt at CI/release.
- Verified: `tsc` clean · `vite build` clean · `en.json` valid.

## How to test in prod
After the demo redeploys, open `https://<demo-host>/wurk`: centered orc hero with Install/Docs buttons, every tab has an icon+summary, click a Dead/Retries row → **centered modal that pops in with a blurred backdrop**, Queues → jobs modal, Search a class name → results (+ sample chips when empty). The GH Pages site (`developerz-ai.github.io/wurk`) gets the matching look on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Live Demo links throughout the interface
  * Introduced dark theme support with improved styling
  * Enhanced search with smart suggestions for short queries
  * Added scroll-reveal animations for visual polish

* **Style**
  * Redesigned Dashboard page with featured branding
  * Introduced consistent page headers with icons across all views
  * Improved modal animations for smoother transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->