### PR TITLE
fix(web): repair WURK_VITE_DEV HMR shell + asset URLs (#181)

### DIFF
--- a/app/controllers/wurk/dashboard_controller.rb
+++ b/app/controllers/wurk/dashboard_controller.rb
@@ -15,7 +15,14 @@ module Wurk
   # Vite dev server (default :5173) so contributors get HMR without
   # rebuilding the bundle on every change.
   class DashboardController < ApplicationController
-    VITE_DEV_URL = 'http://localhost:5173/'
+    # Vite serves the dev shell under its `base` (vite.config.ts), which is the
+    # same path the engine mounts assets at — so derive these from
+    # AssetMount::PREFIX to keep the Ruby side in lockstep. Fetching the server
+    # root instead returns Vite's "did you mean /wurk-assets/" hint page, not the
+    # shell (issue #181).
+    VITE_DEV_HOST = 'http://localhost:5173'
+    VITE_ASSET_BASE = "#{::Wurk::Engine::AssetMount::PREFIX}/".freeze # "/wurk-assets/"
+    VITE_DEV_URL = "#{VITE_DEV_HOST}#{VITE_ASSET_BASE}".freeze
     INDEX_REL_PATH = ['vendor', 'assets', 'dashboard', 'index.html'].freeze
 
     def index
@@ -30,10 +37,21 @@ module Wurk
 
     def fetch_vite_dev_shell
       uri = ::URI.parse(VITE_DEV_URL)
-      ::Net::HTTP.get(uri)
+      rewrite_dev_asset_urls(::Net::HTTP.get(uri))
     rescue ::StandardError => e
       raise "Wurk dashboard: cannot reach Vite dev server at #{VITE_DEV_URL} " \
             "(#{e.class}: #{e.message}). Run `bin/rake frontend:dev` from the gem root."
+    end
+
+    # The shell's entry URLs (`src="/wurk-assets/@vite/client"`,
+    # `src="/wurk-assets/src/main.tsx"`) are base-absolute, but the page is
+    # served from the host origin (e.g. :3000), where that path only maps to the
+    # built bundle. Point them back at the Vite dev server so the browser loads
+    # the modules + HMR client straight from Vite (CORS-enabled in dev). Vite's
+    # `server.origin` covers runtime-generated asset URLs but not these entry
+    # tags, so rewrite them here.
+    def rewrite_dev_asset_urls(html)
+      html.gsub(/(["'])#{::Regexp.escape(VITE_ASSET_BASE)}/, "\\1#{VITE_DEV_URL}")
     end
 
     def read_built_index

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -31,6 +31,9 @@ export default defineConfig({
       },
     },
   ],
+  // Must match Wurk::Engine::AssetMount::PREFIX (lib/wurk/engine.rb): the engine
+  // serves the built bundle under this path and the dev controller fetches the
+  // HMR shell from <vite>/wurk-assets/.
   base: "/wurk-assets/",
   build: {
     manifest: true,
@@ -41,5 +44,13 @@ export default defineConfig({
   server: {
     port: 5173,
     strictPort: true,
+    // HMR dev: the Rails dummy serves the page at :3000/wurk and fetches the
+    // shell from this server (WURK_VITE_DEV=1). `origin` makes Vite emit
+    // absolute asset/HMR URLs (http://localhost:5173/wurk-assets/…) so the
+    // browser loads modules + the HMR client straight from Vite instead of
+    // hitting :3000/wurk-assets (which the engine only serves from the built
+    // bundle). `cors` lets that cross-origin fetch through. See issue #181.
+    origin: "http://localhost:5173",
+    cors: true,
   },
 });

--- a/test/engine/dashboard_dev_shell_test.rb
+++ b/test/engine/dashboard_dev_shell_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative '../engine_test_helper'
+
+# WURK_VITE_DEV=1 HMR path (issue #181). Vite serves the shell + assets under
+# its `base` (== AssetMount::PREFIX), so the controller must fetch the shell
+# from that base (not the server root) and repoint the shell's base-relative
+# asset URLs at the Vite origin, since the page is served from the host app.
+# These cover the URL target + rewrite without needing a running Vite server.
+class DashboardDevShellTest < Wurk::Test::EngineCase
+  parallelize_me!
+
+  def test_vite_dev_url_targets_the_asset_base_not_root
+    assert_equal "#{Wurk::Engine::AssetMount::PREFIX}/", Wurk::DashboardController::VITE_ASSET_BASE
+    assert_equal 'http://localhost:5173/wurk-assets/', Wurk::DashboardController::VITE_DEV_URL
+  end
+
+  def test_dev_shell_asset_urls_rewritten_to_vite_origin
+    out = rewrite(<<~HTML)
+      <script type="module" src="/wurk-assets/@vite/client"></script>
+      <script type="module" src="/wurk-assets/src/main.tsx"></script>
+    HTML
+
+    assert_includes out, 'src="http://localhost:5173/wurk-assets/@vite/client"'
+    assert_includes out, 'src="http://localhost:5173/wurk-assets/src/main.tsx"'
+    refute_includes out, 'src="/wurk-assets/' # no base-relative entry URLs remain
+  end
+
+  def test_dev_shell_leaves_non_asset_urls_untouched
+    assert_includes rewrite('<link rel="icon" href="/favicon.png">'), 'href="/favicon.png"'
+  end
+
+  private
+
+  def rewrite(html)
+    Wurk::DashboardController.new.send(:rewrite_dev_asset_urls, html)
+  end
+end


### PR DESCRIPTION
Closes #181.

## Problem
`WURK_VITE_DEV=1` HMR mode was broken. Two issues, both stemming from Vite's `base: "/wurk-assets/"`:

1. `DashboardController::VITE_DEV_URL` fetched `http://localhost:5173/` (the server **root**), which returns Vite's *"did you mean to visit /wurk-assets/"* hint page — not the SPA shell.
2. Even with the shell, its entry tags are base-relative (`src="/wurk-assets/@vite/client"`, `src="/wurk-assets/src/main.tsx"`). The page is served from the host origin (`:3000`), where `/wurk-assets/*` maps to the engine's **built bundle** (no dev assets) — so the modules 404 and the SPA renders nothing.

## Fix
- **`dashboard_controller.rb`** — `VITE_DEV_URL` now targets the base path (`http://localhost:5173/wurk-assets/`), derived from `Wurk::Engine::AssetMount::PREFIX` so the Ruby side stays in lockstep. The fetched shell's base-relative asset URLs are rewritten to absolute Vite URLs, so the browser loads the modules + HMR client straight from the dev server.
- **`vite.config.ts`** — added `server.origin` + `cors` (Vite's documented "backend serves the page, Vite serves the assets" pattern) so runtime-generated asset/HMR URLs and the cross-origin fetch resolve. Documented that `base` must match `AssetMount::PREFIX`.

## Verification
Booted Vite + the dummy with `WURK_VITE_DEV=1`: `:3000/wurk` now serves the shell with entry URLs rewritten to `http://localhost:5173/wurk-assets/@vite/client` and `…/src/main.tsx`, and those return **HTTP 200** (`Access-Control-Allow-Origin: *`). Full suite **2123 runs, 0 failures**; coverage 96.33% line / 91.74% branch; RuboCop clean; frontend builds. 3 new tests cover the corrected URL constant + the shell rewrite (no running Vite required, so they run in CI).

## How to test in prod
This is a dev-tooling fix (HMR is dev-only; production serves the precompiled bundle and is unaffected). To verify locally:

```bash
# Terminal 1
cd frontend && npm run dev
# Terminal 2
cd test/dummy && WURK_DISABLED=1 WURK_VITE_DEV=1 bin/rails s -p 3000
```
Open http://localhost:3000/wurk → the dashboard renders; edit a component and save → it hot-reloads without a rebuild. (Static/prod path unchanged: `npm run build` then boot without `WURK_VITE_DEV`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for dashboard development shell HMR behavior, including asset URL rewriting validation.

* **Chores**
  * Updated development server configuration to improve asset URL handling and cross-origin HMR setup in development mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->