### PR TITLE
feat(redis): add Sidekiq::RedisConnection.create pool constructor (#163)

### DIFF
--- a/lib/wurk.rb
+++ b/lib/wurk.rb
@@ -7,6 +7,7 @@
 require_relative 'wurk/version'
 require_relative 'wurk/keys'
 require_relative 'wurk/redis_pool'
+require_relative 'wurk/redis_connection'
 require_relative 'wurk/middleware'
 require_relative 'wurk/middleware/chain'
 require_relative 'wurk/component'

--- a/lib/wurk/compat.rb
+++ b/lib/wurk/compat.rb
@@ -103,6 +103,7 @@ module Sidekiq
   ProcessSet       = Wurk::ProcessSet
   Processor        = Wurk::Processor
   Queue            = Wurk::Queue
+  RedisConnection  = Wurk::RedisConnection
   RetrySet         = Wurk::RetrySet
   Scheduled        = Wurk::Scheduled
   ScheduledSet     = Wurk::ScheduledSet

--- a/lib/wurk/redis_connection.rb
+++ b/lib/wurk/redis_connection.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative 'redis_pool'
+
+module Wurk
+  # Sidekiq-compatible pool constructor. `Sidekiq::RedisConnection.create(...)`
+  # is the documented way to build a standalone Redis pool (spec §26) — it's the
+  # default pool for `Sidekiq::Deploy` (§23) and the constructor for per-shard
+  # pools in multi-shard web mounts (Pro §10.2). Returns a `Wurk::RedisPool`
+  # (connection_pool-backed, redis-client adapter), which is `.with`-compatible
+  # with everything that expects a Sidekiq pool.
+  #
+  # Accepts Sidekiq's option keys (`url`, `size`, `pool_timeout`, `name`),
+  # string- or symbol-keyed. Anything omitted falls back to RedisPool's defaults
+  # (URL = ENV["REDIS_URL"] or redis://localhost:6379/0).
+  module RedisConnection
+    # Housekeeping/standalone default; per-capsule pools size to concurrency.
+    DEFAULT_POOL_SIZE = 10
+
+    def self.create(options = {})
+      opts = options.transform_keys(&:to_sym)
+      RedisPool.new(
+        size: opts[:size] || DEFAULT_POOL_SIZE,
+        url: opts[:url] || RedisPool::DEFAULT_URL,
+        timeout: opts[:pool_timeout] || RedisPool::DEFAULT_TIMEOUT,
+        name: opts[:name] || RedisPool::DEFAULT_NAME
+      )
+    end
+  end
+end

--- a/test/unit/compat_aliases_test.rb
+++ b/test/unit/compat_aliases_test.rb
@@ -197,6 +197,12 @@ class CompatAliasesTest < Wurk::Test::UnitCase
     assert_same Wurk::Processor, Sidekiq::Processor
   end
 
+  # #163: Sidekiq::RedisConnection.create is the documented pool constructor.
+  def test_redis_connection_alias
+    assert_same Wurk::RedisConnection, Sidekiq::RedisConnection
+    assert_respond_to Sidekiq::RedisConnection, :create
+  end
+
   def test_queue_alias
     assert_same Wurk::Queue, Sidekiq::Queue
   end

--- a/test/unit/redis_pool_test.rb
+++ b/test/unit/redis_pool_test.rb
@@ -14,6 +14,29 @@ class RedisPoolTest < Wurk::Test::UnitCase
     super
   end
 
+  # --- RedisConnection.create (#163, spec §26) ---
+
+  def test_redis_connection_create_returns_usable_pool
+    @pool = Wurk::RedisConnection.create(url: Wurk::Test.redis_url, size: 3)
+
+    assert_instance_of Wurk::RedisPool, @pool
+    assert_equal 3, @pool.size
+    assert_equal 'PONG', @pool.with { |c| c.call('PING') }
+  end
+
+  def test_redis_connection_create_accepts_string_keys
+    @pool = Wurk::RedisConnection.create('url' => Wurk::Test.redis_url, 'size' => 2, 'pool_timeout' => 3)
+
+    assert_equal 2, @pool.size
+    assert_equal 3, @pool.timeout
+  end
+
+  def test_redis_connection_create_defaults_size_when_omitted
+    @pool = Wurk::RedisConnection.create(url: Wurk::Test.redis_url)
+
+    assert_equal Wurk::RedisConnection::DEFAULT_POOL_SIZE, @pool.size
+  end
+
   # --- happy path (real Redis) ---
 
   def test_initialize_stores_size


### PR DESCRIPTION
Closes #163

P1 drop-in gap from the wiki-coverage audit. Spec §26 documents `Sidekiq::RedisConnection.create(options) -> ConnectionPool` — the standard way to build a standalone Redis pool. It's the default pool for `Sidekiq::Deploy` (§23) and the constructor for per-shard pools in multi-shard web mounts (Pro §10.2). It was **entirely missing** (`grep RedisConnection lib/` → nothing), so drop-in code calling it raised `NameError`.

## Changes
- **`lib/wurk/redis_connection.rb`** (new) — `Wurk::RedisConnection.create` wraps `Wurk::RedisPool` (connection_pool + redis-client adapter, `.with`-compatible). Accepts Sidekiq's option keys (`url`, `size`, `pool_timeout`, `name`), string- or symbol-keyed; omitted keys fall back to `RedisPool`'s defaults (URL = `ENV["REDIS_URL"]` or `redis://localhost:6379/0`).
- **`lib/wurk.rb`** — require it next to `redis_pool`.
- **`lib/wurk/compat.rb`** — `Sidekiq::RedisConnection = Wurk::RedisConnection`.

`Sidekiq::Deploy` already accepts a `pool:` and a returned `Wurk::RedisPool` works unchanged, so no Deploy change is needed. Also unblocks #167 (multi-shard `Sidekiq::Pro::Web.with(redis_pool:)`).

## Tests
- `redis_pool_test.rb` — `create` returns a usable pool (real Redis PING), honors `size`/`pool_timeout`, accepts string keys, defaults size when omitted.
- `compat_aliases_test.rb` — `Sidekiq::RedisConnection` alias resolves and responds to `create`.

## Verification
- `bin/rake test` — 2007 runs, 0 failures
- `bin/rake test:parity` — 20, 0 failures
- `bin/rake test:ecosystem` — all passed
- RuboCop clean on the new file

## How to test in prod
```ruby
pool = Sidekiq::RedisConnection.create(url: "redis://localhost:6379/0", size: 5)
pool.with { |c| c.call("PING") }   # => "PONG"   (raised NameError before)
Sidekiq::Deploy.new(pool).mark!("manual release")
```

Backend-only — no dashboard/visual change, nothing to eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New Redis connection module enables creation of Redis pools with configurable size, URL, and timeout settings.
  * Added Sidekiq-compatible alias for Redis connection module, allowing existing code to work seamlessly.
  * Automatic Redis connection loading when using the gem in standalone mode.

* **Tests**
  * Added comprehensive test coverage for Redis connection creation and compatibility alias.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->