### PR TITLE
feat(web): job/queue mutation endpoints + dashboard action buttons (#102)

### DIFF
--- a/app/controllers/wurk/api_controller.rb
+++ b/app/controllers/wurk/api_controller.rb
@@ -88,10 +88,11 @@ module Wurk
 
     def retries_all
       set = ::Wurk::RetrySet.new
-      count = case params[:cmd]
+      count = case params[:cmd].to_s
               when 'retry'  then set.retry_all
               when 'kill'   then set.kill_all
-              when 'delete' then total = set.size; set.clear; total
+              when 'delete' then clear_set(set)
+              else return render(json: { error: 'unknown action' }, status: :bad_request)
               end
       render json: { ok: true, count: count }
     end
@@ -102,7 +103,11 @@ module Wurk
 
     def scheduled_all
       set = ::Wurk::ScheduledSet.new
-      count = params[:cmd] == 'delete' ? (total = set.size; set.clear; total) : drain_set(set, :add_to_queue)
+      count = case params[:cmd].to_s
+              when 'delete'       then clear_set(set)
+              when 'add_to_queue' then drain_set(set, :add_to_queue)
+              else return render(json: { error: 'unknown action' }, status: :bad_request)
+              end
       render json: { ok: true, count: count }
     end
 
@@ -112,9 +117,10 @@ module Wurk
 
     def dead_all
       set = ::Wurk::DeadSet.new
-      count = case params[:cmd]
+      count = case params[:cmd].to_s
               when 'retry'  then set.retry_all
-              when 'delete' then total = set.size; set.clear; total
+              when 'delete' then clear_set(set)
+              else return render(json: { error: 'unknown action' }, status: :bad_request)
               end
       render json: { ok: true, count: count }
     end
@@ -243,7 +249,8 @@ module Wurk
       return render(json: { error: 'unknown action' }, status: :bad_request) unless method
 
       count = 0
-      entries_for(set, Array(params[:keys])).each do |entry|
+      keys = Array(params[:keys]).map(&:to_s).uniq
+      entries_for(set, keys).each do |entry|
         entry.public_send(method)
         count += 1
       end
@@ -260,6 +267,14 @@ module Wurk
 
         set.fetch(score.to_f, jid)
       end
+    end
+
+    # UNLINKs the whole set, returning the count removed (read before clearing
+    # so the response reports what was deleted).
+    def clear_set(set)
+      total = set.size
+      set.clear
+      total
     end
 
     # Drains a set by applying `method` to every entry until empty. Used for

--- a/app/controllers/wurk/api_controller.rb
+++ b/app/controllers/wurk/api_controller.rb
@@ -24,7 +24,18 @@ module Wurk
 
     skip_forgery_protection only: %i[
       stream reset_limiter pause_cron unpause_cron enqueue_cron
+      clear_queue delete_queue_job
+      retries_bulk retries_all retry_job
+      scheduled_bulk scheduled_all scheduled_job
+      dead_bulk dead_all dead_job
     ]
+
+    # Per-set action whitelists. Maps the SPA's action name to the
+    # SortedEntry/JobSet method. Anything not listed 400s — keeps the bulk/
+    # single dispatchers from reaching arbitrary methods off a request param.
+    RETRY_ACTIONS     = { 'retry' => :retry, 'delete' => :delete, 'kill' => :kill }.freeze
+    SCHEDULED_ACTIONS = { 'delete' => :delete, 'add_to_queue' => :add_to_queue }.freeze
+    DEAD_ACTIONS      = { 'retry' => :retry, 'delete' => :delete }.freeze
 
     # Boot-time flags the SPA reads once to shape the UI (e.g. hide destructive
     # actions and show the read-only banner). Always a GET, so it stays
@@ -52,9 +63,61 @@ module Wurk
       }
     end
 
+    # Empties one queue (UNLINK list + drop from the `queues` set).
+    def clear_queue
+      ::Wurk::Queue.new(params[:name].to_s).clear
+      render json: { ok: true }
+    end
+
+    # Removes a single job from a queue by jid. LREM matches exact bytes, so we
+    # locate the record (Queue#find_job) and let it delete its own value.
+    def delete_queue_job
+      record = ::Wurk::Queue.new(params[:name].to_s).find_job(params[:jid].to_s)
+      return render(json: { error: 'unknown job' }, status: :not_found) unless record
+
+      render json: { ok: true, deleted: record.delete }
+    end
+
     def retries   = render_sorted_set(::Wurk::RetrySet.new)
     def scheduled = render_sorted_set(::Wurk::ScheduledSet.new)
     def dead      = render_sorted_set(::Wurk::DeadSet.new)
+
+    # --- Retry set mutations -------------------------------------------------
+    def retry_job    = single_entry_action(::Wurk::RetrySet.new, RETRY_ACTIONS, params[:cmd])
+    def retries_bulk = bulk_entry_action(::Wurk::RetrySet.new, RETRY_ACTIONS)
+
+    def retries_all
+      set = ::Wurk::RetrySet.new
+      count = case params[:cmd]
+              when 'retry'  then set.retry_all
+              when 'kill'   then set.kill_all
+              when 'delete' then total = set.size; set.clear; total
+              end
+      render json: { ok: true, count: count }
+    end
+
+    # --- Scheduled set mutations ---------------------------------------------
+    def scheduled_job  = single_entry_action(::Wurk::ScheduledSet.new, SCHEDULED_ACTIONS, params[:cmd])
+    def scheduled_bulk = bulk_entry_action(::Wurk::ScheduledSet.new, SCHEDULED_ACTIONS)
+
+    def scheduled_all
+      set = ::Wurk::ScheduledSet.new
+      count = params[:cmd] == 'delete' ? (total = set.size; set.clear; total) : drain_set(set, :add_to_queue)
+      render json: { ok: true, count: count }
+    end
+
+    # --- Dead set mutations --------------------------------------------------
+    def dead_job  = single_entry_action(::Wurk::DeadSet.new, DEAD_ACTIONS, params[:cmd])
+    def dead_bulk = bulk_entry_action(::Wurk::DeadSet.new, DEAD_ACTIONS)
+
+    def dead_all
+      set = ::Wurk::DeadSet.new
+      count = case params[:cmd]
+              when 'retry'  then set.retry_all
+              when 'delete' then total = set.size; set.clear; total
+              end
+      render json: { ok: true, count: count }
+    end
 
     def processes
       render json: ::Wurk::ProcessSet.new.map { |p| ::Wurk::Api::Serializers.process_row(p) }
@@ -159,6 +222,59 @@ module Wurk
     end
 
     private
+
+    # Resolves a single entry by "<score>|<jid>" key and applies a whitelisted
+    # action. 400 on an unknown action, 404 when the key matches nothing (e.g.
+    # the entry was already retried/deleted from another tab).
+    def single_entry_action(set, actions, cmd)
+      method = actions[cmd.to_s]
+      return render(json: { error: 'unknown action' }, status: :bad_request) unless method
+
+      entries = entries_for(set, [params[:key]])
+      return render(json: { error: 'unknown job' }, status: :not_found) if entries.empty?
+
+      entries.each { |entry| entry.public_send(method) }
+      render json: { ok: true, count: entries.size }
+    end
+
+    # Bulk variant: `keys[]` + a single `cmd` applied to every resolved entry.
+    def bulk_entry_action(set, actions)
+      method = actions[params[:cmd].to_s]
+      return render(json: { error: 'unknown action' }, status: :bad_request) unless method
+
+      count = 0
+      entries_for(set, Array(params[:keys])).each do |entry|
+        entry.public_send(method)
+        count += 1
+      end
+      render json: { ok: true, count: count }
+    end
+
+    # Maps "<score>|<jid>" keys to live SortedEntry objects via score-bracketed
+    # fetch (exact float match, narrowed by jid) — avoids depending on float→
+    # string round-tripping between JS and Ruby. Skips malformed/empty keys.
+    def entries_for(set, keys)
+      keys.flat_map do |key|
+        score, jid = key.to_s.split('|', 2)
+        next [] if jid.nil? || jid.empty?
+
+        set.fetch(score.to_f, jid)
+      end
+    end
+
+    # Drains a set by applying `method` to every entry until empty. Used for
+    # scheduled "add to queue all", where each call removes the entry and would
+    # otherwise shift the paged iterator's indices mid-scan.
+    def drain_set(set, method)
+      count = 0
+      until set.size.zero?
+        set.each do |entry|
+          entry.public_send(method)
+          count += 1
+        end
+      end
+      count
+    end
 
     def render_sorted_set(set)
       page = ::Wurk::Api::Pagination.window(params)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,10 +8,27 @@ Wurk::Engine.routes.draw do
     get  'meta',             to: 'api#meta'
     get  'stats',            to: 'api#stats'
     get  'queues',           to: 'api#queues'
