### PR TITLE
fix(deploy): accept a positional label in Deploy.mark! for drop-in parity (#110)

### DIFF
--- a/lib/wurk/deploy.rb
+++ b/lib/wurk/deploy.rb
@@ -24,10 +24,14 @@ module Wurk
     # Sidekiq Pro's LABEL_MAKER so existing deploy hooks keep working.
     LABEL_MAKER = -> { `git log -1 --format="%h %s"`.strip }
 
-    # Class-level shorthand `Wurk::Deploy.mark!(label: "abc")` builds a
-    # one-shot Deploy and delegates. Matches Sidekiq's `Sidekiq::Deploy.mark!`.
-    def self.mark!(label: nil, at: ::Time.now)
-      new.mark!(label: label, at: at)
+    # Class-level shorthand: builds a one-shot Deploy and delegates. Sidekiq's
+    # `Sidekiq::Deploy.mark!` takes a POSITIONAL label (spec §23,
+    # `def self.mark!(label = nil)`) — capistrano-sidekiq and custom deploy
+    # hooks call `Sidekiq::Deploy.mark!("abc123 release")` that way. The `**opts`
+    # also absorbs the `label:` keyword so Wurk's own keyword callers keep
+    # working; positional wins when both are given.
+    def self.mark!(label = nil, at: ::Time.now, **opts)
+      new.mark!(label: label.nil? ? opts[:label] : label, at: at)
     end
 
     def initialize(pool: nil)

--- a/test/unit/deploy_test.rb
+++ b/test/unit/deploy_test.rb
@@ -116,6 +116,32 @@ class DeployTest < Wurk::Test::UnitCase
     assert_kind_of String, Wurk::Deploy.mark!(label: @label, at: @at)
   end
 
+  # Sidekiq's `Sidekiq::Deploy.mark!` takes a POSITIONAL label; capistrano-sidekiq
+  # and custom deploy hooks call it that way. Issue #110.
+  def test_mark_accepts_positional_label
+    iso = Wurk::Deploy.mark!(@label, at: @at)
+
+    assert_equal '2026-05-21T14:37:00Z', iso
+    assert_equal(@label, Wurk.redis { |c| c.call('HGET', '20260521-marks', iso) })
+  end
+
+  # Positional and keyword forms resolve to the same label: the second call for
+  # that label hits the per-label dedupe lock and returns nil.
+  def test_positional_and_keyword_label_are_equivalent
+    first  = Wurk::Deploy.mark!(@label, at: @at)
+    second = Wurk::Deploy.mark!(label: @label, at: @at)
+
+    refute_nil first
+    assert_nil second
+  end
+
+  # The real drop-in path: a Sidekiq deploy hook calls Sidekiq::Deploy.mark!("v1").
+  def test_sidekiq_alias_accepts_positional_label
+    iso = Sidekiq::Deploy.mark!(@label, at: @at)
+
+    assert_equal(@label, Wurk.redis { |c| c.call('HGET', '20260521-marks', iso) })
+  end
+
   def test_sidekiq_deploy_alias_exists
     assert_equal Wurk::Deploy, Sidekiq::Deploy
   end


### PR DESCRIPTION
Closes #110.

## What
Sidekiq's `Sidekiq::Deploy.mark!` takes a **positional** first arg (spec §23: `def self.mark!(label = nil)`). capistrano-sidekiq and custom `after :deploy` hooks call `Sidekiq::Deploy.mark!("abc123 release")` positionally — but Wurk's `mark!` was keyword-only (`mark!(label:)`), so the positional call raised `ArgumentError`, breaking the drop-in contract (pillar 1).

## Change
`lib/wurk/deploy.rb` — the class method now accepts a positional label:
```ruby
def self.mark!(label = nil, at: ::Time.now, **opts)
  new.mark!(label: label.nil? ? opts[:label] : label, at: at)
end
```
- **Positional** label matches Sidekiq (`Sidekiq::Deploy.mark!("v1.2.3")`).
- `**opts` still absorbs the `label:` keyword so Wurk's existing keyword callers (and the test suite / boot usage) keep working; positional wins when both are given.
- The instance method stays keyword-only (`def mark!(at:, label:)`), exactly matching spec §23.
- `at:` continues to work alongside the positional label.

## Tests (`test/unit/deploy_test.rb`, real Redis — no mocks)
- positional invocation writes a mark identical to the keyword form
- positional + keyword resolve to the same label (proven via the per-label dedupe lock: 2nd call → nil)
- the real drop-in path through the `Sidekiq::Deploy` alias accepts a positional label

Existing keyword + no-arg LABEL_MAKER + `at:` + alias tests retained (no regression). Full suite **1943 runs / 0 failures** (coverage line 96.6% / branch 92.72%, both ≥90%), parity 20/0, ecosystem all pass, rubocop clean.

## Hands-on QA (real Redis, DB 13)
```
1. capistrano-style positional via Sidekiq alias  ✓ no raise  ✓ fetchable  ✓ minute-rounded
2. existing keyword form still works              ✓
3. positional + keyword -> same label (dedupe)    ✓ first writes  ✓ second deduped->nil
4. no-arg -> LABEL_MAKER (git sha + subject)       ✓
PASS: 7   FAIL: 0
```

## Acceptance criteria
- [x] `Wurk::Deploy.mark!("some-label")` (positional) writes a mark, same as `mark!(label: "some-label")`
- [x] `Wurk::Deploy.mark!` (no args) still uses LABEL_MAKER
- [x] `at:` keyword continues to work alongside the positional label
- [x] Parity test asserting positional invocation against real Redis
- [x] `Sidekiq::Deploy` alias still resolves

## How to test in prod
```ruby
# the exact capistrano-sidekiq call that used to raise:
Sidekiq::Deploy.mark!("v1.2.3 release")   # => "2026-..-..T..:..:00Z" (iso string, no error)
Sidekiq::Deploy.new.fetch                 # => { "<iso>" => "v1.2.3 release", ... }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deploy marking now supports positional label arguments in addition to keyword arguments for improved API flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->