### PR TITLE
feat(reaper): full-keyspace hourly sweep + boot-time orphan reclaim (#108)

### DIFF
--- a/lib/wurk/fetcher/reaper.rb
+++ b/lib/wurk/fetcher/reaper.rb
@@ -33,10 +33,16 @@ module Wurk
     # is killed into the dead set instead of re-queued, so a job that crashes
     # its worker every time can't loop forever.
     #
-    # SCANs are scoped to the public queues this process serves and gated by
-    # a cluster-wide `SET NX EX` lock, so across a fleet only one process
-    # sweeps per interval ("1/min within process group" in the spec) and the
-    # keyspace touched is bounded to known queues.
+    # The reaper runs two passes, exactly as super_fetch's sweeper does:
+    #
+    #   * a *scoped* sweep every interval ("1/min within process group"): SCANs
+    #     only the public queues this process serves, gated by a cluster `SET NX
+    #     EX` lock so one process sweeps per interval. The cheap common path.
+    #   * a *full* sweep at most once an hour ("full SCAN 1/hr"): SCANs the whole
+    #     `queue:*|*` keyspace, gated by its own hourly lock, so private lists
+    #     whose public queue no live process serves — a renamed/decommissioned
+    #     queue, or a dead host's queue no survivor consumes — are recovered too,
+    #     not stranded forever.
     #
     # Spec: docs/target/sidekiq-pro.md §3.2.
     class Reaper
@@ -47,16 +53,24 @@ module Wurk
       # floor below which cross-host orphans can't be detected anyway.
       DEFAULT_INTERVAL = 60
 
+      # Full-keyspace sweep cadence + its lock TTL: at most once per hour across
+      # the fleet, since a global SCAN is far costlier than the scoped pass.
+      FULL_INTERVAL = 3600
+
       LOCK_KEY = 'super_fetch:reaper'
+      FULL_LOCK_KEY = 'super_fetch:reaper:full'
       SCAN_COUNT = 100
       THREAD_NAME = 'wurk-reaper'
 
       attr_reader :interval
 
-      def initialize(config, interval: DEFAULT_INTERVAL, lock_key: LOCK_KEY)
+      def initialize(config, interval: DEFAULT_INTERVAL, lock_key: LOCK_KEY,
+                     full_interval: FULL_INTERVAL, full_lock_key: FULL_LOCK_KEY)
         @config = config
         @interval = interval
         @lock_key = lock_key
+        @full_interval = full_interval
+        @full_lock_key = full_lock_key
         @thread = nil
         @done = false
         @mutex = ::Mutex.new
@@ -89,12 +103,13 @@ module Wurk
         !@thread.nil? && @thread.alive?
       end
 
-      # One cluster-gated sweep: a no-op (returns 0) unless this process wins
-      # the interval's lock. Used by the loop.
+      # One loop tick: the scoped sweep when this process wins the per-interval
+      # lock, plus the full-keyspace sweep when it also wins the hourly lock.
+      # Returns the total jobs reclaimed across both.
       def reap
-        return 0 unless acquire_lock?
-
-        reclaim!
+        reclaimed = acquire_lock? ? reclaim! : 0
+        reclaimed += reclaim_full! if acquire_full_lock?
+        reclaimed
       end
 
       # One unguarded sweep over every served queue. Returns the number of
@@ -103,6 +118,21 @@ module Wurk
       def reclaim!
         prefixes = live_process_prefixes
         served_queues.sum { |public_q| reclaim_queue(public_q, prefixes) }
+      end
+
+      # One unguarded full-keyspace sweep: every `queue:*|*` private list, even
+      # ones whose public queue this process doesn't serve. Returns the number
+      # of jobs reclaimed. Public so boot paths and tests can drive it without
+      # the hourly lock.
+      def reclaim_full!
+        prefixes = live_process_prefixes
+        reclaimed = 0
+        each_full_private_list do |key, public_q, host, pid|
+          next if owner_alive?(host, pid, prefixes)
+
+          reclaimed += drain(key, public_q)
+        end
+        reclaimed
       end
 
       private
@@ -141,6 +171,39 @@ module Wurk
           end
           break if cursor == '0'
         end
+      end
+
+      # Yields [private_list_key, public_q, host, pid] for every private list in
+      # the keyspace. MATCH `queue:*|*` matches only private lists (public queue
+      # keys carry no `|`); parse_full_key drops anything that isn't a
+      # well-formed `queue:<public>|<host>|<pid>|<idx>`.
+      def each_full_private_list
+        cursor = '0'
+        loop do
+          cursor, keys = redis { |c| c.call('SCAN', cursor, 'MATCH', "#{Keys::QUEUE_PREFIX}*|*", 'COUNT', SCAN_COUNT) }
+          keys.each do |key|
+            parsed = parse_full_key(key)
+            yield key, *parsed if parsed
+          end
+          break if cursor == '0'
+        end
+      end
+
+      # `queue:<public>|<host>|<pid>|<idx>` → [public_q, host, pid], parsed from
+      # the right (pid + idx are integers, host precedes them) so a `|` inside
+      # the queue name is tolerated. nil when the key isn't a well-formed
+      # private list.
+      def parse_full_key(key)
+        parts = key.split('|')
+        return nil if parts.size < 4
+
+        host, pid, idx = parts.last(3)
+        return nil unless integer?(pid) && integer?(idx)
+
+        public_q = parts[0...-3].join('|')
+        return nil unless public_q.start_with?(Keys::QUEUE_PREFIX) && public_q != Keys::QUEUE_PREFIX
+
+        [public_q, host, pid.to_i]
       end
 
       # `<public_q>|<host>|<pid>|<idx>` → [host, pid] (pid as Integer), or
@@ -228,6 +291,10 @@ module Wurk
 
       def acquire_lock?
         redis { |c| c.call('SET', @lock_key, '1', 'NX', 'EX', @interval) } == 'OK'
+      end
+
+      def acquire_full_lock?
+        redis { |c| c.call('SET', @full_lock_key, '1', 'NX', 'EX', @full_interval) } == 'OK'
       end
 
       def spawn_loop_thread

--- a/lib/wurk/launcher.rb
+++ b/lib/wurk/launcher.rb
@@ -83,6 +83,7 @@ module Wurk
       @metrics_rollup&.start
       @managers.each(&:start)
       @reaper.start
+      boot_reclaim
       @health_server&.start
     end
 
@@ -258,6 +259,17 @@ module Wurk
         renew_interval: @config[:leader_renew_interval] || Wurk::Leader::DEFAULT_RENEW_INTERVAL,
         follower_interval: @config[:leader_follower_interval] || Wurk::Leader::DEFAULT_FOLLOWER_INTERVAL
       )
