### PR TITLE
feat(compat): top-level logger= setter + Sidekiq::CurrentAttributes alias (#106, #98)

### DIFF
--- a/lib/wurk.rb
+++ b/lib/wurk.rb
@@ -122,6 +122,10 @@ module Wurk
       configuration.logger
     end
 
+    def logger=(logger)
+      configuration.logger = logger
+    end
+
     # --- JSON ---------------------------------------------------------
 
     def load_json(string)

--- a/lib/wurk/compat.rb
+++ b/lib/wurk/compat.rb
@@ -125,6 +125,11 @@ module Sidekiq
     def redis(&) = Wurk.redis(&)
     def redis_pool = Wurk.redis_pool
     def logger = Wurk.logger
+
+    def logger=(logger)
+      Wurk.logger = logger
+    end
+
     def server? = Wurk.server?
     def pro? = Wurk.pro?
     def ent? = Wurk.ent?

--- a/lib/wurk/middleware/current_attributes.rb
+++ b/lib/wurk/middleware/current_attributes.rb
@@ -36,9 +36,12 @@ module Wurk
         end
 
         # AS::CurrentAttributes#attributes returns a HashWithIndifferentAccess;
-        # we coerce to a plain Hash so JSON encoding is predictable.
+        # we coerce to a plain Hash so JSON encoding is predictable. `.dup` so
+        # the snapshot is a detached copy — Load holds onto the pre-job state
+        # and must not see it mutated when it restores the job's attributes,
+        # and Save must not alias live attributes into the persisted job hash.
         def snapshot(klass)
-          klass.attributes.to_h
+          klass.attributes.to_h.dup
         end
 
         def restore(klass, attrs)
@@ -65,12 +68,17 @@ module Wurk
       end
 
       # Restores each registered CurrentAttributes class for the duration
-      # of the inner block, then resets so the next job in the thread
-      # starts clean. Reset runs in `ensure` to survive raises and Skip.
+      # of the inner block, then puts back whatever was there before — not a
+      # blanket reset. On a server thread the prior state is empty, so this is
+      # equivalent to resetting; but Load also runs on the CLIENT chain (persist
+      # registers it on both), where an enqueue happens mid-request with
+      # request-scoped attributes already set. Resetting there would wipe the
+      # caller's state right after `perform_async`. Save/restore is what Sidekiq
+      # does and is correct on both chains. Restore runs in `ensure` to survive
+      # raises and Skip.
       #
-      # Registered on BOTH chains (persist adds it to client + server), so
-      # `call` takes an optional 4th arg: the client chain passes a
-      # `redis_pool`, the server chain stops at `queue`.
+      # Registered on BOTH chains, so `call` takes an optional 4th arg: the
+      # client chain passes a `redis_pool`, the server chain stops at `queue`.
       class Load
         include Wurk::Middleware::ServerMiddleware
 
@@ -79,12 +87,16 @@ module Wurk
         end
 
         def call(_job_or_class, job, _queue, _redis_pool = nil)
+          previous = @classes.map { |klass| CurrentAttributes.snapshot(klass) }
           @classes.each_with_index do |klass, idx|
             CurrentAttributes.restore(klass, job[CurrentAttributes.key_for(idx)])
           end
           yield
         ensure
-          @classes.each(&:reset)
+          previous&.each_with_index do |attrs, idx|
+            @classes[idx].reset
+            CurrentAttributes.restore(@classes[idx], attrs)
+          end
         end
       end
     end

--- a/lib/wurk/middleware/current_attributes.rb
+++ b/lib/wurk/middleware/current_attributes.rb
@@ -25,6 +25,7 @@ module Wurk
           raise ArgumentError, 'persist requires at least one CurrentAttributes class' if classes.empty?
 
           config.client_middleware.add(Save, classes)
+          config.client_middleware.add(Load, classes)
           config.server_middleware.add(Load, classes)
         end
 
@@ -66,6 +67,10 @@ module Wurk
       # Restores each registered CurrentAttributes class for the duration
       # of the inner block, then resets so the next job in the thread
       # starts clean. Reset runs in `ensure` to survive raises and Skip.
+      #
+      # Registered on BOTH chains (persist adds it to client + server), so
+      # `call` takes an optional 4th arg: the client chain passes a
+      # `redis_pool`, the server chain stops at `queue`.
       class Load
         include Wurk::Middleware::ServerMiddleware
 
@@ -73,7 +78,7 @@ module Wurk
           @classes = classes
         end
 
-        def call(_job_or_class, job, _queue)
+        def call(_job_or_class, job, _queue, _redis_pool = nil)
           @classes.each_with_index do |klass, idx|
             CurrentAttributes.restore(klass, job[CurrentAttributes.key_for(idx)])
           end
@@ -85,3 +90,9 @@ module Wurk
     end
   end
 end
+
+# Drop-in alias. Sidekiq documents the top-level constant
+# `Sidekiq::CurrentAttributes` (with `.persist` and `Save`/`Load` nested),
+# not the `Middleware::`-namespaced form. Set when this opt-in file is
+# required, so `Sidekiq::CurrentAttributes.persist(MyAttrs)` resolves.
+Sidekiq::CurrentAttributes = Wurk::Middleware::CurrentAttributes if defined?(Sidekiq)

--- a/test/unit/compat_aliases_test.rb
+++ b/test/unit/compat_aliases_test.rb
@@ -299,6 +299,25 @@ class CompatAliasesTest < Wurk::Test::UnitCase
     assert_same Wurk.logger, Sidekiq.logger
   end
 
+  # #106: `Sidekiq.logger = Rails.logger` / `Wurk.logger =` set the config logger.
+  def test_logger_setter
+    STATE_MUTEX.synchronize do
+      original = Wurk.configuration.logger
+      custom = Logger.new(IO::NULL)
+
+      Sidekiq.logger = custom
+      assert_same custom, Sidekiq.logger
+      assert_same custom, Wurk.configuration.logger
+
+      other = Logger.new(IO::NULL)
+      Wurk.logger = other
+      assert_same other, Wurk.logger
+      assert_same other, Wurk.configuration.logger
+    ensure
+      Wurk.configuration.logger = original
+    end
+  end
+
   def test_redis_pool
     assert_same Wurk.redis_pool, Sidekiq.redis_pool
   end

--- a/test/unit/middleware_builtins_test.rb
+++ b/test/unit/middleware_builtins_test.rb
@@ -302,7 +302,9 @@ class MiddlewareBuiltinsTest < Wurk::Test::UnitCase
     Wurk::Middleware::CurrentAttributes.persist(FakeCurrent, cfg)
 
     assert cfg.client_middleware.exists?(Wurk::Middleware::CurrentAttributes::Save)
-    refute cfg.client_middleware.exists?(Wurk::Middleware::CurrentAttributes::Load)
+    # Load registers on BOTH chains per docs/target/sidekiq-free.md §10.3:
+    # "adds Save to client_middleware, Load to client+server chains".
+    assert cfg.client_middleware.exists?(Wurk::Middleware::CurrentAttributes::Load)
     assert cfg.server_middleware.exists?(Wurk::Middleware::CurrentAttributes::Load)
   end
 
@@ -318,6 +320,25 @@ class MiddlewareBuiltinsTest < Wurk::Test::UnitCase
     assert_raises(ArgumentError) do
       Wurk::Middleware::CurrentAttributes.persist([], Wurk::Configuration.new)
     end
+  end
+
+  # Load lives on the client chain too, which invokes with a 4th `redis_pool`
+  # arg. Restore must still run when called with the client-chain arity.
+  def test_current_attributes_load_accepts_client_chain_arity
+    seen = nil
+    Wurk::Middleware::CurrentAttributes::Load
+      .new([FakeCurrent])
+      .call('X', { 'cattr' => { user: 7 } }, 'q', nil) { seen = FakeCurrent.attributes[:user] }
+
+    assert_equal 7, seen
+  end
+
+  # #98: the documented drop-in constant is the top-level
+  # `Sidekiq::CurrentAttributes`, aliased when the opt-in file is required.
+  def test_sidekiq_current_attributes_alias
+    assert_same Wurk::Middleware::CurrentAttributes, Sidekiq::CurrentAttributes
+    assert_same Wurk::Middleware::CurrentAttributes::Save, Sidekiq::CurrentAttributes::Save
+    assert_same Wurk::Middleware::CurrentAttributes::Load, Sidekiq::CurrentAttributes::Load
   end
 
   # =====================================================================

--- a/test/unit/middleware_builtins_test.rb
+++ b/test/unit/middleware_builtins_test.rb
@@ -333,6 +333,18 @@ class MiddlewareBuiltinsTest < Wurk::Test::UnitCase
     assert_equal 7, seen
   end
 
+  # On the client chain an enqueue happens mid-request with attributes already
+  # set; Load must restore that caller state afterward, not wipe it to empty.
+  def test_current_attributes_load_restores_caller_state_after_enqueue
+    FakeCurrent.user = 'request-scoped'
+
+    Wurk::Middleware::CurrentAttributes::Load
+      .new([FakeCurrent])
+      .call('X', { 'cattr' => { user: 'job-snapshot' } }, 'q', nil) { :enqueued }
+
+    assert_equal 'request-scoped', FakeCurrent.attributes[:user]
+  end
+
   # #98: the documented drop-in constant is the top-level
   # `Sidekiq::CurrentAttributes`, aliased when the opt-in file is required.
   def test_sidekiq_current_attributes_alias


### PR DESCRIPTION
Closes #106
Closes #98

P1 drop-in alias sweep. Two small, mechanical parity gaps that make common Sidekiq initializer lines raise on Wurk.

## #106 — `Sidekiq.logger=` / `Wurk.logger=` setter
`Sidekiq.logger = Rails.logger` is one of the most common lines in a Sidekiq initializer. Only the getter was aliased, so the setter raised `NoMethodError`.

- `lib/wurk.rb` — `Wurk.logger=` delegates to `configuration.logger=`
- `lib/wurk/compat.rb` — `Sidekiq.logger=` shim

## #98 — `Sidekiq::CurrentAttributes` drop-in
Sidekiq documents the top-level constant `Sidekiq::CurrentAttributes`, but Wurk only exposed it under `Sidekiq::Middleware::CurrentAttributes`, so `Sidekiq::CurrentAttributes.persist(MyAttrs)` raised `NameError`. Also, `persist` registered `Load` on the server chain only, diverging from the spec.

- `lib/wurk/middleware/current_attributes.rb`:
  - Top-level `Sidekiq::CurrentAttributes = Wurk::Middleware::CurrentAttributes` alias, set when the opt-in file is required (so `Save`/`Load` resolve too)
  - `persist` now also registers `Load` on the **client** chain — matches docs/target/sidekiq-free.md §10.3: *"adds Save to client_middleware, Load to client+server chains"*
  - `Load#call` takes an optional 4th `redis_pool` arg so it is valid on both chains (client invokes with 4 args, server with 3)

**Wire-compat:** `cattr` / `cattr_1` / `cattr_N` job-hash keys unchanged.

## Tests
- Flipped `test_current_attributes_persist_registers_on_chains` — previously asserted `Load` was *absent* from the client chain; now asserts presence (the old assertion encoded the bug)
- New: client-chain (4-arg) `Load#call` arity, `Sidekiq::CurrentAttributes` alias resolution, `Sidekiq.logger=` / `Wurk.logger=` round-trip

## Verification
- `bin/rake test` — 1979 runs, 0 failures
- `bin/rake test:parity` — 20 runs, 0 failures
- `bin/rake test:ecosystem` — all suites passed
- Behavioral driver (enqueue→execute round-trip through real chains, nothing mocked) — 15/15 green

## How to test in prod
In a Rails app that has swapped Sidekiq for Wurk, in `config/initializers/`:

```ruby
# #106 — used to raise NoMethodError, now works
Sidekiq.logger = Rails.logger

# #98 — used to raise NameError, now works
require "sidekiq/middleware/current_attributes"
Sidekiq::CurrentAttributes.persist(Current)   # Current < ActiveSupport::CurrentAttributes
```

Then from a console / job:
```ruby
Current.user_id = 42
MyJob.perform_async       # enqueue snapshots Current into the job
# inside MyJob#perform, Current.user_id == 42 is restored, then reset after
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime logger can be set via the public API and is exposed through the Sidekiq compatibility layer.
  * Client-side middleware now restores context attributes when jobs are enqueued and registers the corresponding load/save middleware for client operations.
  * Added a drop-in alias so Sidekiq can use the same context-attributes middleware.

* **Tests**
  * Added coverage verifying logger setter behavior and client/server middleware loading, compatibility, and state restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->