-    get  'queues/:name',     to: 'api#queue', as: :api_queue
+    get  'queues/:name',     to: 'api#queue', as: :api_queue, constraints: { name: %r{[^/]+} }
+    post 'queues/:name/clear',  to: 'api#clear_queue',     as: :api_clear_queue,     constraints: { name: %r{[^/]+} }
+    post 'queues/:name/delete', to: 'api#delete_queue_job', as: :api_delete_queue_job, constraints: { name: %r{[^/]+} }
+
+    # Job-set mutations (retry/delete/kill/requeue/clear). The SPA posts to
+    # these; the Authorization middleware 403s every non-GET in read-only mode,
+    # so they need no extra guard. `:key` is "<score>|<jid>" (Wurk::SortedEntry#id);
+    # `all/:cmd` operates over the whole set; the bare collection POST is a bulk
+    # action over `keys[]`. Spec: docs/target/sidekiq-free.md §25.4.
     get  'retries',          to: 'api#retries'
+    post 'retries',          to: 'api#retries_bulk',   as: :api_retries_bulk
+    post 'retries/all/:cmd', to: 'api#retries_all',    as: :api_retries_all, constraints: { cmd: /retry|delete|kill/ }
+    post 'retries/:key',     to: 'api#retry_job',      as: :api_retry_job,   constraints: { key: %r{[^/]+} }
     get  'scheduled',        to: 'api#scheduled'
+    post 'scheduled',          to: 'api#scheduled_bulk', as: :api_scheduled_bulk
+    post 'scheduled/all/:cmd', to: 'api#scheduled_all',  as: :api_scheduled_all, constraints: { cmd: /delete|add_to_queue/ }
+    post 'scheduled/:key',     to: 'api#scheduled_job',  as: :api_scheduled_job, constraints: { key: %r{[^/]+} }
     get  'dead',             to: 'api#dead'
+    post 'dead',             to: 'api#dead_bulk',      as: :api_dead_bulk
+    post 'dead/all/:cmd',    to: 'api#dead_all',       as: :api_dead_all, constraints: { cmd: /delete|retry/ }
+    post 'dead/:key',        to: 'api#dead_job',       as: :api_dead_job, constraints: { key: %r{[^/]+} }
     get  'processes',        to: 'api#processes'
     get  'batches',          to: 'api#batches'
     get  'batches/:bid',     to: 'api#batch', as: :api_batch

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,17 +17,21 @@ Wurk::Engine.routes.draw do
     # so they need no extra guard. `:key` is "<score>|<jid>" (Wurk::SortedEntry#id);
     # `all/:cmd` operates over the whole set; the bare collection POST is a bulk
     # action over `keys[]`. Spec: docs/target/sidekiq-free.md §25.4.
+    # `all/:cmd` is intentionally unconstrained: the controller validates `:cmd`
+    # against the per-set whitelist and returns a JSON 400 for an unknown action,
+    # matching the single/bulk contract. A route-level constraint would turn that
+    # into a 404 route miss instead.
     get  'retries',          to: 'api#retries'
     post 'retries',          to: 'api#retries_bulk',   as: :api_retries_bulk
-    post 'retries/all/:cmd', to: 'api#retries_all',    as: :api_retries_all, constraints: { cmd: /retry|delete|kill/ }
+    post 'retries/all/:cmd', to: 'api#retries_all',    as: :api_retries_all
     post 'retries/:key',     to: 'api#retry_job',      as: :api_retry_job,   constraints: { key: %r{[^/]+} }
     get  'scheduled',        to: 'api#scheduled'
     post 'scheduled',          to: 'api#scheduled_bulk', as: :api_scheduled_bulk
-    post 'scheduled/all/:cmd', to: 'api#scheduled_all',  as: :api_scheduled_all, constraints: { cmd: /delete|add_to_queue/ }
+    post 'scheduled/all/:cmd', to: 'api#scheduled_all',  as: :api_scheduled_all
     post 'scheduled/:key',     to: 'api#scheduled_job',  as: :api_scheduled_job, constraints: { key: %r{[^/]+} }
     get  'dead',             to: 'api#dead'
     post 'dead',             to: 'api#dead_bulk',      as: :api_dead_bulk
-    post 'dead/all/:cmd',    to: 'api#dead_all',       as: :api_dead_all, constraints: { cmd: /delete|retry/ }
+    post 'dead/all/:cmd',    to: 'api#dead_all',       as: :api_dead_all
     post 'dead/:key',        to: 'api#dead_job',       as: :api_dead_job, constraints: { key: %r{[^/]+} }
     get  'processes',        to: 'api#processes'
     get  'batches',          to: 'api#batches'

--- a/frontend/src/components/JobDetailModal.tsx
+++ b/frontend/src/components/JobDetailModal.tsx
@@ -2,6 +2,7 @@ import { type ReactNode } from 'react';
 import Modal from './Modal';
 import { t } from '../i18n';
 import { formatArgs, isoTime, relativeTime } from '../utils';
+import type { ActionDef } from './JobSetActionBar';
 
 // Union of the fields the various list endpoints expose for a job/entry
 // (queues · retries · scheduled · dead). All optional beyond jid/klass so one
@@ -37,12 +38,34 @@ interface JobDetailModalProps {
   entry: JobEntry | null;
   /** When the entry came from a failed set (retries/dead), show the at-field as "next retry" vs "scheduled". */
   atLabel?: string;
+  /** Single-job actions for the footer (retry/delete/kill/add_to_queue). Omitted in read-only mode. */
+  actions?: ActionDef[];
+  /** Fired with an action's `cmd` when its footer button is clicked. */
+  onAction?: (cmd: string) => void;
   onClose: () => void;
 }
 