+    end
+
+    # Deterministic boot-time orphan sweep: a SIGKILLed sibling's in-flight jobs
+    # would otherwise wait a full reaper interval before recovery. One unguarded
+    # scoped reclaim at start (no cluster lock — every booting worker helps) gets
+    # them re-queued immediately. Best-effort: a Redis hiccup here must not abort
+    # boot. Spec: docs/target/sidekiq-pro.md §3.2.
+    def boot_reclaim
+      @reaper.reclaim!
+    rescue StandardError => e
+      handle_exception(e, context: 'launcher-boot-reclaim') if respond_to?(:handle_exception)
     end
 
     # Reliable-fetch orphan reclamation. Every worker runs one; a cluster

--- a/test/integration/reaper_full_sweep_test.rb
+++ b/test/integration/reaper_full_sweep_test.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Real fork + real `kill -9` integration for the reaper's full-keyspace sweep
+# (#108 acceptance #4). A job is genuinely BLMOVE'd into a private list owned by
+# a forked child, under a queue the reaper's config does NOT serve; the child is
+# killed; and the *full* sweep — not the scoped per-queue one — must re-queue it.
+#
+# NEVER mock Redis. Spec: docs/target/sidekiq-pro.md §3.2.
+class ReaperFullSweepTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @ns        = "reapfull-#{Process.pid}-#{object_id}"
+    @orphan_q  = Wurk::Keys.queue("#{@ns}-orphan") # deliberately NOT served below
+    @config    = Wurk::Configuration.new
+    @config.logger = ::Logger.new(IO::NULL)
+    @config.default_capsule.queues = ["#{@ns}-served"]
+    @observer  = RedisClient.config(url: Wurk::Test.redis_url).new_client
+    @reaper    = Wurk::Fetcher::Reaper.new(@config, lock_key: "rf:#{@ns}", full_lock_key: "rff:#{@ns}")
+    @child_pid = nil
+  end
+
+  def teardown
+    kill_child
+    @observer&.close
+    @config&.reset_redis_pools!
+  ensure
+    super
+  end
+
+  # rubocop:disable Minitest/MultipleAssertions, Metrics/AbcSize
+  def test_full_sweep_reclaims_a_killed_owners_orphan_in_an_unserved_queue
+    @observer.call('RPUSH', @orphan_q, payload('job-1'))
+    @child_pid = fork_fetcher(@orphan_q)
+
+    priv = wait_for_private_list(@orphan_q)
+
+    assert priv, 'child must BLMOVE the job into its private list'
+    assert_equal 1, @observer.call('LLEN', priv)
+    assert_equal 0, @observer.call('LLEN', @orphan_q), 'job is in-flight, off the public queue'
+
+    kill_child # kill -9 + reap, so the OS reports the owner pid as dead
+
+    assert_equal 0, @reaper.reclaim!, 'scoped sweep ignores an unserved queue'
+    assert_equal 1, @reaper.reclaim_full!, 'full sweep recovers the killed owner orphan'
+    assert_equal 0, @observer.call('LLEN', priv), 'private list drained'
+    assert_equal 1, @observer.call('LLEN', @orphan_q), 'job re-queued onto its public queue'
+  end
+  # rubocop:enable Minitest/MultipleAssertions, Metrics/AbcSize
+
+  private
+
+  def payload(jid)
+    Wurk.dump_json('class' => 'NoOp', 'args' => [], 'queue' => "#{@ns}-orphan", 'jid' => jid)
+  end
+
+  # Forks a child that does a genuine reliable-fetch BLMOVE (same command + key
+  # the fetcher uses) into its own pid-keyed private list, then parks until killed.
+  def fork_fetcher(public_q)
+    fork do
+      @observer.close # never share the parent's socket across a fork
+      child = RedisClient.config(url: Wurk::Test.redis_url).new_client
+      priv = Wurk::Fetcher::Reliable.private_queue_name(public_q)
+      child.blocking_call(5, 'BLMOVE', public_q, priv, 'RIGHT', 'LEFT', 2)
+      sleep 60
+    ensure
+      child&.close
+    end
+  end
+
+  def wait_for_private_list(public_q)
+    deadline = monotonic + 10
+    while monotonic < deadline
+      keys = @observer.call('KEYS', "#{public_q}|*")
+      return keys.first unless keys.empty?
+
+      sleep 0.05
+    end
+    nil
+  end
+
+  def kill_child
+    return unless @child_pid
+
+    ::Process.kill('KILL', @child_pid)
+    ::Process.wait(@child_pid)
+  rescue Errno::ESRCH, Errno::ECHILD
+    nil
+  ensure
+    @child_pid = nil
+  end
+
+  def monotonic = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+end

