### PR TITLE
docs(deploy): ship example systemd unit + deployment guide (#111)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,123 @@
+# Deploying Wurk
+
+Wurk is a drop-in for Sidekiq, so it deploys the same way: a long-running worker
+process supervised by your init system, signalled for quiet/reload/stop during a
+deploy. If you already run Sidekiq under systemd or capistrano-sidekiq, the only
+change is the binary name (`sidekiq` → `wurk`) — the signals, flags, and config
+file are identical.
+
+> Authoritative signal reference: [`docs/target/sidekiq-free.md`](target/sidekiq-free.md) §21 (CLI).
+> Migrating an existing app? Start with [`docs/migrate-from-sidekiq.md`](migrate-from-sidekiq.md).
+
+---
+
+## The runner
+
+| Binary | What it does | Sidekiq equivalent |
+|---|---|---|
+| `bundle exec wurk` | Single worker process, thread pool | `sidekiq` |
+| `bundle exec wurkswarm` | Forks N worker children from one preloaded parent (real parallelism) | `sidekiqswarm` |
+
+`sidekiqswarm` ships as an alias for `wurkswarm`, so an existing Enterprise
+`sidekiqswarm` invocation keeps working unchanged.
+
+In a Rails app the engine auto-starts the swarm during boot, so your web/worker
+dynos often need no separate worker command at all — set `WURK_DISABLED=1` on
+processes that should *not* fork workers (e.g. the web process). The standalone
+runners below are for non-Rails apps, or when you want the worker in its own unit.
+
+Common flags (same as Sidekiq): `-c` concurrency, `-q queue[,weight]`, `-r` require
+path, `-t` shutdown timeout (seconds), `-e` environment, `-C` config YAML. With no
+`-C`, Wurk auto-discovers `config/wurk.yml` then `config/sidekiq.yml` (`.erb` ok).
+
+---
+
+## Signals
+
+These are what your deploy tooling sends. Wurk implements the full Sidekiq set.
+
+| Signal | Effect |
+|---|---|
+| `TERM` / `INT` | Graceful shutdown — stop fetching, let in-flight jobs finish up to the shutdown timeout (`-t`, default **25s**), then exit. |
+| `TSTP` | Quiet — stop fetching new work; in-flight jobs finish. Standalone has no resume (quiet, then stop); under `wurkswarm`, `CONT` resumes. |
+| `USR1` | **`wurkswarm` only** — zero-downtime rolling restart: fork a replacement child, wait for its heartbeat, then `TERM` the old one, slot by slot. |
+| `TTIN` / `INFO` | Dump every thread's backtrace to the log (for diagnosing a stuck worker). |
+| `USR2` | Reopen log files (logrotate) on swarm children. |
+
+The standard deploy dance is **quiet, then stop**: send `TSTP` early in the deploy so
+the old worker stops claiming new jobs, then `TERM` once the new release is live. A
+`SIGKILL` at any point is safe — reliable fetch keeps in-flight jobs on a per-process
+private list in Redis, and they're reclaimed on the next boot.
+
+---
+
+## systemd
+
+A ready-to-edit unit ships at [`examples/wurk.service`](../examples/wurk.service).
+Copy it, adjust the paths/user, and install:
+
+```bash
+sudo cp examples/wurk.service /etc/systemd/system/wurk.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now wurk
+```
+
+Then:
+
+```bash
+sudo systemctl reload wurk    # SIGTSTP — quiet (stop fetching, finish in-flight)
+sudo systemctl stop wurk      # SIGTERM — graceful drain up to the shutdown timeout
+sudo systemctl restart wurk   # quiet+stop+start
+journalctl -u wurk -f         # tail logs
+```
+
+Two details that differ from a stock Sidekiq unit:
+
+- **`Type=simple`, not `Type=notify`.** Wurk does not emit `sd_notify` readiness or
+  watchdog pings, so there's no `WatchdogSec`. systemd considers the process ready as
+  soon as `ExecStart` forks.
+- **`TimeoutStopSec` ≥ shutdown timeout.** The unit sets `TimeoutStopSec=30` against
+  the default 25s drain so a clean shutdown always wins before systemd's `SIGKILL`.
+  If you raise `-t`, raise `TimeoutStopSec` to match.
+
+### Multiple workers
+
+Run several workers on one host with a template unit. Save the example as
+`/etc/systemd/system/wurk@.service` and start instances:
+
+```bash
+sudo systemctl enable --now wurk@1 wurk@2 wurk@3
+```
+
+Or run one `wurkswarm` unit instead, which forks children itself — change
+`ExecStart` to `bundle exec wurkswarm -e production` and
+`ExecReload=/bin/kill -USR1 $MAINPID` (rolling restart instead of plain quiet).
+
+---
+
+## capistrano-sidekiq
+
+[`capistrano-sidekiq`](https://github.com/seuros/capistrano-sidekiq) works against
+Wurk unchanged. It shells out to the runner and sends the signals above for
+quiet/restart/stop, and all three are drop-in:
+
+- the `sidekiq` / `sidekiqswarm` binary names resolve via Wurk's aliases,
+- `Sidekiq::CLI` is aliased to `Wurk::CLI`, and
+- the `TSTP` / `TERM` / `USR1` signal semantics match.
+
+If it invokes the binary by literal name (`bundle exec sidekiq`), point it at `wurk`
+instead — either set `sidekiq_role`/`sidekiq_command` config to `wurk`/`wurkswarm`,
+or add a tiny `bin/sidekiq` shim that `exec`s `wurk`. The systemd integration mode of
+capistrano-sidekiq drops in the same way: replace the generated unit's `ExecStart`
+with `bundle exec wurk` and keep the rest.
+
+---
+
+## Heroku / Procfile
+
+```procfile
+worker: bundle exec wurk -e production
+```
+
+Heroku sends `SIGTERM` on dyno cycle, which triggers Wurk's graceful drain — set the
+shutdown timeout (`-t`) below Heroku's 30s kill window so jobs finish cleanly.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -97,19 +97,21 @@ Or run one `wurkswarm` unit instead, which forks children itself — change
 
 ## capistrano-sidekiq
 
-[`capistrano-sidekiq`](https://github.com/seuros/capistrano-sidekiq) works against
-Wurk unchanged. It shells out to the runner and sends the signals above for
-quiet/restart/stop, and all three are drop-in:
+[`capistrano-sidekiq`](https://github.com/seuros/capistrano-sidekiq) shells out to
+the runner and sends the signals above for quiet/restart/stop. The signal handling is
+fully drop-in:
 
-- the `sidekiq` / `sidekiqswarm` binary names resolve via Wurk's aliases,
 - `Sidekiq::CLI` is aliased to `Wurk::CLI`, and
-- the `TSTP` / `TERM` / `USR1` signal semantics match.
+- the `TSTP` / `TERM` / `USR1` signal semantics match exactly.
 
-If it invokes the binary by literal name (`bundle exec sidekiq`), point it at `wurk`
-instead — either set `sidekiq_role`/`sidekiq_command` config to `wurk`/`wurkswarm`,
-or add a tiny `bin/sidekiq` shim that `exec`s `wurk`. The systemd integration mode of
-capistrano-sidekiq drops in the same way: replace the generated unit's `ExecStart`
-with `bundle exec wurk` and keep the rest.
+The one thing to map is the binary name. Wurk ships `wurk`, `wurkswarm`, and a
+`sidekiqswarm` alias — but there is **no `sidekiq` binary** (see
+[`docs/migrate-from-sidekiq.md`](migrate-from-sidekiq.md)). So an Enterprise
+`sidekiqswarm` invocation drops in unchanged, while a `bundle exec sidekiq` invocation
+needs pointing at `wurk`: set `sidekiq_role`/`sidekiq_command` config to
+`wurk`/`wurkswarm`, or add a tiny `bin/sidekiq` shim that `exec`s `wurk`. The systemd
+integration mode drops in the same way — replace the generated unit's `ExecStart` with
+`bundle exec wurk` and keep the rest.
 
 ---
 

--- a/docs/migrate-from-sidekiq.md
+++ b/docs/migrate-from-sidekiq.md
@@ -100,6 +100,9 @@ lines, and systemd units to `wurk`). It takes the familiar flags (`-c` concurren
 config with `-C path`, and auto-discovers `config/wurk.yml` then `config/sidekiq.yml`
 (`.erb` supported). The YAML structure matches Sidekiq's `sidekiq.yml`.
 
+For running the worker under systemd or capistrano-sidekiq — including an example
+unit file and the deploy signal dance — see [`docs/deployment.md`](deployment.md).
+
 ---
 
 ## 2. Redis key layout: identical, no namespace
@@ -216,7 +219,8 @@ by running their own upstream test suites in the [`ecosystem` CI job](../.github
 3. **Re-point the dashboard route** — `mount Wurk::Engine => "/wurk"` (gate it behind
    your app auth — see [`docs/dashboard.md`](dashboard.md)).
 4. **Boot a worker** — `bundle exec wurk` (standalone) or your existing Rails process
-   (the engine auto-starts the swarm unless `WURK_DISABLED=1`).
+   (the engine auto-starts the swarm unless `WURK_DISABLED=1`). Deploying under
+   systemd/capistrano? See [`docs/deployment.md`](deployment.md).
 5. **Verify on the same Redis** — enqueue a test job, watch it run, and confirm the
    dashboard + your existing `redis-cli` checks look normal. Because the schema is
    shared, you can roll one process at a time.

--- a/examples/wurk.service
+++ b/examples/wurk.service
@@ -1,0 +1,67 @@
+# examples/wurk.service
+#
+# Drop-in systemd unit for running Wurk as a background worker, modeled on
+# Sidekiq's examples/systemd/sidekiq.service and adapted to Wurk's signals.
+#
+# Install:
+#   sudo cp examples/wurk.service /etc/systemd/system/wurk.service
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now wurk
+#
+# Reload (quiet — stop fetching, let in-flight jobs finish):
+#   sudo systemctl reload wurk
+#
+# Stop (graceful drain up to the shutdown timeout):
+#   sudo systemctl stop wurk
+#
+# Multiple workers on one host: copy this file to /etc/systemd/system/wurk@.service,
+# replace the fixed paths with %i where it helps, and start instances with
+# `systemctl enable --now wurk@1 wurk@2`. See docs/deployment.md.
+
+[Unit]
+Description=wurk background worker
+# Start after Redis (and your DB) are reachable. Adjust to match your units —
+# e.g. `After=redis.service` if Redis runs on the same host via systemd.
+After=syslog.target network.target
+
+[Service]
+# Type=simple, NOT notify: Wurk does not emit sd_notify readiness/watchdog
+# pings, so there is no WatchdogSec here. systemd treats the process as ready
+# as soon as it forks ExecStart.
+Type=simple
+
+WorkingDirectory=/opt/myapp/current
+
+# Plain bundler install. For rbenv/rvm/chruby, wrap with the version manager,
+# e.g. ExecStart=/home/deploy/.rbenv/shims/bundle exec wurk -e production
+# For fork-based multi-process parallelism, swap `wurk` for `wurkswarm`
+# (the `sidekiqswarm` entry point) — see docs/deployment.md.
+ExecStart=/usr/local/bin/bundle exec wurk -e production
+
+# `systemctl reload` → SIGTSTP: Wurk stops accepting new work and lets
+# in-flight jobs finish. There is no resume in standalone mode — quiet, then
+# stop. (Under wurkswarm, SIGUSR1 does a zero-downtime rolling restart; use
+# ExecReload=/bin/kill -USR1 $MAINPID there instead.)
+ExecReload=/bin/kill -TSTP $MAINPID
+
+# Graceful shutdown: SIGTERM drains in-flight jobs up to Wurk's shutdown
+# timeout (`-t`, default 25s). Keep TimeoutStopSec a few seconds longer so a
+# clean drain always beats systemd's follow-up SIGKILL.
+KillSignal=SIGTERM
+TimeoutStopSec=30
+
+# Restart on crash, never on a clean SIGTERM stop.
+Restart=on-failure
+RestartSec=1
+
+User=deploy
+Group=deploy
+UMask=0002
+
+# Send stdout/stderr to journald: `journalctl -u wurk -f`.
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=wurk
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Closes #111.

## What

Operators migrating an existing Sidekiq **systemd** or **capistrano-sidekiq** deploy had no Wurk equivalent to copy. Wurk already implements the signal semantics these tools rely on (TERM/INT graceful drain, TSTP quiet, swarm USR1 rolling restart), so this is purely an example + documentation addition — no code changes.

- **`examples/wurk.service`** — systemd unit mirroring Sidekiq's, adapted to Wurk's actual signals:
  - `Type=simple` (Wurk emits no `sd_notify` pings, so **no `WatchdogSec`** — using `Type=notify` would hang the unit)
  - `ExecStart=… bundle exec wurk -e production`
  - `ExecReload=/bin/kill -TSTP $MAINPID` (quiet: stop fetching, finish in-flight)
  - `KillSignal=SIGTERM` + `TimeoutStopSec=30` (≥ the 25s default drain timeout)
  - `Restart=on-failure`, journald logging; templated multi-instance + `wurkswarm`/`USR1` notes in comments
- **`docs/deployment.md`** — runner table (`wurk`/`wurkswarm`, `sidekiqswarm` alias), full signal table, systemd install/reload/stop, multi-worker, **capistrano-sidekiq compatibility**, Heroku/Procfile.
- Linked the guide from `docs/migrate-from-sidekiq.md` (config-file section + cutover checklist).

Both `docs/` and `examples/` live on GitHub only (not packaged in the gem) — matching the gemspec's existing policy and Sidekiq's own repo layout.

## Acceptance criteria (#111)

- [x] Example `examples/wurk.service` (Type=simple, ExecStart exe/wurk, ExecReload=`/bin/kill -TSTP`, TimeoutStopSec ≥ shutdown timeout, Restart=on-failure; WatchdogSec correctly omitted — no sd_notify)
- [x] `docs/deployment.md` covering systemd (install/start/reload/quiet/graceful stop) + capistrano-sidekiq compatibility note
- [x] Linked from the migrate-from-sidekiq guide
- [x] Verified the example unit boots the standalone app end to end

## Verification

Drove the **real `exe/wurk` binary** (the exact `ExecStart` command) end-to-end against real Redis, then sent the exact signals the unit uses:

```
=== issue #111 systemd unit behavioral verification ===
  [PASS] ExecStart boots + runs a job
  [PASS] ExecReload (SIGTSTP) quiets the worker
  [PASS] SIGTERM graceful shutdown ("Shutting down"/"Bye!")
  [PASS] SIGTERM exits cleanly (status 0)
```

`systemd-analyze verify examples/wurk.service` reports **no directive/syntax errors** (only the expected placeholder-path note for `/usr/local/bin/bundle`).

## How to test in prod

On a host with the gem installed:

```bash
# 1. Install the unit (edit WorkingDirectory / User / bundle path first)
sudo cp examples/wurk.service /etc/systemd/system/wurk.service
sudo systemctl daemon-reload
sudo systemctl enable --now wurk

# 2. Confirm it's fetching
journalctl -u wurk -f          # look for the boot banner + heartbeat

# 3. Quiet it (deploy step 1) — stops claiming new jobs, finishes in-flight
sudo systemctl reload wurk     # -> SIGTSTP -> "no longer accepting new work"

# 4. Graceful stop (deploy step 2) — drains up to the shutdown timeout, exits 0
sudo systemctl stop wurk       # -> SIGTERM -> "Shutting down" ... "Bye!"
```

capistrano-sidekiq users: point `sidekiq_command`/the generated unit's `ExecStart` at `wurk` (or add a `bin/sidekiq` shim that `exec`s `wurk`) — the `TSTP`/`TERM`/`USR1` signals and the `sidekiqswarm` alias are drop-in. See `docs/deployment.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive deployment guide covering systemd setup, detailed signal semantics, scaling strategies, runner options (single-process vs. prefork), and capistrano-sidekiq compatibility
  * Updated migration guidance to reference the new deployment procedures and cutover checklist
  * Added an example systemd unit and Heroku/Procfile guidance with shutdown-timeout recommendations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->