-export default function JobDetailModal({ entry, atLabel, onClose }: JobDetailModalProps) {
+export default function JobDetailModal({ entry, atLabel, actions, onAction, onClose }: JobDetailModalProps) {
+  const footer =
+    actions && actions.length > 0 && onAction ? (
+      <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end', flexWrap: 'wrap' }}>
+        {actions.map((a) => (
+          <button
+            key={a.cmd}
+            className={`btn btn-sm${a.danger ? ' btn-danger' : ''}`}
+            onClick={() => {
+              if (a.danger && !window.confirm(t('actions.confirm', { action: a.label, scope: t('job.detail').toLowerCase() }))) return;
+              onAction(a.cmd);
+            }}
+          >
+            {a.label}
+          </button>
+        ))}
+      </div>
+    ) : undefined;
+
   return (
-    <Modal open={entry !== null} onClose={onClose} title={entry?.klass ?? t('job.detail')} width={680}>
+    <Modal open={entry !== null} onClose={onClose} title={entry?.klass ?? t('job.detail')} width={680} footer={footer}>
       {entry && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: '0.9rem' }}>

--- a/frontend/src/components/JobDetailModal.tsx
+++ b/frontend/src/components/JobDetailModal.tsx
@@ -42,10 +42,12 @@ interface JobDetailModalProps {
   actions?: ActionDef[];
   /** Fired with an action's `cmd` when its footer button is clicked. */
   onAction?: (cmd: string) => void;
+  /** Disables footer buttons while a single-job mutation is in flight (prevents duplicate dispatches). */
+  pending?: boolean;
   onClose: () => void;
 }
 
-export default function JobDetailModal({ entry, atLabel, actions, onAction, onClose }: JobDetailModalProps) {
+export default function JobDetailModal({ entry, atLabel, actions, onAction, pending = false, onClose }: JobDetailModalProps) {
   const footer =
     actions && actions.length > 0 && onAction ? (
       <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end', flexWrap: 'wrap' }}>
@@ -53,7 +55,9 @@ export default function JobDetailModal({ entry, atLabel, actions, onAction, onCl
           <button
             key={a.cmd}
             className={`btn btn-sm${a.danger ? ' btn-danger' : ''}`}
+            disabled={pending}
             onClick={() => {
+              if (pending) return;
               if (a.danger && !window.confirm(t('actions.confirm', { action: a.label, scope: t('job.detail').toLowerCase() }))) return;
               onAction(a.cmd);
             }}

--- a/frontend/src/components/JobSetActionBar.tsx
+++ b/frontend/src/components/JobSetActionBar.tsx
@@ -1,0 +1,68 @@
+import { t } from '../i18n';
+
+// One button's worth of config: the wire `cmd`, its localized label, whether
+// it's destructive (red + confirm), and the count it'd act on (drives the
+// disabled state for bulk buttons).
+export interface ActionDef {
+  cmd: string;
+  label: string;
+  danger?: boolean;
+}
+
+interface JobSetActionBarProps {
+  bulk: ActionDef[];
+  all: ActionDef[];
+  selectedCount: number;
+  total: number;
+  pending: boolean;
+  onBulk: (cmd: string) => void;
+  onAll: (cmd: string) => void;
+}
+
+// Toolbar shown above a mutable job-set table: bulk actions over the current
+// selection on the left, whole-set ("all") actions on the right. Rendered only
+// when the dashboard is read-write — callers gate on useMeta().read_only.
+export default function JobSetActionBar({
+  bulk,
+  all,
+  selectedCount,
+  total,
+  pending,
+  onBulk,
+  onAll,
+}: JobSetActionBarProps) {
+  const confirmDanger = (a: ActionDef, scope: string) =>
+    !a.danger || window.confirm(t('actions.confirm', { action: a.label, scope }));
+
+  return (
+    <div className="action-bar">
+      <div className="action-bar-group">
+        <span className="action-bar-count">
+          {selectedCount > 0 ? t('actions.selected', { n: selectedCount }) : t('actions.select_hint')}
+        </span>
+        {bulk.map((a) => (
+          <button
+            key={a.cmd}
+            className={`btn btn-sm${a.danger ? ' btn-danger' : ''}`}
+            disabled={pending || selectedCount === 0}
+            onClick={() => confirmDanger(a, t('actions.scope_selected', { n: selectedCount })) && onBulk(a.cmd)}
+          >
+            {a.label}
+          </button>
+        ))}
+      </div>
+      <div className="action-bar-group">
+        {all.map((a) => (
+          <button
+            key={a.cmd}
+            className={`btn btn-sm btn-ghost${a.danger ? ' btn-danger' : ''}`}
+            disabled={pending || total === 0}
+            onClick={() => confirmDanger(a, t('actions.scope_all')) && onAll(a.cmd)}
+          >
+            {`${a.label} ${t('actions.all_suffix')}`}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useJobSetActions.ts
+++ b/frontend/src/hooks/useJobSetActions.ts
@@ -11,12 +11,17 @@ export function entryKey(e: { score: number; jid: string }): string {
   return `${e.score}|${e.jid}`;
 }
 
-function postJSON(url: string, body?: unknown): Promise<Response> {
-  return fetch(url, {
+async function postJSON(url: string, body?: unknown): Promise<Response> {
+  const res = await fetch(url, {
     method: 'POST',
     headers: body ? { 'Content-Type': 'application/json' } : {},
     body: body ? JSON.stringify(body) : undefined,
   });
+  // fetch only rejects on network failure; a 4xx/5xx still resolves. Throw so
+  // the mutation's onError fires (and onSuccess/cache-invalidation does not)
+  // when the server rejects the action (e.g. 403 in read-only, 400/404).
+  if (!res.ok) throw new Error(`Request failed (${res.status})`);
+  return res;
 }
 
 // Single/bulk/all mutations for one job set. Each invalidates both the set's

--- a/frontend/src/hooks/useJobSetActions.ts
+++ b/frontend/src/hooks/useJobSetActions.ts
@@ -1,0 +1,50 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+// The three mutable sorted-set views. The string doubles as the API path
+// segment (`/wurk/api/<set>`) and the TanStack Query key the pages cache under.
+export type JobSetName = 'retries' | 'scheduled' | 'dead';
+
+// Re-targets the exact (score, jid) pair server-side. Mirrors
+// Wurk::SortedEntry#id ("<score>|<jid>"); the controller splits it back apart
+// and resolves via JobSet#fetch, so float→string round-tripping never matters.
+export function entryKey(e: { score: number; jid: string }): string {
+  return `${e.score}|${e.jid}`;
+}
+
+function postJSON(url: string, body?: unknown): Promise<Response> {
+  return fetch(url, {
+    method: 'POST',
+    headers: body ? { 'Content-Type': 'application/json' } : {},
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+// Single/bulk/all mutations for one job set. Each invalidates both the set's
+// own query and `stats` (the nav badges + dashboard counts read from it) so
+// the UI reflects the change without a manual refresh.
+export function useJobSetActions(set: JobSetName) {
+  const qc = useQueryClient();
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: [set] });
+    qc.invalidateQueries({ queryKey: ['stats'] });
+  };
+
+  const single = useMutation({
+    mutationFn: ({ key, cmd }: { key: string; cmd: string }) =>
+      postJSON(`/wurk/api/${set}/${encodeURIComponent(key)}`, { cmd }),
+    onSuccess: invalidate,
+  });
+
+  const bulk = useMutation({
+    mutationFn: ({ keys, cmd }: { keys: string[]; cmd: string }) =>
+      postJSON(`/wurk/api/${set}`, { keys, cmd }),
+    onSuccess: invalidate,
+  });
+
+  const all = useMutation({
+    mutationFn: (cmd: string) => postJSON(`/wurk/api/${set}/all/${cmd}`),
+    onSuccess: invalidate,
+  });
+
+  return { single, bulk, all };
+}

--- a/frontend/src/hooks/useSelection.ts
+++ b/frontend/src/hooks/useSelection.ts
@@ -1,0 +1,31 @@
+import { useCallback, useMemo, useState } from 'react';
+
+// Row-selection state for the bulk-action tables (retries/scheduled/dead).
+// Keyed by the entry's composite key (see entryKey) so a selection survives
+// re-sorting; `toggleAll` works against the currently visible page's keys.
+export function useSelection() {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const toggle = useCallback((key: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  const toggleAll = useCallback((keys: string[]) => {
+    setSelected((prev) => {
+      const allOn = keys.length > 0 && keys.every((k) => prev.has(k));
+      return allOn ? new Set() : new Set(keys);
+    });
+  }, []);
+
+  const clear = useCallback(() => setSelected(new Set()), []);
+
+  return useMemo(
+    () => ({ selected, toggle, toggleAll, clear, count: selected.size }),
+    [selected, toggle, toggleAll, clear]
+  );
+}

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -88,10 +88,19 @@
     "retry": "Retry",
     "delete": "Delete",
     "kill": "Kill",
+    "add_to_queue": "Add to Queue",
+    "clear": "Clear",
     "prev": "Previous",
     "next": "Next",
     "search": "Search",
-    "refresh": "Refresh"
+    "refresh": "Refresh",
+    "all_suffix": "All",
+    "selected": "{n} selected",
+    "select_hint": "Select jobs to act on",
+    "scope_selected": "{n} selected job(s)",
+    "scope_all": "every job in this set",
+    "confirm": "{action} {scope}? This cannot be undone.",
+    "confirm_clear_queue": "Clear all jobs from \"{name}\"? This cannot be undone."
   },
   "readonly": {
     "banner": "Read-only mode"

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -99,6 +99,7 @@
     "select_hint": "Select jobs to act on",
     "scope_selected": "{n} selected job(s)",
     "scope_all": "every job in this set",
+    "scope_this_job": "this job",
     "confirm": "{action} {scope}? This cannot be undone.",
     "confirm_clear_queue": "Clear all jobs from \"{name}\"? This cannot be undone."
   },

--- a/frontend/src/pages/Dead.tsx
+++ b/frontend/src/pages/Dead.tsx
@@ -9,6 +9,10 @@ import { t } from '../i18n';
 import { PageHeader } from '../components/PageHeader';
 import { relativeTime, truncate, formatArgs, isoTime } from '../utils';
 import JobDetailModal, { type JobEntry } from '../components/JobDetailModal';
+import JobSetActionBar, { type ActionDef } from '../components/JobSetActionBar';
+import { useMeta } from '../hooks/useMeta';
+import { useSelection } from '../hooks/useSelection';
+import { useJobSetActions, entryKey } from '../hooks/useJobSetActions';
 
 interface DeadEntry {
   jid: string;
@@ -42,9 +46,20 @@ const SORT: Accessors<DeadEntry> = {
   failed_at: (e) => e.at,
 };
 
+const ACTIONS: ActionDef[] = [
+  { cmd: 'retry', label: t('actions.retry') },
+  { cmd: 'delete', label: t('actions.delete'), danger: true },
+];
+
 export default function Dead() {
   const [page, setPage] = usePageParam();
   const [selected, setSelected] = useState<JobEntry | null>(null);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const { data: meta } = useMeta();
+  const readOnly = meta?.read_only ?? false;
+  const sel = useSelection();
+  const { single, bulk, all } = useJobSetActions('dead');
+  const pending = single.isPending || bulk.isPending || all.isPending;
 
   useEffect(() => {
     document.title = `${t('nav.dead')} — Wurk`;
@@ -59,9 +74,12 @@ export default function Dead() {
   });
 
   const { sorted, sort, toggle } = useSort(data?.entries ?? [], SORT);
+  const pageKeys = sorted.map(entryKey);
 
   if (isLoading) return <div className="empty-state"><span className="spinner" /></div>;
   if (isError || !data) return <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>;
+
+  const allChecked = pageKeys.length > 0 && pageKeys.every((k) => sel.selected.has(k));
 
   return (
     <div>
@@ -73,10 +91,26 @@ export default function Dead() {
         <div className="empty-state">{t('common.empty')}</div>
       ) : (
         <>
+          {!readOnly && (
+            <JobSetActionBar
+              bulk={ACTIONS}
+              all={ACTIONS}
+              selectedCount={sel.count}
+              total={data.total}
+              pending={pending}
+              onBulk={(cmd) => bulk.mutate({ keys: [...sel.selected], cmd }, { onSuccess: sel.clear })}
+              onAll={(cmd) => all.mutate(cmd, { onSuccess: sel.clear })}
+            />
+          )}
           <div className="table-wrapper">
             <table>
               <thead>
                 <tr>
+                  {!readOnly && (
+                    <th className="row-action">
+                      <input type="checkbox" checked={allChecked} onChange={() => sel.toggleAll(pageKeys)} aria-label="Select all" />
+                    </th>
+                  )}
                   <SortableTh label={t('table.jid')} sortKey="jid" sort={sort} onSort={toggle} />
                   <SortableTh label={t('table.class')} sortKey="klass" sort={sort} onSort={toggle} />
                   <SortableTh label={t('table.args')} sortKey="args" sort={sort} onSort={toggle} />
@@ -88,8 +122,14 @@ export default function Dead() {
               <tbody>
                 {sorted.map((entry) => {
                   const argsStr = formatArgs(entry.args);
+                  const key = entryKey(entry);
                   return (
-                    <tr key={entry.jid} className="row-clickable" onClick={() => setSelected(entry)}>
+                    <tr key={entry.jid} className="row-clickable" onClick={() => { setSelected(entry); setSelectedKey(key); }}>
+                      {!readOnly && (
+                        <td className="row-action" onClick={(e) => e.stopPropagation()}>
+                          <input type="checkbox" checked={sel.selected.has(key)} onChange={() => sel.toggle(key)} aria-label="Select job" />
+                        </td>
+                      )}
                       <td
                         title={entry.jid}
                         style={{ fontFamily: 'monospace', fontSize: 12, color: 'var(--text-muted)' }}
@@ -114,7 +154,15 @@ export default function Dead() {
           <Pagination page={page} total={data.total} count={PAGE_SIZE} onChange={setPage} />
         </>
       )}
-      <JobDetailModal entry={selected} atLabel={t('table.failed_at')} onClose={() => setSelected(null)} />
+      <JobDetailModal
+        entry={selected}
+        atLabel={t('table.failed_at')}
+        actions={readOnly ? undefined : ACTIONS}
+        onAction={(cmd) =>
+          selectedKey && single.mutate({ key: selectedKey, cmd }, { onSuccess: () => { setSelected(null); setSelectedKey(null); } })
+        }
+        onClose={() => { setSelected(null); setSelectedKey(null); }}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/Dead.tsx
+++ b/frontend/src/pages/Dead.tsx
@@ -158,6 +158,7 @@ export default function Dead() {
         entry={selected}
         atLabel={t('table.failed_at')}
         actions={readOnly ? undefined : ACTIONS}
+        pending={single.isPending}
         onAction={(cmd) =>
           selectedKey && single.mutate({ key: selectedKey, cmd }, { onSuccess: () => { setSelected(null); setSelectedKey(null); } })
         }

--- a/frontend/src/pages/Queues.tsx
+++ b/frontend/src/pages/Queues.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { Pagination } from '../components/Pagination';
 import { ArgsValue } from '../components/ArgsValue';
@@ -10,6 +10,7 @@ import { PageHeader } from '../components/PageHeader';
 import { relativeTime, truncate, formatArgs } from '../utils';
 import JobDetailModal, { type JobEntry } from '../components/JobDetailModal';
 import Modal from '../components/Modal';
+import { useMeta } from '../hooks/useMeta';
 
 interface QueueSummary {
   name: string;
@@ -49,6 +50,9 @@ const JOB_SORT: Accessors<QueueJob> = {
 function QueueJobs({ name }: { name: string }) {
   const [page, setPage] = usePageParam();
   const [selected, setSelected] = useState<JobEntry | null>(null);
+  const { data: meta } = useMeta();
+  const readOnly = meta?.read_only ?? false;
+  const qc = useQueryClient();
 
   const { data, isLoading, isError } = useQuery<QueueDetail>({
     queryKey: ['queue', name, page],
@@ -56,6 +60,21 @@ function QueueJobs({ name }: { name: string }) {
       fetch(`/wurk/api/queues/${encodeURIComponent(name)}?page=${page - 1}&count=${PAGE_SIZE}`).then(
         (r) => r.json() as Promise<QueueDetail>
       ),
+  });
+
+  // Delete one job from the queue by jid (server LREMs the exact payload).
+  const deleteJob = useMutation({
+    mutationFn: (jid: string) =>
+      fetch(`/wurk/api/queues/${encodeURIComponent(name)}/delete`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jid }),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['queue', name] });
+      qc.invalidateQueries({ queryKey: ['queues'] });
+      qc.invalidateQueries({ queryKey: ['stats'] });
+    },
   });
 
   const { sorted, sort, toggle } = useSort(data?.jobs ?? [], JOB_SORT);
@@ -84,6 +103,7 @@ function QueueJobs({ name }: { name: string }) {
                   <SortableTh label={t('table.class')} sortKey="class" sort={sort} onSort={toggle} />
                   <SortableTh label={t('table.args')} sortKey="args" sort={sort} onSort={toggle} />
                   <SortableTh label={t('table.enqueued_at')} sortKey="enqueued" sort={sort} onSort={toggle} />
+                  {!readOnly && <th className="row-action" />}
                 </tr>
               </thead>
               <tbody>
@@ -101,6 +121,17 @@ function QueueJobs({ name }: { name: string }) {
                       <td style={{ fontWeight: 500 }}>{job.class}</td>
                       <td><ArgsValue str={argsStr} max={60} /></td>
                       <td>{relativeTime(job.enqueued_at)}</td>
+                      {!readOnly && (
+                        <td className="row-action" onClick={(e) => e.stopPropagation()}>
+                          <button
+                            className="btn btn-sm btn-danger"
+                            disabled={deleteJob.isPending}
+                            onClick={() => deleteJob.mutate(job.jid)}
+                          >
+                            {t('actions.delete')}
+                          </button>
+                        </td>
+                      )}
                     </tr>
                   );
                 })}
@@ -124,6 +155,9 @@ const QUEUE_SORT: Accessors<QueueSummary> = {
 
 export default function Queues() {
   const [selectedQueue, setSelectedQueue] = useState<string | null>(null);
+  const { data: meta } = useMeta();
+  const readOnly = meta?.read_only ?? false;
+  const qc = useQueryClient();
 
   useEffect(() => {
     document.title = `${t('nav.queues')} — Wurk`;
@@ -133,6 +167,16 @@ export default function Queues() {
     queryKey: ['queues'],
     queryFn: () => fetch('/wurk/api/queues').then((r) => r.json() as Promise<QueueSummary[]>),
     refetchInterval: 10000,
+  });
+
+  const clearQueue = useMutation({
+    mutationFn: (name: string) =>
+      fetch(`/wurk/api/queues/${encodeURIComponent(name)}/clear`, { method: 'POST' }),
+    onSuccess: (_res, name) => {
+      qc.invalidateQueries({ queryKey: ['queues'] });
+      qc.invalidateQueries({ queryKey: ['queue', name] });
+      qc.invalidateQueries({ queryKey: ['stats'] });
+    },
   });
 
   const { sorted, sort, toggle } = useSort(data ?? [], QUEUE_SORT);
@@ -155,6 +199,7 @@ export default function Queues() {
                 <SortableTh label={t('table.size')} sortKey="size" sort={sort} onSort={toggle} />
                 <SortableTh label={t('table.latency')} sortKey="latency" sort={sort} onSort={toggle} />
                 <SortableTh label={t('table.status')} sortKey="status" sort={sort} onSort={toggle} />
+                {!readOnly && <th className="row-action" />}
               </tr>
             </thead>
             <tbody>
@@ -170,6 +215,19 @@ export default function Queues() {
                       <span className="badge badge-success">Active</span>
                     )}
                   </td>
+                  {!readOnly && (
+                    <td className="row-action" onClick={(e) => e.stopPropagation()}>
+                      <button
+                        className="btn btn-sm btn-danger"
+                        disabled={clearQueue.isPending}
+                        onClick={() => {
+                          if (window.confirm(t('actions.confirm_clear_queue', { name: q.name }))) clearQueue.mutate(q.name);
+                        }}
+                      >
+                        {t('actions.clear')}
+                      </button>
+                    </td>
+                  )}
                 </tr>
               ))}
             </tbody>

--- a/frontend/src/pages/Queues.tsx
+++ b/frontend/src/pages/Queues.tsx
@@ -64,12 +64,15 @@ function QueueJobs({ name }: { name: string }) {
 
   // Delete one job from the queue by jid (server LREMs the exact payload).
   const deleteJob = useMutation({
-    mutationFn: (jid: string) =>
-      fetch(`/wurk/api/queues/${encodeURIComponent(name)}/delete`, {
+    mutationFn: async (jid: string) => {
+      const res = await fetch(`/wurk/api/queues/${encodeURIComponent(name)}/delete`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ jid }),
-      }),
+      });
+      if (!res.ok) throw new Error(`Delete failed (${res.status})`);
+      return res;
+    },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['queue', name] });
       qc.invalidateQueries({ queryKey: ['queues'] });
@@ -126,7 +129,11 @@ function QueueJobs({ name }: { name: string }) {
                           <button
                             className="btn btn-sm btn-danger"
                             disabled={deleteJob.isPending}
-                            onClick={() => deleteJob.mutate(job.jid)}
+                            onClick={() => {
+                              if (window.confirm(t('actions.confirm', { action: t('actions.delete'), scope: t('actions.scope_this_job') }))) {
+                                deleteJob.mutate(job.jid);
+                              }
+                            }}
                           >
                             {t('actions.delete')}
                           </button>
@@ -170,8 +177,11 @@ export default function Queues() {
   });
 
   const clearQueue = useMutation({
-    mutationFn: (name: string) =>
-      fetch(`/wurk/api/queues/${encodeURIComponent(name)}/clear`, { method: 'POST' }),
+    mutationFn: async (name: string) => {
+      const res = await fetch(`/wurk/api/queues/${encodeURIComponent(name)}/clear`, { method: 'POST' });
+      if (!res.ok) throw new Error(`Clear failed (${res.status})`);
+      return res;
+    },
     onSuccess: (_res, name) => {
       qc.invalidateQueries({ queryKey: ['queues'] });
       qc.invalidateQueries({ queryKey: ['queue', name] });

--- a/frontend/src/pages/Retries.tsx
+++ b/frontend/src/pages/Retries.tsx
@@ -6,9 +6,13 @@ import { t } from '../i18n';
 import { PageHeader } from '../components/PageHeader';
 import { relativeTime, truncate, formatArgs, isoTime } from '../utils';
 import JobDetailModal, { type JobEntry } from '../components/JobDetailModal';
+import JobSetActionBar, { type ActionDef } from '../components/JobSetActionBar';
 import { SortableTh } from '../components/SortableTh';
 import { useSort, type Accessors } from '../hooks/useSort';
 import { usePageParam } from '../hooks/usePageParam';
+import { useMeta } from '../hooks/useMeta';
+import { useSelection } from '../hooks/useSelection';
+import { useJobSetActions, entryKey } from '../hooks/useJobSetActions';
 
 interface RetryEntry {
   jid: string;
@@ -43,9 +47,26 @@ const SORT: Accessors<RetryEntry> = {
   at: (e) => e.at,
 };
 
+const BULK: ActionDef[] = [
+  { cmd: 'retry', label: t('actions.retry') },
+  { cmd: 'delete', label: t('actions.delete'), danger: true },
+  { cmd: 'kill', label: t('actions.kill'), danger: true },
+];
+const ALL: ActionDef[] = [
+  { cmd: 'retry', label: t('actions.retry') },
+  { cmd: 'kill', label: t('actions.kill'), danger: true },
+  { cmd: 'delete', label: t('actions.delete'), danger: true },
+];
+
 export default function Retries() {
   const [page, setPage] = usePageParam();
   const [selected, setSelected] = useState<JobEntry | null>(null);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const { data: meta } = useMeta();
+  const readOnly = meta?.read_only ?? false;
+  const sel = useSelection();
+  const { single, bulk, all } = useJobSetActions('retries');
+  const pending = single.isPending || bulk.isPending || all.isPending;
 
   useEffect(() => {
     document.title = `${t('nav.retries')} — Wurk`;
@@ -60,9 +81,12 @@ export default function Retries() {
   });
 
   const { sorted, sort, toggle } = useSort(data?.entries ?? [], SORT);
+  const pageKeys = sorted.map(entryKey);
 
   if (isLoading) return <div className="empty-state"><span className="spinner" /></div>;
   if (isError || !data) return <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>;
+
+  const allChecked = pageKeys.length > 0 && pageKeys.every((k) => sel.selected.has(k));
 
   return (
     <div>
@@ -74,10 +98,26 @@ export default function Retries() {
         <div className="empty-state">{t('common.empty')}</div>
       ) : (
         <>
+          {!readOnly && (
+            <JobSetActionBar
+              bulk={BULK}
+              all={ALL}
+              selectedCount={sel.count}
+              total={data.total}
+              pending={pending}
+              onBulk={(cmd) => bulk.mutate({ keys: [...sel.selected], cmd }, { onSuccess: sel.clear })}
+              onAll={(cmd) => all.mutate(cmd, { onSuccess: sel.clear })}
+            />
+          )}
           <div className="table-wrapper">
             <table>
               <thead>
                 <tr>
+                  {!readOnly && (
+                    <th className="row-action">
+                      <input type="checkbox" checked={allChecked} onChange={() => sel.toggleAll(pageKeys)} aria-label="Select all" />
+                    </th>
+                  )}
                   <SortableTh label={t('table.class')} sortKey="klass" sort={sort} onSort={toggle} />
                   <SortableTh label={t('table.args')} sortKey="args" sort={sort} onSort={toggle} />
                   <SortableTh label={t('table.error')} sortKey="error_class" sort={sort} onSort={toggle} />
@@ -89,8 +129,14 @@ export default function Retries() {
               <tbody>
                 {sorted.map((entry) => {
                   const argsStr = formatArgs(entry.args);
+                  const key = entryKey(entry);
                   return (
-                    <tr key={entry.jid} className="row-clickable" onClick={() => setSelected(entry)}>
+                    <tr key={entry.jid} className="row-clickable" onClick={() => { setSelected(entry); setSelectedKey(key); }}>
+                      {!readOnly && (
+                        <td className="row-action" onClick={(e) => e.stopPropagation()}>
+                          <input type="checkbox" checked={sel.selected.has(key)} onChange={() => sel.toggle(key)} aria-label="Select job" />
+                        </td>
+                      )}
                       <td style={{ fontWeight: 500 }}>{entry.klass}</td>
                       <td><ArgsValue str={argsStr} max={40} /></td>
                       <td title={entry.error_class} style={{ color: 'var(--danger)' }}>
@@ -110,7 +156,15 @@ export default function Retries() {
           <Pagination page={page} total={data.total} count={PAGE_SIZE} onChange={setPage} />
         </>
       )}
-      <JobDetailModal entry={selected} atLabel={t('table.retry_at')} onClose={() => setSelected(null)} />
+      <JobDetailModal
+        entry={selected}
+        atLabel={t('table.retry_at')}
+        actions={readOnly ? undefined : BULK}
+        onAction={(cmd) =>
+          selectedKey && single.mutate({ key: selectedKey, cmd }, { onSuccess: () => { setSelected(null); setSelectedKey(null); } })
+        }
+        onClose={() => { setSelected(null); setSelectedKey(null); }}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/Retries.tsx
+++ b/frontend/src/pages/Retries.tsx
@@ -160,6 +160,7 @@ export default function Retries() {
         entry={selected}
         atLabel={t('table.retry_at')}
         actions={readOnly ? undefined : BULK}
+        pending={single.isPending}
         onAction={(cmd) =>
           selectedKey && single.mutate({ key: selectedKey, cmd }, { onSuccess: () => { setSelected(null); setSelectedKey(null); } })
         }

--- a/frontend/src/pages/Scheduled.tsx
+++ b/frontend/src/pages/Scheduled.tsx
@@ -146,6 +146,7 @@ export default function Scheduled() {
         entry={selected}
         atLabel={t('table.scheduled_at')}
         actions={readOnly ? undefined : ACTIONS}
+        pending={single.isPending}
         onAction={(cmd) =>
           selectedKey && single.mutate({ key: selectedKey, cmd }, { onSuccess: () => { setSelected(null); setSelectedKey(null); } })
         }

--- a/frontend/src/pages/Scheduled.tsx
+++ b/frontend/src/pages/Scheduled.tsx
@@ -9,6 +9,10 @@ import { t } from '../i18n';
 import { PageHeader } from '../components/PageHeader';
 import { relativeTime, truncate, formatArgs, isoTime } from '../utils';
 import JobDetailModal, { type JobEntry } from '../components/JobDetailModal';
+import JobSetActionBar, { type ActionDef } from '../components/JobSetActionBar';
+import { useMeta } from '../hooks/useMeta';
+import { useSelection } from '../hooks/useSelection';
+import { useJobSetActions, entryKey } from '../hooks/useJobSetActions';
 
 interface ScheduledEntry {
   jid: string;
@@ -36,9 +40,20 @@ const SORT: Accessors<ScheduledEntry> = {
   at: (e) => e.at,
 };
 
+const ACTIONS: ActionDef[] = [
+  { cmd: 'add_to_queue', label: t('actions.add_to_queue') },
+  { cmd: 'delete', label: t('actions.delete'), danger: true },
+];
+
 export default function Scheduled() {
   const [page, setPage] = usePageParam();
   const [selected, setSelected] = useState<JobEntry | null>(null);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const { data: meta } = useMeta();
+  const readOnly = meta?.read_only ?? false;
+  const sel = useSelection();
+  const { single, bulk, all } = useJobSetActions('scheduled');
+  const pending = single.isPending || bulk.isPending || all.isPending;
 
   useEffect(() => {
     document.title = `${t('nav.scheduled')} — Wurk`;
@@ -53,9 +68,12 @@ export default function Scheduled() {
   });
 
   const { sorted, sort, toggle } = useSort(data?.entries ?? [], SORT);
+  const pageKeys = sorted.map(entryKey);
 
   if (isLoading) return <div className="empty-state"><span className="spinner" /></div>;
   if (isError || !data) return <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>;
+
+  const allChecked = pageKeys.length > 0 && pageKeys.every((k) => sel.selected.has(k));
 
   return (
     <div>
@@ -67,10 +85,26 @@ export default function Scheduled() {
         <div className="empty-state">{t('common.empty')}</div>
       ) : (
         <>
+          {!readOnly && (
+            <JobSetActionBar
+              bulk={ACTIONS}
+              all={ACTIONS}
+              selectedCount={sel.count}
+              total={data.total}
+              pending={pending}
+              onBulk={(cmd) => bulk.mutate({ keys: [...sel.selected], cmd }, { onSuccess: sel.clear })}
+              onAll={(cmd) => all.mutate(cmd, { onSuccess: sel.clear })}
+            />
+          )}
           <div className="table-wrapper">
             <table>
               <thead>
                 <tr>
+                  {!readOnly && (
+                    <th className="row-action">
+                      <input type="checkbox" checked={allChecked} onChange={() => sel.toggleAll(pageKeys)} aria-label="Select all" />
+                    </th>
+                  )}
                   <SortableTh label={t('table.jid')} sortKey="jid" sort={sort} onSort={toggle} />
                   <SortableTh label={t('table.class')} sortKey="klass" sort={sort} onSort={toggle} />
                   <SortableTh label={t('table.args')} sortKey="args" sort={sort} onSort={toggle} />
@@ -80,8 +114,14 @@ export default function Scheduled() {
               <tbody>
                 {sorted.map((entry) => {
                   const argsStr = formatArgs(entry.args);
+                  const key = entryKey(entry);
                   return (
-                    <tr key={entry.jid} className="row-clickable" onClick={() => setSelected(entry)}>
+                    <tr key={entry.jid} className="row-clickable" onClick={() => { setSelected(entry); setSelectedKey(key); }}>
+                      {!readOnly && (
+                        <td className="row-action" onClick={(e) => e.stopPropagation()}>
+                          <input type="checkbox" checked={sel.selected.has(key)} onChange={() => sel.toggle(key)} aria-label="Select job" />
+                        </td>
+                      )}
                       <td
                         title={entry.jid}
                         style={{ fontFamily: 'monospace', fontSize: 12, color: 'var(--text-muted)' }}
@@ -102,7 +142,15 @@ export default function Scheduled() {
           <Pagination page={page} total={data.total} count={PAGE_SIZE} onChange={setPage} />
         </>
       )}
-      <JobDetailModal entry={selected} atLabel={t('table.scheduled_at')} onClose={() => setSelected(null)} />
+      <JobDetailModal
+        entry={selected}
+        atLabel={t('table.scheduled_at')}
+        actions={readOnly ? undefined : ACTIONS}
+        onAction={(cmd) =>
+          selectedKey && single.mutate({ key: selectedKey, cmd }, { onSuccess: () => { setSelected(null); setSelectedKey(null); } })
+        }
+        onClose={() => { setSelected(null); setSelectedKey(null); }}
+      />
     </div>
   );
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -341,6 +341,50 @@ tbody tr:last-child td {
   border-color: var(--danger);
 }
 
+.btn-sm {
+  padding: 0.3rem 0.7rem;
+  font-size: 12px;
+}
+
+.btn-ghost {
+  background: transparent;
+  border-color: var(--border);
+}
+
+.btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* Bulk/all action toolbar above mutable job-set tables (retries/scheduled/dead). */
+.action-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-bottom: 0.85rem;
+}
+
+.action-bar-group {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.action-bar-count {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-right: 0.25rem;
+}
+
+/* Stop a row checkbox/action click from also opening the detail modal. */
+.row-action {
+  width: 1%;
+  white-space: nowrap;
+}
+
 /* ── Misc ─────────────────────────────────────────────────────────────────*/
 .hamburger {
   background: var(--surface-strong);

--- a/test/engine/api_mutations_test.rb
+++ b/test/engine/api_mutations_test.rb
@@ -113,6 +113,32 @@ class ApiMutationsTest < Wurk::Test::EngineCase
     assert(fetch_set('dead').any? { |j| j['jid'] == jid })
   end
 
+  def test_all_unknown_action_is_400
+    push_to_zset('retry')
+    post '/wurk/api/retries/all/frobnicate'
+
+    assert_equal 400, last_response.status
+    assert_equal 1, fetch_set('retry').size, 'unknown all-action must not mutate'
+  end
+
+  def test_dead_all_kill_is_rejected
+    push_to_zset('dead')
+    post '/wurk/api/dead/all/kill'
+
+    assert_equal 400, last_response.status
+    assert_equal 1, fetch_set('dead').size
+  end
+
+  def test_bulk_deduplicates_repeated_keys
+    score, jid = push_to_zset('retry')
+    key = "#{score}|#{jid}"
+    post '/wurk/api/retries', { keys: [key, key], cmd: 'retry' }
+
+    assert_ok
+    assert_equal 1, json_body[:count], 'duplicate keys must act on the entry once'
+    assert_empty fetch_set('retry')
+  end
+
   # --- Scheduled ----------------------------------------------------------
 
   def test_scheduled_add_to_queue_single

--- a/test/engine/api_mutations_test.rb
+++ b/test/engine/api_mutations_test.rb
@@ -1,0 +1,264 @@
+# frozen_string_literal: true
+
+require_relative '../engine_test_helper'
+
+# Drives the Web UI mutation endpoints (issue #102, spec §25.4) against the
+# booted dummy app and real Redis: retry/delete/kill/requeue/clear across the
+# retry, scheduled, and dead sets plus per-queue clear/delete.
+#
+# Like ApiEndpointsTest we talk to the engine via Rack::Test and read
+# `last_response` directly.
+class ApiMutationsTest < Wurk::Test::EngineCase
+  parallelize_me!
+
+  def setup
+    super
+    @ns = "wurkmut:#{::Process.pid}:#{object_id}"
+    @queue = "#{@ns}-q"
+    @class_name = "ApiMutationJob@#{@ns}"
+  end
+
+  def teardown
+    ::Wurk.redis do |conn|
+      conn.call('DEL', "queue:#{@queue}")
+      conn.call('SREM', 'queues', @queue)
+      cleanup_zset(conn, 'retry')
+      cleanup_zset(conn, 'schedule')
+      cleanup_zset(conn, 'dead')
+    end
+    ::Wurk::Web.reset_config!
+  ensure
+    super
+  end
+
+  # --- Retries: single ----------------------------------------------------
+
+  def test_retry_single_requeues_job
+    score, jid = push_to_zset('retry')
+    post "/wurk/api/retries/#{ekey(score, jid)}", { cmd: 'retry' }
+
+    assert_ok
+    assert_equal 1, json_body[:count]
+    assert_empty fetch_set('retry')
+    assert queue_has_jid?(jid), 'expected job re-enqueued onto its queue'
+  end
+
+  def test_delete_single_removes_from_retry_set
+    score, jid = push_to_zset('retry')
+    post "/wurk/api/retries/#{ekey(score, jid)}", { cmd: 'delete' }
+
+    assert_ok
+    assert_empty fetch_set('retry')
+    refute queue_has_jid?(jid), 'delete must not re-enqueue'
+  end
+
+  def test_kill_single_moves_to_dead_set
+    score, jid = push_to_zset('retry')
+    post "/wurk/api/retries/#{ekey(score, jid)}", { cmd: 'kill' }
+
+    assert_ok
+    assert_empty fetch_set('retry')
+    assert(fetch_set('dead').any? { |j| j['jid'] == jid }, 'expected job in dead set')
+  end
+
+  def test_single_unknown_action_is_400
+    score, jid = push_to_zset('retry')
+    post "/wurk/api/retries/#{ekey(score, jid)}", { cmd: 'nope' }
+
+    assert_equal 400, last_response.status
+  end
+
+  def test_single_unknown_key_is_404
+    post "/wurk/api/retries/#{ekey(123.0, 'deadbeef')}", { cmd: 'retry' }
+
+    assert_equal 404, last_response.status
+  end
+
+  # --- Retries: bulk + all ------------------------------------------------
+
+  def test_bulk_delete_removes_each_key
+    a = push_to_zset('retry')
+    b = push_to_zset('retry')
+    post '/wurk/api/retries', { keys: ["#{a[0]}|#{a[1]}", "#{b[0]}|#{b[1]}"], cmd: 'delete' }
+
+    assert_ok
+    assert_equal 2, json_body[:count]
+    assert_empty fetch_set('retry')
+  end
+
+  def test_all_retry_drains_set
+    push_to_zset('retry')
+    push_to_zset('retry')
+    post '/wurk/api/retries/all/retry'
+
+    assert_ok
+    assert_operator json_body[:count], :>=, 2
+    assert_empty fetch_set('retry')
+  end
+
+  def test_all_delete_clears_set
+    push_to_zset('retry')
+    post '/wurk/api/retries/all/delete'
+
+    assert_ok
+    assert_empty fetch_set('retry')
+  end
+
+  def test_all_kill_moves_to_dead
+    _score, jid = push_to_zset('retry')
+    post '/wurk/api/retries/all/kill'
+
+    assert_ok
+    assert_empty fetch_set('retry')
+    assert(fetch_set('dead').any? { |j| j['jid'] == jid })
+  end
+
+  # --- Scheduled ----------------------------------------------------------
+
+  def test_scheduled_add_to_queue_single
+    score, jid = push_to_zset('schedule')
+    post "/wurk/api/scheduled/#{ekey(score, jid)}", { cmd: 'add_to_queue' }
+
+    assert_ok
+    assert_empty fetch_set('schedule')
+    assert queue_has_jid?(jid)
+  end
+
+  def test_scheduled_all_add_to_queue_drains_set
+    push_to_zset('schedule')
+    push_to_zset('schedule')
+    post '/wurk/api/scheduled/all/add_to_queue'
+
+    assert_ok
+    assert_empty fetch_set('schedule')
+  end
+
+  def test_scheduled_kill_is_rejected
+    score, jid = push_to_zset('schedule')
+    post "/wurk/api/scheduled/#{ekey(score, jid)}", { cmd: 'kill' }
+
+    assert_equal 400, last_response.status
+  end
+
+  # --- Dead (morgue) ------------------------------------------------------
+
+  def test_dead_retry_single_requeues
+    score, jid = push_to_zset('dead')
+    post "/wurk/api/dead/#{ekey(score, jid)}", { cmd: 'retry' }
+
+    assert_ok
+    assert_empty fetch_set('dead')
+    assert queue_has_jid?(jid)
+  end
+
+  def test_dead_all_retry
+    push_to_zset('dead')
+    post '/wurk/api/dead/all/retry'
+
+    assert_ok
+    assert_empty fetch_set('dead')
+  end
+
+  # --- Queues -------------------------------------------------------------
+
+  def test_clear_queue_empties_list
+    push_to_queue
+    post "/wurk/api/queues/#{@queue}/clear"
+
+    assert_ok
+    assert_equal 0, ::Wurk::Queue.new(@queue).size
+  end
+
+  def test_delete_queue_job_by_jid
+    jid = push_to_queue
+    post "/wurk/api/queues/#{@queue}/delete", { jid: jid }
+
+    assert_ok
+    refute queue_has_jid?(jid)
+  end
+
+  def test_delete_queue_job_unknown_is_404
+    push_to_queue
+    post "/wurk/api/queues/#{@queue}/delete", { jid: 'no-such-jid' }
+
+    assert_equal 404, last_response.status
+  end
+
+  # --- Read-only / forgery ------------------------------------------------
+
+  def test_read_only_blocks_mutation
+    ::Wurk::Web.configure { |c| c.read_only = true }
+    score, jid = push_to_zset('retry')
+    post "/wurk/api/retries/#{ekey(score, jid)}", { cmd: 'delete' }
+
+    assert_equal 403, last_response.status
+    assert_equal 1, fetch_set('retry').size, 'read-only must not mutate'
+  end
+
+  private
+
+  def json_body = ::JSON.parse(last_response.body, symbolize_names: true)
+
+  # URL-encodes the "<score>|<jid>" route key exactly as the SPA does
+  # (encodeURIComponent) so the `|` survives Rack::Test's URI parser.
+  def ekey(score, jid) = ::CGI.escape("#{score}|#{jid}")
+
+  def assert_ok
+    assert_equal 200, last_response.status, "non-200 response: body=#{last_response.body[0, 500]}"
+  end
+
+  def job_payload
+    {
+      'class' => @class_name,
+      'args' => [1, 2],
+      'queue' => @queue,
+      'jid' => SecureRandom.hex(12),
+      'created_at' => ::Time.now.to_f,
+      'enqueued_at' => ::Time.now.to_f,
+      'retry_count' => 1,
+      'error_class' => 'RuntimeError',
+      'error_message' => 'boom'
+    }
+  end
+
+  def push_to_queue
+    payload = job_payload
+    ::Wurk.redis do |c|
+      c.call('SADD', 'queues', @queue)
+      c.call('LPUSH', "queue:#{@queue}", ::Wurk.dump_json(payload))
+    end
+    payload['jid']
+  end
+
+  # Returns [score, jid] so callers can build the "<score>|<jid>" route key.
+  def push_to_zset(name)
+    payload = job_payload
+    score = ::Time.now.to_f
+    ::Wurk.redis { |c| c.call('ZADD', name, score.to_s, ::Wurk.dump_json(payload)) }
+    [score, payload['jid']]
+  end
+
+  # Parsed payloads for this test's class only, across a whole zset.
+  def fetch_set(name)
+    ::Wurk.redis { |c| c.call('ZRANGEBYSCORE', name, '-inf', '+inf') }
+          .map { |raw| ::Wurk.load_json(raw) }
+          .select { |h| h['class'] == @class_name }
+  end
+
+  def queue_has_jid?(jid)
+    !::Wurk::Queue.new(@queue).find_job(jid).nil?
+  end
+
+  def cleanup_zset(conn, key)
+    conn.call('ZRANGEBYSCORE', key, '-inf', '+inf').each do |raw|
+      parsed = begin
+        ::Wurk.load_json(raw)
+      rescue ::JSON::ParserError
+        nil
+      end
+      next unless parsed.is_a?(Hash) && parsed['class'] == @class_name
+
+      conn.call('ZREM', key, raw)
+    end
+  end
+end


### PR DESCRIPTION
Closes #102.

## What & why
Sidekiq's OSS Web UI lets operators act on jobs; Wurk's dashboard rendered retries/scheduled/dead/queues **read-only**. This wires the existing data API through to JSON endpoints + React action buttons. Spec: `docs/target/sidekiq-free.md` §25.4.

## Endpoints (config/routes.rb, app/controllers/wurk/api_controller.rb)
| Method | Path | Action |
|---|---|---|
| POST | `retries` / `scheduled` / `dead` | bulk: `keys[]` + `cmd` |
| POST | `<set>/all/:cmd` | whole-set: retry/kill/delete/add_to_queue |
| POST | `<set>/:key` | single (key = `"<score>\|<jid>"`) |
| POST | `queues/:name/clear` | empty a queue |
| POST | `queues/:name/delete` | delete one job by `jid` |

- `:key` is `Wurk::SortedEntry#id` (`"<score>\|<jid>"`), resolved via `JobSet#fetch` (exact score bracket narrowed by jid) — no reliance on JS↔Ruby float string formatting.
- Per-set action whitelists: unknown `cmd` → **400**, unknown key → **404**.
- All actions in `skip_forgery_protection`; the `Authorization` middleware already **403**s every non-GET in read-only mode, so no extra guard is needed.
- Underlying API is unchanged (`SortedEntry#retry/delete/kill/add_to_queue`, `JobSet#retry_all/kill_all`, `Queue#clear`, `JobRecord#delete`) — wire-compat untouched.

## Frontend
- `useJobSetActions` (single/bulk/all + cache invalidation), `useSelection` (row selection), `JobSetActionBar` (bulk + all toolbar).
- Checkbox column + toolbar on Retries/Scheduled/Dead; single actions in the job-detail modal footer; per-queue **Clear** + per-job **Delete** on Queues.
- Every control hidden when `/api/meta`'s `read_only` is true; destructive ops confirm first. New i18n keys added to `en` (other locales fall back to en).

## Tests
- `test/engine/api_mutations_test.rb` — **18** engine tests against real Redis: single/bulk/all/clear/delete across all sets, read-only **403**, unknown-key **404**.
- Full suite **1964 runs / 0 failures**, parity **20/0**, ecosystem **all passed**, coverage **line 96.62% / branch 92.39%** (≥90% gate).
- Verified live via curl against a booted dummy app (single/bulk/all/clear) and the production Vite bundle.

## How to test in prod
On any deploy running this build, from a Rails console or `curl` against the mounted dashboard (replace `/wurk` with your mount, add auth as needed):

```bash
# Clear a queue
curl -X POST https://your-app/wurk/api/queues/default/clear

# Delete a single queued job by jid
curl -X POST https://your-app/wurk/api/queues/default/delete \
  -H 'Content-Type: application/json' -d '{"jid":"<jid>"}'

# Retry the whole retry set / kill all / delete all
curl -X POST https://your-app/wurk/api/retries/all/retry
curl -X POST https://your-app/wurk/api/retries/all/kill
curl -X POST https://your-app/wurk/api/retries/all/delete

# Bulk action over selected entries (key = "<score>|<jid>")
curl -X POST https://your-app/wurk/api/dead \
  -H 'Content-Type: application/json' \
  -d '{"keys":["1700000000.0|abc123"],"cmd":"retry"}'
```

Or just open the dashboard → **Retries / Scheduled / Dead / Queues** and use the new buttons. Set `WURK_WEB_READ_ONLY=1` to confirm every control disappears and mutations 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk action toolbar with select-all and per-row selection, per-set bulk/all actions, and per-job footer action buttons.
  * Queue controls: clear queue and delete individual jobs.
* **Behavior**
  * Read-only mode now hides action controls and blocks mutations.
* **Localization**
  * Added UI strings and confirmation prompts for action scopes and destructive ops.
* **Style**
  * New button and action-bar styles.
* **Tests**
  * End-to-end API mutation tests covering single, bulk, and all operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->