--- a/test/unit/fetcher_reaper_test.rb
+++ b/test/unit/fetcher_reaper_test.rb
@@ -30,7 +30,12 @@ class FetcherReaperTest < Wurk::Test::UnitCase
     # `super_fetch:recovered:<jid>` can't accumulate across runs and tip an
     # otherwise-recoverable job over the poison threshold.
     @salt         = SecureRandom.hex(8)
-    @reaper       = Wurk::Fetcher::Reaper.new(@config, interval: 1, lock_key: "#{Wurk::Fetcher::Reaper::LOCK_KEY}:#{@ns}")
+    @lock_key      = "#{Wurk::Fetcher::Reaper::LOCK_KEY}:#{@ns}"
+    @full_lock_key = "#{Wurk::Fetcher::Reaper::FULL_LOCK_KEY}:#{@ns}"
+    @reaper        = Wurk::Fetcher::Reaper.new(@config, interval: 1, lock_key: @lock_key, full_lock_key: @full_lock_key)
+    # Keys created outside @public_queue (full-sweep tests use foreign queues);
+    # the whole-keyspace scan would see leftovers from prior tests otherwise.
+    @extra_keys    = []
     Wurk::Middleware::PoisonPill.reset!
   end
 
@@ -39,7 +44,8 @@ class FetcherReaperTest < Wurk::Test::UnitCase
     @pool.with do |c|
       keys = c.call('KEYS', "#{@public_queue}*")
       c.call('DEL', *keys) unless keys.empty?
