### PR TITLE
feat(leader): honor SIDEKIQ_LEADER=false as alias for WURK_LEADER=false (#122)

### DIFF
--- a/lib/wurk/component.rb
+++ b/lib/wurk/component.rb
@@ -73,13 +73,14 @@ module Wurk
     # True iff this process currently holds the cluster `dear-leader` lock.
     # Per spec, the check is performed at call time (Wurk does not cache);
     # callers must not poll faster than the 60s follower cadence. Returns
-    # false unconditionally when `WURK_LEADER=false` is set on the process
-    # (opt-out hot-standby). Any Redis error is swallowed → false, so a
-    # transient partition can't propagate as an exception into user code.
+    # false unconditionally when `WURK_LEADER=false` (or `SIDEKIQ_LEADER=false`)
+    # is set on the process (opt-out hot-standby). Any Redis error is swallowed →
+    # false, so a transient partition can't propagate as an exception into user
+    # code.
     #
     # Spec: docs/target/sidekiq-ent.md §6.1.
     def leader?
-      return false if ENV[Wurk::Leader::OPT_OUT_ENV].to_s.downcase == 'false'
+      return false if Wurk::Leader.opted_out?
 
       redis { |c| c.call('GET', Wurk::Leader::DEFAULT_KEY) } == identity
     rescue StandardError

--- a/lib/wurk/leader.rb
+++ b/lib/wurk/leader.rb
@@ -20,7 +20,8 @@ module Wurk
   #
   # Cadence per spec: renew every 15s while leader, recheck every 60s as
   # follower, lock TTL 30s. Opt out a process from campaigning entirely
-  # with `WURK_LEADER=false` (useful for hot-standby pools).
+  # with `WURK_LEADER=false` (or its Sidekiq alias `SIDEKIQ_LEADER=false`),
+  # useful for hot-standby pools.
   #
   # Spec: docs/target/sidekiq-ent.md §6.
   class Leader
@@ -29,8 +30,16 @@ module Wurk
     DEFAULT_TTL = 30
     DEFAULT_RENEW_INTERVAL = 15
     DEFAULT_FOLLOWER_INTERVAL = 60
-    OPT_OUT_ENV = 'WURK_LEADER'
+    OPT_OUT_ENV = 'WURK_LEADER'            # native opt-out env
+    SIDEKIQ_OPT_OUT_ENV = 'SIDEKIQ_LEADER' # Sidekiq Ent drop-in alias (§6.2/§7.2)
     THREAD_NAME = 'wurk-leader'
+
+    # True when this process has opted out of campaigning via `WURK_LEADER=false`
+    # or its Sidekiq alias `SIDEKIQ_LEADER=false` (hot-standby pools that must
+    # never lead). Either env name works.
+    def self.opted_out?
+      [OPT_OUT_ENV, SIDEKIQ_OPT_OUT_ENV].any? { |k| ENV[k].to_s.downcase == 'false' }
+    end
 
     attr_reader :key, :ttl, :owner, :token, :config
 
@@ -53,11 +62,11 @@ module Wurk
       @sleeper = ::ConditionVariable.new
     end
 
-    # `WURK_LEADER=false` makes `acquire` a no-op and `leader?` permanently
-    # false; the renewal thread also refuses to start. Useful for hot-
-    # standby pools that must never campaign.
+    # `WURK_LEADER=false` (or `SIDEKIQ_LEADER=false`) makes `acquire` a no-op and
+    # `leader?` permanently false; the renewal thread also refuses to start.
+    # Useful for hot-standby pools that must never campaign.
     def disabled?
-      ENV[OPT_OUT_ENV].to_s.downcase == 'false'
+      self.class.opted_out?
     end
 
     # SET NX EX. If the key already holds *our* owner string (rare — same

--- a/test/unit/component_test.rb
+++ b/test/unit/component_test.rb
@@ -76,6 +76,30 @@ class ComponentTest < Wurk::Test::UnitCase
     assert_match(/\A[0-9a-f]{12}\z/, @host.process_nonce)
   end
 
+  # --- leader? opt-out (#122) ------------------------------------------
+
+  def test_leader_predicate_false_under_wurk_leader_opt_out
+    ENV_MUTEX.synchronize do
+      saved = ENV.fetch('WURK_LEADER', nil)
+      ENV['WURK_LEADER'] = 'false'
+
+      refute_predicate @host, :leader?
+    ensure
+      saved.nil? ? ENV.delete('WURK_LEADER') : ENV['WURK_LEADER'] = saved
+    end
+  end
+
+  def test_leader_predicate_false_under_sidekiq_leader_opt_out
+    ENV_MUTEX.synchronize do
+      saved = ENV.fetch('SIDEKIQ_LEADER', nil)
+      ENV['SIDEKIQ_LEADER'] = 'false'
+
+      refute_predicate @host, :leader?
+    ensure
+      saved.nil? ? ENV.delete('SIDEKIQ_LEADER') : ENV['SIDEKIQ_LEADER'] = saved
+    end
+  end
+
   def test_process_nonce_stable_within_process
     assert_equal @host.process_nonce, @host.process_nonce
   end

--- a/test/unit/leader_test.rb
+++ b/test/unit/leader_test.rb
@@ -239,6 +239,45 @@ class LeaderTest < Wurk::Test::UnitCase
     end
   end
 
+  # ---- Opt-out via the SIDEKIQ_LEADER alias (#122) ----------------------
+
+  def test_sidekiq_leader_false_disables_acquire
+    with_env('SIDEKIQ_LEADER', 'false') do
+      ldr = build_leader
+
+      refute ldr.acquire
+      assert_predicate ldr, :disabled?
+    end
+  end
+
+  def test_sidekiq_leader_false_skips_redis_write
+    with_env('SIDEKIQ_LEADER', 'false') do
+      build_leader.acquire
+
+      assert_nil(Wurk.redis { |c| c.call('GET', @key) })
+    end
+  end
+
+  def test_sidekiq_leader_false_blocks_start
+    with_env('SIDEKIQ_LEADER', 'false') do
+      ldr = build_leader
+
+      assert_nil ldr.start
+      refute_predicate ldr, :running?
+    end
+  end
+
+  def test_sidekiq_leader_true_does_not_disable
+    with_env('SIDEKIQ_LEADER', 'true') do
+      refute_predicate build_leader, :disabled?
+    end
+  end
+
+  def test_opted_out_class_method_honors_either_env
+    with_env('WURK_LEADER', 'false') { assert_predicate Wurk::Leader, :opted_out? }
+    with_env('SIDEKIQ_LEADER', 'false') { assert_predicate Wurk::Leader, :opted_out? }
+  end
+
   # ---- :leader lifecycle event -----------------------------------------
 
   def test_leader_event_fires_once_on_gain


### PR DESCRIPTION
Closes #122.

Sidekiq Enterprise §6.2/§7.2 documents `SIDEKIQ_LEADER=false` to make a process ineligible to campaign for leader (hot-standby pools). Wurk only recognized `WURK_LEADER`, so a drop-in user setting `SIDEKIQ_LEADER=false` would still campaign and could win leadership — violating the standby invariant.

## What changed
- Centralized the opt-out in `Wurk::Leader.opted_out?`, which accepts **`WURK_LEADER`** (native) or **`SIDEKIQ_LEADER`** (drop-in alias), case-insensitive `== 'false'`.
- `Leader#disabled?` and `Component#leader?` both delegate to it. So under either env name: `acquire` is a no-op, the renewal thread refuses to start, and `leader?` is unconditionally false.

Wire-compat unchanged; the `OPT_OUT_ENV` constant is retained.

## Acceptance criteria (#122)
- [x] With `SIDEKIQ_LEADER=false`: `Leader#acquire` is a no-op, `Leader#start` refuses to start, `Component#leader?` returns false unconditionally
- [x] `WURK_LEADER=false` continues to work
- [x] Unit tests cover both env names (`leader_test.rb` + `component_test.rb`)

## Verification
- `bin/rake test` — 2085 runs, 0 failures (ran **3× clean**)
- New tests: 5 in `leader_test.rb` (SIDEKIQ_LEADER disables acquire / skips Redis write / blocks start / `=true` doesn't disable / `opted_out?` honors either env) + 2 in `component_test.rb` (`leader?` false under each env name)
- End-to-end (real lib): unset→eligible; `WURK_LEADER=false`, `SIDEKIQ_LEADER=false`, and `SIDEKIQ_LEADER=FALSE` → opted out + `acquire=false`; `SIDEKIQ_LEADER=true` → not opted out

## How to test in prod
```bash
# Hot-standby worker that must never lead (cron/periodic stays idle here):
SIDEKIQ_LEADER=false bundle exec wurk
# Confirm from a console on that process:
bundle exec rails runner 'puts Wurk::Leader.opted_out?'   # => true
# The native name still works identically:
WURK_LEADER=false bundle exec wurk
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for the `SIDEKIQ_LEADER` environment variable as an alternative mechanism to `WURK_LEADER` for disabling leader functionality. Both variables support case-insensitive `false` values for opt-out.

* **Tests**
  * Added comprehensive unit test coverage for leader opt-out functionality with both `WURK_LEADER` and `SIDEKIQ_LEADER` environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->