### PR TITLE
feat(fetch): expose config.fetch_poll_interval for reliable-fetch backoff (#109)

### DIFF
--- a/lib/wurk/capsule.rb
+++ b/lib/wurk/capsule.rb
@@ -121,6 +121,12 @@ module Wurk
       @config.lookup(name)
     end
 
+    # Empty-poll BLMOVE backoff for this capsule's reliable fetcher (Pro
+    # super_fetch §3.3). nil → the fetcher falls back to its TIMEOUT default.
+    def fetch_poll_interval
+      @config[:fetch_poll_interval]
+    end
+
     def logger
       @config.logger
     end

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -204,6 +204,19 @@ module Wurk
       @options[:average_scheduled_poll_interval] = interval
     end
 
+    # Reliable-fetch empty-poll backoff: the BLMOVE block timeout (seconds)
+    # used when every served queue is empty. Pro super_fetch §3.3's
+    # `fetch_poll_interval` knob. Unset (nil) → the fetcher's default
+    # (Wurk::Fetcher::Reliable::TIMEOUT, 2s). Also readable as
+    # `config[:fetch_poll_interval]`.
+    def fetch_poll_interval=(seconds)
+      @options[:fetch_poll_interval] = seconds
+    end
+
+    def fetch_poll_interval
+      @options[:fetch_poll_interval]
+    end
+
     # --- Reliability (Sidekiq Pro drop-in no-ops) ------------------------
 
     # Sidekiq Pro's opt-in toggles for reliable fetch and the reliable

--- a/lib/wurk/fetcher/reliable.rb
+++ b/lib/wurk/fetcher/reliable.rb
@@ -15,15 +15,18 @@ module Wurk
     # next boot of this process reclaims it via bulk_requeue.
     #
     # Priority handling: iterate queues_cmd in order with non-blocking
-    # LMOVE, then fall back to a 2s BLMOVE on the first queue so an
+    # LMOVE, then fall back to a blocking BLMOVE on the first queue so an
     # empty poll doesn't spin Redis. BLMOVE has no multi-key form, so
-    # blocking on a single queue is the best Redis gives us.
+    # blocking on a single queue is the best Redis gives us. The block
+    # timeout defaults to TIMEOUT (2s) and is overridable per the Pro
+    # super_fetch §3.3 `config.fetch_poll_interval` knob.
     #
-    # Spec: docs/target/sidekiq-pro.md §3 (super_fetch),
+    # Spec: docs/target/sidekiq-pro.md §3 (super_fetch, §3.3 poll interval),
     # docs/target/sidekiq-free.md §15 (TIMEOUT=2).
     class Reliable < Fetcher
       include Component
 
+      # Default BLMOVE block timeout; overridable via config.fetch_poll_interval.
       TIMEOUT = 2
 
       # Carries the public queue key, the raw (still-JSON) job payload,
@@ -126,12 +129,19 @@ module Wurk
 
       def blmove(public_q)
         priv = self.class.private_queue_name(public_q)
+        timeout = poll_interval
         # Extend the socket read-timeout past BLMOVE's own timeout so the
         # default 1s pool timeout doesn't fire before BLMOVE returns.
         job = config.redis do |conn|
-          conn.blocking_call(TIMEOUT + 1, 'BLMOVE', public_q, priv, 'RIGHT', 'LEFT', TIMEOUT)
+          conn.blocking_call(timeout + 1, 'BLMOVE', public_q, priv, 'RIGHT', 'LEFT', timeout)
         end
         job ? UnitOfWork.new(queue: public_q, job: job, config: config) : nil
+      end
+
+      # BLMOVE block timeout for an empty poll. `config.fetch_poll_interval`
+      # (Pro super_fetch §3.3) overrides the TIMEOUT default; nil → TIMEOUT.
+      def poll_interval
+        config.fetch_poll_interval || TIMEOUT
       end
     end
   end

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -304,6 +304,18 @@ class ConfigurationTest < Wurk::Test::UnitCase
     assert_nil @config.reliable_scheduler!
   end
 
+  # Pro super_fetch §3.3: the fetch-poll backoff knob. Unset → nil (the fetcher
+  # falls back to its TIMEOUT default); settable via the accessor and readable
+  # via the [] options hash.
+  def test_fetch_poll_interval_accessor
+    assert_nil @config.fetch_poll_interval
+
+    @config.fetch_poll_interval = 0.5
+
+    assert_in_delta 0.5, @config.fetch_poll_interval, 1e-9
+    assert_in_delta 0.5, @config[:fetch_poll_interval], 1e-9
+  end
+
   def test_error_handlers_appends
     handler = ->(_ex, _ctx, _cfg) {}
     @config.error_handlers << handler

--- a/test/unit/fetcher_reliable_test.rb
+++ b/test/unit/fetcher_reliable_test.rb
@@ -171,7 +171,42 @@ class FetcherReliableTest < Wurk::Test::UnitCase
     end
   end
 
+  # --- fetch_poll_interval (Pro super_fetch §3.3) -----------------------
+
+  # An empty poll blocks on BLMOVE for TIMEOUT (2s) by default.
+  def test_blmove_block_timeout_defaults_to_timeout
+    args = captured_blmove_args
+    @fetcher.send(:blmove, @public_queue)
+    t = Wurk::Fetcher::Reliable::TIMEOUT
+
+    assert_equal [t + 1, 'BLMOVE', @public_queue, private_queue, 'RIGHT', 'LEFT', t], args
+  end
+
+  # config.fetch_poll_interval overrides the block timeout (and the socket
+  # read-timeout stays one second past it).
+  def test_blmove_honors_config_fetch_poll_interval
+    @config.fetch_poll_interval = 0.25
+    args = captured_blmove_args
+    @fetcher.send(:blmove, @public_queue)
+
+    assert_equal [1.25, 'BLMOVE', @public_queue, private_queue, 'RIGHT', 'LEFT', 0.25], args
+  end
+
   private
+
+  # Stub the capsule's Redis so blmove's BLMOVE timeout args can be captured
+  # without actually blocking on a real empty queue. Returns the array the
+  # recorded `blocking_call` writes its arguments into.
+  def captured_blmove_args
+    box = []
+    conn = Object.new
+    conn.define_singleton_method(:blocking_call) do |*a|
+      box.replace(a)
+      nil
+    end
+    @capsule.define_singleton_method(:redis) { |&blk| blk.call(conn) }
+    box
+  end
 
   def private_queue
     Wurk::Fetcher::Reliable.private_queue_name(@public_queue)


### PR DESCRIPTION
Completes #109. The issue had two gaps; this PR closes the remaining one.

## What

**GAP 2 — `fetch_poll_interval` (this PR).** Sidekiq Pro super_fetch §3.3 documents a `fetch_poll_interval` knob for the empty-poll BLMOVE backoff; Wurk hardcoded it to `Reliable::TIMEOUT = 2`.

**GAP 1 — recovery callback (already shipped in #144).** `config.super_fetch! { |jobstr, pill| }` fires `(jobstr, nil)` on every orphan recovery and `(jobstr, pill)` on a poison kill (`pill` responds to `.jid/.klass/.count/.queue`). Verified still working; no change needed here.

## How

- `config.fetch_poll_interval = <seconds>` accessor (mirrors `average_scheduled_poll_interval=`) plus `config[:fetch_poll_interval]` — both set/read the same `@options` key. Follows the existing Wurk-knob convention (`config[:key] || CONSTANT`, like `cron_tick_interval` / `super_fetch_reaper_interval`), so the Sidekiq-mirror `DEFAULTS` hash stays untouched.
- `Reliable#blmove` blocks for `poll_interval` (= `config.fetch_poll_interval || TIMEOUT`); the socket read-timeout stays one second past it. **Default (unset) keeps the current 2s behavior.**
- `Capsule#fetch_poll_interval` passes the option through to its fetcher.

## Acceptance criteria
- [x] `config.super_fetch! { |jobstr, pill| }` fires on recovery (`pill=nil`) and poison (`pill` with accessors) — delivered in #144.
- [x] Recovered-but-not-poison jobs invoke the callback with `pill=nil` — #144.
- [x] `config.fetch_poll_interval = <seconds>` is accepted and used by the reliable fetch loop's empty-poll backoff (default 2s).
- [x] Tests: callback fires on recovery/poison (#144); `fetch_poll_interval` is honored (this PR).

## Tests
- `test/unit/configuration_test.rb` — accessor sets/reads; `[]` consistent; nil default.
- `test/unit/fetcher_reliable_test.rb` — `blmove` block timeout defaults to `TIMEOUT`, and honors `config.fetch_poll_interval` (captured BLMOVE args, no real blocking).

Local gate (all green): full `bin/rake test` (1923 runs, 0 failures), `test:parity` (20/0), `test:ecosystem` (all passed), coverage **line 96.49% / branch 92.45%** (floor 90).

## How to test in prod

In a server initializer, tighten the empty-queue poll backoff:

```ruby
Sidekiq.configure_server do |config|
  config.super_fetch!                 # reliable fetch (already the Wurk default)
  config.fetch_poll_interval = 0.5    # BLMOVE block timeout on an empty poll (default 2s)
end
```

A lower value makes idle workers pick up the first job after a quiet period faster (at the cost of more Redis `BLMOVE` ops/sec when queues are empty); a higher value trades latency for fewer ops. Leaving it unset keeps the 2s default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a configurable `fetch_poll_interval` setting that allows customization of polling behavior for the reliable job fetcher, enabling users to override default timeout behavior when checking empty queues.

* **Tests**
  * Added unit test coverage for the new polling interval configuration and its integration with the fetcher behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->