### PR TITLE
fix(client): treat job `pool` option as transient (strip + per-call honor) (#95)

### DIFF
--- a/lib/wurk/job_util.rb
+++ b/lib/wurk/job_util.rb
@@ -9,10 +9,12 @@ module Wurk
   #
   # Spec: docs/target/sidekiq-free.md §9 (Sidekiq::JobUtil).
   module JobUtil # rubocop:disable Metrics/ModuleLength
-    # Top-level keys stripped from every payload before raw_push. Mutable so
-    # Pro/Ent/extension code (e.g. TransactionAwareClient adding "client_class")
-    # can append at load time without monkey-patching.
-    TRANSIENT_ATTRIBUTES = [] # rubocop:disable Style/MutableConstant
+    # Top-level keys consumed at enqueue time but stripped from every payload
+    # before raw_push. `pool` selects the Redis pool (resolved in client_push /
+    # build_client) and must never reach the wire — spec §2.2 marks it transient.
+    # Mutable so Pro/Ent/extension code (e.g. TransactionAwareClient adding
+    # "client_class") can append at load time without monkey-patching.
+    TRANSIENT_ATTRIBUTES = ['pool'] # rubocop:disable Style/MutableConstant
 
     RETRY_FOR_MAX = 1_000_000_000
 

--- a/lib/wurk/worker.rb
+++ b/lib/wurk/worker.rb
@@ -117,11 +117,14 @@ module Wurk
       def client_push(item)
         raise ArgumentError, "Job arguments to #{name || self} must have string keys" if symbol_keyed?(item)
 
-        build_client.push(item)
+        # `pool` is a transient enqueue-time attribute: a per-call `set(pool:)`
+        # overrides the class-level option, then it's deleted so it never reaches
+        # the wire (normalize_item strips any class-level pool re-merged below).
+        pool = item.delete('pool') || get_sidekiq_options['pool']
+        build_client(pool).push(item)
       end
 
-      def build_client
-        pool = get_sidekiq_options['pool']
+      def build_client(pool = get_sidekiq_options['pool'])
         Wurk::Client.new(pool: pool)
       end
 

--- a/lib/wurk/worker/setter.rb
+++ b/lib/wurk/worker/setter.rb
@@ -49,7 +49,11 @@ module Wurk
           'class' => @klass,
           'args' => args
         )
-        @klass.build_client.push_bulk(merged)
+        # Mirror client_push: a per-call `set(pool:)` selects the Redis pool and
+        # is removed so it never persists (normalize_item strips the class-level
+        # pool re-merged into each payload).
+        pool = merged.delete('pool') || @klass.get_sidekiq_options['pool']
+        @klass.build_client(pool).push_bulk(merged)
       end
 
       private

--- a/test/unit/client_push_test.rb
+++ b/test/unit/client_push_test.rb
@@ -57,6 +57,14 @@ class ClientPushTest < Wurk::Test::UnitCase
   end
   # rubocop:enable Minitest/MultipleAssertions
 
+  # `pool` is a transient enqueue-time attribute (spec §2.2) — it selects the
+  # Redis pool but must never reach the wire. Issue #95.
+  def test_push_strips_transient_pool_from_payload
+    @client.push(base_item('pool' => 'some-pool'))
+
+    refute first_queued.key?('pool'), 'pool must be stripped before push'
+  end
+
   def test_push_stamps_ms_created_at_in_range
     before = ms_now
     @client.push(base_item)

--- a/test/unit/setter_test.rb
+++ b/test/unit/setter_test.rb
@@ -22,7 +22,7 @@ class SetterTest < Wurk::Test::UnitCase
         'pushed-jid'
       end
 
-      def build_client
+      def build_client(_pool = nil)
         client = Object.new
         captured = self
         client.define_singleton_method(:push_bulk) do |hash|

--- a/test/unit/worker_options_test.rb
+++ b/test/unit/worker_options_test.rb
@@ -168,6 +168,46 @@ class WorkerOptionsTest < Wurk::Test::UnitCase
     assert_kind_of Wurk::Client, ConfiguredWorker.build_client
   end
 
+  # --- pool: transient selection + stripping (#95) ---------------------
+
+  class PoolWorker
+    include Wurk::Worker
+
+    sidekiq_options queue: 'pooled', pool: 'class-pool'
+
+    def perform(*); end
+  end
+
+  # client_push deletes `pool` from the item so it never reaches the wire;
+  # normalize_item then strips any class-level pool re-merged into the payload.
+  def test_client_push_deletes_pool_from_item
+    captured = nil
+    fake = build_fake_client { |item| captured = item }
+    with_stub(PoolWorker, :build_client, fake) do
+      PoolWorker.client_push('class' => PoolWorker, 'args' => [1], 'pool' => 'per-call')
+    end
+
+    refute captured.key?('pool'), 'pool must be deleted from the pushed item'
+  end
+
+  # A per-call set(pool:) overrides the class-level pool option.
+  def test_set_pool_selects_the_per_call_pool
+    pools = capture_build_client_pools(PoolWorker) do
+      PoolWorker.set(pool: 'per-call').perform_async(1)
+    end
+
+    assert_equal ['per-call'], pools
+  end
+
+  # With no per-call pool, selection falls back to the class-level option.
+  def test_perform_async_uses_class_level_pool
+    pools = capture_build_client_pools(PoolWorker) do
+      PoolWorker.perform_async(1)
+    end
+
+    assert_equal ['class-pool'], pools
+  end
+
   # --- set returns Setter ---------------------------------------------
 
   def test_set_returns_setter