-      c.call('DEL', "#{Wurk::Fetcher::Reaper::LOCK_KEY}:#{@ns}")
+      c.call('DEL', @lock_key, @full_lock_key)
+      c.call('DEL', *@extra_keys) unless @extra_keys.empty?
     end
     cleanup_dead_set
     cleanup_recovery_counters
@@ -210,11 +216,14 @@ class FetcherReaperTest < Wurk::Test::UnitCase
 
   # --- cluster lock ------------------------------------------------------
 
-  def test_reap_is_a_noop_when_the_lock_is_held_elsewhere
+  def test_reap_is_a_noop_when_both_locks_are_held_elsewhere
     seed_private_list(DEAD_PID, %w[a])
-    @pool.with { |c| c.call('SET', "#{Wurk::Fetcher::Reaper::LOCK_KEY}:#{@ns}", 'other', 'EX', 30) }
+    @pool.with do |c|
+      c.call('SET', @lock_key, 'other', 'EX', 30)
+      c.call('SET', @full_lock_key, 'other', 'EX', 30)
+    end
 
-    assert_equal 0, @reaper.reap, 'a process that loses the lock does not sweep'
+    assert_equal 0, @reaper.reap, 'a process that loses both locks does not sweep'
     assert_equal 1, llen(private_list(DEAD_PID))
   end
 
@@ -222,6 +231,70 @@ class FetcherReaperTest < Wurk::Test::UnitCase
     seed_private_list(DEAD_PID, %w[a b])
 
     assert_equal 2, @reaper.reap
