### PR TITLE
feat(web): Busy-page process control (quiet/stop) endpoint + buttons (#101)

### DIFF
--- a/app/controllers/wurk/api_controller.rb
+++ b/app/controllers/wurk/api_controller.rb
@@ -28,6 +28,7 @@ module Wurk
       retries_bulk retries_all retry_job
       scheduled_bulk scheduled_all scheduled_job
       dead_bulk dead_all dead_job
+      quiet_process stop_process
     ]
 
     # Per-set action whitelists. Maps the SPA's action name to the
@@ -128,6 +129,13 @@ module Wurk
     def processes
       render json: ::Wurk::ProcessSet.new.map { |p| ::Wurk::Api::Serializers.process_row(p) }
     end
+
+    # Busy-page controls: SIGTSTP (quiet — drop fetch, drain in-flight) and
+    # SIGTERM (stop — graceful shutdown). Both are async; the target notices on
+    # its next heartbeat (≤10s). `identity` absent or "all" signals every live
+    # process.
+    def quiet_process = signal_processes(:quiet!)
+    def stop_process  = signal_processes(:stop!)
 
     def batches
       set = ::Wurk::BatchSet.new
@@ -255,6 +263,24 @@ module Wurk
         count += 1
       end
       render json: { ok: true, count: count }
+    end
+
+    # Sends `method` (:quiet! / :stop!) to one process by identity, or to every
+    # live process when identity is blank/"all". Embedded processes are skipped
+    # (they raise on quiet!/stop! — there's no separate process to signal). 404s
+    # when a named identity isn't in the live set.
+    def signal_processes(method)
+      identity = params[:identity].to_s
+      if identity.empty? || identity == 'all'
+        count = ::Wurk::ProcessSet.new.reject(&:embedded?).each { |p| p.public_send(method) }.size
+        return render(json: { ok: true, count: count })
+      end
+
+      process = ::Wurk::ProcessSet[identity]
+      return render(json: { error: 'unknown process' }, status: :not_found) unless process
+
+      process.public_send(method) unless process.embedded?
+      render json: { ok: true, count: process.embedded? ? 0 : 1 }
     end
 
     # Maps "<score>|<jid>" keys to live SortedEntry objects via score-bracketed

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,12 @@ Wurk::Engine.routes.draw do
     post 'dead/all/:cmd',    to: 'api#dead_all',       as: :api_dead_all
     post 'dead/:key',        to: 'api#dead_job',       as: :api_dead_job, constraints: { key: %r{[^/]+} }
     get  'processes',        to: 'api#processes'
+    # Busy-page process control (quiet/stop). `identity` rides in the body (it
+    # contains ':' and '.', awkward as a path segment); absent or "all" signals
+    # every live process. Read-only mode 403s these via the Authorization
+    # middleware. Spec: docs/target/sidekiq-free.md §25.4 (POST /busy).
+    post 'busy/quiet', to: 'api#quiet_process', as: :api_quiet_process
+    post 'busy/stop',  to: 'api#stop_process',  as: :api_stop_process
     get  'batches',          to: 'api#batches'
     get  'batches/:bid',     to: 'api#batch', as: :api_batch
     get  'limiters',         to: 'api#limiters'

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -90,6 +90,8 @@
     "kill": "Kill",
     "add_to_queue": "Add to Queue",
     "clear": "Clear",
+    "quiet": "Quiet",
+    "stop": "Stop",
     "prev": "Previous",
     "next": "Next",
     "search": "Search",
@@ -100,6 +102,8 @@
     "scope_selected": "{n} selected job(s)",
     "scope_all": "every job in this set",
     "scope_this_job": "this job",
+    "scope_this_process": "this process",
+    "scope_all_processes": "all processes",
     "confirm": "{action} {scope}? This cannot be undone.",
     "confirm_clear_queue": "Clear all jobs from \"{name}\"? This cannot be undone."
   },

--- a/frontend/src/pages/Busy.tsx
+++ b/frontend/src/pages/Busy.tsx
@@ -1,10 +1,12 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { t } from '../i18n';
 import { PageHeader } from '../components/PageHeader';
 import { relativeTime } from '../utils';