@@ -267,9 +307,32 @@ class WorkerOptionsTest < Wurk::Test::UnitCase
   # (not vendored on Ruby 4.x).
   def with_stub(klass, method, value)
     original = klass.singleton_class.instance_method(method)
-    klass.singleton_class.send(:define_method, method) { value }
+    klass.singleton_class.send(:define_method, method) { |*, **| value }
     yield
   ensure
     klass.singleton_class.send(:define_method, method, original)
+  end
+
+  def build_fake_client(&push)
+    fake = Object.new
+    fake.define_singleton_method(:push) { |item| push.call(item) || 'jid' }
+    fake.define_singleton_method(:push_bulk) { |_items| ['jid'] }
+    fake
+  end
+
+  # Stub `build_client(pool)` to record the pool it was handed, returning a
+  # no-op client. Returns the captured pools in call order.
+  def capture_build_client_pools(klass)
+    captured = []
+    fake = build_fake_client { nil }
+    original = klass.singleton_class.instance_method(:build_client)
+    klass.singleton_class.send(:define_method, :build_client) do |pool = nil|
+      captured << pool
+      fake
+    end
+    yield
+    captured
+  ensure
+    klass.singleton_class.send(:define_method, :build_client, original)
   end
 end


### PR DESCRIPTION
Closes #95.

## What
Sidekiq treats `pool` as a **transient enqueue-time attribute**: it selects the Redis pool, then is stripped from the item before push (spec §2.2 marks it `(transient) — stripped before push`). Wurk had two gaps:

1. **`pool` leaked onto the wire.** `TRANSIENT_ATTRIBUTES` was empty, so a class-level `sidekiq_options pool:` survived into the persisted job JSON — a wire-compat violation (pillar 1).
2. **Per-call `set(pool:)` was ignored.** `client_push`/`build_client` read the pool only from class-level options, never from the Setter's per-call opts, so `Klass.set(pool: p).perform_async` enqueued via the wrong pool.

## Change
- `lib/wurk/job_util.rb` — `TRANSIENT_ATTRIBUTES = ['pool']`; `finalize` strips `pool` from every payload.
- `lib/wurk/worker.rb` — `client_push` resolves the pool (`item.delete('pool')` per-call → falls back to `get_sidekiq_options['pool']`), then `build_client(pool)` selects it for that push.
- `lib/wurk/worker/setter.rb` — same resolution for the `perform_bulk` path.

`pool` is the only such key in `lib/`; nothing on the read/server side consumes a payload `pool`, so stripping is safe.

## Tests
- `test/unit/client_push_test.rb` — pushing an item with `pool` strips it from the stored payload (real Redis).
- `test/unit/worker_options_test.rb` — `client_push` deletes `pool` from the item; `set(pool:)` selects the per-call pool; bare `perform_async` falls back to the class-level pool. (`with_stub` made arity-flexible so it survives `build_client`'s new `pool` arg.)
- `test/unit/setter_test.rb` — `SpyWorker#build_client` updated for the new signature.

Full suite **1943 runs / 0 failures** (coverage line 96.6% / branch 92.53%, both ≥90%), parity 20/0, ecosystem all pass, rubocop clean.

## Hands-on QA (real Redis, 2 logical DBs — proves routing, not just stripping)
```
1. class-level sidekiq_options pool:  ✓ routed to class pool (DB14)  ✓ no pool key  ✓ not in default (DB15)
2. set(pool:) does not leak           ✓ no pool key
3. set(pool:) actually ROUTES         ✓ landed in override DB14      ✓ not in default DB15
4. no per-call pool -> default        ✓ landed in default DB15       ✓ not in override DB14
PASS: 8  FAIL: 0
```

## Acceptance criteria
- [x] `pool` consumed at enqueue time to select the Redis pool, removed from the payload
- [x] Persisted job JSON never contains `pool` (class-level and `set(pool:)`)
- [x] `Klass.set(pool: p).perform_async(...)` enqueues via pool `p`
- [x] Regression test asserting absence of `pool` in the queued payload

## How to test in prod
In a Rails console on this branch:

```ruby
Wurk.testing!(:fake)
class CP; include Sidekiq::Job; sidekiq_options pool: "X"; def perform(*); end; end
CP.perform_async(1)
Sidekiq::Queues.jobs_by_class["CP"].first.key?("pool")   # => false (was true)
```
With two real pools, `Klass.set(pool: other_pool).perform_async` lands the job in `other_pool`'s Redis, and the payload carries no `pool` key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a Redis pool at enqueue time, enabling flexible job routing to different pools
  * Pool specification is transient and automatically excluded from stored job payloads

* **Tests**
  * Added test coverage for pool selection and routing behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->