### PR TITLE
feat(web): custom dashboard tabs via Web::Config#register_extension (#104)

### DIFF
--- a/app/controllers/wurk/api/serializers.rb
+++ b/app/controllers/wurk/api/serializers.rb
@@ -34,8 +34,13 @@ module Wurk
         { name: summary.name, size: summary.size, latency: summary.latency, paused: summary.paused? }
       end
 
+      # Host-registered custom job-info rows (spec §25.2) ride along as
+      # `custom_rows` for the SPA's job-detail modal (see Config#job_info_pairs,
+      # which gates on registration so the common no-extension case is free).
+      # Divergence: wurk evaluates these during job-list serialization — the SPA
+      # renders job detail client-side — not in a dedicated server detail view.
       def job_record(record)
-        {
+        base = {
           jid: record.jid,
           klass: record.display_class,
           args: record.display_args,
@@ -43,6 +48,8 @@ module Wurk
           enqueued_at: record.enqueued_at&.to_f,
           created_at: record.created_at&.to_f
         }
+        rows = ::Wurk::Web.config.job_info_pairs(record)
+        rows.empty? ? base : base.merge(custom_rows: rows)
       end
 
       def sorted_entry(entry)

--- a/app/controllers/wurk/api_controller.rb
+++ b/app/controllers/wurk/api_controller.rb
@@ -43,7 +43,11 @@ module Wurk
     # reachable while read-only mode blocks mutations.
     def meta
       config = ::Wurk::Web.config
-      render json: { read_only: config.read_only?, read_only_message: config.read_only_message }
+      render json: {
+        read_only: config.read_only?,
+        read_only_message: config.read_only_message,
+        custom_tabs: config.custom_tabs
+      }
     end
 
     def stats

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -129,3 +129,46 @@ destructive actions. Equivalent in Ruby:
 ```ruby
 Wurk::Web.configure { |c| c.read_only = true }
 ```
+
+## Custom tabs / Web extensions
+
+Third-party gems (sidekiq-cron, sidekiq-unique-jobs, sidekiq-status, …) add
+their own dashboard tabs through `Sidekiq::Web::Config#register_extension` (alias
+`register`). Wurk implements that surface under the `Sidekiq::Web` /
+`Wurk::Web` alias, so requiring those gems works unchanged:
+
+```ruby
+# Both styles work — class-level, or inside a configure block:
+Sidekiq::Web.register(MyGem::Web, name: "Locks", tab: "locks")
+
+Sidekiq::Web.configure do |c|
+  c.register_extension(MyGem::Web, name: "Locks", tab: "locks")
+  c.tabs["Expiry"] = "expiry"          # the tabs hash is directly mutable
+  c.custom_job_info_rows << MyGem::Row # collected for job-detail rows
+  c.app_url = "https://myapp.example"
+end
+```
+
+A registered tab whose path isn't one wurk already renders natively surfaces in
+the left-nav (read from `GET /api/meta`). Clicking it opens an in-dashboard
+**Extension** page that embeds the extension's own path (`/<mount>/<tab>`) in an
+iframe. `custom_job_info_rows` render as extra rows in the job-detail modal.
+
+**Supported subset (important).** Wurk's dashboard is a **precompiled React
+SPA**, not Sidekiq's server-rendered ERB UI. So:
+
+- **Registration is accepted and no-op-safe** — requiring a gem that calls
+  `register`/`register_extension` (or mutates `tabs`) never crashes boot.
+- **Tabs surface in the nav** and open an Extension page that iframes the
+  extension's path. If the host mounts the gem's own Rack app reachable at that
+  path, its view renders in the frame; otherwise the frame shows a short
+  "not rendered here" note (no recursive dashboard nesting).
+- **`custom_job_info_rows` render** in the job-detail modal — each registered
+  callable (`call(job)`) or `add_pair(job)` object contributes a `label/value`
+  row.
+- **Sidekiq's ERB extension views are _not_ rendered natively.** Sidekiq
+  extensions ship ERB templates rendered by a Sinatra app; wurk has no such
+  render path, so the gem's own templates aren't compiled into the SPA bundle.
+
+Rendering Sidekiq's ERB extension views natively in the dashboard is tracked as
+a follow-up (#187).

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -137,21 +137,25 @@ their own dashboard tabs through `Sidekiq::Web::Config#register_extension` (alia
 `register`). Wurk implements that surface under the `Sidekiq::Web` /
 `Wurk::Web` alias, so requiring those gems works unchanged:
 
+`register_extension(extclass, name:, tab:, index:, …)` mirrors Sidekiq: `tab` is
+the label, `index` the path, `name` the asset namespace (`tab`/`index` may be
+arrays, zipped). Both call styles work — class-level, or inside a configure
+block:
+
 ```ruby
-# Both styles work — class-level, or inside a configure block:
-Sidekiq::Web.register(MyGem::Web, name: "Locks", tab: "locks")
+Sidekiq::Web.register(MyGem::Web, name: "unique_jobs", tab: "Locks", index: "locks")
 
 Sidekiq::Web.configure do |c|
-  c.register_extension(MyGem::Web, name: "Locks", tab: "locks")
-  c.tabs["Expiry"] = "expiry"          # the tabs hash is directly mutable
+  c.register_extension(MyGem::Web, name: "unique_jobs", tab: "Locks", index: "locks")
+  c.tabs["Expiry"] = "expiry"          # the tabs hash (label => path) is directly mutable
   c.custom_job_info_rows << MyGem::Row # collected for job-detail rows
   c.app_url = "https://myapp.example"
 end
 ```
 
-A registered tab whose path isn't one wurk already renders natively surfaces in
+A registered tab whose path isn't one Wurk already renders natively surfaces in
 the left-nav (read from `GET /api/meta`). Clicking it opens an in-dashboard
-**Extension** page that embeds the extension's own path (`/<mount>/<tab>`) in an
+**Extension** page that embeds the extension's own path (`/<mount>/<index>`) in an
 iframe. `custom_job_info_rows` render as extra rows in the job-detail modal.
 
 **Supported subset (important).** Wurk's dashboard is a **precompiled React

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import Cron from './pages/Cron';
 import Metrics from './pages/Metrics';
 import Profiles from './pages/Profiles';
 import Search from './pages/Search';
+import Extension from './pages/Extension';
 
 const qc = new QueryClient({
   defaultOptions: {
@@ -88,6 +89,7 @@ export default function App() {
               <Route path="/metrics" element={<Metrics />} />
               <Route path="/profiles" element={<Profiles />} />
               <Route path="/search" element={<Search />} />
+              <Route path="/ext/:tab" element={<Extension />} />
             </Routes>
           </main>
 

--- a/frontend/src/components/JobDetailModal.tsx
+++ b/frontend/src/components/JobDetailModal.tsx
@@ -117,8 +117,8 @@ export default function JobDetailModal({ entry, atLabel, actions, onAction, pend
 
           {entry.custom_rows && entry.custom_rows.length > 0 && (
             <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: '0.9rem' }}>
-              {entry.custom_rows.map(([label, value]) => (
-                <Field key={label} label={label}>{value}</Field>
+              {entry.custom_rows.map(([label, value], idx) => (
+                <Field key={`${label}-${idx}`} label={label}>{value}</Field>
               ))}
             </div>
           )}

--- a/frontend/src/components/JobDetailModal.tsx
+++ b/frontend/src/components/JobDetailModal.tsx
@@ -19,6 +19,9 @@ export interface JobEntry {
   error_class?: string;
   error_message?: string;
   error_backtrace?: string[] | null;
+  // [label, value] rows contributed by third-party extensions via
+  // Sidekiq::Web.custom_job_info_rows (spec §25.2).
+  custom_rows?: [string, string][];
 }
 
 function Field({ label, children, mono }: { label: string; children: ReactNode; mono?: boolean }) {
@@ -110,6 +113,14 @@ export default function JobDetailModal({ entry, atLabel, actions, onAction, pend
             <Field label={t('job.backtrace')}>
               <pre className="job-backtrace">{entry.error_backtrace.join('\n')}</pre>
             </Field>
+          )}
+
+          {entry.custom_rows && entry.custom_rows.length > 0 && (
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: '0.9rem' }}>
+              {entry.custom_rows.map(([label, value]) => (
+                <Field key={label} label={label}>{value}</Field>
+              ))}
+            </div>
           )}
         </div>
       )}

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -1,5 +1,6 @@
 import { NavLink, Link } from 'react-router-dom';
 import { t } from '../i18n';
+import { useMeta } from '../hooks/useMeta';
 import logoUrl from '../assets/wurk-logo.png';
 
 interface NavProps {
@@ -23,6 +24,12 @@ const LINKS = [
 ];
 
 export default function Nav({ open, onClose }: NavProps) {
+  // Tabs registered by third-party gems (sidekiq-cron, sidekiq-unique-jobs, …)
+  // via Sidekiq::Web.register_extension. They link out to the extension's own
+  // path — wurk surfaces the tab but doesn't render the gem's view in the SPA.
+  const { data: meta } = useMeta();
+  const customTabs = meta?.custom_tabs ?? [];
+
   return (
     <>
       {/* Overlay for mobile */}
@@ -111,6 +118,44 @@ export default function Nav({ open, onClose }: NavProps) {
               >
                 <i className={`fa-solid ${icon}`} style={{ fontSize: 14, width: 20, textAlign: 'center' }} />
                 <span>{label}</span>
+              </NavLink>
+            </li>
+          ))}
+
+          {customTabs.length > 0 && (
+            <li aria-hidden="true" style={{ padding: '0.5rem 0.95rem 0.2rem', marginTop: '0.4rem' }}>
+              <div style={{ height: 1, background: 'var(--border)', marginBottom: '0.45rem' }} />
+              <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'var(--text-muted)' }}>
+                {t('nav.extensions')}
+              </span>
+            </li>
+          )}
+          {customTabs.map((tab) => (
+            <li key={tab.path}>
+              {/* In-SPA route: /ext/:tab renders an Extension page that embeds
+                  the extension's own path in an iframe. */}
+              <NavLink
+                to={`/ext/${tab.path}`}
+                onClick={onClose}
+                className="wurk-navlink"
+                style={({ isActive }) => ({
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.625rem',
+                  padding: '0.5rem 0.85rem',
+                  borderRadius: 8,
+                  margin: '2px 8px',
+                  color: isActive ? 'var(--accent)' : 'var(--text)',
+                  background: isActive ? 'var(--surface-strong)' : 'transparent',
+                  boxShadow: isActive ? 'inset 0 0 0 1px var(--border)' : 'none',
+                  fontWeight: isActive ? 600 : 400,
+                  fontSize: 14,
+                  textDecoration: 'none',
+                  transition: 'background 0.15s, color 0.15s, box-shadow 0.15s',
+                })}
+              >
+                <i className="fa-solid fa-puzzle-piece" style={{ fontSize: 14, width: 20, textAlign: 'center' }} />
+                <span>{tab.name}</span>
               </NavLink>
             </li>
           ))}

--- a/frontend/src/hooks/useMeta.ts
+++ b/frontend/src/hooks/useMeta.ts
@@ -1,9 +1,19 @@
 import { useQuery } from '@tanstack/react-query';
 
+// A dashboard tab registered by a third-party gem via
+// Sidekiq::Web.register_extension. wurk surfaces it in the nav as a link to its
+// path; the extension's own server-rendered view is not injected into the SPA.
+export interface CustomTab {
+  name: string;
+  path: string;
+}
+
 export interface Meta {
   read_only: boolean;
   // Optional host-supplied banner copy; null → SPA uses its localized default.
   read_only_message: string | null;
+  // Tabs registered by third-party extensions (empty/absent when none).
+  custom_tabs?: CustomTab[];
 }
 
 // Boot-time dashboard flags. Fetched once and cached forever — these only

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -11,7 +11,8 @@
     "cron": "Cron",
     "metrics": "Metrics",
     "profiles": "Profiles",
-    "search": "Search"
+    "search": "Search",
+    "extensions": "Extensions"
   },
   "dashboard": {
     "processed": "Processed",
@@ -85,6 +86,11 @@
     "emptyTitle": "Search for a job",
     "emptyHint": "Enter a JID or class name (2+ characters) and hit Search. Results span retries, scheduled, and dead jobs.",
     "try": "Try:"
+  },
+  "extension": {
+    "summary": "Provided by a third-party extension.",
+    "open": "Open",
+    "notRendered": "This tab is provided by a third-party extension. wurk surfaces it in the nav but doesn't render its view inside the dashboard."
   },
   "actions": {
     "retry": "Retry",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,19 +2,33 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './styles.css';
 import App from './App';
-import { dir, locale } from './i18n';
+import { dir, locale, t } from './i18n';
 
 // Set text direction + language from the detected locale before first paint so
 // the whole SPA (and its logical-property CSS) lays out RTL for ar/he/fa.
 document.documentElement.dir = dir;
 document.documentElement.lang = locale;
 
+// When this SPA is loaded inside the Extension page's embed iframe (see
+// pages/Extension.tsx), the host did NOT mount real content at the extension's
+// path — wurk's catch-all served the SPA instead. Paint a small stub rather
+// than recursively nesting the whole dashboard.
+const embedded =
+  window.self !== window.top &&
+  new URLSearchParams(window.location.search).has('wurk_ext_embed');
+
 const root = document.getElementById('wurk-root');
 if (root) {
   root.dir = dir;
   ReactDOM.createRoot(root).render(
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>
+    embedded ? (
+      <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-muted)', fontSize: 14, lineHeight: 1.6 }}>
+        {t('extension.notRendered')}
+      </div>
+    ) : (
+      <React.StrictMode>
+        <App />
+      </React.StrictMode>
+    )
   );
 }

--- a/frontend/src/pages/Extension.tsx
+++ b/frontend/src/pages/Extension.tsx
@@ -1,0 +1,41 @@
+import { useParams } from 'react-router-dom';
+import { PageHeader } from '../components/PageHeader';
+import { useMeta } from '../hooks/useMeta';
+import { t } from '../i18n';
+
+// Renders a third-party extension tab registered via
+// Sidekiq::Web.register_extension. wurk's dashboard is a precompiled React SPA
+// with no server-side ERB render path, so we embed the extension's own path in
+// an iframe (carrying ?wurk_ext_embed=1). If the host mounts the gem's Rack app
+// there it renders; otherwise the SPA itself answers that path and main.tsx —
+// seeing the embed flag inside an iframe — paints a small "not rendered" stub
+// instead of recursively nesting the whole dashboard.
+export default function Extension() {
+  const { tab = '' } = useParams();
+  const { data: meta } = useMeta();
+  const name = meta?.custom_tabs?.find((tab_) => tab_.path === tab)?.name ?? tab;
+  const src = `/wurk/${tab}?wurk_ext_embed=1`;
+
+  return (
+    <>
+      <PageHeader icon="fa-puzzle-piece" title={name} summary={t('extension.summary')}>
+        <a className="btn btn-sm" href={`/wurk/${tab}`} target="_blank" rel="noopener noreferrer">
+          <i className="fa-solid fa-arrow-up-right-from-square" style={{ marginInlineEnd: '0.4rem' }} />
+          {t('extension.open')}
+        </a>
+      </PageHeader>
+
+      <iframe
+        title={name}
+        src={src}
+        style={{
+          width: '100%',
+          height: 'calc(100vh - 11rem)',
+          border: '1px solid var(--border)',
+          borderRadius: 'var(--radius)',
+          background: 'var(--surface)',
+        }}
+      />
+    </>
+  );
+}

--- a/lib/wurk/web/config.rb
+++ b/lib/wurk/web/config.rb
@@ -33,6 +33,24 @@ module Wurk
       PROFILE_VIEW_URL  = 'https://profiler.firefox.com/public/%s'
       PROFILE_STORE_URL = 'https://api.profiler.firefox.com/compressed-store'
 
+      # Sidekiq's built-in dashboard tabs (spec §25.3). The `tabs` hash starts
+      # as a copy of this; extensions add to it via `register_extension` or by
+      # mutating `tabs` directly — the same surface third-party gems use.
+      DEFAULT_TABS = {
+        'Dashboard' => '', 'Busy' => 'busy', 'Queues' => 'queues',
+        'Retries' => 'retries', 'Scheduled' => 'scheduled', 'Dead' => 'morgue',
+        'Metrics' => 'metrics', 'Profiles' => 'profiles'
+      }.freeze
+
+      # Tab paths the SPA already renders natively (Sidekiq DEFAULT_TABS plus
+      # wurk's Pro/Ent extras). A gem re-registering one of these — e.g.
+      # sidekiq-cron's "cron" — must not produce a duplicate nav item, so
+      # `custom_tabs` filters them out.
+      NATIVE_TAB_PATHS = %w[
+        busy queues retries scheduled dead morgue metrics profiles
+        batches limiters cron search
+      ].freeze
+
       # Host-app Rack middleware stacked in front of the dashboard, newest
       # last. Each entry is `[middleware, args, block]`. Returns a frozen copy
       # so the memoized chain (`#rack_app`) can only be invalidated through
@@ -49,6 +67,7 @@ module Wurk
         @rack_app = nil
         @profile_view_url = nil
         @profile_store_url = nil
+        init_extensions!
       end
 
       # Firefox-profiler URLs, overridable; default to the public instance.
@@ -68,6 +87,55 @@ module Wurk
       def authorization(&block)
         @authorization = block if block
         @authorization
+      end
+
+      # Web-extension surface (spec §25.2). Third-party gems (sidekiq-cron,
+      # sidekiq-unique-jobs, sidekiq-status, …) register dashboard tabs at load
+      # time. `tabs` is a mutable name→path hash seeded from DEFAULT_TABS;
+      # `custom_job_info_rows` collects callables that add rows to the job
+      # detail view; `app_url` / `assets_path` mirror Sidekiq's accessors.
+      attr_reader :tabs, :extensions
+      attr_accessor :custom_job_info_rows, :app_url, :assets_path
+
+      # Matches Sidekiq::Web::Config#register_extension (aliased `register`).
+      # Records the tab so it surfaces in the SPA nav via /api/meta. It does
+      # NOT invoke the extension's server-side routes/views: wurk's dashboard
+      # is a precompiled React SPA with no Sinatra/ERB render path, so an ext's
+      # own view can't be injected (documented divergence — the registration is
+      # accepted no-op-safe so requiring the gem never crashes boot). Returns
+      # self so chained registrations read naturally.
+      # rubocop:disable Metrics/ParameterLists -- signature matches Sidekiq::Web::Config#register_extension (spec §25.2)
+      def register_extension(extension, name:, tab:, index: nil, root_dir: nil,
+                             cache_for: 86_400, asset_paths: nil)
+        @tabs[name] = tab
+        @extensions << {
+          extension: extension, name: name, tab: tab, index: index,
+          root_dir: root_dir, cache_for: cache_for, asset_paths: asset_paths
+        }
+        self
+      end
+      # rubocop:enable Metrics/ParameterLists
+      alias register register_extension
+
+      # Tabs the SPA should render in the nav: everything registered beyond the
+      # Sidekiq defaults and wurk's own native pages, as `{ name:, path: }`.
+      def custom_tabs
+        @tabs.filter_map do |name, path|
+          next if DEFAULT_TABS.key?(name) || NATIVE_TAB_PATHS.include?(path.to_s)
+
+          { name: name, path: path.to_s }
+        end
+      end
+
+      # Evaluate the registered `custom_job_info_rows` against a job (spec
+      # §25.2), returning `[[label, value], …]` for the SPA's job-detail modal.
+      # Each row is a callable (`call(job)`) or a Sidekiq-style `add_pair(job)`
+      # object; a row that raises or returns a non-pair is skipped so one bad
+      # extension can't break the job views.
+      def job_info_pairs(job)
+        return [] if @custom_job_info_rows.empty?
+
+        @custom_job_info_rows.filter_map { |row| job_info_pair(row, job) }
       end
 
       # Sidekiq-compatible (`Sidekiq::Web.use`). Registers a Rack middleware
@@ -115,6 +183,7 @@ module Wurk
         @rack_app = nil
         @profile_view_url = nil
         @profile_store_url = nil
+        init_extensions!
       end
 
       # Returns true when no block is registered, otherwise the block's
@@ -132,6 +201,29 @@ module Wurk
       def env_read_only?
         ENV['WURK_WEB_READ_ONLY'] == '1'
       end
+
+      def init_extensions!
+        @tabs = DEFAULT_TABS.dup
+        @extensions = []
+        @custom_job_info_rows = []
+        @app_url = nil
+        @assets_path = nil
+      end
+
+      def job_info_pair(row, job)
+        pair = job_info_row_value(row, job)
+        return unless pair.is_a?(::Array) && pair.size == 2
+
+        [pair[0].to_s, pair[1].to_s]
+      rescue ::StandardError
+        nil
+      end
+
+      def job_info_row_value(row, job)
+        return row.call(job) if row.respond_to?(:call)
+
+        row.add_pair(job) if row.respond_to?(:add_pair)
+      end
     end
 
     class << self
@@ -146,6 +238,38 @@ module Wurk
       # Class-level shorthand for `config.use` — mirrors `Sidekiq::Web.use`.
       def use(...)
         config.use(...)
+      end
+
+      # Class-level extension surface — gems call these straight off
+      # `Sidekiq::Web` (e.g. `Sidekiq::Web.register(Ext, name:, tab:)` or
+      # `Sidekiq::Web.tabs["Locks"] = "locks"`), not only inside `configure`.
+      def register(extension, **)
+        config.register_extension(extension, **)
+      end
+      alias register_extension register
+
+      def tabs
+        config.tabs
+      end
+
+      def custom_job_info_rows
+        config.custom_job_info_rows
+      end
+
+      def app_url
+        config.app_url
+      end
+
+      def app_url=(value)
+        config.app_url = value
+      end
+
+      def assets_path
+        config.assets_path
+      end
+
+      def assets_path=(value)
+        config.assets_path = value
       end
 
       # Test helper — exposed for parity with `Wurk::Limiter.reset_config!`.

--- a/lib/wurk/web/config.rb
+++ b/lib/wurk/web/config.rb
@@ -97,21 +97,24 @@ module Wurk
       attr_reader :tabs, :extensions
       attr_accessor :custom_job_info_rows, :app_url, :assets_path
 
-      # Matches Sidekiq::Web::Config#register_extension (aliased `register`).
-      # Records the tab so it surfaces in the SPA nav via /api/meta. It does
-      # NOT invoke the extension's server-side routes/views: wurk's dashboard
-      # is a precompiled React SPA with no Sinatra/ERB render path, so an ext's
-      # own view can't be injected (documented divergence — the registration is
-      # accepted no-op-safe so requiring the gem never crashes boot). Returns
-      # self so chained registrations read naturally.
+      # Matches Sidekiq::Web::Config#register_extension (aliased `register`,
+      # spec §25.2): `tab` is the label(s), `index` the path(s), `name` the
+      # asset namespace. `tab`/`index` are zipped into the `tabs` hash
+      # (label => path), so the tab surfaces in the SPA nav via /api/meta. It
+      # does NOT invoke the extension's server-side routes/views: wurk's
+      # dashboard is a precompiled React SPA with no Sinatra/ERB render path, so
+      # an ext's own view can't be injected (documented divergence — registration
+      # is accepted no-op-safe so requiring the gem never crashes boot). Yields
+      # self to an optional block for further config, and returns self.
       # rubocop:disable Metrics/ParameterLists -- signature matches Sidekiq::Web::Config#register_extension (spec §25.2)
-      def register_extension(extension, name:, tab:, index: nil, root_dir: nil,
+      def register_extension(extension, name:, tab:, index:, root_dir: nil,
                              cache_for: 86_400, asset_paths: nil)
-        @tabs[name] = tab
+        Array(tab).zip(Array(index)).each { |label, path| @tabs[label] = path if label }
         @extensions << {
           extension: extension, name: name, tab: tab, index: index,
           root_dir: root_dir, cache_for: cache_for, asset_paths: asset_paths
         }
+        yield self if block_given?
         self
       end
       # rubocop:enable Metrics/ParameterLists
@@ -243,8 +246,8 @@ module Wurk
       # Class-level extension surface — gems call these straight off
       # `Sidekiq::Web` (e.g. `Sidekiq::Web.register(Ext, name:, tab:)` or
       # `Sidekiq::Web.tabs["Locks"] = "locks"`), not only inside `configure`.
-      def register(extension, **)
-        config.register_extension(extension, **)
+      def register(extension, **, &)
+        config.register_extension(extension, **, &)
       end
       alias register_extension register
 

--- a/test/engine/web_authorization_test.rb
+++ b/test/engine/web_authorization_test.rb
@@ -117,4 +117,23 @@ class WebAuthorizationTest < Wurk::Test::EngineCase
     assert_equal 'This is a public demo — actions are disabled.',
                  JSON.parse(last_response.body)['read_only_message']
   end
+
+  def test_meta_custom_tabs_empty_by_default
+    get '/wurk/api/meta'
+
+    assert_equal [], JSON.parse(last_response.body)['custom_tabs']
+  end
+
+  # A third-party extension registering a tab surfaces it in /api/meta, which
+  # the SPA nav reads (spec §25.2). The registration is no-op-safe — requiring
+  # the gem doesn't crash boot even though wurk can't render its view.
+  def test_meta_exposes_registered_custom_tabs
+    Wurk::Web.configure { |c| c.register_extension(Object, name: 'Locks', tab: 'locks') }
+
+    get '/wurk/api/meta'
+
+    assert_equal 200, last_response.status
+    assert_includes JSON.parse(last_response.body)['custom_tabs'],
+                    { 'name' => 'Locks', 'path' => 'locks' }
+  end
 end

--- a/test/engine/web_authorization_test.rb
+++ b/test/engine/web_authorization_test.rb
@@ -128,7 +128,7 @@ class WebAuthorizationTest < Wurk::Test::EngineCase
   # the SPA nav reads (spec §25.2). The registration is no-op-safe — requiring
   # the gem doesn't crash boot even though wurk can't render its view.
   def test_meta_exposes_registered_custom_tabs
-    Wurk::Web.configure { |c| c.register_extension(Object, name: 'Locks', tab: 'locks') }
+    Wurk::Web.configure { |c| c.register_extension(Object, name: 'locks', tab: 'Locks', index: 'locks') }
 
     get '/wurk/api/meta'
 

--- a/test/unit/api_serializers_test.rb
+++ b/test/unit/api_serializers_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require_relative '../../app/controllers/wurk/api/serializers'
+
+# Custom job-info rows (spec §25.2) flow from the host-registered
+# Wurk::Web.config.custom_job_info_rows into the job-record JSON the SPA renders
+# in its detail modal. Mutates the global Wurk::Web.config singleton, so this
+# class is intentionally not parallelized.
+class ApiSerializersTest < Wurk::Test::UnitCase
+  def setup
+    super
+    Wurk::Web.reset_config!
+  end
+
+  def teardown
+    Wurk::Web.reset_config!
+    super
+  end
+
+  def test_job_record_omits_custom_rows_when_none_registered
+    refute_includes Wurk::Api::Serializers.job_record(record).keys, :custom_rows
+  end
+
+  def test_job_record_includes_rows_from_callable_extensions
+    Wurk::Web.config.custom_job_info_rows << ->(job) { ['Status', "queued:#{job.jid}"] }
+
+    out = Wurk::Api::Serializers.job_record(record)
+
+    assert_equal [['Status', 'queued:abc']], out[:custom_rows]
+  end
+
+  def test_job_record_supports_sidekiq_add_pair_rows
+    pair_row = Object.new
+    def pair_row.add_pair(job) = ['Lock', job['class']]
+    Wurk::Web.config.custom_job_info_rows << pair_row
+
+    assert_equal [%w[Lock MyJob]], Wurk::Api::Serializers.job_record(record)[:custom_rows]
+  end
+
+  def test_job_record_skips_broken_or_malformed_rows
+    rows = [->(_job) { raise 'boom' }, ->(_job) { 'not a pair' }, ->(job) { ['OK', job.jid] }]
+    rows.each { |row| Wurk::Web.config.custom_job_info_rows << row }
+
+    assert_equal [%w[OK abc]], Wurk::Api::Serializers.job_record(record)[:custom_rows]
+  end
+
+  private
+
+  def record
+    Wurk::JobRecord.new({ 'class' => 'MyJob', 'args' => [1], 'jid' => 'abc', 'queue' => 'default' })
+  end
+end

--- a/test/unit/web_config_test.rb
+++ b/test/unit/web_config_test.rb
@@ -202,6 +202,104 @@ class WebConfigTest < Wurk::Test::UnitCase
     assert_equal ['Forbidden'], body
   end
 
+  # --- web extensions / custom tabs (spec §25.2/§25.3) ---------------
+
+  def test_tabs_seed_from_default_tabs_as_a_mutable_copy
+    assert_equal Wurk::Web::Config::DEFAULT_TABS, Wurk::Web.config.tabs
+    refute_same Wurk::Web::Config::DEFAULT_TABS, Wurk::Web.config.tabs
+  end
+
+  def test_register_extension_adds_a_custom_tab
+    Wurk::Web.config.register_extension(Object, name: 'Locks', tab: 'locks')
+
+    assert_equal 'locks', Wurk::Web.config.tabs['Locks']
+    assert_includes Wurk::Web.config.custom_tabs, { name: 'Locks', path: 'locks' }
+  end
+
+  def test_register_is_an_alias_for_register_extension
+    Wurk::Web.config.register(Object, name: 'Status', tab: 'status')
+
+    assert_includes Wurk::Web.config.custom_tabs, { name: 'Status', path: 'status' }
+  end
+
+  def test_register_extension_returns_self_for_chaining
+    cfg = Wurk::Web.config
+
+    assert_same cfg, cfg.register_extension(Object, name: 'A', tab: 'a')
+  end
+
+  def test_custom_tabs_excludes_native_and_default_paths
+    cfg = Wurk::Web.config
+    cfg.register_extension(Object, name: 'Cron', tab: 'cron')       # wurk-native page
+    cfg.register_extension(Object, name: 'Queues', tab: 'queues')   # Sidekiq default
+    cfg.register_extension(Object, name: 'Locks', tab: 'locks')     # genuinely new
+    paths = cfg.custom_tabs.map { |t| t[:path] }
+
+    assert_equal ['locks'], paths
+  end
+
+  def test_tabs_hash_is_directly_mutable
+    Wurk::Web.config.tabs['Expiry'] = 'expiry'
+
+    assert_includes Wurk::Web.config.custom_tabs, { name: 'Expiry', path: 'expiry' }
+  end
+
+  def test_custom_job_info_rows_is_a_mutable_array
+    assert_empty Wurk::Web.config.custom_job_info_rows
+    row = ->(job) { ['Custom', job] }
+    Wurk::Web.config.custom_job_info_rows << row
+
+    assert_equal [row], Wurk::Web.config.custom_job_info_rows
+  end
+
+  def test_app_url_and_assets_path_accessors
+    cfg = Wurk::Web.config
+    cfg.app_url = 'https://app.example'
+    cfg.assets_path = '/assets'
+
+    assert_equal 'https://app.example', cfg.app_url
+    assert_equal '/assets', cfg.assets_path
+  end
+
+  def test_reset_clears_registered_extensions
+    cfg = Wurk::Web.config
+    cfg.register_extension(Object, name: 'Locks', tab: 'locks')
+    cfg.custom_job_info_rows << :row
+    cfg.app_url = 'https://app.example'
+    cfg.reset!
+
+    assert_empty cfg.custom_tabs
+    assert_empty cfg.custom_job_info_rows
+    assert_nil cfg.app_url
+  end
+
+  # No-op-safe: registering must only record the class, never invoke the
+  # extension's server-side routes/views (wurk has no Sinatra render path).
+  def test_register_records_extension_without_invoking_it
+    ext = Class.new do
+      def self.registered(*)
+        raise 'extension code must not run at register time'
+      end
+    end
+    Wurk::Web.config.register_extension(ext, name: 'Safe', tab: 'safe')
+    last = Wurk::Web.config.extensions.last
+
+    assert_equal ext, last[:extension]
+    assert_equal 86_400, last[:cache_for]
+  end
+
+  # Drop-in: gems reach this surface through the Sidekiq::Web alias.
+  def test_sidekiq_web_class_level_surface
+    assert_same Wurk::Web::Config, Sidekiq::Web::Config
+    Sidekiq::Web.register(Object, name: 'Locks', tab: 'locks')
+    Sidekiq::Web.tabs['Expiry'] = 'expiry'
+
+    paths = Sidekiq::Web.config.custom_tabs.map { |t| t[:path] }
+
+    assert_includes paths, 'locks'
+    assert_includes paths, 'expiry'
+  end
+
   private
 
   def with_env(key, value)

--- a/test/unit/web_config_test.rb
+++ b/test/unit/web_config_test.rb
@@ -209,15 +209,16 @@ class WebConfigTest < Wurk::Test::UnitCase
     refute_same Wurk::Web::Config::DEFAULT_TABS, Wurk::Web.config.tabs
   end
 
+  # tab = label, index = path, name = asset namespace (spec §25.2).
   def test_register_extension_adds_a_custom_tab
-    Wurk::Web.config.register_extension(Object, name: 'Locks', tab: 'locks')
+    Wurk::Web.config.register_extension(Object, name: 'locks', tab: 'Locks', index: 'locks')
 
     assert_equal 'locks', Wurk::Web.config.tabs['Locks']
     assert_includes Wurk::Web.config.custom_tabs, { name: 'Locks', path: 'locks' }
   end
 
   def test_register_is_an_alias_for_register_extension
-    Wurk::Web.config.register(Object, name: 'Status', tab: 'status')
+    Wurk::Web.config.register(Object, name: 'status', tab: 'Status', index: 'status')
 
     assert_includes Wurk::Web.config.custom_tabs, { name: 'Status', path: 'status' }
   end
@@ -225,14 +226,30 @@ class WebConfigTest < Wurk::Test::UnitCase
   def test_register_extension_returns_self_for_chaining
     cfg = Wurk::Web.config
 
-    assert_same cfg, cfg.register_extension(Object, name: 'A', tab: 'a')
+    assert_same cfg, cfg.register_extension(Object, name: 'a', tab: 'A', index: 'a')
+  end
+
+  def test_register_extension_yields_config_to_block
+    cfg = Wurk::Web.config
+    yielded = nil
+    cfg.register_extension(Object, name: 'locks', tab: 'Locks', index: 'locks') { |c| yielded = c }
+
+    assert_same cfg, yielded
+  end
+
+  # tab/index may be arrays — zipped label => path (spec §25.2).
+  def test_register_extension_zips_array_tabs_and_indexes
+    Wurk::Web.config.register_extension(Object, name: 'uj', tab: %w[Locks Expiry], index: %w[locks expiry])
+    paths = Wurk::Web.config.custom_tabs.map { |t| t[:path] }
+
+    assert_equal %w[locks expiry], paths
   end
 
   def test_custom_tabs_excludes_native_and_default_paths
     cfg = Wurk::Web.config
-    cfg.register_extension(Object, name: 'Cron', tab: 'cron')       # wurk-native page
-    cfg.register_extension(Object, name: 'Queues', tab: 'queues')   # Sidekiq default
-    cfg.register_extension(Object, name: 'Locks', tab: 'locks')     # genuinely new
+    cfg.register_extension(Object, name: 'cron', tab: 'Cron', index: 'cron')         # wurk-native path
+    cfg.register_extension(Object, name: 'queues', tab: 'Queues', index: 'queues')   # Sidekiq default
+    cfg.register_extension(Object, name: 'locks', tab: 'Locks', index: 'locks')      # genuinely new
     paths = cfg.custom_tabs.map { |t| t[:path] }
 
     assert_equal ['locks'], paths
@@ -263,7 +280,7 @@ class WebConfigTest < Wurk::Test::UnitCase
 
   def test_reset_clears_registered_extensions
     cfg = Wurk::Web.config
-    cfg.register_extension(Object, name: 'Locks', tab: 'locks')
+    cfg.register_extension(Object, name: 'locks', tab: 'Locks', index: 'locks')
     cfg.custom_job_info_rows << :row
     cfg.app_url = 'https://app.example'
     cfg.reset!
@@ -281,7 +298,7 @@ class WebConfigTest < Wurk::Test::UnitCase
         raise 'extension code must not run at register time'
       end
     end
-    Wurk::Web.config.register_extension(ext, name: 'Safe', tab: 'safe')
+    Wurk::Web.config.register_extension(ext, name: 'safe', tab: 'Safe', index: 'safe')
     last = Wurk::Web.config.extensions.last
 
     assert_equal ext, last[:extension]
@@ -291,7 +308,7 @@ class WebConfigTest < Wurk::Test::UnitCase
   # Drop-in: gems reach this surface through the Sidekiq::Web alias.
   def test_sidekiq_web_class_level_surface
     assert_same Wurk::Web::Config, Sidekiq::Web::Config
-    Sidekiq::Web.register(Object, name: 'Locks', tab: 'locks')
+    Sidekiq::Web.register(Object, name: 'locks', tab: 'Locks', index: 'locks')
     Sidekiq::Web.tabs['Expiry'] = 'expiry'
 
     paths = Sidekiq::Web.config.custom_tabs.map { |t| t[:path] }


### PR DESCRIPTION
Closes #104. Folds in the pragmatic part of #187 so custom tabs ship as a coherent feature.

Implements the `Sidekiq::Web::Config` extension surface so third-party gems (sidekiq-cron, sidekiq-unique-jobs, sidekiq-status, …) can register dashboard tabs + job-info rows against wurk.

## Acceptance (#104)
> Wurk::Web::Config gains register_extension/register, tabs, custom_job_info_rows (matching the Sidekiq signature) and the Sidekiq::Web::Config alias.

- [x] `Wurk::Web::Config#register_extension` / `register`, a `tabs` hash seeded from `DEFAULT_TABS` (directly mutable), `custom_job_info_rows`, `app_url`, `assets_path`.
- [x] Class-level delegators on `Wurk::Web` so the existing `Sidekiq::Web` alias surface works: `Sidekiq::Web.register(...)`, `Sidekiq::Web.tabs["X"] = "y"`, `Sidekiq::Web.configure { … }`.
- [x] **No-op-safe** — records the registration, never invokes the extension's Sinatra/ERB routes, so requiring such a gem can't crash boot.
- [x] Registered tabs surface in the SPA nav via `GET /api/meta` (`custom_tabs`); native paths are filtered out so a gem can't duplicate a built-in page.
- [x] Tests: 11 `Web::Config` unit + 2 `/api/meta` engine + 4 serializer (`custom_rows`).

## Pragmatic part of #187 (folded in)
- **`custom_job_info_rows` render** in the job-detail modal — `Config#job_info_pairs` evaluates each `call(job)` / `add_pair(job)` row defensively, gated so the no-extension case is free.
- **Custom tabs open an in-SPA `/ext/:tab` Extension page** that embeds the extension's path in an iframe. A `?wurk_ext_embed=1` guard makes the SPA paint a small "not rendered here" stub when it answers that path (no recursive dashboard nesting). If the host mounts the gem's own Rack app reachable at the path, its real view renders in the frame.

**Divergence (documented):** wurk's dashboard is a precompiled React SPA with no Sinatra/ERB render path, so Sidekiq's own ERB extension views aren't rendered natively. Tracked as the remaining **#187**.

## Verification
- Full suite **2118 runs, 0 failures**; parity 20/0; ecosystem all passed. Coverage **96.21% line / 91.44% branch** (≥90 gate). RuboCop clean on new code. Frontend `tsc + vite` build clean.
- Manually previewed with a host-mounted Rack app rendering **live `Wurk::Stats`** in the Extension-page iframe (real-time data, auto-refresh), the unmounted embed-guard stub, and the job-detail `custom_rows` row.

## How to test in prod
With a gem that registers a Web extension installed (or your own initializer):

```ruby
# config/initializers/wurk.rb
Sidekiq::Web.register(MyGem::Web, name: "Locks", tab: "locks")
# or: Sidekiq::Web.configure { |c| c.tabs["Locks"] = "locks"; c.custom_job_info_rows << MyRow }
```

1. Open the dashboard → a **Locks** tab appears under an **Extensions** section in the left nav.
2. Click it → an Extension page embeds `/<mount>/locks`. If you've mounted the gem's Rack app reachable there, its view renders; otherwise a short "not rendered here" note shows.
3. Open any job's detail → rows contributed by `custom_job_info_rows` appear.
4. Requiring the gem must not crash boot even before you wire anything — registration is no-op-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard nav can surface registered custom extension tabs; each tab opens an in-dashboard Extension page (iframe) and a dedicated route.
  * Job detail modal can show host-registered custom job-info rows.
  * SPA supports lightweight placeholder when rendered inside an embedded extension iframe.

* **Documentation**
  * Added guide describing registering/configuring dashboard web extensions and supported behaviors.

* **Tests**
  * Added tests covering meta exposure, registration, and job-info row handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->