+import { useMeta } from '../hooks/useMeta';
 
 interface Process {
+  identity: string;
   pid: number;
   hostname: string;
   queues: string[];
@@ -12,9 +14,16 @@ interface Process {
   busy: number;
   quiet: boolean;
   beat_at: number;
+  embedded?: boolean;
 }
 
+type Signal = 'quiet' | 'stop';
+
 export default function Busy() {
+  const { data: meta } = useMeta();
+  const readOnly = meta?.read_only ?? false;
+  const qc = useQueryClient();
+
   useEffect(() => {
     document.title = `${t('nav.busy')} — Wurk`;
   }, []);
@@ -25,15 +34,56 @@ export default function Busy() {
     refetchInterval: 5000,
   });
 
+  // Quiet (SIGTSTP) / stop (SIGTERM) one process by identity, or all when
+  // identity is omitted. Both are async — the process reacts on its next
+  // heartbeat — so we just refetch rather than optimistically updating.
+  const control = useMutation({
+    mutationFn: async ({ signal, identity }: { signal: Signal; identity?: string }) => {
+      const res = await fetch(`/wurk/api/busy/${signal}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ identity: identity ?? 'all' }),
+      });
+      if (!res.ok) throw new Error(`${signal} failed (${res.status})`);
+      return res;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['processes'] }),
+  });
+
+  const confirmStop = (scope: string) =>
+    window.confirm(t('actions.confirm', { action: t('actions.stop'), scope }));
+
   if (isLoading) return <div className="empty-state"><span className="spinner" /></div>;
   if (isError || !data) return <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>;
+
+  const controllable = data.some((p) => !p.embedded);
 
   return (
     <div>
       <PageHeader icon="fa-gears" title={t('nav.busy')} summary={t('summaries.busy')}>
-        <span className="badge badge-muted">
-          {data.length} {t('dashboard.processes').toLowerCase()}
-        </span>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.6rem' }}>
+          <span className="badge badge-muted">
+            {data.length} {t('dashboard.processes').toLowerCase()}
+          </span>
+          {!readOnly && controllable && (
+            <>
+              <button
+                className="btn btn-sm btn-ghost"
+                disabled={control.isPending}
+                onClick={() => control.mutate({ signal: 'quiet' })}
+              >
+                {`${t('actions.quiet')} ${t('actions.all_suffix')}`}
+              </button>
+              <button
+                className="btn btn-sm btn-ghost btn-danger"
+                disabled={control.isPending}
+                onClick={() => confirmStop(t('actions.scope_all_processes')) && control.mutate({ signal: 'stop' })}
+              >
+                {`${t('actions.stop')} ${t('actions.all_suffix')}`}
+              </button>
+            </>
+          )}
+        </div>
       </PageHeader>
 
       {data.length === 0 ? (
@@ -51,7 +101,7 @@ export default function Busy() {
             const isRecent = Date.now() / 1000 - proc.beat_at < 30;
 
             return (
-              <div key={`${proc.hostname}-${proc.pid}`} className="card">
+              <div key={proc.identity ?? `${proc.hostname}-${proc.pid}`} className="card">
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '0.75rem' }}>
                   <div>
                     <div style={{ fontWeight: 600, fontSize: 15 }}>{proc.hostname}</div>
@@ -107,6 +157,25 @@ export default function Busy() {
                     ))}
                   </div>
                 </div>
+
+                {!readOnly && !proc.embedded && (
+                  <div style={{ display: 'flex', gap: '0.4rem', marginTop: '0.85rem' }}>
+                    <button
+                      className="btn btn-sm"
+                      disabled={control.isPending}
+                      onClick={() => control.mutate({ signal: 'quiet', identity: proc.identity })}
+                    >
+                      {t('actions.quiet')}
+                    </button>
+                    <button
+                      className="btn btn-sm btn-danger"
+                      disabled={control.isPending}
+                      onClick={() => confirmStop(t('actions.scope_this_process')) && control.mutate({ signal: 'stop', identity: proc.identity })}
+                    >
+                      {t('actions.stop')}
+                    </button>
+                  </div>
+                )}
               </div>
             );
           })}

--- a/frontend/src/pages/Busy.tsx
+++ b/frontend/src/pages/Busy.tsx
@@ -18,6 +18,12 @@ interface Process {
 }
 
 type Signal = 'quiet' | 'stop';
+// Discriminated so "all" is only ever sent for an explicit all-processes click —
+// a missing/empty `proc.identity` can never silently fall back to signalling
+// every process.
+type ControlTarget =
+  | { signal: Signal; scope: 'all' }
+  | { signal: Signal; scope: 'one'; identity: string };
 
 export default function Busy() {
   const { data: meta } = useMeta();
@@ -35,14 +41,16 @@ export default function Busy() {
   });
 
   // Quiet (SIGTSTP) / stop (SIGTERM) one process by identity, or all when
-  // identity is omitted. Both are async — the process reacts on its next
+  // scope is 'all'. Both are async — the process reacts on its next
   // heartbeat — so we just refetch rather than optimistically updating.
   const control = useMutation({
-    mutationFn: async ({ signal, identity }: { signal: Signal; identity?: string }) => {
+    mutationFn: async (target: ControlTarget) => {
+      const { signal } = target;
+      const identity = target.scope === 'all' ? 'all' : target.identity;
       const res = await fetch(`/wurk/api/busy/${signal}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ identity: identity ?? 'all' }),
+        body: JSON.stringify({ identity }),
       });
       if (!res.ok) throw new Error(`${signal} failed (${res.status})`);
       return res;
@@ -70,14 +78,14 @@ export default function Busy() {
               <button
                 className="btn btn-sm btn-ghost"
                 disabled={control.isPending}
-                onClick={() => control.mutate({ signal: 'quiet' })}
+                onClick={() => control.mutate({ signal: 'quiet', scope: 'all' })}
               >
                 {`${t('actions.quiet')} ${t('actions.all_suffix')}`}
               </button>
               <button
                 className="btn btn-sm btn-ghost btn-danger"
                 disabled={control.isPending}
-                onClick={() => confirmStop(t('actions.scope_all_processes')) && control.mutate({ signal: 'stop' })}
+                onClick={() => confirmStop(t('actions.scope_all_processes')) && control.mutate({ signal: 'stop', scope: 'all' })}
               >
                 {`${t('actions.stop')} ${t('actions.all_suffix')}`}
               </button>
@@ -163,14 +171,14 @@ export default function Busy() {
                     <button
                       className="btn btn-sm"
                       disabled={control.isPending}
-                      onClick={() => control.mutate({ signal: 'quiet', identity: proc.identity })}
+                      onClick={() => control.mutate({ signal: 'quiet', scope: 'one', identity: proc.identity })}
                     >
                       {t('actions.quiet')}
                     </button>
                     <button
                       className="btn btn-sm btn-danger"
                       disabled={control.isPending}
-                      onClick={() => confirmStop(t('actions.scope_this_process')) && control.mutate({ signal: 'stop', identity: proc.identity })}
+                      onClick={() => confirmStop(t('actions.scope_this_process')) && control.mutate({ signal: 'stop', scope: 'one', identity: proc.identity })}
                     >
                       {t('actions.stop')}
                     </button>

--- a/test/engine/busy_control_test.rb
+++ b/test/engine/busy_control_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require_relative '../engine_test_helper'
+
+# Drives the Busy-page process-control endpoints (issue #101, spec §25.4
+# POST /busy): quiet (SIGTSTP) and stop (SIGTERM) for one process by identity
+# or every live process. Asserts the signal lands on the process's
+# `<identity>-signals` LIST (the same channel the heartbeat drains).
+class BusyControlTest < Wurk::Test::EngineCase
+  parallelize_me!
+
+  def setup
+    super
+    @ns = "wurkbusy:#{::Process.pid}:#{object_id.to_s(16)}"
+    @identity = "host-#{@ns}:1234:abcd"
+  end
+
+  def teardown
+    ::Wurk.redis do |c|
+      c.call('SREM', ::Wurk::Keys::PROCESSES, @identity, "#{@identity}-emb")
+      c.call('DEL', @identity, "#{@identity}-signals", "#{@identity}-emb", "#{@identity}-emb-signals")
+    end
+  ensure
+    super
+  end
+
+  def test_quiet_pushes_tstp_to_the_process_signal_list
+    seed_process(@identity)
+    post '/wurk/api/busy/quiet', { identity: @identity }
+
+    assert_ok
+    assert_equal 1, json_body[:count]
+    assert_equal 'TSTP', last_signal(@identity)
+  end
+
+  def test_stop_pushes_term_to_the_process_signal_list
+    seed_process(@identity)
+    post '/wurk/api/busy/stop', { identity: @identity }
+
+    assert_ok
+    assert_equal 1, json_body[:count]
+    assert_equal 'TERM', last_signal(@identity)
+  end
+
+  def test_unknown_identity_is_404
+    post '/wurk/api/busy/stop', { identity: 'no-such-process' }
+
+    assert_equal 404, last_response.status
+  end
+
+  def test_quiet_all_signals_every_non_embedded_process
+    seed_process(@identity)
+    emb = "#{@identity}-emb"
+    seed_process(emb, embedded: true)
+
+    post '/wurk/api/busy/quiet', { identity: 'all' }
+
+    assert_ok
+    assert_operator json_body[:count], :>=, 1
+    assert_equal 'TSTP', last_signal(@identity)
+    # Embedded processes are skipped — no separate process to signal.
+    assert_nil last_signal(emb)
+  end
+
+  def test_embedded_single_process_is_a_noop
+    emb = "#{@identity}-emb"
+    seed_process(emb, embedded: true)
+
+    post '/wurk/api/busy/stop', { identity: emb }
+
+    assert_ok
+    assert_equal 0, json_body[:count]
+    assert_nil last_signal(emb)
+  end
+
+  private
+
+  def json_body = ::JSON.parse(last_response.body, symbolize_names: true)
+
+  def assert_ok
+    assert_equal 200, last_response.status, "non-200 response: body=#{last_response.body[0, 500]}"
+  end
+
+  def seed_process(identity, embedded: false)
+    info = {
+      'hostname' => 'testhost', 'pid' => 1234, 'tag' => @ns,
+      'concurrency' => 5, 'queues' => ['default'],
+      'identity' => identity, 'version' => ::Wurk::VERSION, 'embedded' => embedded
+    }
+    ::Wurk.redis do |c|
+      c.call('SADD', ::Wurk::Keys::PROCESSES, identity)
+      c.call('HSET', identity, 'info', ::Wurk.dump_json(info),
+             'busy', '0', 'beat', ::Time.now.to_f.to_s, 'quiet', 'false',
+             'rss', '1000', 'rtt_us', '10', 'concurrency', '5')
+    end
+  end
+
+  def last_signal(identity)
+    ::Wurk.redis { |c| c.call('LINDEX', "#{identity}-signals", 0) }
+  end
+end


### PR DESCRIPTION
Closes #101.

## What & why
Sidekiq's OSS Web UI exposes `POST /busy` to quiet/stop a worker process; Wurk's Busy page was read-only. `Wurk::Process#quiet!`/`#stop!` already existed — this wires them to JSON endpoints + UI controls. Spec: `docs/target/sidekiq-free.md` §25.4.

## Endpoints (config/routes.rb, app/controllers/wurk/api_controller.rb)
| Method | Path | Action |
|---|---|---|
| POST | `busy/quiet` | SIGTSTP — drop fetch, drain in-flight |
| POST | `busy/stop` | SIGTERM — graceful shutdown |

- `identity` rides in the **body** (it contains `:` and `.`, awkward as a path segment); absent or `"all"` signals **every live process**.
- **Embedded** processes are skipped (`quiet!`/`stop!` raise on them — there's no separate process to signal); a named embedded identity returns `count: 0`.
- **404** on an unknown identity.
- Added to `skip_forgery_protection`; the `Wurk::Web::Authorization` middleware already **403**s every non-GET in read-only mode, so no extra guard.

## Frontend (Busy.tsx)
- Per-card **Quiet** / **Stop** buttons + header **Quiet All** / **Stop All**.
- Hidden when `/api/meta`'s `read_only` is true; **confirm** before stop; non-2xx responses treated as failures (so cache invalidation only runs on success).
- Embedded processes render no controls. Exposes `identity` on the `Process` shape.

## Tests
- `test/engine/busy_control_test.rb` — **5** engine tests vs real Redis: single quiet→`TSTP`, single stop→`TERM`, quiet-all (skips embedded), unknown→**404**, embedded single→no-op.
- Full suite **0 failures**, coverage **line 96.62% / branch 92.49%**, TSC clean, bundle builds.
- Verified live via curl against a booted dummy app (quiet/stop/all/404/embedded).

## How to test in prod
On a deploy with workers running, open the dashboard → **Busy** and click **Quiet**/**Stop** on a process (or **Quiet All**/**Stop All**). Or via curl against the mounted dashboard:

```bash
# Quiet one process (SIGTSTP) — drops fetch, finishes in-flight
curl -X POST https://your-app/wurk/api/busy/quiet \
  -H 'Content-Type: application/json' -d '{"identity":"<host:pid:nonce>"}'

# Stop one process (SIGTERM) — graceful shutdown
curl -X POST https://your-app/wurk/api/busy/stop \
  -H 'Content-Type: application/json' -d '{"identity":"<host:pid:nonce>"}'

# Quiet / stop ALL live processes
curl -X POST https://your-app/wurk/api/busy/quiet -H 'Content-Type: application/json' -d '{"identity":"all"}'
curl -X POST https://your-app/wurk/api/busy/stop  -H 'Content-Type: application/json' -d '{"identity":"all"}'
```
Both signals are async — the target reacts on its next heartbeat (≤10s). Set `WURK_WEB_READ_ONLY=1` to confirm the controls disappear and the endpoints 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "quiet" and "stop" controls on the busy page for individual processes (when not embedded) and for all non-embedded processes.

* **Behavior**
  * Controls are disabled in read-only mode; per-process controls use a process identity to target actions.

* **Documentation**
  * Added UI text translations for the new actions and scope labels.

* **Tests**
  * Added tests validating signaling behavior, broadcasting, no-op for embedded processes, and unknown-identity errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->