### PR TITLE
fix(boot): enter server mode before the app loads so configure_server fires (#191)

### DIFF
--- a/lib/wurk.rb
+++ b/lib/wurk.rb
@@ -190,6 +190,17 @@ module Wurk
 
     attr_writer :server
 
+    # Enter server mode: set the module flag (read by third-party gems via
+    # `Sidekiq.server?`) AND the per-config `server?` predicate that gates
+    # `configure_server`. Both must be set before the app's initializers run,
+    # or `configure_server` blocks (server middleware, error handlers,
+    # lifecycle hooks) are silently skipped. Defaults to the global config; the
+    # CLI passes its own (possibly test-injected) Configuration instance.
+    def enter_server_mode(config = configuration)
+      @server = true
+      config[:server] = true
+    end
+
     # Wurk ships Pro+Ent features in the free gem; these flags exist solely
     # for third-party gems that branch on Sidekiq.pro? / Sidekiq.ent?.
     def pro?

--- a/lib/wurk/cli.rb
+++ b/lib/wurk/cli.rb
@@ -93,6 +93,12 @@ module Wurk
 
     # `boot_app:` / `warmup:` are test seams. Production always passes true.
     def run(boot_app: true, warmup: true)
+      # Mark server mode BEFORE the app loads so `configure_server` blocks in
+      # the required initializer actually fire (they gate on `config.server?`).
+      # Matches Sidekiq, which sets `Sidekiq.server = true` before requiring
+      # the app in its CLI. Skipping this silently drops server middleware,
+      # error handlers, and lifecycle hooks registered via configure_server.
+      enter_server_mode
       boot_application if boot_app
       self_read, self_write = ::IO.pipe
       trap_signals(self_write)
@@ -118,6 +124,10 @@ module Wurk
     # `SIDEKIQ_PRELOAD_APP` whole-app eager-load) and boots `Process.warmup`
     # before the fork so children share warmed pages (copy-on-write). Spec §7.
     def run_swarm(boot_app: true, warmup: true)
+      # Server mode before the app loads — see #run. The flag rides through the
+      # fork into every child (the config object is copied), so configure_server
+      # blocks registered in the parent take effect in the workers.
+      enter_server_mode
       if boot_app
         preload_bundler_groups
         boot_application
@@ -126,7 +136,6 @@ module Wurk
       validate_redis!
       validate_pool_sizes!
       @config[:identity] = identity
-      Wurk.server = true
       ::Process.warmup if warmup && ::Process.respond_to?(:warmup) && ENV['RUBY_DISABLE_WARMUP'] != '1'
       @swarm = Wurk::Swarm.new(topology: @config.topology, config: @config)
       @swarm.boot(install_signals: true)
@@ -145,8 +154,11 @@ module Wurk
 
     # --- run helpers ----------------------------------------------------
 
+    def enter_server_mode
+      Wurk.enter_server_mode(@config)
+    end
+
     def launch(self_read)
-      Wurk.server = true
       @launcher = Wurk::Launcher.new(@config)
       begin
         @launcher.run

--- a/lib/wurk/railtie.rb
+++ b/lib/wurk/railtie.rb
@@ -1,16 +1,23 @@
 # frozen_string_literal: true
 
-require "rails/railtie"
+require 'rails/railtie'
 
 module Wurk
   # Boot the swarm after the host app has fully initialized.
   # Skip when: WURK_DISABLED=1, Rails console mode, or Rails test env.
   # See docs/idea/03-process-model.md for the exact ordering.
   class Railtie < ::Rails::Railtie
-    config.after_initialize do |app|
-      next if ENV["WURK_DISABLED"] == "1"
-      next if defined?(::Rails::Console)
-      next if ::Rails.env.test?
+    # This Rails process forks the workers, so it IS the server. Enter server
+    # mode BEFORE config/initializers load — otherwise the app's
+    # `Sidekiq.configure_server` blocks gate on `config.server?` (still false)
+    # and are silently dropped. Gated identically to the swarm boot: a process
+    # that won't run workers (disabled / console / test) is not a server.
+    initializer 'wurk.server_mode', before: :load_config_initializers do
+      Wurk.enter_server_mode unless Wurk::Railtie.skip_boot?
+    end
+
+    config.after_initialize do |_app|
+      next if Wurk::Railtie.skip_boot?
 
       swarm = Wurk::Swarm.new(topology: Wurk.configuration.topology)
       swarm.boot
@@ -23,6 +30,13 @@ module Wurk
       rescue StandardError => e
         Wurk.configuration.logger.error { "wurk supervisor thread died: #{e.class}: #{e.message}" }
       end
+    end
+
+    # A process that won't run workers isn't a server: skip both server mode
+    # and the swarm boot. Console mode is detected reliably here — the console
+    # command file defines ::Rails::Console before initializers run.
+    def self.skip_boot?
+      ENV['WURK_DISABLED'] == '1' || defined?(::Rails::Console) || ::Rails.env.test?
     end
   end
 end

--- a/test/engine/railtie_test.rb
+++ b/test/engine/railtie_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative '../engine_test_helper'
+
+# The railtie owns two boot decisions, both gated by Railtie.skip_boot?:
+#   * entering server mode before config/initializers load (#191), and
+#   * forking + supervising the swarm in after_initialize.
+# A process that won't run workers (WURK_DISABLED / console / test) is not a
+# server and must do neither — otherwise the test suite itself would fork a
+# swarm and flip Sidekiq.server? on every engine run.
+class RailtieTest < Wurk::Test::EngineCase
+  def test_skip_boot_is_true_in_test_environment
+    assert_predicate ::Rails.env, :test?, 'precondition: engine tests run under the test env'
+    assert_predicate Wurk::Railtie, :skip_boot?, 'test env must never auto-boot the swarm or enter server mode'
+  end
+
+  def test_skip_boot_is_true_when_wurk_disabled
+    original = ENV.fetch('WURK_DISABLED', nil)
+    ENV['WURK_DISABLED'] = '1'
+
+    assert_predicate Wurk::Railtie, :skip_boot?
+  ensure
+    original.nil? ? ENV.delete('WURK_DISABLED') : (ENV['WURK_DISABLED'] = original)
+  end
+end

--- a/test/integration/configure_server_boot_test.rb
+++ b/test/integration/configure_server_boot_test.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'tmpdir'
+require 'fileutils'
+
+# Spawns the REAL exe/wurk binary against real Redis to prove that
+# `Sidekiq.configure_server` blocks fire in a booted worker (#191). Server mode
+# must be entered before the `-r` initializer loads, or the block — and the
+# server middleware / error handlers / lifecycle hooks inside it — is silently
+# dropped. Also asserts `configure_client` does NOT fire in the server.
+class ConfigureServerBootTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  POLL_TIMEOUT = 30.0
+  POLL_INTERVAL = 0.1
+  BOOT_TIMEOUT = 5
+
+  def setup
+    super
+    @ns = "cfgsrv-#{::Process.pid}-#{object_id}"
+    @server_key = "#{@ns}-server-startup"
+    @module_flag_key = "#{@ns}-module-flag"
+    @client_key = "#{@ns}-client"
+    @boot_file = ::File.join(::Dir.tmpdir, "#{@ns}-boot.rb")
+    @observer = RedisClient.config(url: Wurk::Test.redis_url).new_client
+  end
+
+  def teardown
+    @observer&.call('DEL', @server_key, @module_flag_key, @client_key)
+    @observer&.close
+    ::FileUtils.rm_f(@boot_file)
+  ensure
+    super
+  end
+
+  def test_configure_server_block_fires_in_booted_worker
+    write_boot_file
+    pid = spawn_worker
+
+    begin
+      assert wait_for_key(@server_key),
+             'configure_server { on(:startup) } never fired in the booted worker'
+      assert_equal 'true', @observer.call('GET', @module_flag_key),
+                   'Sidekiq.server? must be true inside the booted worker'
+      assert_nil @observer.call('GET', @client_key),
+                 'configure_client must NOT fire in a server process'
+    ensure
+      stop(pid)
+    end
+  end
+
+  private
+
+  # The `-r` initializer: registers a server hook + a client block, both writing
+  # to Redis. Only the server hook should run.
+  def write_boot_file
+    ::File.write(@boot_file, <<~RUBY)
+      require 'redis-client'
+      url = ENV.fetch('REDIS_URL')
+
+      Wurk.configure_server do |config|
+        config.redis = { url: url }
+        # Record the module flag at block-run time (deterministic — separate
+        # process, no parallel teardown can race it).
+        c = RedisClient.config(url: url).new_client
+        c.call('SET', #{@module_flag_key.inspect}, Sidekiq.server?.to_s)
+        c.call('EXPIRE', #{@module_flag_key.inspect}, 60)
+        c.close
+        config.on(:startup) do
+          c = RedisClient.config(url: url).new_client
+          c.call('SET', #{@server_key.inspect}, '1')
+          c.call('EXPIRE', #{@server_key.inspect}, 60)
+          c.close
+        end
+      end
+
+      Wurk.configure_client do |_config|
+        c = RedisClient.config(url: url).new_client
+        c.call('SET', #{@client_key.inspect}, '1')
+        c.call('EXPIRE', #{@client_key.inspect}, 60)
+        c.close
+      end
+    RUBY
+  end
+
+  def spawn_worker
+    exe = ::File.expand_path('../../exe/wurk', __dir__)
+    ::Process.spawn(
+      { 'REDIS_URL' => Wurk::Test.redis_url },
+      'bundle', 'exec', exe,
+      '-r', @boot_file, '-q', "#{@ns}-q", '-c', '1', '-e', 'production', '-t', BOOT_TIMEOUT.to_s,
+      chdir: ::File.expand_path('../..', __dir__), out: ::IO::NULL, err: ::IO::NULL
+    )
+  end
+
+  def wait_for_key(key)
+    deadline = monotonic_now + POLL_TIMEOUT
+    while monotonic_now < deadline
+      val = @observer.call('GET', key)
+      return val if val
+
+      sleep POLL_INTERVAL
+    end
+    nil
+  end
+
+  def stop(pid)
+    return unless pid_alive?(pid)
+
+    ::Process.kill('TERM', pid)
+    deadline = monotonic_now + BOOT_TIMEOUT + 5
+    while monotonic_now < deadline
+      return if ::Process.wait(pid, ::Process::WNOHANG)
+
+      sleep POLL_INTERVAL
+    end
+    ::Process.kill('KILL', pid)
+    ::Process.wait(pid)
+  rescue Errno::ECHILD
+    nil
+  end
+
+  def pid_alive?(pid)
+    ::Process.kill(0, pid)
+    true
+  rescue Errno::ESRCH, Errno::EPERM
+    false
+  end
+
+  def monotonic_now
+    ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+  end
+end

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -38,6 +38,31 @@ class CLITest < Wurk::Test::UnitCase
     assert_includes Wurk::CLI.ancestors, Wurk::Component
   end
 
+  # #191: server mode must be entered so `configure_server` blocks in the
+  # booted app actually fire (they gate on `config.server?`). Asserts the
+  # per-config gate (deterministic, local to @cli.config) — the process-global
+  # `Wurk.server?` side effect is verified in the isolated worker spawned by
+  # ConfigureServerBootTest, where a sibling test's teardown can't race it.
+  def test_enter_server_mode_opens_the_configure_server_gate
+    refute_predicate @cli.config, :server?, 'precondition: not yet in server mode'
+
+    @cli.send(:enter_server_mode)
+
+    assert_predicate @cli.config, :server?, 'config.server? gates configure_server — must be true'
+
+    yielded = false
+    @cli.config.configure_server { yielded = true }
+    assert yielded, 'configure_server must fire once server mode is entered'
+  end
+
+  def test_wurk_enter_server_mode_sets_server_flag_on_given_config
+    config = Wurk::Configuration.new
+
+    Wurk.enter_server_mode(config)
+
+    assert config[:server], 'enter_server_mode must open the per-config gate'
+  end
+
   def test_instance_is_memoized_singleton
     a = Wurk::CLI.instance
     b = Wurk::CLI.instance


### PR DESCRIPTION
Closes #191.

## The bug

`Sidekiq.configure_server` / `Wurk.configure_server` blocks gate on `config.server?` (`config[:server] == true`), but **nothing ever set that flag in a real worker**. So every `configure_server` block was silently skipped — dropping server middleware, error/death handlers, and lifecycle hooks (`on(:startup)`, `on(:fork)`, …). `Wurk.server = true` only set the *module* flag (and only after the app had already loaded), which is a different flag from the one the gate reads.

**Verified** before the fix: a *direct* `on(:startup)` fired, the *same hook via `configure_server`* did not.

## The fix

Enter server mode — both flags, together — **before the app/initializers load**, matching Sidekiq (which sets `Sidekiq.server = true` before requiring the app in its CLI).

- `Wurk.enter_server_mode(config = configuration)` sets the module flag (read via `Sidekiq.server?`) **and** the per-config gate.
- `CLI#run` / `#run_swarm` call it first, before `boot_application`. The flag rides the fork into every swarm child (the config object is copied).
- The railtie enters server mode in an initializer ordered `before: :load_config_initializers`, gated by `Railtie.skip_boot?` — the existing `WURK_DISABLED` / console / test guard, extracted and shared with the swarm-boot decision so a non-worker process isn't treated as a server.

## Acceptance criteria (#191)

- [x] `Sidekiq.configure_server` blocks execute in `exe/wurk`, `exe/wurkswarm`, and the railtie auto-fork worker
- [x] Server middleware / error handlers / `on(:startup)` registered via `configure_server` take effect
- [x] `configure_client` still does NOT fire in the server
- [x] Integration test (real boot) asserts a `configure_server`-registered hook fires

## Verification

- **Unit** (`cli_test`): `enter_server_mode` opens the per-config gate so `configure_server` yields.
- **Engine** (`railtie_test`): `Railtie.skip_boot?` is true in the test env / under `WURK_DISABLED` (so the suite never auto-forks a swarm or flips `Sidekiq.server?`).
- **Integration** (`configure_server_boot_test`, spawns the **real `exe/wurk`** against real Redis): a `configure_server { on(:startup) }` block fires, `Sidekiq.server?` is `true` in the worker, and `configure_client` does **not** fire.

Full `bin/rake test` (2128 runs) + `bin/rake test:parity` (20) green; touched/new files rubocop-clean.

## Unblocks #121

This is the dependency I flagged on #192 (`on(:fork)`). With this fix, the documented `Sidekiq.configure_server { |c| c.on(:fork) }` registration path actually fires in workers. Recommended merge order: this PR, then #192.

## How to test in prod

```ruby
# config/initializers/wurk.rb
Sidekiq.configure_server do |config|
  config.server_middleware { |c| c.add MyServerMiddleware }
  config.on(:startup) { Rails.logger.info "wurk worker booting" }
end
```

Boot a worker (`bundle exec wurk`, `bundle exec wurkswarm`, or a Rails app via the railtie). The middleware now wraps job execution and the `:startup` line logs once per worker — previously both were silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed server initialization sequence to ensure configuration takes effect properly.

* **Tests**
  * Added tests for server startup behavior and configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->