### PR TITLE
feat(batch): track currently-failing jobs + Sidekiq::Pro::BatchStatus endpoint (#112, #116)

### DIFF
--- a/lib/wurk/batch/server_middleware.rb
+++ b/lib/wurk/batch/server_middleware.rb
@@ -3,6 +3,8 @@
 require 'json'
 require_relative '../middleware'
 require_relative '../lua'
+require_relative '../job'
+require_relative '../job_retry'
 
 module Wurk
   class Batch
@@ -10,6 +12,13 @@ module Wurk
     # On success → BATCH_ACK_SUCCESS → if pending hit zero and no deaths,
     # enqueue `:success` callback jobs; if live jids hit zero, enqueue
     # `:complete` callback jobs.
+    #
+    # On a job raising (and thus heading to retry), records a transient
+    # failure → BATCH_ACK_FAILED → the jid joins `b-<bid>-failed` and
+    # `failures` reflects the count of currently-failing jobs. A later
+    # successful retry clears it; a terminal death moves it to `b-<bid>-died`.
+    # Clean handled exits (JobRetry::Skip from expiry/interrupt, cooperative
+    # IterableJob interruption) are re-raised without counting as failures.
     #
     # Invalidated batches short-circuit: the job is skipped without
     # raising — counts as a "success" for batch purposes per spec §12.
@@ -29,11 +38,23 @@ module Wurk
           return
         end
 
-        yield
-        ack_success(bid, job['jid'])
+        run_and_ack(bid, job['jid']) { yield }
       end
 
       private
+
+      # A handled/skip exit or a cooperative interruption is not a failure —
+      # re-raise it untouched. Any other exception means the job failed and
+      # will retry (or eventually die): record it before re-raising.
+      def run_and_ack(bid, jid)
+        yield
+        ack_success(bid, jid)
+      rescue Wurk::JobRetry::Handled, Wurk::Job::Interrupted
+        raise
+      rescue StandardError
+        ack_failed(bid, jid)
+        raise
+      end
 
       def invalidated?(bid)
         redis_pool.with { |conn| conn.call('HGET', "b-#{bid}", 'invalidated') } == '1'
@@ -44,7 +65,7 @@ module Wurk
           Wurk::Lua::Loader.eval_cached(
             conn,
             :batch_ack_success,
-            keys: ["b-#{bid}", "b-#{bid}-jids"],
+            keys: ["b-#{bid}", "b-#{bid}-jids", "b-#{bid}-failed"],
             argv: [jid]
           )
         end
@@ -52,6 +73,17 @@ module Wurk
         return if pending.negative?
 
         Wurk::Batch::Callbacks.maybe_fire(bid, pending: pending, live: live)
+      end
+
+      def ack_failed(bid, jid)
+        redis_pool.with do |conn|
+          Wurk::Lua::Loader.eval_cached(
+            conn,
+            :batch_ack_failed,
+            keys: ["b-#{bid}", "b-#{bid}-failed"],
+            argv: [jid]
+          )
+        end
       end
     end
   end

--- a/lib/wurk/batch/status.rb
+++ b/lib/wurk/batch/status.rb
@@ -54,6 +54,15 @@ module Wurk
         Wurk.redis { |conn| conn.call('SMEMBERS', "b-#{@bid}-failed") }
       end
 
+      # Deprecated pre-Pro8 surface (spec §2.5): an array of per-failure error
+      # detail. The Pro8 data model (§2.8) drops the `b-<bid>-failinfo` hash in
+      # favour of the `failed_jids` set, which Wurk tracks — so the per-jid
+      # error payload is intentionally not persisted and this returns []. Kept
+      # so drop-in callers referencing `#failure_info` don't NameError.
+      def failure_info
+        []
+      end
+
       def dead_jids
         Wurk.redis { |conn| conn.call('SMEMBERS', "b-#{@bid}-died") }
       end

--- a/lib/wurk/compat.rb
+++ b/lib/wurk/compat.rb
@@ -24,6 +24,10 @@ module Sidekiq
     # drops in unchanged. `Wurk::Web` is already required by the time this file
     # loads (lib/wurk.rb requires wurk/web before wurk/compat).
     Web = Wurk::Web
+
+    # `use Sidekiq::Pro::BatchStatus` — the polling Rack middleware that serves
+    # GET /batch_status/<bid>.json. Spec: docs/target/sidekiq-pro.md §10.3.
+    BatchStatus = Wurk::Web::BatchStatus
   end
 
   # Sidekiq Enterprise feature surface (`unique!`, `Crypto`, `Unique.locked?`).

--- a/lib/wurk/lua.rb
+++ b/lib/wurk/lua.rb
@@ -75,17 +75,20 @@ module Wurk
     # against double-success on a flaky retry). A success also clears any
     # outstanding "currently failing" record for the jid (a retry that finally
     # passed), decrementing `failures` so it converges to the count of jobs
-    # *still* failing — Sidekiq Pro semantics, spec §2.5.
+    # *still* failing — Sidekiq Pro semantics, spec §2.5. The failed-set clear
+    # runs *before* the live-jids check so an invalidated batch (BATCH_INVALIDATE
+    # deletes the jids set) still converges failures to 0 on its short-circuited
+    # success ack, instead of stranding the jid in failed forever.
     # KEYS = [b-<bid>, b-<bid>-jids, b-<bid>-failed]
     # ARGV = [jid]
     # Returns [new_pending, live_jids_remaining], or [-1, -1] when the jid
     # was not a member (treat as already acked).
     BATCH_ACK_SUCCESS = <<~LUA
+      if redis.call("srem", KEYS[3], ARGV[1]) == 1 then
+        redis.call("hincrby", KEYS[1], "failures", -1)
+      end
       local removed = redis.call("srem", KEYS[2], ARGV[1])
       if removed == 1 then
-        if redis.call("srem", KEYS[3], ARGV[1]) == 1 then
-          redis.call("hincrby", KEYS[1], "failures", -1)
-        end
         local pending = redis.call("hincrby", KEYS[1], "pending", -1)
         return { pending, redis.call("scard", KEYS[2]) }
       end

--- a/lib/wurk/lua.rb
+++ b/lib/wurk/lua.rb
@@ -72,23 +72,48 @@ module Wurk
 
     # Pro Batch: ACK a job that completed successfully. SREM from the live
     # jids set and decrement pending iff the jid was a member (idempotent
-    # against double-success on a flaky retry).
-    # KEYS = [b-<bid>, b-<bid>-jids]
+    # against double-success on a flaky retry). A success also clears any
+    # outstanding "currently failing" record for the jid (a retry that finally
+    # passed), decrementing `failures` so it converges to the count of jobs
+    # *still* failing — Sidekiq Pro semantics, spec §2.5.
+    # KEYS = [b-<bid>, b-<bid>-jids, b-<bid>-failed]
     # ARGV = [jid]
     # Returns [new_pending, live_jids_remaining], or [-1, -1] when the jid
     # was not a member (treat as already acked).
     BATCH_ACK_SUCCESS = <<~LUA
       local removed = redis.call("srem", KEYS[2], ARGV[1])
       if removed == 1 then
+        if redis.call("srem", KEYS[3], ARGV[1]) == 1 then
+          redis.call("hincrby", KEYS[1], "failures", -1)
+        end
         local pending = redis.call("hincrby", KEYS[1], "pending", -1)
         return { pending, redis.call("scard", KEYS[2]) }
       end
       return { -1, -1 }
     LUA
 
-    # Pro Batch: ACK a job that exhausted retries and died. Records death,
-    # bumps failures, and SREMs from live jids so the batch can fire
-    # `:complete` even with terminally failed jobs.
+    # Pro Batch: record a job that failed and will retry (transient failure).
+    # SADDs the jid to the `failed` set and bumps `failures` only on the first
+    # add, so `failures` == SCARD(b-<bid>-failed) == the number of jobs
+    # currently in a failing/retrying state. Re-failures of the same jid are
+    # idempotent. Cleared by BATCH_ACK_SUCCESS (retry passed) or
+    # BATCH_ACK_COMPLETE (job died). Spec §2.5, §2.8.
+    # KEYS = [b-<bid>, b-<bid>-failed]
+    # ARGV = [jid]
+    # Returns 1.
+    BATCH_ACK_FAILED = <<~LUA
+      if redis.call("sadd", KEYS[2], ARGV[1]) == 1 then
+        redis.call("hincrby", KEYS[1], "failures", 1)
+      end
+      return 1
+    LUA
+
+    # Pro Batch: ACK a job that exhausted retries and died. Moves the jid from
+    # "currently failing" to "died": SREMs from the failed set (decrementing
+    # `failures` if it was recorded as failing), SADDs to died, and SREMs from
+    # live jids so the batch can fire `:complete` even with terminally failed
+    # jobs. `b-<bid>-failed` holds only currently-retrying jids; `b-<bid>-died`
+    # holds terminally-dead ones (spec §2.8 — the two sets are distinct).
     # KEYS = [b-<bid>, b-<bid>-jids, b-<bid>-died, b-<bid>-failed]
     # ARGV = [jid]
     # Returns [live_jids_remaining, died_count, first_death]. `first_death`
@@ -97,9 +122,10 @@ module Wurk
     BATCH_ACK_COMPLETE = <<~LUA
       local was_pre_existing_death = redis.call("scard", KEYS[3])
       redis.call("srem", KEYS[2], ARGV[1])
-      redis.call("sadd", KEYS[4], ARGV[1])
+      if redis.call("srem", KEYS[4], ARGV[1]) == 1 then
+        redis.call("hincrby", KEYS[1], "failures", -1)
+      end
       local died_added = redis.call("sadd", KEYS[3], ARGV[1])
-      redis.call("hincrby", KEYS[1], "failures", 1)
       local first_death = 0
       if was_pre_existing_death == 0 and died_added == 1 then
         first_death = 1
@@ -172,6 +198,7 @@ module Wurk
       reliable_schedule_promote: RELIABLE_SCHEDULE_PROMOTE,
       batch_push: BATCH_PUSH,
       batch_ack_success: BATCH_ACK_SUCCESS,
+      batch_ack_failed: BATCH_ACK_FAILED,
       batch_ack_complete: BATCH_ACK_COMPLETE,
       batch_invalidate: BATCH_INVALIDATE,
       fast_delete_job: FAST_DELETE_JOB,

--- a/lib/wurk/web.rb
+++ b/lib/wurk/web.rb
@@ -3,6 +3,7 @@
 require_relative 'web/config'
 require_relative 'web/search'
 require_relative 'web/enterprise'
+require_relative 'web/batch_status'
 
 module Wurk
   # Web UI namespace. Holds three sibling concerns:

--- a/lib/wurk/web/batch_status.rb
+++ b/lib/wurk/web/batch_status.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative '../batch/status'
+
+module Wurk
+  class Web
+    # Lightweight Rack middleware for batch-progress polling without mounting
+    # the full dashboard. Drop into a rack stack and app JS can drive progress
+    # bars off plain JSON:
+    #
+    #   # config.ru
+    #   use Sidekiq::Pro::BatchStatus
+    #   run Rails.application
+    #
+    # `GET /batch_status/<bid>.json` → `Wurk::Batch::Status#data` JSON
+    # (bid, total, pending, failures, complete, created_at, description, …).
+    # Unknown/expired bid → 404. Every other request passes straight through.
+    #
+    # Spec: docs/target/sidekiq-pro.md §10.3.
+    class BatchStatus
+      ROUTE = %r{\A/batch_status/(?<bid>[^/]+)\.json\z}
+
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        match = env['REQUEST_METHOD'] == 'GET' && ROUTE.match(env['PATH_INFO'])
+        return @app.call(env) unless match
+
+        status = Wurk::Batch::Status.new(match[:bid])
+        status.exists? ? json(200, status.data) : json(404, { 'error' => 'not_found' })
+      end
+
+      private
+
+      def json(code, payload)
+        [code, { 'content-type' => 'application/json' }, [Wurk.dump_json(payload)]]
+      end
+    end
+  end
+end

--- a/test/unit/batch_lifecycle_test.rb
+++ b/test/unit/batch_lifecycle_test.rb
@@ -174,6 +174,70 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
     assert_equal 1, callbacks_fired(event: 'death', bid: batch.bid)
   end
 
+  # --- currently-failing tracking (#112) ---------------------------------
+
+  # A job that raises (heading to retry) is recorded as currently-failing;
+  # the count converges to 0 / [] once the retry succeeds.
+  def test_failing_then_succeeding_job_converges_to_zero_failures
+    batch = new_batch
+    batch.jobs { perform_one }
+    jid = jid_for(@queue, batch.bid)
+
+    fail_job(batch.bid, jid)
+    status = Wurk::Batch::Status.new(batch.bid)
+
+    assert_equal 1, status.failures
+    assert_equal [jid], status.failed_jids
+
+    ack_success(batch.bid, jid)
+    status.reload!
+
+    assert_equal 0, status.failures
+    assert_empty status.failed_jids
+  end
+
+  # Re-failing the same jid across retries doesn't double-count.
+  def test_repeated_failures_of_same_jid_count_once
+    batch = new_batch
+    batch.jobs { perform_one }
+    jid = jid_for(@queue, batch.bid)
+
+    3.times { fail_job(batch.bid, jid) }
+
+    assert_equal 1, Wurk::Batch::Status.new(batch.bid).failures
+  end
+
+  # A job that fails then exhausts retries leaves currently-failing (it's now
+  # dead): failures returns to 0, jid moves from failed → died.
+  def test_failing_then_dying_job_moves_to_died
+    batch = new_batch(death: 'D')
+    batch.jobs { perform_one }
+    jid = jid_for(@queue, batch.bid)
+
+    fail_job(batch.bid, jid)
+    kill(batch.bid, jid)
+    status = Wurk::Batch::Status.new(batch.bid)
+
+    assert_equal 0, status.failures
+    assert_empty status.failed_jids
+    assert_equal [jid], status.dead_jids
+  end
+
+  # A clean handled exit (JobRetry::Skip — e.g. expiry/interrupt) is not a
+  # batch failure.
+  def test_handled_skip_is_not_counted_as_failure
+    batch = new_batch
+    batch.jobs { perform_one }
+    jid = jid_for(@queue, batch.bid)
+
+    mw = build_server_middleware
+    assert_raises(Wurk::JobRetry::Skip) do
+      mw.call(nil, { 'bid' => batch.bid, 'jid' => jid }, @queue) { raise Wurk::JobRetry::Skip }
+    end
+
+    assert_equal 0, Wurk::Batch::Status.new(batch.bid).failures
+  end
+
   # --- nested death cascade ----------------------------------------------
 
   def test_child_death_fires_parent_death_callback_exactly_once
@@ -400,6 +464,20 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
 
   def kill(bid, jid)
     Wurk::Batch::DeathHandler.call({ 'bid' => bid, 'jid' => jid }, RuntimeError.new('boom'))
+  end
+
+  def build_server_middleware
+    mw = Wurk::Batch::ServerMiddleware.new
+    mw.config = Wurk.configuration
+    mw
+  end
+
+  # Runs the batch server middleware with a raising block — the same path a
+  # job hitting an exception (and heading to retry) takes.
+  def fail_job(bid, jid)
+    build_server_middleware.call(nil, { 'bid' => bid, 'jid' => jid }, @queue) { raise 'boom' }
+  rescue RuntimeError
+    nil
   end
 
   def queued(queue)

--- a/test/unit/batch_lifecycle_test.rb
+++ b/test/unit/batch_lifecycle_test.rb
@@ -223,6 +223,25 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
     assert_equal [jid], status.dead_jids
   end
 
+  # Invalidation deletes the live jids set, so a failing job's short-circuited
+  # success ack must still clear it from currently-failing (converge to 0).
+  def test_invalidated_batch_with_failing_job_converges_failures
+    batch = new_batch
+    batch.jobs { perform_one }
+    jid = jid_for(@queue, batch.bid)
+
+    fail_job(batch.bid, jid)
+    assert_equal 1, Wurk::Batch::Status.new(batch.bid).failures
+
+    batch.invalidate_all
+    # Invalidated → ServerMiddleware short-circuits to ack_success.
+    build_server_middleware.call(nil, { 'bid' => batch.bid, 'jid' => jid }, @queue) { :ok }
+    status = Wurk::Batch::Status.new(batch.bid)
+
+    assert_equal 0, status.failures
+    assert_empty status.failed_jids
+  end
+
   # A clean handled exit (JobRetry::Skip — e.g. expiry/interrupt) is not a
   # batch failure.
   def test_handled_skip_is_not_counted_as_failure
@@ -473,11 +492,12 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
   end
 
   # Runs the batch server middleware with a raising block — the same path a
-  # job hitting an exception (and heading to retry) takes.
+  # job hitting an exception (and heading to retry) takes. Only the synthetic
+  # 'boom' is swallowed; a real regression on the ack path still fails loudly.
   def fail_job(bid, jid)
     build_server_middleware.call(nil, { 'bid' => bid, 'jid' => jid }, @queue) { raise 'boom' }
-  rescue RuntimeError
-    nil
+  rescue RuntimeError => e
+    raise unless e.message == 'boom'
   end
 
   def queued(queue)

--- a/test/unit/batch_status_test.rb
+++ b/test/unit/batch_status_test.rb
@@ -134,6 +134,13 @@ class BatchStatusTest < Wurk::Test::UnitCase
     assert_empty Wurk::Batch::Status.new(@bid).failed_jids
   end
 
+  # Deprecated pre-Pro8 surface: present so drop-in callers resolve, returns [].
+  def test_failure_info_returns_empty_array
+    seed_batch
+
+    assert_equal [], Wurk::Batch::Status.new(@bid).failure_info
+  end
+
   # --- tags --------------------------------------------------------------
 
   def test_tags_round_trips_json

--- a/test/unit/compat_aliases_test.rb
+++ b/test/unit/compat_aliases_test.rb
@@ -43,6 +43,11 @@ class CompatAliasesTest < Wurk::Test::UnitCase
     assert_same Sidekiq::Web, Sidekiq::Pro::Web
   end
 
+  # #116: `use Sidekiq::Pro::BatchStatus` polling middleware.
+  def test_pro_batch_status_alias
+    assert_same Wurk::Web::BatchStatus, Sidekiq::Pro::BatchStatus
+  end
+
   def test_enterprise_sentinel_defined
     assert(defined?(Sidekiq::Enterprise))
     assert_kind_of Module, Sidekiq::Enterprise

--- a/test/unit/lua_test.rb
+++ b/test/unit/lua_test.rb
@@ -32,7 +32,7 @@ class LuaTest < Wurk::Test::UnitCase
   def test_scripts_registry_holds_expected_keys
     assert_equal(
       %i[zpopbyscore bulk_push reliable_schedule_promote
-         batch_push batch_ack_success batch_ack_complete batch_invalidate
+         batch_push batch_ack_success batch_ack_failed batch_ack_complete batch_invalidate
          fast_delete_job fast_delete_by_class
          limiter_concurrent_acquire limiter_concurrent_release
          limiter_bucket_acquire limiter_window_acquire limiter_leaky_acquire
@@ -166,21 +166,55 @@ class LuaTest < Wurk::Test::UnitCase
   def test_batch_ack_success_decrements_pending_only_for_known_jid
     bkey = "#{@ns}:b-y"
     jids = "#{@ns}:b-y-jids"
+    failed = "#{@ns}:b-y-failed"
     @pool.with do |c|
       c.call('HSET', bkey, 'total', 2, 'pending', 2)
       c.call('SADD', jids, 'A', 'B')
 
-      pending, live = Wurk::Lua::Loader.eval_cached(c, :batch_ack_success, keys: [bkey, jids], argv: ['A'])
+      pending, live = Wurk::Lua::Loader.eval_cached(c, :batch_ack_success, keys: [bkey, jids, failed], argv: ['A'])
 
       assert_equal 1, pending
       assert_equal 1, live
       assert_equal '1', c.call('HGET', bkey, 'pending')
 
-      pending, live = Wurk::Lua::Loader.eval_cached(c, :batch_ack_success, keys: [bkey, jids], argv: ['ZZZ'])
+      pending, live = Wurk::Lua::Loader.eval_cached(c, :batch_ack_success, keys: [bkey, jids, failed], argv: ['ZZZ'])
 
       assert_equal(-1, pending)
       assert_equal(-1, live)
       assert_equal '1', c.call('HGET', bkey, 'pending')
+    end
+  end
+
+  # A retry that finally succeeds clears the jid from the failed set and
+  # decrements failures (currently-failing count converges).
+  def test_batch_ack_success_clears_prior_failure
+    bkey = "#{@ns}:b-yf"
+    jids = "#{@ns}:b-yf-jids"
+    failed = "#{@ns}:b-yf-failed"
+    @pool.with do |c|
+      c.call('HSET', bkey, 'total', 1, 'pending', 1, 'failures', 1)
+      c.call('SADD', jids, 'A')
+      c.call('SADD', failed, 'A')
+
+      Wurk::Lua::Loader.eval_cached(c, :batch_ack_success, keys: [bkey, jids, failed], argv: ['A'])
+
+      assert_equal '0', c.call('HGET', bkey, 'failures')
+      assert_equal 0, c.call('SISMEMBER', failed, 'A')
+    end
+  end
+
+  # Transient failure: records the jid and bumps failures only on first add.
+  def test_batch_ack_failed_records_currently_failing_idempotently
+    bkey = "#{@ns}:b-fail"
+    failed = "#{@ns}:b-fail-failed"
+    @pool.with do |c|
+      c.call('HSET', bkey, 'total', 1, 'pending', 1, 'failures', 0)
+
+      Wurk::Lua::Loader.eval_cached(c, :batch_ack_failed, keys: [bkey, failed], argv: ['A'])
+      Wurk::Lua::Loader.eval_cached(c, :batch_ack_failed, keys: [bkey, failed], argv: ['A'])
+
+      assert_equal '1', c.call('HGET', bkey, 'failures')
+      assert_equal 1, c.call('SISMEMBER', failed, 'A')
     end
   end
 
@@ -200,9 +234,11 @@ class LuaTest < Wurk::Test::UnitCase
       assert_equal 1, live
       assert_equal 1, died_n
       assert_equal 1, first
-      assert_equal '1', c.call('HGET', bkey, 'failures')
+      # A job that dies without a prior transient failure leaves `failures`
+      # untouched and lands in `died` only — not `failed` (spec §2.8).
+      assert_equal '0', c.call('HGET', bkey, 'failures')
       assert_equal 1, c.call('SISMEMBER', died, 'A')
-      assert_equal 1, c.call('SISMEMBER', failed, 'A')
+      assert_equal 0, c.call('SISMEMBER', failed, 'A')
 
       _live, _died_n, second_first = Wurk::Lua::Loader.eval_cached(
         c, :batch_ack_complete, keys: [bkey, jids, died, failed], argv: ['B']
@@ -212,6 +248,26 @@ class LuaTest < Wurk::Test::UnitCase
     end
   end
   # rubocop:enable Minitest/MultipleAssertions
+
+  # A job that was failing (in the failed set) then dies moves out of
+  # currently-failing: failures decrements and the jid leaves the failed set.
+  def test_batch_ack_complete_clears_prior_failure_on_death
+    bkey   = "#{@ns}:b-df"
+    jids   = "#{@ns}:b-df-jids"
+    died   = "#{@ns}:b-df-died"
+    failed = "#{@ns}:b-df-failed"
+    @pool.with do |c|
+      c.call('HSET', bkey, 'total', 1, 'pending', 1, 'failures', 1)
+      c.call('SADD', jids, 'A')
+      c.call('SADD', failed, 'A')
+
+      Wurk::Lua::Loader.eval_cached(c, :batch_ack_complete, keys: [bkey, jids, died, failed], argv: ['A'])
+
+      assert_equal '0', c.call('HGET', bkey, 'failures')
+      assert_equal 0, c.call('SISMEMBER', failed, 'A')
+      assert_equal 1, c.call('SISMEMBER', died, 'A')
+    end
+  end
 
   def test_batch_invalidate_clears_jids_and_flags_hash
     bkey = "#{@ns}:b-z"

--- a/test/unit/web_batch_status_test.rb
+++ b/test/unit/web_batch_status_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'json'
+
+# Drives the Sidekiq::Pro::BatchStatus polling middleware (#116) against real
+# Redis. Mounts it in a bare Rack stack and asserts the JSON shape, the 404 on
+# unknown bid, and pass-through for unrelated requests.
+class WebBatchStatusTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  # Inner app records whether it was reached and echoes a sentinel body.
+  APP = lambda do |_env|
+    [200, { 'content-type' => 'text/plain' }, ['downstream']]
+  end
+
+  def setup
+    super
+    @pool = Wurk.configuration.redis_pool
+    @bid  = "wbs-#{Process.pid}-#{object_id}"
+    @mw   = Sidekiq::Pro::BatchStatus.new(APP)
+  end
+
+  def teardown
+    @pool.with { |c| c.call('UNLINK', *Wurk::Batch.keys_for(@bid)) }
+  ensure
+    super
+  end
+
+  def test_alias_resolves_to_web_batch_status
+    assert_same Wurk::Web::BatchStatus, Sidekiq::Pro::BatchStatus
+  end
+
+  def test_serves_status_json_for_known_bid
+    @pool.with { |c| c.call('HSET', "b-#{@bid}", 'total', 3, 'pending', 1, 'description', 'import') }
+
+    code, headers, body = @mw.call(rack_env("/batch_status/#{@bid}.json"))
+    payload = JSON.parse(body.join)
+
+    assert_equal 200, code
+    assert_equal 'application/json', headers['content-type']
+    assert_equal @bid, payload['bid']
+    assert_equal 3, payload['total']
+    assert_equal 1, payload['pending']
+    assert_equal 'import', payload['description']
+  end
+
+  def test_includes_failures_and_failed_jids
+    @pool.with do |c|
+      c.call('HSET', "b-#{@bid}", 'total', 2, 'pending', 2, 'failures', 1)
+      c.call('SADD', "b-#{@bid}-failed", 'jid1')
+    end
+
+    _code, _headers, body = @mw.call(rack_env("/batch_status/#{@bid}.json"))
+    payload = JSON.parse(body.join)
+
+    assert_equal 1, payload['failures']
+    assert_equal ['jid1'], payload['failed_jids']
+  end
+
+  def test_404_for_unknown_bid
+    code, _headers, body = @mw.call(rack_env('/batch_status/does-not-exist.json'))
+
+    assert_equal 404, code
+    assert_equal 'not_found', JSON.parse(body.join)['error']
+  end
+
+  def test_passes_through_unrelated_paths
+    code, _headers, body = @mw.call(rack_env('/some/other/path'))
+
+    assert_equal 200, code
+    assert_equal 'downstream', body.join
+  end
+
+  def test_passes_through_non_get_methods
+    @pool.with { |c| c.call('HSET', "b-#{@bid}", 'total', 1) }
+
+    _code, _headers, body = @mw.call(rack_env("/batch_status/#{@bid}.json", method: 'POST'))
+
+    assert_equal 'downstream', body.join
+  end
+
+  private
+
+  def rack_env(path, method: 'GET')
+    { 'REQUEST_METHOD' => method, 'PATH_INFO' => path }
+  end
+end


### PR DESCRIPTION
Closes #112
Closes #116

Two related P2 Batch::Status parity gaps in one PR — they're cohesive (both center on `Batch::Status`: #112 fixes *what* `failures`/`failed_jids` report, #116 serves that same status over HTTP) and test on independent surfaces (batch retry-lifecycle vs. a Rack endpoint).

## #112 — `failures` / `failed_jids` track currently-failing (retrying) jobs
Before, `failures` and `b-<bid>-failed` were only written on **terminal death**, so a batch whose jobs failed once and succeeded on retry reported `failures == 0` and empty `failed_jids` the whole time — diverging from Sidekiq Pro, where `#failures` is the count of jobs *currently* failing (spec §2.5/§2.8).

- **New `BATCH_ACK_FAILED` Lua** — a job that raises (heads to retry) SADDs its jid to `b-<bid>-failed` and bumps `failures` once (idempotent across repeated retries), so the invariant `failures == SCARD(b-<bid>-failed)` holds.
- **`BATCH_ACK_SUCCESS`** — a retry that finally passes SREMs from `failed` and decrements `failures` (converges to `0` / `[]`).
- **`BATCH_ACK_COMPLETE`** (death) — moves the jid *out* of currently-failing: SREM `failed` (decrement) + SADD `died`. So `b-<bid>-failed` holds only retrying jids and `b-<bid>-died` only terminally-dead ones (spec §2.8 — distinct sets). Death no longer blindly bumps `failures`.
- **`ServerMiddleware`** records the transient failure when a batch job raises; clean handled exits (`JobRetry::Skip` from expiry/interrupt, cooperative `IterableJob` interruption) are re-raised **without** counting as failures.
- **`Status#failure_info`** added as the documented-deprecated pre-Pro8 accessor (returns `[]`; the Pro8 model uses `failed_jids`).

## #116 — `Sidekiq::Pro::BatchStatus` polling middleware
`Status#data` already existed; this is the thin Rack wrapper Sidekiq Pro documents (§10.3):

```ruby
# config.ru
use Sidekiq::Pro::BatchStatus
run Rails.application
```
`GET /batch_status/<bid>.json` → `Batch::Status#data` JSON; 404 on unknown bid; everything else passes through.

## Wire-compat
Uses the existing `b-<bid>-failed` / `b-<bid>-died` sets and the `failures` hash field exactly as the spec data model defines them — **no Redis key schema or job JSON changes**. Only *when* the failed-set/failures are written changed, to match Pro semantics.

## Tests
- `lua_test.rb` — the 3 ack scripts: failed-record idempotence, success clears prior failure, death moves failed→died and decrements; registry updated.
- `batch_lifecycle_test.rb` — end-to-end through the real `ServerMiddleware`/`DeathHandler` against Redis: fail→retry-success converges to 0; repeated fails count once; fail→die moves to `died`; `JobRetry::Skip` not counted.
- `batch_status_test.rb` — `failure_info` accessor.
- `web_batch_status_test.rb` (new) — endpoint mounted in a bare Rack app: JSON shape, failures/failed_jids included, 404, pass-through, non-GET pass-through.
- `compat_aliases_test.rb` — `Sidekiq::Pro::BatchStatus` alias.

## Verification
- `bin/rake test` — 2002 runs, 0 failures
- `bin/rake test:parity` — 20, 0 failures
- `bin/rake test:ecosystem` — all passed
- RuboCop clean on all touched files

## How to test in prod
With a batch whose job fails then succeeds on retry:
```ruby
b = Sidekiq::Batch.new
b.jobs { FlakyJob.perform_async }   # fails once, succeeds on retry
st = Sidekiq::Batch::Status.new(b.bid)
st.failures      # => 1 while retrying  (was always 0 before)
st.failed_jids   # => ["<jid>"]        (was always [] before)
# after the retry succeeds:
st.failures      # => 0 ;  st.failed_jids => []
```
And the polling endpoint, in `config.ru`:
```ruby
use Sidekiq::Pro::BatchStatus
```
```
$ curl localhost:3000/batch_status/<bid>.json
{"bid":"...","total":100,"pending":7,"failures":1,"failed_jids":["..."],...}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an HTTP batch status endpoint to query batch progress, failures, and metadata.
  * Improved transient-failure tracking so retries don’t inflate failure counts.

* **Chores**
  * Restored compatibility for legacy failure-info callers (returns safe empty response).
  * Refined batch acknowledgement behavior to more reliably record successes, transient failures, and final deaths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->