### PR TITLE
feat(swarm): standalone sidekiqswarm fork-supervisor binary (#170)

### DIFF
--- a/exe/sidekiqswarm
+++ b/exe/sidekiqswarm
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Drop-in alias for `wurkswarm`. Sidekiq Enterprise apps invoke `sidekiqswarm`
+# in their Procfile / systemd unit; this keeps that exact command working after
+# a one-line gem swap. Same behavior — forks the worker swarm from a preloaded
+# parent. Spec: docs/target/sidekiq-ent.md §7.
+load File.expand_path('wurkswarm', __dir__)

--- a/exe/wurkswarm
+++ b/exe/wurkswarm
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Standalone multi-process runner — forks N worker children from a preloaded
+# parent (fork-based real parallelism). Does NOT load the Rails engine.
+# Usage: `exe/wurkswarm -C config/wurk.yml`. Drop-in alias: `sidekiqswarm`.
+
+$stdout.sync = true
+$LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
+
+require 'wurk'
+
+begin
+  cli = Wurk::CLI.instance
+  cli.parse
+  cli.run_swarm
+rescue StandardError => e
+  raise e if $DEBUG
+
+  warn "wurkswarm: #{e.message}"
+  warn e.backtrace.join("\n")
+  exit 1
+end

--- a/lib/wurk/cli.rb
+++ b/lib/wurk/cli.rb
@@ -107,6 +107,26 @@ module Wurk
       launch(self_read)
     end
 
+    # Standalone multi-process boot — the `sidekiqswarm` entry point (Ent §7).
+    # The parent loads the app once, forks N worker children per the configured
+    # topology, then supervises them (respawn on crash, rolling restart on
+    # SIGUSR1, memory-based recycling). The parent itself never fetches.
+    #
+    # This is the only way to get fork-based parallelism without Rails — the
+    # railtie auto-boot path is Rails-only. Boots `Process.warmup` before the
+    # fork so children share warmed pages (copy-on-write). Spec §7.
+    def run_swarm(boot_app: true, warmup: true)
+      boot_application if boot_app
+      validate_redis!
+      validate_pool_sizes!
+      @config[:identity] = identity
+      Wurk.server = true
+      ::Process.warmup if warmup && ::Process.respond_to?(:warmup) && ENV['RUBY_DISABLE_WARMUP'] != '1'
+      @swarm = Wurk::Swarm.new(topology: @config.topology, config: @config)
+      @swarm.boot(install_signals: true)
+      @swarm.supervise
+    end
+
     def handle_signal(sig)
       logger.debug { "Got #{sig} signal" }
       handler = SIGNAL_HANDLERS[sig]

--- a/lib/wurk/swarm/child_boot.rb
+++ b/lib/wurk/swarm/child_boot.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative '../component'
 require_relative '../launcher'
 require_relative '../fetcher/reliable'
 
@@ -16,6 +17,8 @@ module Wurk
     # Kept separate from Wurk::Swarm so the parent supervisor stays
     # focused on PID supervision (SRP).
     class ChildBoot
+      include Component
+
       CHILD_SIGNALS = { 'TERM' => :term, 'INT' => :term, 'TSTP' => :tstp, 'USR2' => :usr2 }.freeze
 
       def initialize(config, slot, index)
@@ -30,6 +33,12 @@ module Wurk
         reconnect_after_fork
         Wurk.server = true
         apply_slot_to_config
+        # :startup must fire in each worker child before its managers spin up
+        # (Sidekiq contract, reraise: true). The parent supervisor never runs
+        # jobs, so the non-swarm CLI path fires it once per process — for the
+        # swarm, each child fires it here. Its own forked copy of the bucket is
+        # cleared after, so siblings still fire their own.
+        fire_event(:startup, reraise: true)
         launcher = Wurk::Launcher.new(@config)
         install_signal_handlers(launcher)
         launcher.run

--- a/test/integration/swarm_cli_test.rb
+++ b/test/integration/swarm_cli_test.rb
@@ -32,11 +32,12 @@ class SwarmCliTest < Wurk::Test::UnitCase
     @ns = "swarmcli-#{::Process.pid}-#{object_id}"
     @queue_name = "#{@ns}-q"
     @sentinel_key = "#{@ns}-sentinel"
+    @startup_key = "#{@ns}-startup"
     @observer = RedisClient.config(url: Wurk::Test.redis_url).new_client
   end
 
   def teardown
-    @observer&.call('DEL', @sentinel_key, "queue:#{@queue_name}")
+    @observer&.call('DEL', @sentinel_key, @startup_key, "queue:#{@queue_name}")
     @observer&.close
   ensure
     super
@@ -63,6 +64,27 @@ class SwarmCliTest < Wurk::Test::UnitCase
                    'the job should run in a forked child, not the swarm parent'
       refute_equal ::Process.pid.to_s, sentinel_pid,
                    'the job should not run in the test process'
+    ensure
+      stop(parent_pid)
+    end
+  end
+
+  # config.on(:startup) hooks must fire in each swarm worker child before its
+  # managers spin up (Sidekiq lifecycle contract).
+  def test_run_swarm_fires_startup_in_child
+    startup_key = @startup_key
+    redis_url = Wurk::Test.redis_url
+    parent_pid = fork_swarm_cli do |config|
+      config.on(:startup) do
+        c = RedisClient.config(url: redis_url).new_client
+        c.call('SET', startup_key, ::Process.pid.to_s)
+        c.call('EXPIRE', startup_key, 60)
+        c.close
+      end
+    end
+
+    begin
+      assert wait_for_key(@startup_key), ':startup hook never fired in a swarm child'
     ensure
       stop(parent_pid)
     end
@@ -99,6 +121,7 @@ class SwarmCliTest < Wurk::Test::UnitCase
       config = build_config
       config.default_capsule.queues = [@queue_name]
       config.topology = Wurk::Topology.flat(count: 1, queues: [@queue_name], concurrency: 1)
+      yield config if block_given?
       cli = Wurk::CLI.instance
       cli.instance_variable_set(:@config, config)
       cli.run_swarm(boot_app: false, warmup: false)

--- a/test/integration/swarm_cli_test.rb
+++ b/test/integration/swarm_cli_test.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Top-level so the constant resolves in the forked swarm child.
+class SwarmCliSentinelWorker
+  include Wurk::Job
+
+  def perform(redis_url, sentinel_key)
+    client = RedisClient.config(url: redis_url).new_client
+    client.call('SET', sentinel_key, ::Process.pid.to_s)
+    client.call('EXPIRE', sentinel_key, 60)
+  ensure
+    client&.close
+  end
+end
+
+# Real fork, real Redis. Exercises the standalone `sidekiqswarm` entry point
+# (#170): Wurk::CLI#run_swarm loads, forks worker children per the configured
+# topology, and supervises — the only fork-based parallelism path without Rails.
+# Boots run_swarm in a subprocess, enqueues a job, asserts a child runs it,
+# then SIGTERMs the parent for a graceful drain.
+class SwarmCliTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  POLL_TIMEOUT = 30.0
+  POLL_INTERVAL = 0.1
+  SHUTDOWN_TIMEOUT = 10
+
+  def setup
+    super
+    @ns = "swarmcli-#{::Process.pid}-#{object_id}"
+    @queue_name = "#{@ns}-q"
+    @sentinel_key = "#{@ns}-sentinel"
+    @observer = RedisClient.config(url: Wurk::Test.redis_url).new_client
+  end
+
+  def teardown
+    @observer&.call('DEL', @sentinel_key, "queue:#{@queue_name}")
+    @observer&.close
+  ensure
+    super
+  end
+
+  # The drop-in binary and its native form must ship as executables.
+  def test_swarm_binaries_present_and_executable
+    %w[wurkswarm sidekiqswarm].each do |bin|
+      path = ::File.expand_path("../../exe/#{bin}", __dir__)
+
+      assert ::File.executable?(path), "exe/#{bin} should exist and be executable"
+    end
+  end
+
+  def test_run_swarm_forks_a_child_that_runs_a_job
+    push_sentinel_job
+    parent_pid = fork_swarm_cli
+
+    begin
+      sentinel_pid = wait_for_key(@sentinel_key)
+
+      assert sentinel_pid, "job never ran via run_swarm within #{POLL_TIMEOUT}s"
+      refute_equal parent_pid.to_s, sentinel_pid,
+                   'the job should run in a forked child, not the swarm parent'
+      refute_equal ::Process.pid.to_s, sentinel_pid,
+                   'the job should not run in the test process'
+    ensure
+      stop(parent_pid)
+    end
+  end
+
+  private
+
+  def push_sentinel_job
+    config = build_config
+    cap = config.default_capsule
+    cap.queues = [@queue_name]
+    Wurk::Client.new(pool: cap.redis_pool, config: config).push(
+      'class' => SwarmCliSentinelWorker.name,
+      'args' => [Wurk::Test.redis_url, @sentinel_key],
+      'queue' => @queue_name
+    )
+  ensure
+    config&.reset_redis_pools!
+  end
+
+  def build_config
+    config = Wurk::Configuration.new
+    config.logger = ::Logger.new(IO::NULL)
+    config[:timeout] = SHUTDOWN_TIMEOUT
+    config
+  end
+
+  # Drives the real CLI#run_swarm in a subprocess so SIGTERM exercises the
+  # swarm's own signal handling (install_signals: true).
+  def fork_swarm_cli
+    ::Process.fork do
+      $stdout.reopen(IO::NULL)
+      $stderr.reopen(IO::NULL)
+      config = build_config
+      config.default_capsule.queues = [@queue_name]
+      config.topology = Wurk::Topology.flat(count: 1, queues: [@queue_name], concurrency: 1)
+      cli = Wurk::CLI.instance
+      cli.instance_variable_set(:@config, config)
+      cli.run_swarm(boot_app: false, warmup: false)
+      exit 0
+    end
+  end
+
+  def wait_for_key(key)
+    deadline = monotonic_now + POLL_TIMEOUT
+    while monotonic_now < deadline
+      val = @observer.call('GET', key)
+      return val if val
+
+      sleep POLL_INTERVAL
+    end
+    nil
+  end
+
+  def stop(pid)
+    return unless pid_alive?(pid)
+
+    ::Process.kill('TERM', pid)
+    deadline = monotonic_now + SHUTDOWN_TIMEOUT + 5
+    while monotonic_now < deadline
+      return if ::Process.wait(pid, ::Process::WNOHANG)
+
+      sleep POLL_INTERVAL
+    end
+    ::Process.kill('KILL', pid)
+    ::Process.wait(pid)
+  rescue Errno::ECHILD
+    nil
+  end
+
+  def pid_alive?(pid)
+    ::Process.kill(0, pid)
+    true
+  rescue Errno::ESRCH, Errno::EPERM
+    false
+  end
+
+  def monotonic_now
+    ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+  end
+end

--- a/wurk.gemspec
+++ b/wurk.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   ]
 
   spec.bindir      = "exe"
