### PR TITLE
feat(dashboard): GitHub source link at the bottom of the nav

### DIFF
--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -114,6 +114,31 @@ export default function Nav({ open, onClose }: NavProps) {
             </li>
           ))}
         </ul>
+
+        {/* Footer: link out to the source repo. Pinned to the bottom because the
+            nav list above is flex:1. Muted by default; hover lifts like a nav item. */}
+        <div style={{ height: 1, background: 'var(--border)', margin: '0.5rem 1rem' }} />
+        <a
+          href="https://github.com/developerz-ai/wurk"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="wurk-navlink"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.625rem',
+            padding: '0.5rem 0.85rem',
+            margin: '2px 8px 0.85rem',
+            borderRadius: 8,
+            color: 'var(--text-muted)',
+            fontSize: 13,
+            textDecoration: 'none',
+            transition: 'background 0.15s, color 0.15s',
+          }}
+        >
+          <i className="fa-brands fa-github" style={{ fontSize: 16, width: 20, textAlign: 'center' }} />
+          <span>GitHub</span>
+        </a>
       </nav>
 
       <style>{`


### PR DESCRIPTION
Adds a **GitHub** link pinned to the bottom of the left nav, linking to the source repo.

## What
- A muted `GitHub` link (FontAwesome brand icon) below a divider at the bottom of the nav. The nav list above is `flex: 1`, so the link sits at the bottom regardless of viewport height.
- `href="https://github.com/developerz-ai/wurk"`, `target="_blank"`, `rel="noopener noreferrer"`.
- Reuses the shared `.wurk-navlink` hover style (background lift + accent on hover); resting state is `--text-muted` to read as a secondary/footer link.

Frontend-only, no API change.

## Verification
Rendered the built bundle headlessly (Playwright): the link is present with the right `href`/`target`/`rel`/text and is pinned to the bottom of the nav (link bottom ≈ nav bottom). `npm run build` (tsc + vite) passes clean. See the nav screenshot below.

## How to test in prod
Open the dashboard — the left nav now has a **GitHub** link at the bottom that opens the source repo in a new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)