### PR TITLE
feat(pro): wire super_fetch! recovery callback through the reaper (#113)

### DIFF
--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -62,7 +62,7 @@ module Wurk
       end
     end
 
-    attr_reader :capsules, :directory, :redis_config
+    attr_reader :capsules, :directory, :redis_config, :super_fetch_callback
     attr_accessor :thread_priority
 
     # Pro parity: callable that builds the statsd / dogstatsd client.
@@ -209,10 +209,15 @@ module Wurk
     # Sidekiq Pro's opt-in toggles for reliable fetch and the reliable
     # scheduler. Both are already the default in Wurk — the fetcher is always
     # the reliable BLMOVE fetcher with orphan reclamation, and the scheduler is
-    # always atomic Lua — so these accept the call and do nothing. They exist
-    # only so a Pro initializer drops in unchanged instead of raising
-    # NoMethodError. Spec: docs/target/sidekiq-pro.md §3 (super_fetch).
-    def super_fetch!(*)
+    # always atomic Lua — so the toggle itself is a no-op. They exist only so a
+    # Pro initializer drops in unchanged instead of raising NoMethodError.
+    #
+    # The optional block is Pro's recovery callback: `|jobstr, pill|`, fired
+    # once per orphan recovery (`pill` nil) and once on a poison kill (`pill`
+    # responds to .jid/.klass/.count/.queue). The reaper drives it via
+    # Wurk::Middleware::PoisonPill.track!. Spec: docs/target/sidekiq-pro.md §3.1.
+    def super_fetch!(*, &block)
+      @super_fetch_callback = block if block
       nil
     end
 

--- a/lib/wurk/fetcher/reaper.rb
+++ b/lib/wurk/fetcher/reaper.rb
@@ -219,7 +219,7 @@ module Wurk
       end
 
       def poison_off(public_q, job, queue_name)
-        return unless Middleware::PoisonPill.track!(job, queue: queue_name) == :poison
+        return unless Middleware::PoisonPill.track!(job, queue: queue_name, config: @config) == :poison
 
         # track! already ZADDed the payload to the dead set; pull the copy we
         # just LMOVE'd onto the public tail so it isn't also re-run.

--- a/lib/wurk/middleware/poison_pill.rb
+++ b/lib/wurk/middleware/poison_pill.rb
@@ -29,6 +29,12 @@ module Wurk
       KEY_PREFIX = 'super_fetch:recovered:'
       DEAD_RECORD_LIMIT = 100
 
+      # The `pill` handed to a Pro `super_fetch! { |jobstr, pill| }` recovery
+      # callback on the kill path. Responds to .jid/.klass/.count/.queue so a
+      # `pill.jid`-style Pro initializer drops in. `.count` shadows Struct#count
+      # by design — Pro's API names it that. Spec: sidekiq-pro.md §3.1.
+      Pill = ::Struct.new(:jid, :klass, :count, :queue, keyword_init: true) # rubocop:disable Lint/StructNewOverride
+
       module_function
 
       # Called per recovered orphan job. Returns `:poison` when the threshold
@@ -37,23 +43,34 @@ module Wurk
       # here). Emits `jobs.recovered.fetch` on every call, `jobs.poison`
       # only on the kill path.
       #
+      # Fires the Pro `super_fetch!` recovery callback (config.super_fetch_callback)
+      # exactly once per call: `(jobstr, nil)` on plain recovery, `(jobstr, pill)`
+      # on the kill path. The poison-only `on_poison` Hash callbacks fire
+      # independently inside #mark_poison.
+      #
       # @param payload [String, Hash] the job JSON or pre-parsed hash.
       # @param queue   [String, nil] the public queue name (without `queue:`).
+      # @param config  [Configuration] config that owns the super_fetch! callback;
+      #   defaults to the global so non-reaper callers (tests) need not pass it.
       # @return [Symbol] :recovered | :poison
-      def track!(payload, queue: nil)
+      def track!(payload, queue: nil, config: Wurk.configuration)
         job = parse(payload)
-        return :recovered unless job
+        unless job
+          fire_super_fetch(config, payload, nil)
+          return :recovered
+        end
 
         jid = job['jid']
         klass = job['class']
         emit_recovered_fetch(klass, queue)
-        return :recovered if jid.nil? || jid.empty?
 
-        count = bump_counter(jid)
-        if count >= RECOVERY_THRESHOLD
+        count = bump_counter(jid) if jid && !jid.empty?
+        if count && count >= RECOVERY_THRESHOLD
           mark_poison(payload, job, queue: queue, count: count)
+          fire_super_fetch(config, payload, Pill.new(jid: jid, klass: klass, count: count, queue: queue))
           :poison
         else
+          fire_super_fetch(config, payload, nil)
           :recovered
         end
       end
@@ -143,6 +160,19 @@ module Wurk
         rescue StandardError => e
           Wurk.configuration.handle_exception(e, context: 'Wurk::Middleware::PoisonPill')
         end
+      end
+
+      # Invoke the Pro recovery callback registered via config.super_fetch! { }.
+      # No-op unless one is registered. `jobstr` is the raw job JSON so a Pro
+      # `|jobstr, pill|` block sees exactly what Sidekiq Pro hands it.
+      def fire_super_fetch(config, payload, pill)
+        cb = config.super_fetch_callback
+        return unless cb
+
+        jobstr = payload.is_a?(::String) ? payload : Wurk.dump_json(payload)
+        cb.call(jobstr, pill)
+      rescue StandardError => e
+        config.handle_exception(e, context: 'Wurk::Middleware::PoisonPill')
       end
     end
   end

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -287,6 +287,19 @@ class ConfigurationTest < Wurk::Test::UnitCase
     assert_nil @config.super_fetch!(timeout: 3)
   end
 
+  def test_super_fetch_callback_nil_by_default
+    assert_nil @config.super_fetch_callback
+  end
+
+  # Pro's recovery callback: `super_fetch! { |jobstr, pill| }` stores the block
+  # (still returning nil) so the reaper can invoke it. Spec: sidekiq-pro.md §3.1.
+  def test_super_fetch_bang_stores_the_recovery_block
+    block = ->(_jobstr, _pill) {}
+
+    assert_nil @config.super_fetch!(&block)
+    assert_same block, @config.super_fetch_callback
+  end
+
   def test_reliable_scheduler_bang_is_a_noop
     assert_nil @config.reliable_scheduler!
   end

--- a/test/unit/fetcher_reaper_test.rb
+++ b/test/unit/fetcher_reaper_test.rb
@@ -99,6 +99,45 @@ class FetcherReaperTest < Wurk::Test::UnitCase
     @pool.with { |c| c.call('DEL', other_priv) }
   end
 
+  # --- super_fetch! recovery callback (Pro §3.1) -------------------------
+
+  # A recovery block registered on the reaper's config fires once per orphan
+  # reclaimed, with the raw job string and pill=nil (non-poison). This is the
+  # end-to-end path: stranded private list → reaper sweep → callback.
+  def test_recovery_callback_fires_with_job_string_on_reclaim
+    recovered = []
+    @config.super_fetch! { |jobstr, pill| recovered << [jobstr, pill] }
+    seed_private_list(DEAD_PID, %w[one two])
+
+    @reaper.reclaim!
+
+    assert_equal [payload('one'), payload('two')].sort, recovered.map(&:first).sort
+    assert(recovered.all? { |_, pill| pill.nil? }, 'a non-poison recovery passes pill=nil')
+  end
+
+  # On the poison path the same block receives a pill responding to
+  # .jid/.klass/.count/.queue, so a `pill.jid`-style Pro initializer drops in.
+  # rubocop:disable Minitest/MultipleAssertions, Metrics/AbcSize
+  def test_recovery_callback_receives_pill_on_poison_kill
+    jid = SecureRandom.hex(12)
+    pill = nil
+    @config.super_fetch! { |_jobstr, p| pill = p if p }
+    # Two prior recoveries on record; this reclaim is the 3rd → poison.
+    Wurk.redis { |c| c.call('SET', recovery_key(jid), '2') }
+    @pool.with { |c| c.call('RPUSH', private_list(DEAD_PID), payload('poison', jid: jid)) }
+
+    @reaper.reclaim!
+
+    refute_nil pill, 'a poison kill hands the recovery block a pill'
+    assert_equal jid, pill.jid
+    assert_equal 'ReaperTestJob', pill.klass
+    assert_equal 3, pill.count
+    assert_equal @queue_name, pill.queue
+  ensure
+    Wurk.redis { |c| c.call('DEL', recovery_key(jid)) }
+  end
+  # rubocop:enable Minitest/MultipleAssertions, Metrics/AbcSize
+
   # --- poison-pill cap ---------------------------------------------------
 
   # rubocop:disable Metrics/AbcSize, Minitest/MultipleAssertions

--- a/test/unit/middleware_poison_pill_test.rb
+++ b/test/unit/middleware_poison_pill_test.rb
@@ -194,7 +194,105 @@ class MiddlewarePoisonPillTest < Wurk::Test::UnitCase
     assert_raises(ArgumentError) { Wurk::Middleware::PoisonPill.on_poison }
   end
 
+  # --- super_fetch! recovery callback (Pro §3.1: |jobstr, pill|) -----------
+
+  def test_super_fetch_callback_fires_with_job_string_and_nil_pill_on_recovery
+    recorded = []
+    cfg = recovery_config { |jobstr, pill| recorded << [jobstr, pill] }
+    json = payload_json
+
+    Wurk::Middleware::PoisonPill.track!(json, queue: @queue, config: cfg)
+
+    assert_equal [[json, nil]], recorded, 'a non-poison recovery passes the raw jobstr and pill=nil'
+  end
+
+  # Even a payload that can't be parsed is still a recovery — the block fires
+  # once with the raw string and no pill (the `unless job` branch in track!).
+  def test_super_fetch_callback_fires_for_unparseable_payload
+    recorded = []
+    cfg = recovery_config { |jobstr, pill| recorded << [jobstr, pill] }
+
+    Wurk::Middleware::PoisonPill.track!('not-json{{', queue: @queue, config: cfg)
+
+    assert_equal [['not-json{{', nil]], recorded
+  end
+
+  # rubocop:disable Minitest/MultipleAssertions, Metrics/AbcSize
+  def test_super_fetch_callback_receives_pill_on_poison_kill
+    recorded = []
+    cfg = recovery_config { |jobstr, pill| recorded << [jobstr, pill] }
+    json = payload_json
+    3.times { Wurk::Middleware::PoisonPill.track!(json, queue: @queue, config: cfg) }
+
+    assert_equal 3, recorded.size, 'the block fires once per recovery'
+    assert(recorded[0..1].all? { |_, pill| pill.nil? }, 'sub-threshold recoveries carry no pill')
+
+    jobstr, pill = recorded.last
+
+    assert_equal json, jobstr
+    assert_equal @jid, pill.jid
+    assert_equal 'PoisonPillTestJob', pill.klass
+    assert_equal 3, pill.count
+    assert_equal @queue, pill.queue
+  end
+  # rubocop:enable Minitest/MultipleAssertions, Metrics/AbcSize
+
+  # The two-arg super_fetch block and the legacy on_poison Hash callback are
+  # independent registries; both must fire on a poison kill.
+  def test_super_fetch_and_on_poison_both_fire_on_poison
+    super_pill = nil
+    on_poison_hash = nil
+    cfg = recovery_config { |_jobstr, pill| super_pill = pill }
+    Wurk::Middleware::PoisonPill.on_poison { |h| on_poison_hash = h }
+    json = payload_json
+
+    3.times { Wurk::Middleware::PoisonPill.track!(json, queue: @queue, config: cfg) }
+
+    assert_equal @jid, super_pill&.jid, 'super_fetch block saw the pill'
+    assert_equal @jid, on_poison_hash&.[](:jid), 'legacy on_poison Hash still fires'
+  end
+
+  def test_super_fetch_callback_errors_are_swallowed
+    cfg = recovery_config { |_jobstr, _pill| raise 'boom' }
+
+    assert_silent do
+      Wurk::Middleware::PoisonPill.track!(payload_json, queue: @queue, config: cfg)
+    end
+  end
+
+  # A pre-parsed Hash payload is serialized back to a job string for the block,
+  # so the callback always sees a String regardless of how track! was called.
+  def test_super_fetch_callback_serializes_hash_payload_to_job_string
+    recorded = []
+    cfg = recovery_config { |jobstr, _pill| recorded << jobstr }
+    hash = { 'jid' => @jid, 'class' => 'X' }
+
+    Wurk::Middleware::PoisonPill.track!(hash, queue: @queue, config: cfg)
+
+    assert_equal [Wurk.dump_json(hash)], recorded
+  end
+
+  # A blank jid is a plain recovery — no counter bump, never poison — and still
+  # fires the block once with pill=nil.
+  def test_super_fetch_callback_treats_blank_jid_as_plain_recovery
+    recorded = []
+    cfg = recovery_config { |_jobstr, pill| recorded << pill }
+
+    Wurk::Middleware::PoisonPill.track!({ 'jid' => '', 'class' => 'X' }, queue: @queue, config: cfg)
+
+    assert_equal [nil], recorded
+  end
+
   private
+
+  # A throwaway config carrying only the recovery block + a NULL logger, so a
+  # swallowed callback error reports silently. track! still uses global Redis.
+  def recovery_config(&)
+    cfg = Wurk::Configuration.new
+    cfg.logger = ::Logger.new(IO::NULL)
+    cfg.super_fetch!(&)
+    cfg
+  end
 
   def payload_json(extra = {})
     Wurk.dump_json({


### PR DESCRIPTION
## What

Sidekiq Pro lets you register an orphan-recovery callback by passing a block to `super_fetch!`:

```ruby
Sidekiq.configure_server do |config|
  config.super_fetch! do |jobstr, pill|
    Rails.logger.warn "recovered: #{jobstr}"
    Rails.logger.warn "poison: #{pill.jid} #{pill.klass}" if pill
  end
end
```

Wurk's `Configuration#super_fetch!(*)` accepted but **silently discarded** the block (`def super_fetch!(*); nil; end`), so a drop-in Pro initializer lost every orphan-recovery and poison-kill notification — operators went blind to reliable-fetch recoveries. Closes #113.

## How

- `Configuration#super_fetch!` now stores the block as `super_fetch_callback` (still returns `nil`, so the existing no-op toggle behavior is preserved).
- `PoisonPill.track!` — the reaper's **single** per-recovery hook — fires the callback exactly once per call:
  - `(jobstr, nil)` on every plain orphan recovery,
  - `(jobstr, pill)` on a poison kill, where `pill` is a `Struct` responding to `.jid/.klass/.count/.queue` (matches Pro's documented shape so `pill.jid`-style initializers drop in).
- The callback source is threaded through `track!(config:)` from the reaper's own config, matching how the reaper already resolves `handle_exception` (Component). Defaults to the global `Wurk.configuration` so non-reaper callers need not pass it.
- Legacy `PoisonPill.on_poison { |hash| }` (Hash, poison-only) is untouched and still fires independently inside `mark_poison`.

Spec: `docs/target/sidekiq-pro.md` §3.1.

## Acceptance criteria

- [x] `config.super_fetch! { |jobstr, pill| }` stores the block and invokes it on every orphan recovery (`pill=nil`) and poison kill (`pill` responds to `.jid/.klass/.count/.queue`).
- [x] The reaper/poison path calls the registered block; existing `PoisonPill.on_poison` continues to work.
- [x] A parity-style test boots `super_fetch!` with a recovery block, strands a private-list job for a dead process, runs a reaper sweep, and asserts the block fired with the job string (`test/unit/fetcher_reaper_test.rb`).

## Tests

- `test/unit/configuration_test.rb` — block is stored; `super_fetch!` still returns `nil`; reader nil by default.
- `test/unit/middleware_poison_pill_test.rb` — callback fires with `(jobstr, nil)` on recovery, `(jobstr, pill)` on poison; both registries fire on poison; Hash-payload serialization; blank-jid path; error swallowing.
- `test/unit/fetcher_reaper_test.rb` — end-to-end reaper sweep fires the callback (recovery + poison pill).

Local gate (all green): full `bin/rake test` (1920 runs, 0 failures), `test:parity` (20, 0), `test:ecosystem` (all passed), kill-9 swarm integration, coverage **line 96.47% / branch 92.39%** (floor 90%).

## How to test in prod

In a `Sidekiq.configure_server` (or `Wurk.configure_server`) initializer, register a recovery callback and watch it fire when a worker dies mid-job:

```ruby
Sidekiq.configure_server do |config|
  config.super_fetch! do |jobstr, pill|
    job = JSON.parse(jobstr)
    if pill
      # poison: this job has crashed its worker 3x in 72h and was killed to the dead set
      Rails.logger.error("[wurk] poison job killed: #{pill.klass} jid=#{pill.jid} count=#{pill.count} queue=#{pill.queue}")
      # page someone, bump a metric, etc.
    else
      Rails.logger.warn("[wurk] recovered orphan: #{job['class']} jid=#{job['jid']}")
    end
  end
end
```

To exercise it: enqueue a job, `kill -9` the worker process holding it (its in-flight job is stranded in a per-process private list), and within ~60s the orphan sweeper reclaims it — the recovery block fires with `pill=nil`. A job that kills its worker on every run trips the poison cap on the 3rd recovery and fires the block with a non-nil `pill`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recovery callbacks can now be configured to execute when jobs require recovery, with enhanced support for identifying and handling problematic jobs that exceed recovery thresholds.

* **Tests**
  * Comprehensive test coverage added to validate recovery callback execution across configuration, job recovery operations, and middleware components for both standard and problematic recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->