### PR TITLE
feat(capsule): honor config[:fetch_class] / fetch_setup for pluggable fetch (#107)

### DIFF
--- a/lib/wurk/capsule.rb
+++ b/lib/wurk/capsule.rb
@@ -63,7 +63,7 @@ module Wurk
     # by hand; centralizing it here covers the standalone CLI and embedded
     # paths too (the bug behind a nil `fetcher` in `exe/wurk`). Idempotent.
     def prepare!
-      @fetcher ||= Wurk::Fetcher::Reliable.new(self)
+      @fetcher ||= build_fetcher
       redis_pool
       local_redis_pool
       client_middleware
@@ -139,6 +139,19 @@ module Wurk
     def stop; end
 
     private
+
+    # Drop-in fetch pluggability (spec §5 / §4.1): instantiate
+    # `config[:fetch_class]` when the host set one — a custom or Pro fetcher —
+    # else the default reliable BLMOVE fetcher (`Sidekiq::BasicFetch`). A
+    # `config[:fetch_setup]` callable, if present, is handed the freshly built
+    # fetcher so it can configure it before the manager starts pulling work.
+    def build_fetcher
+      klass = @config[:fetch_class] || Wurk::Fetcher::Reliable
+      fetcher = klass.new(self)
+      setup = @config[:fetch_setup]
+      setup.call(fetcher) if setup.respond_to?(:call)
+      fetcher
+    end
 
     def parse_queue_entry(entry)
       qname, weight_str = entry.to_s.split(',', 2)

--- a/test/unit/capsule_test.rb
+++ b/test/unit/capsule_test.rb
@@ -79,6 +79,56 @@ class CapsuleTest < Wurk::Test::UnitCase
     assert_same custom, @capsule.fetcher
   end
 
+  # --- fetch_class / fetch_setup pluggability (#107) --------------------
+
+  # A capsule whose config sets config[:fetch_class] uses it instead of the
+  # default reliable fetcher. Spec: sidekiq-free.md §5 (config[:fetch_class]
+  # || Sidekiq::BasicFetch).
+  StubFetcher = Class.new do
+    attr_reader :capsule
+
+    def initialize(capsule)
+      @capsule = capsule
+    end
+  end
+
+  def test_prepare_honors_config_fetch_class
+    @config[:fetch_class] = StubFetcher
+
+    @capsule.prepare!
+
+    assert_instance_of StubFetcher, @capsule.fetcher
+    assert_same @capsule, @capsule.fetcher.capsule
+  end
+
+  def test_prepare_falls_back_to_reliable_without_fetch_class
+    assert_nil @config[:fetch_class]
+
+    @capsule.prepare!
+
+    assert_instance_of Wurk::Fetcher::Reliable, @capsule.fetcher
+  end
+
+  # config[:fetch_setup] is handed the freshly built fetcher so it can
+  # configure it (spec §4.1 fetch_setup callable).
+  def test_prepare_invokes_fetch_setup_with_the_built_fetcher
+    seen = nil
+    @config[:fetch_class] = StubFetcher
+    @config[:fetch_setup] = ->(fetcher) { seen = fetcher }
+
+    @capsule.prepare!
+
+    assert_same @capsule.fetcher, seen
+  end
+
+  def test_prepare_ignores_non_callable_fetch_setup
+    @config[:fetch_setup] = 'not callable'
+
+    @capsule.prepare! # must not raise
+
+    assert_instance_of Wurk::Fetcher::Reliable, @capsule.fetcher
+  end
+
   def test_prepare_materializes_lazy_pools
     @capsule.prepare!
 


### PR DESCRIPTION
Closes #107.

## What

Sidekiq's drop-in contract (`docs/target/sidekiq-free.md` §5 / §4.1) makes the fetcher pluggable via `config[:fetch_class] || Sidekiq::BasicFetch`, plus an optional `config[:fetch_setup]` callable. Wurk's `Capsule#prepare!` hardcoded `Wurk::Fetcher::Reliable.new(self)` and never read either key — a custom or Pro fetcher dropped in via config was silently ignored.

## Change

`prepare!` now delegates to a private `build_fetcher`:

```ruby
def build_fetcher
  klass = @config[:fetch_class] || Wurk::Fetcher::Reliable
  fetcher = klass.new(self)
  setup = @config[:fetch_setup]
  setup.call(fetcher) if setup.respond_to?(:call)
  fetcher
end
```

- Instantiates `config[:fetch_class]` when set, else the reliable BLMOVE default.
- Hands the freshly built fetcher to a `config[:fetch_setup]` callable if present.
- No `Configuration` change: `fetch_class`/`fetch_setup` are `@options` keys reached via the existing `config[:...]`.

## Acceptance criteria (#107)

- [x] `prepare!` instantiates `config[:fetch_class]` when set, falling back to `Wurk::Fetcher::Reliable` (`Sidekiq::BasicFetch`).
- [x] `fetch_setup` callable (if present) is invoked — handed the built fetcher.
- [x] Unit test: stub `fetch_class` on a capsule, `prepare!`, assert `cap.fetcher` is the stub.
- [x] Drop-in preserved: default capsule still uses reliable fetch; `Sidekiq::BasicFetch` alias unchanged. The nil-before-`prepare!` and explicit `capsule.fetcher=` injection contracts are both kept (`||=`).

## Tests

4 new tests in `test/unit/capsule_test.rb` (fetch_class honored, default fallback, fetch_setup receives the instance, non-callable fetch_setup ignored).

- `bin/rake test` → 1976 runs, 0 failures
- `bin/rake test:parity` → 20 runs, 0 failures
- `bin/rake test:ecosystem` → all suites passed
- rubocop clean

## How to test in prod

In a Sidekiq drop-in app on Wurk, plug in a custom fetcher via your initializer and confirm Wurk uses it:

```ruby
# config/initializers/wurk.rb (or sidekiq.rb)
class AuditFetcher < Wurk::Fetcher::Reliable
  def retrieve_work
    Rails.logger.info("[AuditFetcher] tick")
    super
  end
end

Sidekiq.configure_server do |config|
  config[:fetch_class] = AuditFetcher
  config[:fetch_setup] = ->(f) { Rails.logger.info("[fetch_setup] built #{f.class}") }
end
```

Boot a worker and watch the log: you should see the `[fetch_setup] built AuditFetcher` line once at startup and `[AuditFetcher] tick` as it polls. Remove the `fetch_class`/`fetch_setup` lines and it transparently falls back to the default reliable fetcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Capsule now supports pluggable fetcher implementations and setup callbacks via configuration, enabling custom fetch behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->