+  end
+
+  # Losing the scoped lock but winning the (separate) hourly lock still runs the
+  # full sweep — the two gates are independent.
+  def test_reap_runs_full_sweep_when_only_scoped_lock_is_held
+    seed_private_list(DEAD_PID, %w[a b])
+    @pool.with { |c| c.call('SET', @lock_key, 'other', 'EX', 30) }
+
+    assert_equal 2, @reaper.reap, 'full sweep reclaims even when the scoped lock is lost'
+  end
+
+  # --- full-keyspace sweep (acceptance #4) -------------------------------
+
+  # The headline gap: a private list whose public queue this process does NOT
+  # serve (renamed/decommissioned queue, or a dead host's queue no survivor
+  # consumes) is invisible to the scoped sweep but recovered by the full one.
+  # rubocop:disable Minitest/MultipleAssertions
+  # One scenario: scoped sweep misses it, full sweep recovers it onto the
+  # foreign public queue and drains the private list. Cohesive — keep together.
+  def test_reclaim_full_reclaims_orphan_in_an_unserved_queue
+    foreign_q = Wurk::Keys.queue("#{@ns}-foreign")
+    private_key = "#{foreign_q}|#{@host}|#{DEAD_PID}|0"
+    @extra_keys.push(foreign_q, private_key)
+    @pool.with { |c| c.call('RPUSH', private_key, payload('x'), payload('y')) }
+
+    # Scoped sweep can't see it (foreign_q isn't a served queue)...
+    assert_equal 0, @reaper.reclaim!, 'scoped sweep ignores unserved queues'
+    # ...but the full sweep recovers it to its own public queue.
+    assert_equal 2, @reaper.reclaim_full!
+    assert_equal 0, llen(private_key), 'orphan private list drained'
+    assert_equal 2, llen(foreign_q), 'jobs re-queued onto the foreign public queue'
+  end
+  # rubocop:enable Minitest/MultipleAssertions
+
+  def test_reclaim_full_leaves_a_live_owners_list_untouched
+    foreign_q = Wurk::Keys.queue("#{@ns}-live")
+    private_key = "#{foreign_q}|#{@host}|#{Process.pid}|0" # this very process — alive
+    @extra_keys.push(foreign_q, private_key)
+    @pool.with { |c| c.call('RPUSH', private_key, payload('z')) }
+
+    assert_equal 0, @reaper.reclaim_full!, 'a live owner is never reclaimed'
+    assert_equal 1, llen(private_key)
+  end
+
+  def test_reclaim_full_ignores_public_queues_and_malformed_keys
+    @pool.with do |c|
+      c.call('RPUSH', Wurk::Keys.queue("#{@ns}-plain"), payload('public')) # no pipe → not a private list
+      c.call('RPUSH', "#{Wurk::Keys.queue("#{@ns}-bad")}|#{@host}|notapid|0", payload('bad'))
+    end
+    @extra_keys.push(Wurk::Keys.queue("#{@ns}-plain"), "#{Wurk::Keys.queue("#{@ns}-bad")}|#{@host}|notapid|0")
+
+    assert_equal 0, @reaper.reclaim_full!
+  end
+
+  # A `|` inside the queue name must still parse: the owner triple is taken from
+  # the right, so the public queue is everything before host|pid|idx.
+  def test_reclaim_full_tolerates_a_pipe_in_the_queue_name
+    foreign_q = Wurk::Keys.queue("#{@ns}|piped")
+    private_key = "#{foreign_q}|#{@host}|#{DEAD_PID}|0"
+    @extra_keys.push(foreign_q, private_key)
+    @pool.with { |c| c.call('RPUSH', private_key, payload('p')) }
+
+    assert_equal 1, @reaper.reclaim_full!
+    assert_equal 1, llen(foreign_q), 'reclaimed onto the correctly-parsed public queue'
   end
 
   # --- thread lifecycle --------------------------------------------------

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -166,6 +166,27 @@ class LauncherTest < Wurk::Test::UnitCase
     assert started, 'run should start the reliable-fetch reaper'
   end
 
+  def test_run_does_a_boot_time_reclaim
+    launcher = Wurk::Launcher.new(@config)
+    stub_managers(launcher)
+    reclaimed = false
+    reaper = launcher.instance_variable_get(:@reaper)
+    reaper.define_singleton_method(:start) {} # don't spawn the loop thread
+    reaper.define_singleton_method(:reclaim!) { reclaimed = true }
+
+    launcher.run(async_beat: false)
+
+    assert reclaimed, 'run should do a deterministic boot-time orphan reclaim'
+  end
+
+  # boot_reclaim is best-effort: a Redis hiccup at boot must not abort startup.
+  def test_boot_reclaim_swallows_reaper_errors
+    launcher = Wurk::Launcher.new(@config)
+    launcher.instance_variable_get(:@reaper).define_singleton_method(:reclaim!) { raise 'redis down' }
+
+    launcher.send(:boot_reclaim) # must not raise
+  end
+
   def test_run_starts_each_manager
     launcher = Wurk::Launcher.new(@config)
     stub_managers(launcher)


### PR DESCRIPTION
## What

Hardens the reliable-fetch orphan reaper to match super_fetch's two-pass sweeper (spec §3.2). Closes #108.

Before: the reaper only SCANned the queues *this* process serves, once per interval. Two gaps:
1. A private list whose public queue **no live process serves** — a renamed/decommissioned queue, or a dead host's queue no survivor consumes — was **stranded forever**.
2. A SIGKILLed sibling's in-flight jobs waited a **full interval** (up to 60s) before recovery.

## Acceptance (issue #108)

- [x] Full-keyspace `SCAN MATCH queue:*|*` pass at most **once per hour**, rate-limited via a separate cluster `SET NX EX 3600` lock, reclaiming any orphaned private list independent of `served_queues`
- [x] The scoped per-minute sweep is **retained** for the common path
- [x] A deterministic **boot-time `reclaim!`** runs once at launcher start
- [x] Integration test: fetch into a private list under a queue **not** in config's queues, **kill the owner**, assert the full sweep re-queues it
- [x] Wire-compat: private list naming + LMOVE direction unchanged

## Changes

- `Reaper#reclaim_full!` — unguarded full-keyspace sweep (`queue:*|*`), parsing public-queue + owner from each key **from the right** so a `|` inside a queue name is tolerated. In the loop, gated by its own hourly `SET NX EX 3600` lock (`FULL_LOCK_KEY`); the scoped per-minute pass keeps its existing lock. `reap()` runs both, each behind its own gate (independent).
- `Launcher#boot_reclaim` — one scoped `reclaim!` at startup (no cluster lock — every booting worker helps), best-effort so a Redis hiccup can't abort boot.

## Testing

- `fetcher_reaper_test` — new unit cases: full sweep reclaims an orphan in an **unserved** queue, leaves a **live** owner untouched, ignores public/malformed keys, tolerates a `|` in the queue name; plus the two-independent-locks behaviour of `reap()`. Per-test lock keys namespaced so the new hourly lock can't leak across the parallel runner.
- `reaper_full_sweep_test` (**integration**) — **real fork + real `kill -9`**: a child genuinely BLMOVEs a job into its pid-keyed private list under an unserved queue, gets killed, and the full sweep re-queues it.
- `launcher_test` — boot-time reclaim is invoked on `run`; `boot_reclaim` swallows reaper errors.
- Behavioral driver (real fork/kill against real Redis) — all checks pass. Full suite **2069 / 0** (×3), parity **20 / 0**, ecosystem **pass**, coverage **96.09% line / 91.2% branch** (≥90%).

## How to test in prod

No config needed — the reaper runs automatically on every worker. To observe the new behaviour:

```bash
# Simulate a stranded private list under a queue no worker serves:
redis-cli RPUSH "queue:decommissioned|$(hostname)|999999|0" '{"class":"X","args":[],"queue":"decommissioned","jid":"abc"}'

# Within an hour (or immediately if you restart a worker — boot reclaim runs the
# scoped pass; the hourly full pass picks up unserved queues), the job is moved
# back onto its public queue:
redis-cli LLEN "queue:decommissioned"        # => 1, recovered
redis-cli LLEN "queue:decommissioned|$(hostname)|999999|0"   # => 0, drained
```

A SIGKILLed worker's in-flight jobs are now recovered the moment a sibling boots (or on the next reaper tick), not after a full interval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced job recovery mechanism with full keyspace scanning to reclaim orphaned jobs from killed worker processes.
  * Added deterministic boot-time orphan reclaim during startup to re-queue in-flight jobs.

* **Tests**
  * Added comprehensive test coverage for full-keyspace sweep recovery and boot-time orphan reclaim scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->