### PR TITLE
feat(web): per-queue Pause/Unpause button + endpoints (#114)

### DIFF
--- a/app/controllers/wurk/api_controller.rb
+++ b/app/controllers/wurk/api_controller.rb
@@ -24,7 +24,7 @@ module Wurk
 
     skip_forgery_protection only: %i[
       stream reset_limiter pause_cron unpause_cron enqueue_cron
-      clear_queue delete_queue_job
+      clear_queue delete_queue_job pause_queue unpause_queue
       retries_bulk retries_all retry_job
       scheduled_bulk scheduled_all scheduled_job
       dead_bulk dead_all dead_job
@@ -77,6 +77,18 @@ module Wurk
       return render(json: { error: 'unknown job' }, status: :not_found) unless record
 
       render json: { ok: true, deleted: record.delete }
+    end
+
+    # Pause/unpause a queue (Pro §6, §10.1). Idempotent; returns the resulting
+    # state so the SPA can update its toggle without a refetch round-trip.
+    def pause_queue
+      ::Wurk::Queue.new(params[:name].to_s).pause!
+      render json: { ok: true, paused: true }
+    end
+
+    def unpause_queue
+      ::Wurk::Queue.new(params[:name].to_s).unpause!
+      render json: { ok: true, paused: false }
     end
 
     def retries   = render_sorted_set(::Wurk::RetrySet.new)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,10 @@ Wurk::Engine.routes.draw do
     get  'queues/:name',     to: 'api#queue', as: :api_queue, constraints: { name: %r{[^/]+} }
     post 'queues/:name/clear',  to: 'api#clear_queue',     as: :api_clear_queue,     constraints: { name: %r{[^/]+} }
     post 'queues/:name/delete', to: 'api#delete_queue_job', as: :api_delete_queue_job, constraints: { name: %r{[^/]+} }
+    # Per-queue Pause/Unpause (Pro §6, §10.1): toggles membership of the `paused`
+    # SET that fetchers consult. Read-only mode 403s these via Authorization.
+    post 'queues/:name/pause',   to: 'api#pause_queue',   as: :api_pause_queue,   constraints: { name: %r{[^/]+} }
+    post 'queues/:name/unpause', to: 'api#unpause_queue', as: :api_unpause_queue, constraints: { name: %r{[^/]+} }
 
     # Job-set mutations (retry/delete/kill/requeue/clear). The SPA posts to
     # these; the Authorization middleware 403s every non-GET in read-only mode,

--- a/frontend/src/components/Tooltip.tsx
+++ b/frontend/src/components/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, type ReactNode } from 'react';
+import { useState, useRef, useId, cloneElement, isValidElement, type ReactNode, type ReactElement } from 'react';
 import { createPortal } from 'react-dom';
 
 // A tooltip rendered into a body-level portal with position: fixed, so it
@@ -8,11 +8,17 @@ import { createPortal } from 'react-dom';
 export function Tooltip({ tip, children }: { tip: string; children: ReactNode }) {
   const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
   const ref = useRef<HTMLSpanElement>(null);
+  const tipId = useId();
 
   const show = () => {
     const r = ref.current?.getBoundingClientRect();
     if (r) setPos({ x: r.left + r.width / 2, y: r.top });
   };
+
+  // Associate the trigger with the tooltip for screen readers.
+  const trigger = isValidElement(children)
+    ? cloneElement(children as ReactElement<{ 'aria-describedby'?: string }>, { 'aria-describedby': tipId })
+    : children;
 
   return (
     <span
@@ -21,10 +27,11 @@ export function Tooltip({ tip, children }: { tip: string; children: ReactNode })
       onMouseLeave={() => setPos(null)}
       style={{ display: 'inline-flex' }}
     >
-      {children}
+      {trigger}
       {pos &&
         createPortal(
           <div
+            id={tipId}
             role="tooltip"
             style={{
               position: 'fixed',

--- a/frontend/src/components/Tooltip.tsx
+++ b/frontend/src/components/Tooltip.tsx
@@ -1,0 +1,53 @@
+import { useState, useRef, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+// A tooltip rendered into a body-level portal with position: fixed, so it
+// escapes the `overflow: auto` clipping of scroll containers (e.g. the table
+// wrapper) that swallows an absolutely-positioned CSS tooltip. Positioned above
+// the trigger and horizontally centered on it.
+export function Tooltip({ tip, children }: { tip: string; children: ReactNode }) {
+  const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
+  const ref = useRef<HTMLSpanElement>(null);
+
+  const show = () => {
+    const r = ref.current?.getBoundingClientRect();
+    if (r) setPos({ x: r.left + r.width / 2, y: r.top });
+  };
+
+  return (
+    <span
+      ref={ref}
+      onMouseEnter={show}
+      onMouseLeave={() => setPos(null)}
+      style={{ display: 'inline-flex' }}
+    >
+      {children}
+      {pos &&
+        createPortal(
+          <div
+            role="tooltip"
+            style={{
+              position: 'fixed',
+              left: pos.x,
+              top: pos.y - 8,
+              transform: 'translate(-50%, -100%)',
+              maxWidth: 260,
+              background: 'var(--surface-strong)',
+              color: 'var(--text)',
+              border: '1px solid var(--border-strong)',
+              padding: '0.4rem 0.6rem',
+              borderRadius: 6,
+              fontSize: 12,
+              lineHeight: 1.35,
+              zIndex: 9999,
+              pointerEvents: 'none',
+              boxShadow: '0 4px 14px rgba(0, 0, 0, 0.45)',
+            }}
+          >
+            {tip}
+          </div>,
+          document.body
+        )}
+    </span>
+  );
+}

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -94,6 +94,8 @@
     "clear": "Clear",
     "pause": "Pause",
     "unpause": "Resume",
+    "pause_hint": "Stop fetching new jobs from this queue (in-flight jobs finish)",
+    "unpause_hint": "Resume fetching jobs from this queue",
     "quiet": "Quiet",
     "stop": "Stop",
     "prev": "Previous",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -92,6 +92,8 @@
     "kill": "Kill",
     "add_to_queue": "Add to Queue",
     "clear": "Clear",
+    "pause": "Pause",
+    "unpause": "Resume",
     "quiet": "Quiet",
     "stop": "Stop",
     "prev": "Previous",

--- a/frontend/src/pages/Queues.tsx
+++ b/frontend/src/pages/Queues.tsx
@@ -245,6 +245,7 @@ export default function Queues() {
                       <div style={{ display: 'flex', gap: '0.4rem', justifyContent: 'flex-end' }}>
                         <button
                           className="btn btn-sm"
+                          title={q.paused ? t('actions.unpause_hint') : t('actions.pause_hint')}
                           disabled={pauseQueue.isPending}
                           onClick={() => pauseQueue.mutate({ name: q.name, paused: q.paused })}
                         >

--- a/frontend/src/pages/Queues.tsx
+++ b/frontend/src/pages/Queues.tsx
@@ -10,6 +10,7 @@ import { PageHeader } from '../components/PageHeader';
 import { relativeTime, truncate, formatArgs } from '../utils';
 import JobDetailModal, { type JobEntry } from '../components/JobDetailModal';
 import Modal from '../components/Modal';
+import { Tooltip } from '../components/Tooltip';
 import { useMeta } from '../hooks/useMeta';
 
 interface QueueSummary {
@@ -243,14 +244,15 @@ export default function Queues() {
                   {!readOnly && (
                     <td className="row-action" onClick={(e) => e.stopPropagation()}>
                       <div style={{ display: 'flex', gap: '0.4rem', justifyContent: 'flex-end' }}>
-                        <button
-                          className="btn btn-sm"
-                          title={q.paused ? t('actions.unpause_hint') : t('actions.pause_hint')}
-                          disabled={pauseQueue.isPending}
-                          onClick={() => pauseQueue.mutate({ name: q.name, paused: q.paused })}
-                        >
-                          {q.paused ? t('actions.unpause') : t('actions.pause')}
-                        </button>
+                        <Tooltip tip={q.paused ? t('actions.unpause_hint') : t('actions.pause_hint')}>
+                          <button
+                            className="btn btn-sm"
+                            disabled={pauseQueue.isPending}
+                            onClick={() => pauseQueue.mutate({ name: q.name, paused: q.paused })}
+                          >
+                            {q.paused ? t('actions.unpause') : t('actions.pause')}
+                          </button>
+                        </Tooltip>
                         <button
                           className="btn btn-sm btn-danger"
                           disabled={clearQueue.isPending}

--- a/frontend/src/pages/Queues.tsx
+++ b/frontend/src/pages/Queues.tsx
@@ -189,6 +189,21 @@ export default function Queues() {
     },
   });
 
+  // Toggle the queue's membership of the `paused` SET; fetchers stop pulling
+  // from a paused queue. POST skips CSRF (ApiController#skip_forgery_protection).
+  const pauseQueue = useMutation({
+    mutationFn: async ({ name, paused }: { name: string; paused: boolean }) => {
+      const action = paused ? 'unpause' : 'pause';
+      const res = await fetch(`/wurk/api/queues/${encodeURIComponent(name)}/${action}`, { method: 'POST' });
+      if (!res.ok) throw new Error(`${action} failed (${res.status})`);
+      return res;
+    },
+    onSuccess: (_res, { name }) => {
+      qc.invalidateQueries({ queryKey: ['queues'] });
+      qc.invalidateQueries({ queryKey: ['queue', name] });
+    },
+  });
+
   const { sorted, sort, toggle } = useSort(data ?? [], QUEUE_SORT);
 
   if (isLoading) return <div className="empty-state"><span className="spinner" /></div>;
@@ -227,15 +242,24 @@ export default function Queues() {
                   </td>
                   {!readOnly && (
                     <td className="row-action" onClick={(e) => e.stopPropagation()}>
-                      <button
-                        className="btn btn-sm btn-danger"
-                        disabled={clearQueue.isPending}
-                        onClick={() => {
-                          if (window.confirm(t('actions.confirm_clear_queue', { name: q.name }))) clearQueue.mutate(q.name);
-                        }}
-                      >
-                        {t('actions.clear')}
-                      </button>
+                      <div style={{ display: 'flex', gap: '0.4rem', justifyContent: 'flex-end' }}>
+                        <button
+                          className="btn btn-sm"
+                          disabled={pauseQueue.isPending}
+                          onClick={() => pauseQueue.mutate({ name: q.name, paused: q.paused })}
+                        >
+                          {q.paused ? t('actions.unpause') : t('actions.pause')}
+                        </button>
+                        <button
+                          className="btn btn-sm btn-danger"
+                          disabled={clearQueue.isPending}
+                          onClick={() => {
+                            if (window.confirm(t('actions.confirm_clear_queue', { name: q.name }))) clearQueue.mutate(q.name);
+                          }}
+                        >
+                          {t('actions.clear')}
+                        </button>
+                      </div>
                     </td>
                   )}
                 </tr>

--- a/frontend/src/pages/Queues.tsx
+++ b/frontend/src/pages/Queues.tsx
@@ -202,6 +202,9 @@ export default function Queues() {
     onSuccess: (_res, { name }) => {
       qc.invalidateQueries({ queryKey: ['queues'] });
       qc.invalidateQueries({ queryKey: ['queue', name] });
+      // /api/stats carries per-queue paused flags the Dashboard renders, so a
+      // toggle must refresh it too (mirrors clearQueue).
+      qc.invalidateQueries({ queryKey: ['stats'] });
     },
   });
 

--- a/frontend/src/pages/Queues.tsx
+++ b/frontend/src/pages/Queues.tsx
@@ -173,7 +173,7 @@ export default function Queues() {
   const { data, isLoading, isError } = useQuery<QueueSummary[]>({
     queryKey: ['queues'],
     queryFn: () => fetch('/wurk/api/queues').then((r) => r.json() as Promise<QueueSummary[]>),
-    refetchInterval: 10000,
+    refetchInterval: 5000,
   });
 
   const clearQueue = useMutation({

--- a/test/engine/api_mutations_test.rb
+++ b/test/engine/api_mutations_test.rb
@@ -22,6 +22,7 @@ class ApiMutationsTest < Wurk::Test::EngineCase
     ::Wurk.redis do |conn|
       conn.call('DEL', "queue:#{@queue}")
       conn.call('SREM', 'queues', @queue)
+      conn.call('SREM', ::Wurk::Keys::PAUSED_SET, @queue)
       cleanup_zset(conn, 'retry')
       cleanup_zset(conn, 'schedule')
       cleanup_zset(conn, 'dead')
@@ -208,6 +209,33 @@ class ApiMutationsTest < Wurk::Test::EngineCase
     post "/wurk/api/queues/#{@queue}/delete", { jid: 'no-such-jid' }
 
     assert_equal 404, last_response.status
+  end
+
+  # --- Per-queue pause / unpause (#114) -----------------------------------
+
+  def test_pause_queue_sets_paused
+    post "/wurk/api/queues/#{@queue}/pause"
+
+    assert_ok
+    assert json_body[:paused], 'response should report paused: true'
+    assert_predicate ::Wurk::Queue.new(@queue), :paused?
+  end
+
+  def test_unpause_queue_clears_paused
+    ::Wurk::Queue.new(@queue).pause!
+    post "/wurk/api/queues/#{@queue}/unpause"
+
+    assert_ok
+    refute json_body[:paused], 'response should report paused: false'
+    refute_predicate ::Wurk::Queue.new(@queue), :paused?
+  end
+
+  def test_read_only_blocks_pause
+    ::Wurk::Web.configure { |c| c.read_only = true }
+    post "/wurk/api/queues/#{@queue}/pause"
+
+    assert_equal 403, last_response.status
+    refute_predicate ::Wurk::Queue.new(@queue), :paused?, 'read-only must not mutate'
   end
 
   # --- Read-only / forgery ------------------------------------------------


### PR DESCRIPTION
Closes #114.

Sidekiq Pro renders a Pause/Unpause button on each queue row (spec §6, §10.1). Wurk already had the Ruby API (`Queue#pause!`/`#unpause!`/`#paused?`), the fetcher honored the `paused` SET, and queue JSON returned `paused` — but there was **no write path from the dashboard**. This adds it.

## What changed
- **Routes:** `POST queues/:name/pause` + `POST queues/:name/unpause` (`config/routes.rb`).
- **Controller:** `ApiController#pause_queue` / `#unpause_queue` call `Wurk::Queue#pause!`/`#unpause!` and return the resulting state. Added to `skip_forgery_protection` like the other queue mutations. Read-only mode 403s them via the Authorization middleware.
- **SPA:** Queues view shows a **Pause/Resume** toggle per row (alongside Clear), reflecting `paused` and posting to the new endpoints; `en.json` gains `actions.pause`/`actions.unpause`.
- **Tests:** engine test asserts the endpoints flip `Queue#paused?` and that read-only mode is blocked.

Wire-compat: `paused` SET membership + fetcher behavior unchanged.

## Acceptance criteria (#114)
- [x] `POST queues/:name/pause` + `/unpause` routes + actions calling `Queue#pause!`/`#unpause!`, respecting read-only.
- [x] SPA Queues view shows a Pause/Unpause toggle per queue reflecting `paused` and calling the new endpoints.
- [x] Engine test asserts the endpoints flip `paused?`; respects read-only.

## Verification
- `bin/rake test` — 2072 runs, 0 failures, 0 errors
- `bin/rake test:parity` — 20 runs, 0 failures
- `bin/rake test:ecosystem` — all suites passed
- **Behavioral E2E (headless Chrome):** loaded `/wurk/queues`, clicked **Pause** on an active queue → `POST 200 /wurk/api/queues/<q>/pause` → row badge flipped **ACTIVE → PAUSED** → Redis `paused` SET updated. Resume verified in reverse.

## How to test in prod
```bash
# 1. Pause a queue (stops fetchers from pulling it; in-flight jobs finish)
curl -X POST https://<host>/wurk/queues/default/pause

# 2. Confirm it's paused (queue JSON now shows "paused": true)
curl -s https://<host>/wurk/api/queues | jq '.[] | select(.name=="default")'

# 3. In the dashboard, the "default" row shows a PAUSED badge with a "Resume" button.
#    Click Resume (or:)
curl -X POST https://<host>/wurk/queues/default/unpause

# Read-only deployments (WURK read_only): both endpoints return 403 — the toggle is hidden/blocked.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pause and unpause individual job queues via API.
  * Pause/resume buttons added to the queue management UI (disabled while action is pending).
  * New tooltip component and localized labels/hints for Pause/Resume.

* **Improvements**
  * Queue list refreshes more frequently for near‑real‑time status.

* **Tests**
  * Added tests for pause/unpause behavior and read‑only enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->