-  spec.executables = ["wurk"]
+  spec.executables = ["wurk", "wurkswarm", "sidekiqswarm"]
   spec.require_paths = ["lib"]
 
   # Bounded ranges (not pessimistic `~>`) where a newer major is already in


### PR DESCRIPTION
Closes #170

Ent parity gap from the wiki-coverage audit. Wurk's forking `Wurk::Swarm` was reachable **only** through the Rails railtie, so **standalone (non-Rails) deployments got no fork-based parallelism** — the headline "faster via fork" pillar — and `bundle exec sidekiqswarm` didn't resolve.

## Changes
- **`lib/wurk/cli.rb`** — new `Wurk::CLI#run_swarm`: loads the app once (CoW-friendly `Process.warmup` before fork), forks N worker children per the configured topology, then supervises them (respawn on crash, SIGUSR1 rolling restart, memory-based recycling). The parent itself never fetches — matching the Ent swarm model (§7). Reuses the existing `Wurk::Swarm`, which already does all the forking/supervision.
- **`exe/wurkswarm`** (new) — native standalone swarm runner; does not load Rails.
- **`exe/sidekiqswarm`** (new) — drop-in alias that `load`s `wurkswarm`, so Ent apps whose Procfile/systemd invoke `sidekiqswarm` keep working after a one-line gem swap.
- **`wurk.gemspec`** — `executables = ["wurk", "wurkswarm", "sidekiqswarm"]`.

