### PR TITLE
feat(swarm): honor SIDEKIQ_PRELOAD / SIDEKIQ_PRELOAD_APP in swarm parent (#172)

### DIFF
--- a/lib/wurk/cli.rb
+++ b/lib/wurk/cli.rb
@@ -113,10 +113,16 @@ module Wurk
     # SIGUSR1, memory-based recycling). The parent itself never fetches.
     #
     # This is the only way to get fork-based parallelism without Rails — the
-    # railtie auto-boot path is Rails-only. Boots `Process.warmup` before the
-    # fork so children share warmed pages (copy-on-write). Spec §7.
+    # railtie auto-boot path is Rails-only. Honors the swarm preload knobs
+    # (`WURK_PRELOAD`/`SIDEKIQ_PRELOAD` Bundler groups, `WURK_PRELOAD_APP`/
+    # `SIDEKIQ_PRELOAD_APP` whole-app eager-load) and boots `Process.warmup`
+    # before the fork so children share warmed pages (copy-on-write). Spec §7.
     def run_swarm(boot_app: true, warmup: true)
-      boot_application if boot_app
+      if boot_app
+        preload_bundler_groups
+        boot_application
+        eager_load_application
+      end
       validate_redis!
       validate_pool_sizes!
       @config[:identity] = identity
@@ -318,6 +324,51 @@ module Wurk
     end
 
     # --- application bootstrap --------------------------------------------
+
+    # Spec §7.2/§7.3. Before the swarm parent forks, `Bundler.require` the
+    # configured groups so their gems are resident in the parent and paged
+    # copy-on-write into every child. Comma-separated group list; the native
+    # `WURK_PRELOAD` wins over the `SIDEKIQ_PRELOAD` drop-in alias. Defaults to
+    # the `default` group; an explicit empty value (`WURK_PRELOAD=`) disables
+    # the preload. Runs before `boot_application` so groups load before the app.
+    def preload_bundler_groups
+      return unless defined?(::Bundler)
+
+      groups = preload_groups
+      ::Bundler.require(*groups) unless groups.empty?
+    end
+
+    def preload_groups
+      raw = ENV['WURK_PRELOAD'] || ENV['SIDEKIQ_PRELOAD'] || 'default'
+      raw.split(',').map(&:strip).reject(&:empty?).map(&:to_sym)
+    end
+
+    # Spec §7.2. `WURK_PRELOAD_APP=1` (alias `SIDEKIQ_PRELOAD_APP=1`) eager-loads
+    # the whole Rails app in the parent before forking, so the entire object
+    # space — not just the constants autoload happened to touch — is shared
+    # copy-on-write, trading parent boot time for child RSS savings (~20–30%).
+    #
+    # Intentional divergence from Sidekiq's default-0: wurk's swarm forks
+    # children from a preloaded parent — they inherit the app rather than
+    # re-requiring it — so the app entrypoint (`-r`) is always loaded in the
+    # parent regardless of this flag. PRELOAD_APP only toggles the extra Rails
+    # eager-load; for a non-Rails `-r` file there is nothing further to load.
+    def eager_load_application
+      return unless preload_app?
+
+      app = rails_application
+      app.eager_load! if app.respond_to?(:eager_load!)
+    end
+
+    def rails_application
+      return unless defined?(::Rails) && ::Rails.respond_to?(:application)
+
+      ::Rails.application
+    end
+
+    def preload_app?
+      (ENV['WURK_PRELOAD_APP'] || ENV.fetch('SIDEKIQ_PRELOAD_APP', nil)) == '1'
+    end
 
     # Standalone mode must NOT load wurk/rails — even when pointed at a Rails
     # app, that's the host's call to wire the railtie. The CLI only `require`s

--- a/test/integration/swarm_cli_test.rb
+++ b/test/integration/swarm_cli_test.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative '../test_helper'
+require 'tmpdir'
+require 'fileutils'
 
 # Top-level so the constant resolves in the forked swarm child.
 class SwarmCliSentinelWorker
@@ -33,11 +35,12 @@ class SwarmCliTest < Wurk::Test::UnitCase
     @queue_name = "#{@ns}-q"
     @sentinel_key = "#{@ns}-sentinel"
     @startup_key = "#{@ns}-startup"
+    @preload_key = "#{@ns}-preload"
     @observer = RedisClient.config(url: Wurk::Test.redis_url).new_client
   end
 
   def teardown
-    @observer&.call('DEL', @sentinel_key, @startup_key, "queue:#{@queue_name}")
+    @observer&.call('DEL', @sentinel_key, @startup_key, @preload_key, "queue:#{@queue_name}")
     @observer&.close
   ensure
     super
@@ -90,7 +93,65 @@ class SwarmCliTest < Wurk::Test::UnitCase
     end
   end
 
+  # Real fork: the swarm PARENT must Bundler.require the SIDEKIQ_PRELOAD groups
+  # before forking children (Ent §7.2). Boot run_swarm with boot_app:true so the
+  # preload path runs; observe — via a Bundler.require shim that records the
+  # groups to Redis instead of loading gems — that the configured groups were
+  # required in the parent, and that it still forks a child that runs the job.
+  def test_run_swarm_parent_honors_sidekiq_preload_before_forking
+    require_file = ::File.join(::Dir.tmpdir, "#{@ns}-app.rb")
+    ::File.write(require_file, "# swarm preload boot sentinel\n")
+    push_sentinel_job
+    parent_pid = fork_swarm_parent(require_file)
+
+    begin
+      groups = wait_for_key(@preload_key)
+
+      assert groups, "swarm parent never ran the SIDEKIQ_PRELOAD require within #{POLL_TIMEOUT}s"
+      assert_equal 'default,assets', groups,
+                   'swarm parent should Bundler.require the configured preload groups before fork'
+      assert wait_for_key(@sentinel_key), 'swarm child never ran the job after preload'
+    ensure
+      stop(parent_pid)
+      ::FileUtils.rm_f(require_file)
+    end
+  end
+
   private
+
+  # Forks the real CLI#run_swarm with boot_app:true and SIDEKIQ_PRELOAD set. The
+  # Bundler.require shim is installed inside the child only (the parent test
+  # process is untouched by fork) and records the requested groups to Redis.
+  def fork_swarm_parent(require_file)
+    ::Process.fork do
+      $stdout.reopen(IO::NULL)
+      $stderr.reopen(IO::NULL)
+      ENV['SIDEKIQ_PRELOAD'] = 'default,assets'
+      record_bundler_groups_to_redis(@preload_key)
+      boot_swarm_child(require_file)
+    end
+  end
+
+  def record_bundler_groups_to_redis(preload_key)
+    redis_url = Wurk::Test.redis_url
+    ::Bundler.define_singleton_method(:require) do |*groups|
+      c = RedisClient.config(url: redis_url).new_client
+      c.call('SET', preload_key, groups.join(','))
+      c.call('EXPIRE', preload_key, 60)
+      c.close
+    end
+  end
+
+  def boot_swarm_child(require_file)
+    config = build_config
+    config[:require] = require_file
+    config.default_capsule.queues = [@queue_name]
+    config.topology = Wurk::Topology.flat(count: 1, queues: [@queue_name], concurrency: 1)
+    cli = Wurk::CLI.instance
+    cli.instance_variable_set(:@config, config)
+    cli.run_swarm(boot_app: true, warmup: false)
+    exit 0
+  end
 
   def push_sentinel_job
     config = build_config

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -513,6 +513,153 @@ class CLITest < Wurk::Test::UnitCase
     end
   end
 
+  # --- swarm preload knobs (Ent §7.2) ---------------------------------
+
+  def test_preload_groups_defaults_to_default_group
+    with_env('WURK_PRELOAD' => nil, 'SIDEKIQ_PRELOAD' => nil) do
+      assert_equal [:default], @cli.send(:preload_groups)
+    end
+  end
+
+  def test_preload_groups_parses_comma_list_and_strips_blanks
+    with_env('WURK_PRELOAD' => ' default , assets ,', 'SIDEKIQ_PRELOAD' => nil) do
+      assert_equal %i[default assets], @cli.send(:preload_groups)
+    end
+  end
+
+  def test_preload_groups_native_env_wins_over_sidekiq_alias
+    with_env('WURK_PRELOAD' => 'web', 'SIDEKIQ_PRELOAD' => 'worker') do
+      assert_equal [:web], @cli.send(:preload_groups)
+    end
+  end
+
+  def test_preload_groups_falls_back_to_sidekiq_alias
+    with_env('WURK_PRELOAD' => nil, 'SIDEKIQ_PRELOAD' => 'worker') do
+      assert_equal [:worker], @cli.send(:preload_groups)
+    end
+  end
+
+  def test_preload_groups_empty_value_disables
+    with_env('WURK_PRELOAD' => '', 'SIDEKIQ_PRELOAD' => nil) do
+      assert_empty @cli.send(:preload_groups)
+    end
+  end
+
+  def test_preload_bundler_groups_requires_configured_groups
+    with_env('WURK_PRELOAD' => 'default,assets', 'SIDEKIQ_PRELOAD' => nil) do
+      with_stub_bundler_require do |calls|
+        @cli.send(:preload_bundler_groups)
+
+        assert_equal [%i[default assets]], calls
+      end
+    end
+  end
+
+  def test_preload_bundler_groups_empty_value_skips_require
+    with_env('WURK_PRELOAD' => '', 'SIDEKIQ_PRELOAD' => nil) do
+      with_stub_bundler_require do |calls|
+        @cli.send(:preload_bundler_groups)
+
+        assert_empty calls
+      end
+    end
+  end
+
+  def test_preload_app_true_for_native_or_alias
+    with_env('WURK_PRELOAD_APP' => '1', 'SIDEKIQ_PRELOAD_APP' => nil) do
+      assert @cli.send(:preload_app?)
+    end
+    with_env('WURK_PRELOAD_APP' => nil, 'SIDEKIQ_PRELOAD_APP' => '1') do
+      assert @cli.send(:preload_app?)
+    end
+  end
+
+  def test_preload_app_native_zero_overrides_alias_and_default_false
+    with_env('WURK_PRELOAD_APP' => '0', 'SIDEKIQ_PRELOAD_APP' => '1') do
+      refute @cli.send(:preload_app?), 'native WURK_PRELOAD_APP=0 must override the alias'
+    end
+    with_env('WURK_PRELOAD_APP' => nil, 'SIDEKIQ_PRELOAD_APP' => nil) do
+      refute @cli.send(:preload_app?)
+    end
+  end
+
+  def test_eager_load_application_eager_loads_when_enabled
+    loaded = []
+    fake_app = Object.new
+    fake_app.define_singleton_method(:eager_load!) { loaded << :loaded }
+    with_env('WURK_PRELOAD_APP' => '1', 'SIDEKIQ_PRELOAD_APP' => nil) do
+      @cli.define_singleton_method(:rails_application) { fake_app }
+      @cli.send(:eager_load_application)
+    end
+
+    assert_equal [:loaded], loaded
+  end
+
+  def test_eager_load_application_noop_when_disabled
+    loaded = []
+    fake_app = Object.new
+    fake_app.define_singleton_method(:eager_load!) { loaded << :loaded }
+    with_env('WURK_PRELOAD_APP' => nil, 'SIDEKIQ_PRELOAD_APP' => nil) do
+      @cli.define_singleton_method(:rails_application) { fake_app }
+      @cli.send(:eager_load_application)
+    end
+
+    assert_empty loaded
+  end
+
+  def test_eager_load_application_noop_without_rails_application
+    with_env('WURK_PRELOAD_APP' => '1', 'SIDEKIQ_PRELOAD_APP' => nil) do
+      @cli.define_singleton_method(:rails_application) { nil }
+
+      assert_nil @cli.send(:eager_load_application)
+    end
+  end
+
+  # rails_application reflects whether Rails is loaded in this worker; assert the
+  # branch that matches the current process rather than forcing a global ::Rails.
+  def test_rails_application_reflects_rails_presence
+    result = @cli.send(:rails_application)
+    if defined?(::Rails) && ::Rails.respond_to?(:application)
+      assert_equal ::Rails.application, result
+    else
+      assert_nil result
+    end
+  end
+
+  def test_run_swarm_preloads_then_boots_then_eager_loads
+    order = []
+    @cli.define_singleton_method(:preload_bundler_groups) { order << :preload }
+    @cli.define_singleton_method(:boot_application) { order << :boot }
+    @cli.define_singleton_method(:eager_load_application) { order << :eager }
+    @cli.define_singleton_method(:validate_redis!) { nil }
+    @cli.define_singleton_method(:validate_pool_sizes!) { nil }
+    @cli.define_singleton_method(:identity) { 'host:1:abc' }
+    fake_swarm = Object.new
+    fake_swarm.define_singleton_method(:boot) { |**| nil }
+    fake_swarm.define_singleton_method(:supervise) { order << :supervise }
+
+    with_stub_swarm(fake_swarm) { @cli.run_swarm(boot_app: true, warmup: false) }
+
+    assert_equal %i[preload boot eager supervise], order
+  end
+
+  def test_run_swarm_skips_boot_steps_when_boot_app_false
+    called = []
+    %i[preload_bundler_groups boot_application eager_load_application].each do |m|
+      @cli.define_singleton_method(m) { called << m }
+    end
+    @cli.define_singleton_method(:validate_redis!) { nil }
+    @cli.define_singleton_method(:validate_pool_sizes!) { nil }
+    @cli.define_singleton_method(:identity) { 'host:1:abc' }
+    fake_swarm = Object.new
+    fake_swarm.define_singleton_method(:boot) { |**| nil }
+    fake_swarm.define_singleton_method(:supervise) { nil }
+
+    with_stub_swarm(fake_swarm) { @cli.run_swarm(boot_app: false, warmup: false) }
+
+    assert_empty called
+  end
+
   private
 
   # `validate!` requires `:require` to point at a real file (or a Rails dir
@@ -555,5 +702,33 @@ class CLITest < Wurk::Test::UnitCase
     yield
   ensure
     Wurk::Launcher.define_singleton_method(:new, original)
+  end
+
+  def with_stub_swarm(fake)
+    original = Wurk::Swarm.method(:new)
+    Wurk::Swarm.define_singleton_method(:new) { |*, **| fake }
+    yield
+  ensure
+    Wurk::Swarm.define_singleton_method(:new, original)
+  end
+
+  # Capture the groups passed to Bundler.require without actually loading gems.
+  def with_stub_bundler_require
+    calls = []
+    original = ::Bundler.method(:require)
+    ::Bundler.define_singleton_method(:require) { |*groups| calls << groups }
+    yield calls
+  ensure
+    ::Bundler.define_singleton_method(:require, original)
+  end
+
+  # Set the given ENV vars (nil = unset) for the block, then restore the prior
+  # values. Mirrors the per-test save/restore the rest of this suite uses.
+  def with_env(vars)
+    prev = vars.keys.to_h { |k| [k, ENV.fetch(k, nil)] }
+    vars.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
+    yield
+  ensure
+    prev.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
   end
 end


### PR DESCRIPTION
Closes #172.

Spec §7.2/§7.3: the standalone `sidekiqswarm` parent should preload Bundler groups (and optionally the whole app) before forking children for copy-on-write RSS savings. Neither knob was wired (`grep PRELOAD lib/ exe/` was empty).

## Acceptance
> The standalone swarm parent honors `SIDEKIQ_PRELOAD` (groups) and `SIDEKIQ_PRELOAD_APP` (full app) before forking children.

- [x] **`SIDEKIQ_PRELOAD`** (+ native `WURK_PRELOAD`) — the swarm parent `Bundler.require`s the configured comma-separated groups before booting the app, so the gems are resident in the parent and paged copy-on-write into children. Default `default`; an explicit empty value (`SIDEKIQ_PRELOAD=`) disables it.
- [x] **`SIDEKIQ_PRELOAD_APP=1`** (+ native `WURK_PRELOAD_APP`) — eager-loads the whole Rails app in the parent so the full object space (not just autoloaded constants) is shared CoW.
- [x] Order matches the spec: `Bundler.require` → require app → eager-load → fork.
- [x] Native `WURK_*` wins over the `SIDEKIQ_*` alias (mirrors `WURK_COUNT`/`SIDEKIQ_COUNT` and the #122 leader alias). Swarm-only (`run_swarm`); single-process `wurk` is untouched, matching Sidekiq.

## Intentional divergence (documented in code)
wurk's swarm forks children from a **preloaded** parent — `ChildBoot` inherits the app rather than re-`require`ing it — so the app entrypoint (`-r`) is always loaded in the parent regardless of `PRELOAD_APP`. The flag therefore only toggles the extra Rails eager-load; it can't make wurk *not* load the app in the parent (that's architectural, and it's the CoW-optimal mode). The issue explicitly flagged this as an acceptable documented-divergence.

## Verification
- Full suite **2101 runs, 0 failures**; parity **20, 0**; ecosystem **all passed**. Coverage **96.37% line / 91.67% branch** (≥90 gate). RuboCop clean.
- **Unit** (`test/unit/cli_test.rb`): 14 tests — group parsing, alias precedence, empty-disables, eager-load on/off, boot ordering.
- **Integration** (`test/integration/swarm_cli_test.rb`): real fork — boots `run_swarm` in a subprocess with `SIDEKIQ_PRELOAD=default,assets` and asserts the parent `Bundler.require`d `[:default, :assets]` **before** forking a child that then runs a real job.

## How to test in prod
On a host running the standalone swarm (`bundle exec sidekiqswarm` / `wurkswarm`):

1. **Preload extra Bundler groups in the parent** — set `SIDEKIQ_PRELOAD=default,assets` (comma-separated, your Gemfile's groups) and boot the swarm. The parent loads those groups once; children share them copy-on-write. Confirm lower aggregate RSS vs. per-child loading (e.g. `ps -o rss= -p <child pids>`).
2. **Disable preload** — set `SIDEKIQ_PRELOAD=` (empty) to skip the Bundler group preload.
3. **Whole-app eager-load** — set `SIDEKIQ_PRELOAD_APP=1` to eager-load the full Rails app in the parent before fork (maximizes CoW sharing). Native `WURK_PRELOAD` / `WURK_PRELOAD_APP` work identically and take precedence over the `SIDEKIQ_*` names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved application startup performance through enhanced preloading and copy-on-write memory optimization
  * Added optional Rails eager-loading support during application initialization
  * New environment variables for controlling preload and eager-load behavior

* **Tests**
  * Comprehensive test coverage added for initialization, preloading, and eager-loading functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->