### PR TITLE
feat(boot): auto-register Metrics::History on server chain + Sidekiq::Metrics::Middleware alias (#100)

### DIFF
--- a/lib/wurk.rb
+++ b/lib/wurk.rb
@@ -230,6 +230,13 @@ Wurk.configuration.server_middleware.add(Wurk::Limiter::ServerMiddleware)
 # Spec: docs/target/sidekiq-pro.md §9.
 Wurk.configuration.server_middleware.add(Wurk::Metrics::Statsd)
 
+# Historical metrics middleware: records per-class processed/failed/ms into
+# Redis time-buckets so the dashboard history pane has data on a default boot.
+# Sidekiq auto-installs `Sidekiq::Metrics::Middleware` on the server for
+# embedded/CLI; we mirror that here at load. Runs server-side only (the chain
+# never executes in a client-only process). Spec: docs/target/sidekiq-free.md §10.3.
+Wurk.configuration.server_middleware.add(Wurk::Metrics::History)
+
 # Pro Fast API: Lua-backed Queue#delete_job / #delete_by_class plus
 # SortedSet#scan { |JobRecord| … }. Mixed in via include/prepend on the
 # existing data API classes so the surface is wire-compat with Sidekiq Pro.

--- a/lib/wurk/metrics/history.rb
+++ b/lib/wurk/metrics/history.rb
@@ -147,5 +147,10 @@ module Wurk
       end
       private_class_method :with_pool
     end
+
+    # Sidekiq exposes this as `Sidekiq::Metrics::Middleware` (via
+    # `Sidekiq::Metrics`, aliased to `Wurk::Metrics` in compat). Mirror that
+    # name so the drop-in constant resolves. Spec: docs/target/sidekiq-free.md §10.3.
+    Middleware = History
   end
 end

--- a/test/unit/compat_aliases_test.rb
+++ b/test/unit/compat_aliases_test.rb
@@ -158,6 +158,12 @@ class CompatAliasesTest < Wurk::Test::UnitCase
     assert_same Wurk::Manager, Sidekiq::Manager
   end
 
+  # #100: Sidekiq exposes the historical metrics middleware as
+  # Sidekiq::Metrics::Middleware; it maps to Wurk::Metrics::History.
+  def test_metrics_middleware_alias
+    assert_same Wurk::Metrics::History, Sidekiq::Metrics::Middleware
+  end
+
   def test_middleware_module_alias
     assert_same Wurk::Middleware, Sidekiq::Middleware
   end

--- a/test/unit/metrics_history_test.rb
+++ b/test/unit/metrics_history_test.rb
@@ -196,8 +196,9 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
   def test_re_adding_history_keeps_a_single_entry
     chain = Wurk::Configuration.new.server_middleware
     chain.add(Wurk::Metrics::History)
+    chain.add(Wurk::Metrics::History) # gem auto-registered, then app re-adds
 
-    assert_equal 1, chain.entries.count { |e| e.klass == Wurk::Metrics::History }
+    assert_equal(1, chain.entries.count { |e| e.klass == Wurk::Metrics::History })
   end
 
   # End-to-end through the default capsule's bound chain — exactly how the
@@ -208,12 +209,9 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
   def test_default_server_chain_records_without_initializer
     before = ::Time.now.utc
     Wurk.configuration.default_capsule.server_middleware.invoke(nil, { 'class' => @klass }, 'default') { :ok }
-    after = ::Time.now.utc
 
-    minutes = [before, after].map { |t| Wurk::Metrics::History.minute_key(t) }.uniq
-    recorded = minutes.any? { |m| Wurk.redis { |c| c.call('HGET', m, "#{@klass}|p") } == '1' }
-
-    assert recorded, "expected processed=1 in one of #{minutes.inspect}"
+    assert recorded_processed_between?(before, ::Time.now.utc),
+           'expected processed=1 in the minute bucket'
   end
 
   def test_middleware_records_failure_when_perform_raises
@@ -252,5 +250,14 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
     mw = Wurk::Metrics::History.new
     mw.config = Wurk.configuration
     mw
+  end
+
+  # The middleware records at its own Time.now, so the bucket lands in the
+  # minute of either `started_at` or `ended_at` (the window around the invoke).
+  # True if the processed counter shows 1 in either candidate minute bucket.
+  def recorded_processed_between?(started_at, ended_at)
+    [started_at, ended_at].map { |t| Wurk::Metrics::History.minute_key(t) }.uniq.any? do |minute|
+      Wurk.redis { |c| c.call('HGET', minute, "#{@klass}|p") } == '1'
+    end
   end
 end

--- a/test/unit/metrics_history_test.rb
+++ b/test/unit/metrics_history_test.rb
@@ -190,16 +190,30 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
     assert Wurk.configuration.server_middleware.exists?(Wurk::Metrics::History)
   end
 
+  # An app that also registers History in an initializer must not double-count:
+  # Chain#add removes any existing entry for the klass before appending, so
+  # re-adding replaces rather than duplicates.
+  def test_re_adding_history_keeps_a_single_entry
+    chain = Wurk::Configuration.new.server_middleware
+    chain.add(Wurk::Metrics::History)
+
+    assert_equal 1, chain.entries.count { |e| e.klass == Wurk::Metrics::History }
+  end
+
   # End-to-end through the default capsule's bound chain — exactly how the
   # Processor invokes it (lib/wurk/processor.rb:226). Running a job records the
   # minute bucket with no host-app initializer, because History is
-  # auto-registered on boot.
+  # auto-registered on boot. The record uses Time.now inside the middleware, so
+  # accept either candidate minute to stay deterministic across a minute tick.
   def test_default_server_chain_records_without_initializer
+    before = ::Time.now.utc
     Wurk.configuration.default_capsule.server_middleware.invoke(nil, { 'class' => @klass }, 'default') { :ok }
+    after = ::Time.now.utc
 
-    minute = Wurk::Metrics::History.minute_key(::Time.now.utc)
+    minutes = [before, after].map { |t| Wurk::Metrics::History.minute_key(t) }.uniq
+    recorded = minutes.any? { |m| Wurk.redis { |c| c.call('HGET', m, "#{@klass}|p") } == '1' }
 
-    assert_equal('1', Wurk.redis { |c| c.call('HGET', minute, "#{@klass}|p") })
+    assert recorded, "expected processed=1 in one of #{minutes.inspect}"
   end
 
   def test_middleware_records_failure_when_perform_raises

--- a/test/unit/metrics_history_test.rb
+++ b/test/unit/metrics_history_test.rb
@@ -184,6 +184,24 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
     assert_equal('1', Wurk.redis { |c| c.call('HGET', minute, "#{@klass}|p") })
   end
 
+  # #100: History must be on the server chain by default — no host-app
+  # initializer required.
+  def test_auto_registered_on_server_chain
+    assert Wurk.configuration.server_middleware.exists?(Wurk::Metrics::History)
+  end
+
+  # End-to-end through the default capsule's bound chain — exactly how the
+  # Processor invokes it (lib/wurk/processor.rb:226). Running a job records the
+  # minute bucket with no host-app initializer, because History is
+  # auto-registered on boot.
+  def test_default_server_chain_records_without_initializer
+    Wurk.configuration.default_capsule.server_middleware.invoke(nil, { 'class' => @klass }, 'default') { :ok }
+
+    minute = Wurk::Metrics::History.minute_key(::Time.now.utc)
+
+    assert_equal('1', Wurk.redis { |c| c.call('HGET', minute, "#{@klass}|p") })
+  end
+
   def test_middleware_records_failure_when_perform_raises
     mw = build_middleware
     job = { 'class' => @klass }


### PR DESCRIPTION
Closes #100

P1 drop-in parity (sibling of #99). Sidekiq auto-installs `Sidekiq::Metrics::Middleware` on the server middleware chain for embedded/CLI servers, recording per-class processed/failed/ms time-series. Wurk's equivalent, `Wurk::Metrics::History`, was defined (`lib/wurk/metrics/history.rb`) and required (`lib/wurk.rb`) but **never added to the server chain** anywhere in `lib/` — only demo/test initializers registered it. Result: default Wurk servers recorded no per-class metric history, and the dashboard history pane / `Metrics::Query` read empty data.

## Changes
- **`lib/wurk.rb`** — `Wurk.configuration.server_middleware.add(Wurk::Metrics::History)` at load, mirroring how `Wurk::Metrics::Statsd` is auto-registered. Runs server-side only (the server chain never executes in a client-only process), so this matches the established `expiry`/`poison_pill`/`statsd` pattern.
- **`lib/wurk/metrics/history.rb`** — adds the `Sidekiq::Metrics::Middleware` drop-in alias (`Wurk::Metrics::Middleware = History`; compat already aliases `Sidekiq::Metrics` → `Wurk::Metrics`).

**Wire-compat:** the `j|YYMMDD|H:M` minute / `j|YYMMDD|H:m0` rollup / `<klass>-YYMMDD-H` hour bucket schema is unchanged — only *when* the middleware is registered changed.

## Tests
- `test/unit/metrics_history_test.rb` — History is on the server chain by default; and an end-to-end record through the **default capsule-bound chain** (exactly how `Processor` invokes it, `lib/wurk/processor.rb:226`) writes the minute bucket with no host-app initializer.
- `test/unit/compat_aliases_test.rb` — `Sidekiq::Metrics::Middleware` resolves to `Wurk::Metrics::History`.

The middleware's *recording* behavior (bucket fields, TTLs, success/failure, pipelining) is already thoroughly covered in `metrics_history_test.rb`; this PR adds the boot-wiring + alias coverage.

## Verification
- `bin/rake test` — 1983 runs, 0 failures
- `bin/rake test:parity` — 20 runs, 0 failures
- `bin/rake test:ecosystem` — all suites passed
- QA driver (real Redis: registration + alias + record via default chain) — all green

## How to test in prod
In a Rails app running Wurk in place of Sidekiq, **with no metrics initializer**, run any job, then check Redis for the per-class history buckets:

```ruby
SomeJob.perform_async
# a minute later, in a console:
require "time"
minute = Wurk::Metrics::History.minute_key(Time.now.utc)   # e.g. "j|260607|6:57"
Wurk.redis { |c| c.call("HGETALL", minute) }
# => includes "SomeJob|p", "SomeJob|ms", ... — previously empty without an initializer

Sidekiq::Metrics::Middleware   # => Wurk::Metrics::History (drop-in alias now resolves)
```

The dashboard history pane will populate on a default boot, matching Sidekiq.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Historical metrics collection is now auto-enabled on server startup, populating the dashboard history pane by default.
  * Added a compatibility alias so existing integrations recognize the metrics middleware seamlessly.

* **Tests**
  * Added tests to verify automatic registration, idempotent registration, and that metrics are recorded correctly without extra initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->