Note: incompatible parent-only flags (`-d`/`-L`/`-P`) aren't part of Wurk's option set, so they already error as unknown options — no explicit rejection needed. Child-count tuning via `SIDEKIQ_COUNT` is tracked separately (#120); this PR boots the configured topology (default 1 slot).

## Tests
- `test/integration/swarm_cli_test.rb` (new, **real fork + real Redis**) — `run_swarm` forks a child that runs an enqueued job (asserts a *different* PID ran it, then SIGTERMs the parent for a graceful drain); and both binaries ship executable.
- Swarm internals (boot/supervise/respawn/rolling-restart) remain covered by `swarm_boot_test`, `graceful_shutdown_test`, `rolling_restart_test`.

## Verification
- `bin/rake test` — 2005 runs, 0 failures
- `bin/rake test:parity` — 20, 0 failures
- `bin/rake test:ecosystem` — all passed
- `gem build wurk.gemspec` — succeeds with the new executables
- RuboCop clean on all changed files

## How to test in prod
In a non-Rails app (or any app), instead of `bundle exec wurk`:
```
bundle exec sidekiqswarm -C config/wurk.yml
# forks worker children from a preloaded parent; SIGTERM drains gracefully,
# SIGUSR1 does a rolling restart. Drop-in for an Ent app's `sidekiqswarm`.
```

Backend/runtime only — no dashboard/visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced wurkswarm executable for multi-process fork-based worker management.
  * Added sidekiqswarm as a backwards-compatible command alias.
  * Gem now ships the additional executables for both commands.

* **Behavioral Changes**
  * Startup hooks now run inside each forked worker process.

* **Tests**
  * Added integration tests validating swarm CLI behavior and startup hooks with Redis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->