### PR TITLE
Dashboard mobile + polish: in-card table scroll, modal pager footer, nav/args/logo fixes (#145)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="dark" />
     <meta name="theme-color" content="#0d1117" />
+    <!-- The dashboard is dark-only. Tell the Dark Reader extension not to
+         re-invert it — otherwise it washes the already-dark UI to white. -->
+    <meta name="darkreader-lock" />
     <meta name="description" content="Wurk — background job processing dashboard." />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <title>Wurk</title>

--- a/frontend/src/components/ArgsValue.tsx
+++ b/frontend/src/components/ArgsValue.tsx
@@ -1,0 +1,10 @@
+import { truncate } from '../utils';
+
+// Job args table cell. Empty args (`[]`) render as a muted em-dash rather than
+// a literal "[]", which reads as noise; non-empty args show the truncated JSON.
+export function ArgsValue({ str, max }: { str: string; max: number }) {
+  if (str === '[]' || str === '') {
+    return <span style={{ color: 'var(--text-muted)' }}>—</span>;
+  }
+  return <span title={str}>{truncate(str, max)}</span>;
+}

--- a/frontend/src/components/JobDetailModal.tsx
+++ b/frontend/src/components/JobDetailModal.tsx
@@ -61,7 +61,11 @@ export default function JobDetailModal({ entry, atLabel, onClose }: JobDetailMod
           </div>
 
           <Field label={t('job.args')} mono>
-            <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{formatArgs(entry.args)}</pre>
+            {formatArgs(entry.args) === '[]' || formatArgs(entry.args) === '' ? (
+              <span style={{ color: 'var(--text-muted)' }}>—</span>
+            ) : (
+              <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{formatArgs(entry.args)}</pre>
+            )}
           </Field>
 
           {(entry.error_class || entry.error_message) && (

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -97,11 +97,11 @@ export default function Nav({ open, onClose }: NavProps) {
                   padding: '0.5rem 0.85rem',
                   borderRadius: 8,
                   margin: '2px 8px',
+                  // Text stays white for every item; the active one is marked by
+                  // a subtle dark raised pill + hairline, not a bright white box.
                   color: isActive ? 'var(--accent)' : 'var(--text)',
-                  background: isActive ? 'var(--accent-soft)' : 'transparent',
-                  boxShadow: isActive
-                    ? 'inset 0 0 0 1px color-mix(in oklch, var(--accent) 30%, transparent)'
-                    : 'none',
+                  background: isActive ? 'var(--surface-strong)' : 'transparent',
+                  boxShadow: isActive ? 'inset 0 0 0 1px var(--border)' : 'none',
                   fontWeight: isActive ? 600 : 400,
                   fontSize: 14,
                   textDecoration: 'none',
@@ -118,7 +118,7 @@ export default function Nav({ open, onClose }: NavProps) {
 
       <style>{`
         .wurk-navlink:hover {
-          background: color-mix(in oklch, var(--color-base-content) 8%, transparent) !important;
+          background: var(--surface-hover) !important;
           color: var(--accent) !important;
           text-decoration: none !important;
         }

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from 'react-router-dom';
+import { NavLink, Link } from 'react-router-dom';
 import { t } from '../i18n';
 import logoUrl from '../assets/wurk-logo.png';
 
@@ -56,12 +56,16 @@ export default function Nav({ open, onClose }: NavProps) {
         }}
       >
         <div style={{ padding: '1.25rem 1rem 0.75rem' }}>
-          <span
+          <Link
+            to="/"
+            onClick={onClose}
+            aria-label="Wurk — dashboard home"
             style={{
               fontSize: 20,
               fontWeight: 800,
               letterSpacing: '-0.03em',
               color: 'var(--text)',
+              textDecoration: 'none',
               display: 'flex',
               alignItems: 'center',
               gap: '0.55rem',
@@ -73,7 +77,7 @@ export default function Nav({ open, onClose }: NavProps) {
               style={{ height: 48, width: 'auto', display: 'block', filter: 'drop-shadow(0 2px 6px rgba(0,0,0,0.45))' }}
             />
             Wurk
-          </span>
+          </Link>
         </div>
 
         <div style={{ height: 1, background: 'var(--border)', margin: '0 1rem 0.5rem' }} />

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -11,17 +11,7 @@ export function Pagination({ page, total, count, onChange }: PaginationProps) {
   const totalPages = Math.max(1, Math.ceil(total / count));
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: '0.75rem',
-        padding: '0.75rem 0',
-        justifyContent: 'flex-end',
-        color: 'var(--text-muted)',
-        fontSize: 13,
-      }}
-    >
+    <div className="pagination">
       <button
         className="btn"
         disabled={page <= 1}

--- a/frontend/src/pages/Dead.tsx
+++ b/frontend/src/pages/Dead.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { Pagination } from '../components/Pagination';
+import { ArgsValue } from '../components/ArgsValue';
 import { SortableTh } from '../components/SortableTh';
 import { useSort, type Accessors } from '../hooks/useSort';
 import { usePageParam } from '../hooks/usePageParam';
@@ -96,7 +97,7 @@ export default function Dead() {
                         {truncate(entry.jid, 12)}
                       </td>
                       <td style={{ fontWeight: 500 }}>{entry.klass}</td>
-                      <td title={argsStr}>{truncate(argsStr, 40)}</td>
+                      <td><ArgsValue str={argsStr} max={40} /></td>
                       <td title={entry.error_class} style={{ color: 'var(--danger)' }}>
                         {truncate(entry.error_class, 25)}
                       </td>

--- a/frontend/src/pages/Queues.tsx
+++ b/frontend/src/pages/Queues.tsx
@@ -63,7 +63,7 @@ function QueueJobs({ name }: { name: string }) {
   if (isError || !data) return <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>;
 
   return (
-    <div>
+    <div className="qjobs">
       <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '1rem' }}>
         <span style={{ color: 'var(--text-muted)', fontSize: 13 }}>
           {data.size.toLocaleString()} jobs · latency {data.latency.toFixed(3)}s

--- a/frontend/src/pages/Queues.tsx
+++ b/frontend/src/pages/Queues.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { Pagination } from '../components/Pagination';
+import { ArgsValue } from '../components/ArgsValue';
 import { SortableTh } from '../components/SortableTh';
 import { useSort, type Accessors } from '../hooks/useSort';
 import { usePageParam } from '../hooks/usePageParam';
@@ -98,7 +99,7 @@ function QueueJobs({ name }: { name: string }) {
                         {truncate(job.jid, 12)}
                       </td>
                       <td style={{ fontWeight: 500 }}>{job.class}</td>
-                      <td title={argsStr}>{truncate(argsStr, 60)}</td>
+                      <td><ArgsValue str={argsStr} max={60} /></td>
                       <td>{relativeTime(job.enqueued_at)}</td>
                     </tr>
                   );

--- a/frontend/src/pages/Retries.tsx
+++ b/frontend/src/pages/Retries.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { Pagination } from '../components/Pagination';
+import { ArgsValue } from '../components/ArgsValue';
 import { t } from '../i18n';
 import { PageHeader } from '../components/PageHeader';
 import { relativeTime, truncate, formatArgs, isoTime } from '../utils';
@@ -91,7 +92,7 @@ export default function Retries() {
                   return (
                     <tr key={entry.jid} className="row-clickable" onClick={() => setSelected(entry)}>
                       <td style={{ fontWeight: 500 }}>{entry.klass}</td>
-                      <td title={argsStr}>{truncate(argsStr, 40)}</td>
+                      <td><ArgsValue str={argsStr} max={40} /></td>
                       <td title={entry.error_class} style={{ color: 'var(--danger)' }}>
                         {truncate(entry.error_class, 30)}
                       </td>

--- a/frontend/src/pages/Scheduled.tsx
+++ b/frontend/src/pages/Scheduled.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { Pagination } from '../components/Pagination';
+import { ArgsValue } from '../components/ArgsValue';
 import { SortableTh } from '../components/SortableTh';
 import { useSort, type Accessors } from '../hooks/useSort';
 import { usePageParam } from '../hooks/usePageParam';
@@ -88,7 +89,7 @@ export default function Scheduled() {
                         {truncate(entry.jid, 12)}
                       </td>
                       <td style={{ fontWeight: 500 }}>{entry.klass}</td>
-                      <td title={argsStr}>{truncate(argsStr, 60)}</td>
+                      <td><ArgsValue str={argsStr} max={60} /></td>
                       <td title={isoTime(entry.at)}>
                         {relativeTime(entry.at)}
                       </td>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -351,6 +351,15 @@ tbody tr:last-child td {
   display: none;
 }
 
+/* The shell is a flex row (nav + main). A flex item defaults to min-width:auto,
+   which refuses to shrink below its content's intrinsic width — so a table wider
+   than the viewport blew the whole page out and scrolled the page horizontally.
+   min-width:0 lets `.main-content` shrink to the available space, which in turn
+   lets each `.table-wrapper`'s own `overflow:auto` take the horizontal scroll. */
+.main-content {
+  min-width: 0;
+}
+
 @media (max-width: 767px) {
   .hamburger {
     display: block;
@@ -373,6 +382,26 @@ tbody tr:last-child td {
 
   .table-wrapper {
     max-height: calc(100vh - 10rem);
+  }
+
+  /* Freeze the identifier (first) column so it stays on-screen while the rest
+     of a wide row scrolls horizontally inside the wrapper. The pinned column is
+     solid (drops the zebra stripe under it) with a hairline edge marking the
+     frozen boundary — the standard frozen-pane affordance. Header corner sits
+     on top of both the sticky header row and the sticky column. */
+  .table-wrapper th:first-child,
+  .table-wrapper td:first-child {
+    position: sticky;
+    left: 0;
+    background: var(--surface);
+    box-shadow: 1px 0 0 var(--border);
+  }
+  .table-wrapper td:first-child {
+    z-index: 2;
+  }
+  .table-wrapper th:first-child {
+    z-index: 3;
+    background: var(--surface-strong);
   }
 
   /* Comfortable tap targets for pager controls. */

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -76,6 +76,9 @@ body {
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+  /* Kill the mobile tap-highlight flash (shows as a coloured box on tapped
+     links/rows — e.g. the red flash on nav items on Android). */
+  -webkit-tap-highlight-color: transparent;
 }
 
 a {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -633,6 +633,45 @@ tbody tr:last-child td {
   border-top: 1px solid var(--border);
 }
 
+/* Pager shown under list tables (pages) and inside the queue-jobs modal. */
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 0.75rem 0;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+/* In a modal the whole body used to scroll, so the pager sat at the very bottom
+   and you had to scroll the entire table to reach Prev/Next. Instead, lay the
+   jobs list out as a flex column that fills the modal body: the table flexes and
+   scrolls in the middle (its own card scroll, as on a page) while the pager stays
+   a fixed footer bar — Prev/Next are always reachable. */
+.modal-body:has(.qjobs) {
+  display: flex;
+  flex-direction: column;
+}
+.qjobs {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+.qjobs .table-wrapper {
+  flex: 1;
+  min-height: 0;
+  max-height: none;
+}
+.qjobs .pagination {
+  flex: 0 0 auto;
+  margin: 0.4rem -1.1rem -1.1rem;
+  padding: 0.65rem 1.1rem;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+}
+
 .job-backtrace {
   margin: 0;
   font-size: 12px;


### PR DESCRIPTION
Dashboard mobile-UX and polish pass. All CSS/TSX (no Ruby touched). Closes #145.

## Changes

### 1. Mobile: tables scroll in-card, not the whole page (#145)
A flexbox `min-width: auto` trap meant `.main-content` refused to shrink below a wide table's intrinsic width, so wide tables blew the page out and scrolled the **whole page** horizontally. Fix: `min-width: 0` on the flex item so each `.table-wrapper`'s own `overflow:auto` takes the horizontal scroll. On mobile the **first (identifier) column is frozen** (`position: sticky; left: 0`) so the jid/name stays visible while you scroll the row.

### 2. Pagination is a fixed footer in the jobs modal
The queue-jobs modal scrolled its whole body, so Prev/Next sat at the bottom of the scroll and you had to scroll the entire table to reach them. The list is now a flex column filling the modal body: the table flexes & scrolls in the middle (its card scroll, unchanged) while the pager stays a fixed footer.

### 3. Empty args render as a muted em-dash
`[]` for empty job args read as noise across Queues/Retries/Scheduled/Dead. A small shared `ArgsValue` cell shows a muted `—` instead.

### 4. Nav logo links to the dashboard home
The logo was a non-clickable label; it now links to `/`.

### 5. Nav active/hover highlight de-whitened
The active nav item used a white-tinted pill (10% white fill + 30%-white inset border) that read as "too white" when paging through nav. Text stays white on every item; the active one is now marked by a subtle dark raised pill (`--surface-strong`) + a neutral hairline. Hover uses `--surface-hover`.

### 6. Misc polish
- `<meta name="darkreader-lock">` so the Dark Reader extension stops force-inverting the (already dark) UI to white.
- `-webkit-tap-highlight-color: transparent` to kill the mobile tap-flash on links/rows.

## Verification

Headless (Playwright @ real built CSS) + manual on a local preview:
- Mobile 375px: page no longer overflows (scrollWidth == viewport); table scrolls in-card; first column sticky. (Without the fix the page overflows to 1032px — the bug.)
- Modal pager: pinned to the modal bottom, Next reachable with the table at top **and** bottom.
- Logo click on `/retries` → navigates to `/` (home).
- `rake frontend:build` (tsc + vite) passes clean.

## How to test in prod

After this ships in a release, open the dashboard on a phone (or DevTools device mode):
- Go to **Retries** or **Queues** — a wide table scrolls sideways *within its card*; the page/nav stay put; the first column stays pinned.
- Open a queue with many jobs — the **Prev/Next** pager stays visible as a footer while the table scrolls.
- Empty-args rows show `—` instead of `[]`.
- Click the **Wurk logo** → returns to the dashboard home.
- If you use the Dark Reader extension, the dashboard no longer washes to white.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized job-arguments display component with improved truncation and full-value access; applied across job views and detail modal

* **Bug Fixes**
  * Eliminated mobile tap-highlight flash
  * Fixed table horizontal scrolling issues and modal layout to keep pagination accessible

* **Style**
  * Enhanced navigation active/hover styling and refined pagination appearance
  * Added sticky first-column table positioning
  * Added Dark Reader compatibility meta to support dark-only dashboard display
<!-- end of auto-generated comment: release notes by coderabbit.ai -->