### PR TITLE
feat(swarm): honor SIDEKIQ_COUNT for swarm child count, default to CPU count (#120)

### DIFF
--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'etc'
 require 'logger'
 require_relative 'middleware/chain'
 require_relative 'capsule'
@@ -377,7 +378,24 @@ module Wurk
     # a topology. queue_specs (not queues) so weights survive the round-trip.
     def default_topology
       cap = default_capsule
-      Wurk::Topology.flat(count: 1, queues: cap.queue_specs, concurrency: cap.concurrency)
+      Wurk::Topology.flat(count: default_child_count, queues: cap.queue_specs, concurrency: cap.concurrency)
+    end
+
+    # Number of swarm children when the host hasn't declared a topology
+    # (Sidekiq Ent §7.2). Defaults to the CPU count. A whole number is an
+    # absolute count; a fractional value is a CPU multiplier (e.g. `0.5` → half
+    # the cores, rounded), supported since Sidekiq 8.0.2. WURK_COUNT is the
+    # native name, SIDEKIQ_COUNT the drop-in alias. Unparseable input falls back
+    # to the CPU count; the result is floored at 1 so the swarm always forks.
+    def default_child_count
+      raw = ENV['WURK_COUNT'] || ENV['SIDEKIQ_COUNT']
+      return Etc.nprocessors if raw.nil? || raw.strip.empty?
+
+      value = Float(raw)
+      count = (value % 1).zero? ? value.to_i : (value * Etc.nprocessors).round
+      [count, 1].max
+    rescue ArgumentError, TypeError
+      Etc.nprocessors
     end
 
     def guard_frozen!

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -1,12 +1,23 @@
 # frozen_string_literal: true
 
 require_relative '../test_helper'
+require 'etc'
 
 class ConfigurationTest < Wurk::Test::UnitCase
   parallelize_me!
 
   def setup
     @config = Wurk::Configuration.new
+    # default_topology reads these; neutralize the ambient env so the count
+    # tests are deterministic and teardown always restores the originals.
+    @count_env = { 'WURK_COUNT' => ENV['WURK_COUNT'], 'SIDEKIQ_COUNT' => ENV['SIDEKIQ_COUNT'] }
+    ENV.delete('WURK_COUNT')
+    ENV.delete('SIDEKIQ_COUNT')
+  end
+
+  def teardown
+    @count_env.each { |k, v| v.nil? ? ENV.delete(k) : (ENV[k] = v) }
+    super
   end
 
   # --- DEFAULTS ----------------------------------------------------------
@@ -525,15 +536,53 @@ class ConfigurationTest < Wurk::Test::UnitCase
     assert_instance_of Wurk::Topology, @config.topology
   end
 
-  def test_topology_defaults_to_one_flat_fork_from_default_capsule
+  def test_topology_defaults_to_one_flat_fork_per_cpu
     @config.queues = %w[critical default]
     @config.concurrency = 7
 
     slot = @config.topology.slots.first
 
-    assert_equal 1, @config.topology.total_processes
+    assert_equal Etc.nprocessors, @config.topology.total_processes
     assert_equal %w[critical default], slot.queues
     assert_equal 7, slot.concurrency
+  end
+
+  def test_topology_count_honors_sidekiq_count
+    ENV['SIDEKIQ_COUNT'] = '4'
+
+    assert_equal 4, @config.topology.total_processes
+  end
+
+  def test_topology_count_fractional_sidekiq_count_multiplies_cpu
+    ENV['SIDEKIQ_COUNT'] = '0.5'
+
+    assert_equal [(0.5 * Etc.nprocessors).round, 1].max, @config.topology.total_processes
+  end
+
+  def test_topology_count_wurk_count_takes_precedence_over_sidekiq_count
+    ENV['WURK_COUNT'] = '3'
+    ENV['SIDEKIQ_COUNT'] = '7'
+
+    assert_equal 3, @config.topology.total_processes
+  end
+
+  def test_topology_count_invalid_value_falls_back_to_cpu
+    ENV['SIDEKIQ_COUNT'] = 'not-a-number'
+
+    assert_equal Etc.nprocessors, @config.topology.total_processes
+  end
+
+  def test_topology_count_is_floored_at_one
+    ENV['SIDEKIQ_COUNT'] = '0'
+
+    assert_equal 1, @config.topology.total_processes
+  end
+
+  def test_explicit_topology_overrides_sidekiq_count
+    ENV['SIDEKIQ_COUNT'] = '8'
+    @config.topology = Wurk::Topology.flat(count: 2, queues: ['default'], concurrency: 1)
+
+    assert_equal 2, @config.topology.total_processes
   end
 
   def test_topology_default_preserves_weighted_queue_specs


### PR DESCRIPTION
Closes #120.

Sidekiq Enterprise §7.2: `SIDEKIQ_COUNT` sets the number of swarm children, defaulting to the CPU count, with fractional CPU multipliers (e.g. `0.5`) supported since 8.0.2. Wurk's `default_topology` hardcoded `count: 1`, so a drop-in user setting `SIDEKIQ_COUNT=8` still got a single fork.

## What changed
- `Configuration#default_topology` now derives the child count via a new `default_child_count`:
  - **unset** → `Etc.nprocessors` (CPU count)
  - **whole number** (`4`) → absolute count
  - **fractional** (`0.5`) → `round(value * Etc.nprocessors)` — CPU multiplier (Sidekiq 8.0.2+)
  - **`WURK_COUNT`** is the native name, **`SIDEKIQ_COUNT`** the drop-in alias (WURK_COUNT wins)
  - unparseable input falls back to CPU count; result floored at 1 so the swarm always forks
- An explicit `config.topology=` still wins — `topology` is memoized, so the default is never computed when a custom topology is declared.

Wire-compat unchanged; this only affects the default fork count.

## Acceptance criteria (#120)
- [x] `SIDEKIQ_COUNT=4` boots 4 swarm children
- [x] Unset env on a multi-core box boots `Etc.nprocessors` children
- [x] `SIDEKIQ_COUNT=0.5` boots `round(0.5 * nprocessors)` children
- [x] An explicit `config.topology=` still wins

## Verification
- `bin/rake test` — 2078 runs, 0 failures (ran 4× clean)
- New unit tests in `configuration_test.rb` cover: `=4`, `=0.5` multiplier, `WURK_COUNT` precedence, invalid→CPU fallback, floor-at-1, and explicit-topology override. The existing "default = 1 fork" test was updated to "1 fork per CPU".
- End-to-end (real lib, cpu=6): unset→6, `=4`→4, `=0.5`→3, `WURK_COUNT=3`/`SIDEKIQ_COUNT=9`→3, bogus→6, `=0`→1.

Note: the count *derivation* is unit-tested at the Configuration level (fast, deterministic); actual multi-child forking is already covered by `test/integration/swarm_boot_test.rb` with explicit topologies, so no heavy N-fork boot test was added.

## How to test in prod
```bash
# Run the worker with a fixed child count (overrides the CPU-count default):
SIDEKIQ_COUNT=4 bundle exec wurk        # → 4 swarm children
# Or half the cores:
SIDEKIQ_COUNT=0.5 bundle exec wurk      # → round(0.5 × CPU) children
# Confirm from a console:
bundle exec rails runner 'puts Wurk.configuration.topology.total_processes'
# Unset SIDEKIQ_COUNT → defaults to the box's CPU count.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worker configuration now automatically scales based on CPU core count.
  * Environment variables (`WURK_COUNT`/`SIDEKIQ_COUNT`) can override default worker count, with support for fractional CPU multipliers.
  * Graceful error handling with automatic fallback to CPU detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->