### PR TITLE
feat(statsd): Server::Statsd alias + Pro batch metrics + Pro.dogstatsd accessor (#115, #168, #169)

### DIFF
--- a/lib/sidekiq/middleware/server/statsd.rb
+++ b/lib/sidekiq/middleware/server/statsd.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Drop-in require shim for Sidekiq Pro's documented statsd setup:
+#
+#   require "sidekiq/middleware/server/statsd"
+#   chain.add Sidekiq::Middleware::Server::Statsd
+#
+# The constant itself is defined by Wurk (lib/wurk/metrics/statsd.rb, aliased as
+# Wurk::Middleware::Server::Statsd → Sidekiq::Middleware::Server::Statsd via the
+# compat layer). This file just ensures Wurk is loaded so the verbatim Pro
+# `require` resolves instead of raising LoadError. Spec: docs/target/sidekiq-pro.md §9.1.
+require 'wurk' unless defined?(Wurk::Metrics::Statsd)

--- a/lib/sidekiq/middleware/server/statsd.rb
+++ b/lib/sidekiq/middleware/server/statsd.rb
@@ -9,4 +9,4 @@
 # Wurk::Middleware::Server::Statsd → Sidekiq::Middleware::Server::Statsd via the
 # compat layer). This file just ensures Wurk is loaded so the verbatim Pro
 # `require` resolves instead of raising LoadError. Spec: docs/target/sidekiq-pro.md §9.1.
-require 'wurk' unless defined?(Wurk::Metrics::Statsd)
+require 'wurk' unless defined?(::Sidekiq::Middleware::Server::Statsd)

--- a/lib/sidekiq/middleware/server/statsd.rb
+++ b/lib/sidekiq/middleware/server/statsd.rb
@@ -9,4 +9,4 @@
 # Wurk::Middleware::Server::Statsd → Sidekiq::Middleware::Server::Statsd via the
 # compat layer). This file just ensures Wurk is loaded so the verbatim Pro
 # `require` resolves instead of raising LoadError. Spec: docs/target/sidekiq-pro.md §9.1.
-require 'wurk' unless defined?(::Sidekiq::Middleware::Server::Statsd)
+require 'wurk' unless defined?(Sidekiq::Middleware::Server::Statsd)

--- a/lib/wurk/batch.rb
+++ b/lib/wurk/batch.rb
@@ -234,6 +234,8 @@ module Wurk
       Wurk.redis { |conn| conn.pipelined { |pipe| pipelined_first_flush(pipe, now) } }
       @parent_bid = current_parent_bid
       @flushed_once = true
+      # Pro statsd metric (spec §9.3); no-op without a dogstatsd client.
+      Wurk::Metrics::Statsd.increment('batch.created')
     end
 
     def pipelined_first_flush(pipe, now)

--- a/lib/wurk/batch/callbacks.rb
+++ b/lib/wurk/batch/callbacks.rb
@@ -69,12 +69,20 @@ module Wurk
       # Pro statsd metric (spec §9.3): wall-clock seconds from batch creation to
       # full success. `created_at` shares the CLOCK_REALTIME epoch we record it
       # with. No-op without a dogstatsd client.
+      #
+      # Strictly best-effort: `fire_success` has already burned the `success`
+      # dedup key by the time we run, so a raise here (e.g. a Redis hiccup on the
+      # HGET) would permanently strand the success callbacks and linger that
+      # follow — a retry can't re-fire them. Swallow and log instead.
       def emit_duration_metric(bid)
         created = Wurk.redis { |conn| conn.call('HGET', "b-#{bid}", 'created_at') }
         return if created.nil? || created.to_s.empty?
 
         seconds = ::Process.clock_gettime(::Process::CLOCK_REALTIME) - created.to_f
         Wurk::Metrics::Statsd.distribution('batch.duration_dist', seconds)
+      rescue StandardError => e
+        Wurk.logger.warn("batch #{bid}: duration metric emit failed: #{e.class}: #{e.message}")
+        nil
       end
 
       # Post-success retention: a succeeded batch no longer coordinates any

--- a/lib/wurk/batch/callbacks.rb
+++ b/lib/wurk/batch/callbacks.rb
@@ -61,8 +61,20 @@ module Wurk
         return unless dedup_set(bid, 'success')
 
         record_event(bid, 'success_at')
+        emit_duration_metric(bid)
         enqueue_callbacks(bid, 'success')
         apply_linger(bid)
+      end
+
+      # Pro statsd metric (spec §9.3): wall-clock seconds from batch creation to
+      # full success. `created_at` shares the CLOCK_REALTIME epoch we record it
+      # with. No-op without a dogstatsd client.
+      def emit_duration_metric(bid)
+        created = Wurk.redis { |conn| conn.call('HGET', "b-#{bid}", 'created_at') }
+        return if created.nil? || created.to_s.empty?
+
+        seconds = ::Process.clock_gettime(::Process::CLOCK_REALTIME) - created.to_f
+        Wurk::Metrics::Statsd.distribution('batch.duration_dist', seconds)
       end
 
       # Post-success retention: a succeeded batch no longer coordinates any

--- a/lib/wurk/compat.rb
+++ b/lib/wurk/compat.rb
@@ -28,6 +28,19 @@ module Sidekiq
     # `use Sidekiq::Pro::BatchStatus` — the polling Rack middleware that serves
     # GET /batch_status/<bid>.json. Spec: docs/target/sidekiq-pro.md §10.3.
     BatchStatus = Wurk::Web::BatchStatus
+
+    # Pro module-level statsd accessor (spec §1): `Sidekiq::Pro.dogstatsd = ...`.
+    # Delegates to the canonical `config.dogstatsd=` (spec §9.1), so either form
+    # feeds the same Wurk::Metrics::Statsd client.
+    class << self
+      def dogstatsd=(builder)
+        Wurk.configuration.dogstatsd = builder
+      end
+
+      def dogstatsd
+        Wurk.configuration.dogstatsd
+      end
+    end
   end
 
   # Sidekiq Enterprise feature surface (`unique!`, `Crypto`, `Unique.locked?`).

--- a/lib/wurk/metrics/statsd.rb
+++ b/lib/wurk/metrics/statsd.rb
@@ -194,4 +194,15 @@ module Wurk
       end
     end
   end
+
+  module Middleware
+    # Sidekiq Pro documents the statsd server middleware as
+    # `Sidekiq::Middleware::Server::Statsd` (spec §9.1) — the drop-in snippet is
+    # `require "sidekiq/middleware/server/statsd"; chain.add Sidekiq::Middleware::Server::Statsd`.
+    # Expose that namespace pointing at our implementation. `Sidekiq::Middleware`
+    # aliases `Wurk::Middleware`, so this makes the Sidekiq constant resolve too.
+    module Server
+      Statsd = Wurk::Metrics::Statsd
+    end
+  end
 end

--- a/test/unit/batch_lifecycle_test.rb
+++ b/test/unit/batch_lifecycle_test.rb
@@ -157,6 +157,23 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
     assert_equal 1, callbacks_fired(event: 'complete', bid: batch.bid)
   end
 
+  # The duration statsd metric is best-effort: fire_success has already burned
+  # the `success` dedup key by the time it runs, so a raise there would strand
+  # the success callbacks + linger with no retry to re-fire them.
+  def test_success_callbacks_still_fire_when_duration_metric_raises
+    batch = new_batch(success: 'S', complete: 'C')
+    batch.jobs { perform_one }
+
+    with_raising_distribution do
+      ack_success(batch.bid, jid_for(@queue, batch.bid))
+    end
+
+    assert_equal 1, callbacks_fired(event: 'success', bid: batch.bid),
+                 'success callback must enqueue even when the duration metric raises'
+    refute_equal(-1, @pool.with { |c| c.call('TTL', "b-#{batch.bid}") },
+                 'linger must still apply when the duration metric raises')
+  end
+
   def test_complete_fires_but_success_does_not_on_death
     batch = new_batch(success: 'S', complete: 'C', death: 'D')
     batch.jobs { perform_one }
@@ -502,6 +519,17 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
 
   def queued(queue)
     @pool.with { |c| c.call('LRANGE', "queue:#{queue}", 0, -1) }.map { |s| JSON.parse(s) }
+  end
+
+  # Minitest 6 dropped minitest/mock; hand-rolled stub that makes the duration
+  # metric emission blow up (the Redis-hiccup case the rescue guards against).
+  def with_raising_distribution
+    sc = Wurk::Metrics::Statsd.singleton_class
+    original = Wurk::Metrics::Statsd.method(:distribution)
+    sc.define_method(:distribution) { |*_args, **_kw| raise 'statsd down' }
+    yield
+  ensure
+    sc.define_method(:distribution) { |*a, **k| original.call(*a, **k) }
   end
 
   def jid_for(queue, bid)

--- a/test/unit/compat_aliases_test.rb
+++ b/test/unit/compat_aliases_test.rb
@@ -48,6 +48,30 @@ class CompatAliasesTest < Wurk::Test::UnitCase
     assert_same Wurk::Web::BatchStatus, Sidekiq::Pro::BatchStatus
   end
 
+  # #115: drop-in Pro statsd middleware constant.
+  def test_server_statsd_middleware_alias
+    assert_same Wurk::Metrics::Statsd, Sidekiq::Middleware::Server::Statsd
+  end
+
+  # #169: `Sidekiq::Pro.dogstatsd =` delegates to config.dogstatsd; the
+  # use_datadog_extensions flag is tolerated.
+  def test_pro_dogstatsd_accessor
+    STATE_MUTEX.synchronize do
+      previous = Wurk.configuration.dogstatsd
+      client = -> { :statsd }
+      Sidekiq::Pro.dogstatsd = client
+
+      assert_same client, Sidekiq::Pro.dogstatsd
+      assert_same client, Wurk.configuration.dogstatsd
+
+      Wurk.configuration[:use_datadog_extensions] = false
+
+      assert_equal false, Wurk.configuration[:use_datadog_extensions]
+    ensure
+      Wurk.configuration.dogstatsd = previous
+    end
+  end
+
   def test_enterprise_sentinel_defined
     assert(defined?(Sidekiq::Enterprise))
     assert_kind_of Module, Sidekiq::Enterprise

--- a/test/unit/compat_aliases_test.rb
+++ b/test/unit/compat_aliases_test.rb
@@ -58,6 +58,7 @@ class CompatAliasesTest < Wurk::Test::UnitCase
   def test_pro_dogstatsd_accessor
     STATE_MUTEX.synchronize do
       previous = Wurk.configuration.dogstatsd
+      previous_dd = Wurk.configuration[:use_datadog_extensions]
       client = -> { :statsd }
       Sidekiq::Pro.dogstatsd = client
 
@@ -69,6 +70,7 @@ class CompatAliasesTest < Wurk::Test::UnitCase
       assert_equal false, Wurk.configuration[:use_datadog_extensions]
     ensure
       Wurk.configuration.dogstatsd = previous
+      Wurk.configuration[:use_datadog_extensions] = previous_dd
     end
   end
 

--- a/test/unit/metrics_statsd_test.rb
+++ b/test/unit/metrics_statsd_test.rb
@@ -107,6 +107,46 @@ class MetricsStatsdTest < Wurk::Test::UnitCase
     assert_equal 1, fake.calls.size
   end
 
+  # --- #115: Pro drop-in statsd setup snippet (spec §9.1) -----------------
+
+  def test_server_statsd_alias_and_verbatim_snippet
+    require 'sidekiq/middleware/server/statsd'
+
+    assert_same Wurk::Metrics::Statsd, Sidekiq::Middleware::Server::Statsd
+
+    chain = Wurk::Middleware::Chain.new
+    chain.add Sidekiq::Middleware::Server::Statsd
+    Sidekiq::Middleware::Server::Statsd.options = ->(_w, _j, _q) { { tags: ['x'] } }
+
+    assert chain.exists?(Wurk::Metrics::Statsd)
+  end
+
+  # --- #168: Pro batch statsd metrics (spec §9.3) -------------------------
+
+  def test_batch_created_metric_emitted_on_first_flush
+    fake = FakeClient.new
+    Wurk.configuration.dogstatsd = fake
+
+    batch = Wurk::Batch.new
+    batch.jobs { Wurk::Client.push('class' => 'NoOp', 'args' => [], 'queue' => 'sq') }
+
+    assert_includes fake.calls.map { |c| c[1] }, 'sidekiq.batch.created'
+  end
+
+  def test_batch_duration_dist_metric_emitted_on_success
+    fake = FakeClient.new
+    Wurk.configuration.dogstatsd = fake
+
+    batch = Wurk::Batch.new
+    batch.jobs { Wurk::Client.push('class' => 'NoOp', 'args' => [], 'queue' => 'sq') }
+    Wurk::Batch::Callbacks.fire_success(batch.bid)
+
+    dist = fake.calls.find { |c| c[0] == :distribution && c[1] == 'sidekiq.batch.duration_dist' }
+
+    assert dist, "expected sidekiq.batch.duration_dist, got #{fake.calls.map { |c| c[1] }}"
+    assert_operator dist[2], :>=, 0.0
+  end
+
   # rubocop:disable Metrics/AbcSize
   def test_metric_names_get_sidekiq_prefix
     fake = FakeClient.new


### PR DESCRIPTION
Closes #115
Closes #168
Closes #169

Three related Pro statsd/dogstatsd gaps from the wiki-coverage audit, all thin layers over the existing `Wurk::Metrics::Statsd`. Grouped because they're one cohesive surface and test independently.

## #115 — `Sidekiq::Middleware::Server::Statsd`
Sidekiq Pro's documented statsd setup (§9.1) is `require "sidekiq/middleware/server/statsd"; chain.add Sidekiq::Middleware::Server::Statsd`. The constant didn't resolve.
- Added `Wurk::Middleware::Server::Statsd = Wurk::Metrics::Statsd` (the `Sidekiq::Middleware` alias makes the Sidekiq constant resolve).
- Added a require-shim at `lib/sidekiq/middleware/server/statsd.rb` so the verbatim `require` doesn't `LoadError`.
- `.options=` already existed and works.

## #168 — Pro batch statsd metrics (§9.3)
Emit the two batch-level metrics that were missing:
- `sidekiq.batch.created` (counter) on a batch's first flush.
- `sidekiq.batch.duration_dist` (distribution, seconds) on `:success`.
Both no-op without a dogstatsd client (existing `Statsd` class-method path).

## #169 — `Sidekiq::Pro.dogstatsd`
- `Sidekiq::Pro.dogstatsd=` / `.dogstatsd` module accessor delegating to the canonical `config.dogstatsd=` (§9.1), so either form feeds the same client.
- `config[:use_datadog_extensions] = false` is tolerated (generic config option).

## Tests
- `metrics_statsd_test` — the verbatim Pro snippet (require + `chain.add` + `.options=`), and both batch metrics fire via a fake client.
- `compat_aliases_test` — `Sidekiq::Middleware::Server::Statsd` alias, `Sidekiq::Pro.dogstatsd` delegation, `use_datadog_extensions` accepted.

## Verification
- `bin/rake test` — 2034 runs, 0 failures
- `bin/rake test:parity` — 20, 0 failures
- `bin/rake test:ecosystem` — all passed
- RuboCop clean on new code (only pre-existing ClassLength/ModuleLength on batch.rb/callbacks.rb, nudged by a few lines)

## How to test in prod
```ruby
Sidekiq.configure_server do |config|
  config.server_middleware do |chain|
    require "sidekiq/middleware/server/statsd"
    chain.add Sidekiq::Middleware::Server::Statsd
  end
end
Sidekiq::Pro.dogstatsd = -> { Datadog::Statsd.new("localhost", 8125) }
# Run a batch → emits sidekiq.batch.created then sidekiq.batch.duration_dist.
```

Backend-only — no dashboard/visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch jobs now emit StatsD/Datadog metrics: creation events and duration distributions for improved lifecycle visibility.
  * Added Sidekiq Pro compatibility shims so Pro-style middleware and dogstatsd accessors resolve to the app’s metrics implementation.

* **Bug Fixes**
  * Metric emission is best-effort and won’t interrupt batch success processing if it fails; errors are logged and suppressed.

* **Tests**
  * Added unit and regression tests validating metrics, compatibility shims, and resilient success callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->