### PR TITLE
feat(client): Sidekiq::TransactionAwareClient + Sidekiq.transactional_push! (#164)

### DIFF
--- a/lib/wurk.rb
+++ b/lib/wurk.rb
@@ -19,6 +19,7 @@ require_relative 'wurk/configuration'
 require_relative 'wurk/job_util'
 require_relative 'wurk/client'
 require_relative 'wurk/client/buffered'
+require_relative 'wurk/transaction_aware_client'
 require_relative 'wurk/worker'
 require_relative 'wurk/worker/setter'
 require_relative 'wurk/job'
@@ -149,6 +150,13 @@ module Wurk
     # stringified so symbol-keyed callers don't shadow string keys.
     def default_job_options=(hash)
       @default_job_options = default_job_options.merge(hash.transform_keys(&:to_s))
+    end
+
+    # Opt in to enqueue-after-commit globally: every `perform_async` builds a
+    # Wurk::TransactionAwareClient that defers its push to the surrounding
+    # ActiveRecord transaction's commit. Idempotent. Spec: sidekiq-free.md §3.
+    def transactional_push!
+      default_job_options['client_class'] = Wurk::TransactionAwareClient
     end
 
     # --- strict args -------------------------------------------------

--- a/lib/wurk/compat.rb
+++ b/lib/wurk/compat.rb
@@ -127,6 +127,7 @@ module Sidekiq
   SortedEntry      = Wurk::SortedEntry
   Stats            = Wurk::Stats
   Testing          = Wurk::Testing
+  TransactionAwareClient = Wurk::TransactionAwareClient
   Queues           = Wurk::Queues
   EmptyQueueError  = Wurk::Testing::EmptyQueueError
   Web              = Wurk::Web
@@ -161,6 +162,7 @@ module Sidekiq
     end
 
     def strict_args!(mode = :raise) = Wurk.strict_args!(mode)
+    def transactional_push! = Wurk.transactional_push!
     def testing!(mode = :fake, &) = Wurk.testing!(mode, &)
     def testing? = Wurk.testing?
     def load_json(str) = Wurk.load_json(str)

--- a/lib/wurk/transaction_aware_client.rb
+++ b/lib/wurk/transaction_aware_client.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+require_relative 'client'
+require_relative 'job_util'
+
+module Wurk
+  # Opt-in enqueue client that holds each `push` until the surrounding
+  # ActiveRecord transaction commits, so a job never references a row a
+  # rollback erased — the canonical "enqueue after commit" pattern.
+  #
+  # Enable globally with `Wurk.transactional_push!` (aliased
+  # `Sidekiq.transactional_push!`), which sets `default_job_options
+  # ["client_class"]`; the worker DSL then builds this client instead of the
+  # plain `Wurk::Client`.
+  #
+  # The jid is pre-allocated and returned synchronously so the caller can
+  # reference it inside the transaction; the actual Redis write runs in an
+  # after-commit hook. `push_bulk` is intentionally NOT deferred — it matches
+  # Sidekiq, whose batching/scheduling machinery can't ride the commit hook.
+  #
+  # Spec: docs/target/sidekiq-free.md §8.
+  class TransactionAwareClient
+    def initialize(pool: nil, config: nil)
+      @redis_client = Wurk::Client.new(pool: pool, config: config)
+    end
+
+    # True inside a `Batch#jobs` block. The batch counts jobs at push time, so
+    # deferring would desync its totals — push immediately instead.
+    def batching?
+      !Thread.current[Wurk::Batch::THREAD_KEY].nil?
+    end
+
+    # @return [String] the pre-allocated jid (returned before the deferred push runs).
+    def push(item)
+      item['jid'] ||= SecureRandom.hex(12)
+
+      if batching?
+        @redis_client.push(item)
+      else
+        register_after_commit { @redis_client.push(item) }
+      end
+
+      item['jid']
+    end
+
+    # Bulk enqueue is never transactional (Sidekiq parity) — straight to Redis.
+    def push_bulk(items)
+      @redis_client.push_bulk(items)
+    end
+
+    private
+
+    # Routes the push to the host's after-commit hook. AR 7.2+ exposes
+    # `ActiveRecord.after_all_transactions_commit`, which runs the block now
+    # when there's no open transaction and after commit when there is — so the
+    # "not in a transaction" and "ActiveRecord absent" cases both degrade to an
+    # immediate push, exactly the graceful no-op the spec calls for.
+    def register_after_commit(&)
+      if defined?(::ActiveRecord) && ::ActiveRecord.respond_to?(:after_all_transactions_commit)
+        ::ActiveRecord.after_all_transactions_commit(&)
+      elsif defined?(::AfterCommitEverywhere)
+        ::AfterCommitEverywhere.after_commit(&)
+      else
+        yield
+      end
+    end
+  end
+
+  # The class-level `client_class` option carries a Class object, so it must
+  # never reach the wire. Append it to the transient list the canonical way the
+  # comment in JobUtil anticipates, rather than baking it into the base literal.
+  JobUtil::TRANSIENT_ATTRIBUTES << 'client_class' unless JobUtil::TRANSIENT_ATTRIBUTES.include?('client_class')
+end

--- a/lib/wurk/worker.rb
+++ b/lib/wurk/worker.rb
@@ -121,11 +121,19 @@ module Wurk
         # overrides the class-level option, then it's deleted so it never reaches
         # the wire (normalize_item strips any class-level pool re-merged below).
         pool = item.delete('pool') || get_sidekiq_options['pool']
-        build_client(pool).push(item)
+        build_client(pool, client_class: item.delete('client_class')).push(item)
       end
 
-      def build_client(pool = get_sidekiq_options['pool'])
-        Wurk::Client.new(pool: pool)
+      # `client_class` swaps the enqueue client (e.g. TransactionAwareClient via
+      # Wurk.transactional_push!). Resolution order: per-call `set(client_class:)`,
+      # then the class option, then the live process default, then Wurk::Client.
+      # The default_job_options fallback keeps a global `transactional_push!`
+      # order-independent: a class whose options memoized before the opt-in (its
+      # inherited copy is a stale dup) still routes through the new client.
+      def build_client(pool = get_sidekiq_options['pool'], client_class: nil)
+        klass = client_class || get_sidekiq_options['client_class'] ||
+                Wurk.default_job_options['client_class'] || Wurk::Client
+        klass.new(pool: pool)
       end
 
       # --- Sidekiq::Testing class-level helpers (spec §24.3) --------------

--- a/test/unit/transaction_aware_client_test.rb
+++ b/test/unit/transaction_aware_client_test.rb
@@ -1,0 +1,260 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'json'
+
+# Drives Wurk::TransactionAwareClient (Sidekiq::TransactionAwareClient) against
+# real Redis. Covers the enqueue-after-commit contract from issue #164 /
+# spec §8: jid returned synchronously, the push held until the surrounding
+# ActiveRecord transaction commits, dropped on rollback, push_bulk never
+# deferred, and graceful immediate-push when ActiveRecord is absent.
+#
+# A stand-in `::ActiveRecord` (defined per-test, removed in ensure) captures the
+# after-commit blocks so we can assert deferral and simulate commit/rollback.
+# Safe because each test class runs in its own forked worker and its methods run
+# sequentially (parallelize_me! is a no-op hook here).
+class TransactionAwareClientTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  JID_PATTERN = /\A[0-9a-f]{24}\z/
+
+  def setup
+    super
+    @queue            = "taq-#{Process.pid}-#{object_id}"
+    @class_name       = "TxnAwareJob@#{Process.pid}-#{object_id}"
+    @pool             = Wurk.configuration.redis_pool
+    @saved_job_opts   = Wurk.default_job_options.dup
+  end
+
+  def teardown
+    Wurk.instance_variable_set(:@default_job_options, @saved_job_opts)
+    @pool.with do |conn|
+      conn.call('DEL', "queue:#{@queue}")
+      conn.call('SREM', 'queues', @queue)
+    end
+  ensure
+    super
+  end
+
+  # --- Sidekiq.transactional_push! opt-in --------------------------------
+
+  def test_transactional_push_sets_client_class_and_returns_true
+    assert Wurk.transactional_push!
+    assert_same Wurk::TransactionAwareClient, Wurk.default_job_options['client_class']
+  end
+
+  def test_sidekiq_alias_resolves_to_wurk_class
+    assert_same Wurk::TransactionAwareClient, Sidekiq::TransactionAwareClient
+  end
+
+  def test_sidekiq_transactional_push_delegates
+    Sidekiq.transactional_push!
+
+    assert_same Wurk::TransactionAwareClient, Wurk.default_job_options['client_class']
+  end
+
+  def test_client_class_is_a_transient_attribute
+    assert_includes Wurk::JobUtil::TRANSIENT_ATTRIBUTES, 'client_class'
+  end
+
+  # --- push deferral / commit / rollback ---------------------------------
+
+  # rubocop:disable Minitest/MultipleAssertions
+  # One story: jid is returned synchronously, the enqueue is deferred, and the
+  # deferred push persists that same jid. Splitting would obscure the contract.
+  def test_push_returns_jid_synchronously_but_defers_the_enqueue
+    client = Wurk::TransactionAwareClient.new
+
+    with_fake_active_record do |pending|
+      jid = client.push(item)
+
+      assert_match JID_PATTERN, jid
+      assert_equal 1, pending.size, 'push must register exactly one after-commit hook'
+      assert_equal 0, queue_len, 'nothing may hit Redis before commit'
+
+      pending.each(&:call) # simulate transaction commit
+
+      assert_equal 1, queue_len
+      assert_equal jid, first_queued['jid'], 'the deferred push must persist the pre-allocated jid'
+    end
+  end
+  # rubocop:enable Minitest/MultipleAssertions
+
+  def test_rollback_drops_the_push
+    client = Wurk::TransactionAwareClient.new
+
+    with_fake_active_record do |_pending|
+      client.push(item)
+      # never invoke the captured hooks → transaction rolled back
+    end
+
+    assert_equal 0, queue_len, 'a rolled-back transaction must enqueue nothing'
+  end
+
+  def test_push_runs_immediately_when_no_after_commit_hook_available
+    client = Wurk::TransactionAwareClient.new
+
+    jid = without_const(:ActiveRecord) { without_const(:AfterCommitEverywhere) { client.push(item) } }
+
+    assert_match JID_PATTERN, jid
+    assert_equal 1, queue_len, 'without an after-commit hook the push must go straight through'
+  end
+
+  def test_push_routes_through_after_commit_everywhere_when_active_record_absent
+    client = Wurk::TransactionAwareClient.new
+    pending = []
+    ace = Module.new
+    ace.define_singleton_method(:after_commit) { |&blk| pending << blk }
+
+    without_const(:ActiveRecord) do
+      with_const(:AfterCommitEverywhere, ace) { client.push(item) }
+    end
+
+    assert_equal 1, pending.size, 'must fall back to AfterCommitEverywhere.after_commit'
+    assert_equal 0, queue_len, 'still deferred until the captured hook runs'
+  end
+
+  def test_push_bulk_is_never_deferred
+    client = Wurk::TransactionAwareClient.new
+
+    with_fake_active_record do |pending|
+      jids = client.push_bulk('class' => @class_name, 'queue' => @queue, 'args' => [[1], [2], [3]])
+
+      assert_equal 3, jids.size
+      assert_empty pending, 'push_bulk must not register an after-commit hook'
+      assert_equal 3, queue_len, 'bulk pushes go straight to Redis'
+    end
+  end
+
+  def test_batching_pushes_immediately # rubocop:disable Metrics/AbcSize
+    client = Wurk::TransactionAwareClient.new
+    bid = "btest-#{Process.pid}-#{object_id}"
+    previous = Thread.current[Wurk::Batch::THREAD_KEY]
+    Thread.current[Wurk::Batch::THREAD_KEY] = Struct.new(:bid).new(bid) # stand-in active batch
+
+    with_fake_active_record do |pending|
+      assert_predicate client, :batching?
+      client.push(item)
+
+      assert_empty pending, 'inside a batch the push must not defer'
+      assert_equal 1, queue_len
+    end
+  ensure
+    Thread.current[Wurk::Batch::THREAD_KEY] = previous
+    @pool.with { |c| c.call('DEL', "b-#{bid}", "b-#{bid}-jids") } if bid
+  end
+
+  # --- end-to-end through the worker DSL ---------------------------------
+
+  # rubocop:disable Minitest/MultipleAssertions, Metrics/AbcSize
+  # End-to-end acceptance: one perform_async, deferred, committed, asserting the
+  # full payload shape lands correctly. Cohesive — keep it as one scenario.
+  def test_perform_async_defers_when_transactional_push_enabled
+    Wurk.transactional_push!
+    klass = build_worker
+    jid = nil
+
+    with_fake_active_record do |pending|
+      jid = klass.perform_async(1, 2)
+
+      assert_match JID_PATTERN, jid
+      assert_equal 0, queue_len, 'perform_async must defer under transactional_push!'
+
+      pending.each(&:call)
+
+      assert_equal 1, queue_len
+      payload = first_queued
+
+      assert_equal jid, payload['jid']
+      assert_equal [1, 2], payload['args']
+      refute payload.key?('client_class'), 'client_class must never reach the wire'
+    end
+  end
+  # rubocop:enable Minitest/MultipleAssertions, Metrics/AbcSize
+
+  # A class whose sidekiq_options memoized BEFORE the global opt-in must still
+  # route through the transactional client — transactional_push! lives in an
+  # initializer, but option memoization order shouldn't decide correctness.
+  def test_transactional_push_applies_to_classes_defined_before_opt_in
+    klass = build_worker # memoizes options here, before the opt-in below
+    Wurk.transactional_push!
+
+    with_fake_active_record do |pending|
+      klass.perform_async(:x)
+
+      assert_equal 1, pending.size, 'global opt-in must reach pre-defined classes'
+      assert_equal 0, queue_len
+    end
+  end
+
+  def test_per_call_set_client_class_overrides_default
+    klass = build_worker # plain Wurk::Client by default
+
+    with_fake_active_record do |pending|
+      klass.set(client_class: Wurk::TransactionAwareClient).perform_async(:x)
+
+      assert_equal 1, pending.size, 'set(client_class:) must route through the transactional client'
+      assert_equal 0, queue_len
+    end
+  end
+
+  private
+
+  def item
+    { 'class' => @class_name, 'queue' => @queue, 'args' => [1] }
+  end
+
+  def queue_len
+    @pool.with { |c| c.call('LLEN', "queue:#{@queue}") }.to_i
+  end
+
+  def first_queued
+    raw = @pool.with { |c| c.call('LRANGE', "queue:#{@queue}", 0, 0) }.first
+    raw && JSON.parse(raw)
+  end
+
+  def build_worker
+    queue = @queue
+    Class.new do
+      include Wurk::Worker
+
+      sidekiq_options queue: queue
+      def perform(*); end
+    end
+  end
+
+  # Swaps in a minimal ActiveRecord stand-in whose after_all_transactions_commit
+  # captures blocks into `pending` instead of running them, so the test controls
+  # commit (call them) vs rollback (drop them). The real ActiveRecord — which the
+  # engine suites load into this process — is saved and restored, so nothing
+  # leaks to other suites sharing the worker.
+  def with_fake_active_record
+    pending = []
+    ar = Module.new
+    ar.define_singleton_method(:after_all_transactions_commit) { |&blk| pending << blk }
+    with_const(:ActiveRecord, ar) { yield pending }
+  end
+
+  # Temporarily binds Object::<name> to value, restoring whatever was there
+  # (including nothing) afterward. Never destroys a real constant.
+  def with_const(name, value)
+    had = Object.const_defined?(name, false)
+    previous = Object.const_get(name, false) if had
+    Object.send(:remove_const, name) if had
+    Object.const_set(name, value)
+    yield
+  ensure
+    Object.send(:remove_const, name) if Object.const_defined?(name, false)
+    Object.const_set(name, previous) if had
+  end
+
+  # Temporarily unbinds Object::<name>, restoring it afterward.
+  def without_const(name)
+    had = Object.const_defined?(name, false)
+    previous = Object.const_get(name, false) if had
+    Object.send(:remove_const, name) if had
+    yield
+  ensure
+    Object.const_set(name, previous) if had && !Object.const_defined?(name, false)
+  end
+end

--- a/test/unit/worker_options_test.rb
+++ b/test/unit/worker_options_test.rb
@@ -326,7 +326,7 @@ class WorkerOptionsTest < Wurk::Test::UnitCase
     captured = []
     fake = build_fake_client { nil }
     original = klass.singleton_class.instance_method(:build_client)
-    klass.singleton_class.send(:define_method, :build_client) do |pool = nil|
+    klass.singleton_class.send(:define_method, :build_client) do |pool = nil, **_opts|
       captured << pool
       fake
     end


### PR DESCRIPTION
## What

Implements **`Sidekiq.transactional_push!`** + **`Sidekiq::TransactionAwareClient`** (parity spec §3 / §8) — the opt-in "enqueue after commit" pattern. Closes #164.

When enabled, every `perform_async` builds a `Wurk::TransactionAwareClient` that:
- **pre-allocates the jid** and returns it synchronously, so the caller can reference it inside the transaction;
- **defers the actual Redis write** to `ActiveRecord.after_all_transactions_commit` (AR 7.2+), falling back to `AfterCommitEverywhere`, then to an immediate push when no after-commit hook is available;
- so a job **never references a row a rollback erased**.

`push_bulk` stays non-transactional, and pushes inside a `Batch#jobs` block run immediately (batch coordination counts at push time).

## Acceptance (issue #164)

- [x] `Sidekiq.transactional_push!` swaps in `Sidekiq::TransactionAwareClient`
- [x] `perform_async` defers the enqueue to `after_commit`; jid returned synchronously; rollback drops it; `push_bulk` unaffected
- [x] No-ops gracefully when not inside a transaction / ActiveRecord absent

## Changes

- `lib/wurk/transaction_aware_client.rb` — the client. Appends `"client_class"` to `JobUtil::TRANSIENT_ATTRIBUTES` (the Class option must never hit the wire).
- `Wurk.transactional_push!` → sets `default_job_options["client_class"]`.
- `Worker.build_client`/`client_push` honor `client_class`: per-call `set(client_class:)` → class option → **live `default_job_options`** → `Wurk::Client`. The live-default fallback keeps a global `transactional_push!` order-independent (a class whose options memoized before the opt-in otherwise holds a stale dup — found via the QA driver below).
- `compat.rb` — `Sidekiq::TransactionAwareClient` alias + `Sidekiq.transactional_push!`.

## Testing

- New `test/unit/transaction_aware_client_test.rb` (13 cases): jid-synchronous deferral, commit, rollback, bulk-not-deferred, batching-immediate, AR-absent fallback, AfterCommitEverywhere fallback, end-to-end `perform_async`, per-call `set(client_class:)`, and pre-opt-in ordering.
- **Behavioral driver against real ActiveRecord 8.1 + sqlite + real Redis** — all checks pass (defer-until-commit, rollback drops, jid synchronous, `client_class` never on the wire, bulk immediate). This caught a real order-dependence bug that the fake-AR unit tests missed.
- Full suite **2048 / 0 failures**, parity **20 / 0**, ecosystem **pass**, coverage **96.21% line / 91.71% branch** (≥90% gate).

## How to test in prod

In an initializer (e.g. `config/initializers/sidekiq.rb`):

```ruby
Sidekiq.transactional_push!
```

Then, anywhere you enqueue inside a DB transaction:

```ruby
ActiveRecord::Base.transaction do
  order = Order.create!(...)
  OrderConfirmationJob.perform_async(order.id)   # returns a jid immediately…
  # …but the job is NOT in Redis yet
end
# …it lands in Redis only now, after COMMIT — so the worker always sees a persisted Order.
```

Verify the deferral with `redis-cli`:

```bash
# Inside the transaction the queue stays empty; after commit it has 1 job:
redis-cli LLEN queue:default
```

Roll the transaction back (`raise ActiveRecord::Rollback`) and the job never appears. Bulk enqueues (`perform_bulk` / `push_bulk`) are intentionally **not** deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transactional job enqueuing: jobs are now deferred until after database transaction commits and dropped on rollback.
  * Introduced `Wurk.transactional_push!` to globally opt into this behavior.
  * Added `Sidekiq.transactional_push!` for Sidekiq compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->