### PR TITLE
feat(scheduled): wire reliable_scheduler! to atomic promotion (#166)

### DIFF
--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -234,7 +234,12 @@ module Wurk
       nil
     end
 
+    # Pro reliable scheduler (§4): promote due jobs from retry/schedule onto
+    # their target queue in a single atomic Lua (ZRANGEBYSCORE+ZREM+LPUSH),
+    # closing the pop→push job-loss window of the default poller. Swaps the
+    # pluggable `scheduled_enq` for the atomic promoter; idempotent.
     def reliable_scheduler!(*)
+      self[:scheduled_enq] = Wurk::Scheduled::ReliableEnq
       nil
     end
 

--- a/lib/wurk/scheduled.rb
+++ b/lib/wurk/scheduled.rb
@@ -67,6 +67,48 @@ module Wurk
       end
     end
 
+    # Reliable variant of Enq (Pro §4). The default Enq pops then pushes —
+    # a crash between the ZPOPBYSCORE and the client push loses the job.
+    # ReliableEnq instead promotes every due job from each set onto its target
+    # queue in a single atomic Lua (ZRANGEBYSCORE → LPUSH queue:<q> → ZREM),
+    # so there is no window where a job exists in neither place. Swapped in by
+    # `config.reliable_scheduler!` via the `scheduled_enq` seam.
+    #
+    # Spec: docs/target/sidekiq-pro.md §4.
+    class ReliableEnq
+      include Component
+
+      def initialize(container)
+        @config = container
+        @done = false
+      end
+
+      def enqueue_jobs(sorted_sets = SETS)
+        @config.redis do |conn|
+          sorted_sets.each { |sset| promote(conn, sset) }
+        end
+      end
+
+      def terminate
+        @done = true
+      end
+
+      private
+
+      def promote(conn, sset)
+        Wurk::Lua::Loader.eval_cached(
+          conn,
+          :reliable_schedule_promote,
+          keys: [sset, Keys::QUEUES_SET],
+          argv: [real_time.to_s, Keys::QUEUE_PREFIX]
+        )
+      end
+
+      def real_time
+        ::Process.clock_gettime(::Process::CLOCK_REALTIME)
+      end
+    end
+
     # Single thread that wakes on a randomized interval, drains both ZSETs,
     # then sleeps again. Random spread prevents the cluster from dogpiling
     # Redis at the top of each cadence.

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -300,8 +300,11 @@ class ConfigurationTest < Wurk::Test::UnitCase
     assert_same block, @config.super_fetch_callback
   end
 
-  def test_reliable_scheduler_bang_is_a_noop
+  def test_reliable_scheduler_bang_swaps_in_atomic_promoter
+    assert_nil @config[:scheduled_enq]
+
     assert_nil @config.reliable_scheduler!
+    assert_equal Wurk::Scheduled::ReliableEnq, @config[:scheduled_enq]
   end
 
   # Pro super_fetch §3.3: the fetch-poll backoff knob. Unset → nil (the fetcher

--- a/test/unit/scheduled_poller_test.rb
+++ b/test/unit/scheduled_poller_test.rb
@@ -85,6 +85,30 @@ class ScheduledPollerTest < Wurk::Test::UnitCase
     assert_equal(1, @pool.with { |c| c.call('LLEN', @queue_list) })
   end
 
+  # --- ReliableEnq (#166, atomic promote, no pop→push loss window) ---------
+
+  def test_reliable_enq_atomically_promotes_due_jobs_to_their_queue
+    job = schedule_job(set: @schedule, at: Time.now.to_f - 5)
+
+    Wurk::Scheduled::ReliableEnq.new(@config).enqueue_jobs([@schedule])
+
+    @pool.with do |c|
+      assert_equal 0, c.call('ZCARD', @schedule)
+      assert_equal 1, c.call('LLEN', @queue_list)
+      assert_equal job, Wurk.load_json(c.call('LRANGE', @queue_list, 0, -1).first)
+      assert_equal 1, c.call('SISMEMBER', 'queues', @queue)
+    end
+  end
+
+  def test_reliable_enq_leaves_future_jobs_in_set
+    schedule_job(set: @schedule, at: Time.now.to_f + 600)
+
+    Wurk::Scheduled::ReliableEnq.new(@config).enqueue_jobs([@schedule])
+
+    assert_equal(1, @pool.with { |c| c.call('ZCARD', @schedule) })
+    assert_equal(0, @pool.with { |c| c.call('LLEN', @queue_list) })
+  end
+
   def test_enqueue_leaves_future_jobs_in_set
     schedule_job(set: @schedule, at: Time.now.to_f + 600)
 


### PR DESCRIPTION
Closes #166

Pro parity gap from the wiki-coverage audit. `config.reliable_scheduler!` was a **no-op** whose comment claimed the scheduler is "always atomic Lua" — which wasn't true: the default `Scheduled::Enq` pops (`ZPOPBYSCORE`) then pushes via a **separate** client call, so a crash between the two loses the job. The atomic `RELIABLE_SCHEDULE_PROMOTE` Lua already existed but was **never wired** (referenced only by its own definition and a unit test).

## Changes
- **`lib/wurk/configuration.rb`** — `reliable_scheduler!` now swaps in `Scheduled::ReliableEnq` via the existing pluggable `config[:scheduled_enq]` seam (idempotent; still returns nil).
- **`lib/wurk/scheduled.rb`** — new `Scheduled::ReliableEnq`: promotes every due job from each set onto its target queue in a **single atomic Lua** (`ZRANGEBYSCORE` → `LPUSH queue:<q>` → `ZREM`), so there's no window where a job exists in neither place. The default poller path is unchanged.

No new Lua, no key-schema change — just wires the existing atomic script. Spec: docs/target/sidekiq-pro.md §4.

## Tests
- `scheduled_poller_test.rb` — `ReliableEnq` atomically promotes a past-due job to its queue (asserts ZSET emptied, payload on the queue, queue registered) and leaves future jobs in place.
- `configuration_test.rb` — `reliable_scheduler!` swaps in `Scheduled::ReliableEnq` (was asserting the old no-op).

## Verification
- `bin/rake test` — 2009 runs, 0 failures
- `bin/rake test:parity` — 20, 0 failures
- `bin/rake test:ecosystem` — all passed
- RuboCop clean on the changed lib files

## How to test in prod
```ruby
Sidekiq.configure_server { |config| config.reliable_scheduler! }
# Schedule a job; under reliable mode it's promoted to its queue via a single
# atomic Lua — no pop-then-push window where a crash drops the job.
SomeJob.perform_in(5.seconds)
```
Backend-only — no dashboard/visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled the Pro-tier reliable scheduler feature, which atomically promotes scheduled jobs to their designated queues with improved consistency and reliability guarantees

* **Tests**
  * Added comprehensive unit tests covering reliable scheduler job promotion behavior, including verification of atomic promotion and proper handling of future-scheduled jobs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->