### PR TITLE
feat(swarm): honor SIDEKIQ_MAXMEM_MB for memory-based child recycling (#119)

### DIFF
--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -355,6 +355,26 @@ module Wurk
       @topology = value
     end
 
+    # Memory-based child recycling (Sidekiq Ent §7.5): the swarm parent TERMs
+    # (and respawns) any child whose RSS exceeds this many MB. Set in code or
+    # via SIDEKIQ_MAXMEM_MB (WURK_MAXMEM_MB is the native alias); an explicit
+    # value wins over the env. nil/0 disables recycling (the default).
+    def memory_limit_mb
+      @memory_limit_mb || env_memory_limit_mb
+    end
+
+    def memory_limit_mb=(value)
+      guard_frozen!
+      @memory_limit_mb = value.nil? ? nil : Integer(value)
+    end
+
+    # Threshold in KB, the unit the swarm compares against /proc/<pid>/statm
+    # (pages × 4KB). nil when recycling is disabled.
+    def memory_limit_kb
+      mb = memory_limit_mb
+      mb&.positive? ? mb * 1024 : nil
+    end
+
     def freeze!
       return self if @frozen
 
@@ -399,6 +419,17 @@ module Wurk
       [count, 1].max
     rescue ArgumentError, TypeError
       Etc.nprocessors
+    end
+
+    # SIDEKIQ_MAXMEM_MB is the drop-in name; WURK_MAXMEM_MB the native alias.
+    # Unparseable / empty input disables recycling rather than raising at boot.
+    def env_memory_limit_mb
+      raw = ENV['WURK_MAXMEM_MB'] || ENV['SIDEKIQ_MAXMEM_MB']
+      return nil if raw.nil? || raw.strip.empty?
+
+      Integer(raw)
+    rescue ArgumentError, TypeError
+      nil
     end
 
     def guard_frozen!

--- a/lib/wurk/swarm.rb
+++ b/lib/wurk/swarm.rb
@@ -36,7 +36,7 @@ module Wurk
 
     attr_reader :topology, :children
 
-    def initialize(topology:, config: Wurk.configuration, memory_limit: nil,
+    def initialize(topology:, config: Wurk.configuration, memory_limit: config.memory_limit_kb,
                    shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT)
       @topology = topology
       @config = config

--- a/test/integration/swarm_boot_test.rb
+++ b/test/integration/swarm_boot_test.rb
@@ -35,6 +35,7 @@ class SwarmBootTest < Wurk::Test::UnitCase
     @ns = "swarmboot-#{Process.pid}-#{object_id}"
     @queue_name = "#{@ns}-q"
     @sentinel_key = "#{@ns}-sentinel"
+    @boot_log_key = "#{@ns}-boot-log"
     @config = Wurk::Configuration.new
     @config.logger = ::Logger.new(IO::NULL)
     @config[:timeout] = 5
@@ -42,7 +43,7 @@ class SwarmBootTest < Wurk::Test::UnitCase
   end
 
   def teardown
-    @observer_pool&.call('DEL', @sentinel_key, "queue:#{@queue_name}",
+    @observer_pool&.call('DEL', @sentinel_key, @boot_log_key, "queue:#{@queue_name}",
                          private_queue_key(@queue_name))
     @observer_pool&.close
     @config&.reset_redis_pools!
@@ -74,6 +75,33 @@ class SwarmBootTest < Wurk::Test::UnitCase
     end
   end
 
+  # #119 (Ent §7.5): a child whose RSS exceeds the memory limit is TERMed and
+  # respawned. A 1 MB limit guarantees every real Ruby child exceeds it. Each
+  # child logs its pid on startup; we boot, wait for the first child to be
+  # fully up (so the supervisor's immediate first memory check can't TERM it
+  # mid-boot), then start the supervisor and watch a different pid take over.
+  def test_swarm_recycles_a_child_that_exceeds_the_memory_limit # rubocop:disable Metrics/AbcSize,Minitest/MultipleAssertions
+    log_boot_pids
+    @config.memory_limit_mb = 1
+    swarm = Wurk::Swarm.new(topology: topology_n(1), config: @config, shutdown_timeout: 5)
+
+    original = swarm.boot(install_signals: false).first
+    begin
+      assert_equal original.to_s, wait_for_boot_count(1)&.first,
+                   "first child #{original} never finished booting"
+
+      supervisor = Thread.new { swarm.supervise }
+      pids = wait_for_boot_count(2)
+
+      assert pids, "child was never recycled+respawned within #{POLL_TIMEOUT}s (saw #{boot_pids.inspect})"
+      refute_equal pids[0], pids[1], 'the bloated child should be replaced by a new pid'
+      refute pid_alive?(original), 'the original (bloated) child should have been terminated'
+    ensure
+      swarm.shutdown(timeout: 5)
+      supervisor&.join(10)
+    end
+  end
+
   def test_boot_raises_when_topology_is_empty
     swarm = Wurk::Swarm.new(topology: Wurk::Topology.new, config: @config)
     assert_raises(ArgumentError) { swarm.boot(install_signals: false) }
@@ -93,6 +121,35 @@ class SwarmBootTest < Wurk::Test::UnitCase
 
   def topology_n(count)
     Wurk::Topology.flat(count: count, queues: [@queue_name], concurrency: 1)
+  end
+
+  # Each child appends its pid to a Redis list as it boots (via :startup),
+  # giving a race-free, fork-safe record of the recycle → respawn sequence.
+  def log_boot_pids
+    redis_url = Wurk::Test.redis_url
+    key = @boot_log_key
+    @config.on(:startup) do
+      c = RedisClient.config(url: redis_url).new_client
+      c.call('RPUSH', key, ::Process.pid.to_s)
+      c.call('EXPIRE', key, 60)
+    ensure
+      c&.close
+    end
+  end
+
+  def boot_pids
+    @observer_pool.call('LRANGE', @boot_log_key, 0, -1)
+  end
+
+  def wait_for_boot_count(count)
+    deadline = monotonic_now + POLL_TIMEOUT
+    while monotonic_now < deadline
+      pids = boot_pids
+      return pids if pids.size >= count
+
+      sleep POLL_INTERVAL
+    end
+    nil
   end
 
   def push_sentinel_job

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -6,17 +6,18 @@ require 'etc'
 class ConfigurationTest < Wurk::Test::UnitCase
   parallelize_me!
 
+  ENV_KNOBS = %w[WURK_COUNT SIDEKIQ_COUNT WURK_MAXMEM_MB SIDEKIQ_MAXMEM_MB].freeze
+
   def setup
     @config = Wurk::Configuration.new
-    # default_topology reads these; neutralize the ambient env so the count
-    # tests are deterministic and teardown always restores the originals.
-    @count_env = { 'WURK_COUNT' => ENV['WURK_COUNT'], 'SIDEKIQ_COUNT' => ENV['SIDEKIQ_COUNT'] }
-    ENV.delete('WURK_COUNT')
-    ENV.delete('SIDEKIQ_COUNT')
+    # default_topology / memory_limit_mb read these; neutralize the ambient env
+    # so the tests are deterministic and teardown always restores the originals.
+    @saved_env = ENV_KNOBS.to_h { |k| [k, ENV.fetch(k, nil)] }
+    ENV_KNOBS.each { |k| ENV.delete(k) }
   end
 
   def teardown
-    @count_env.each { |k, v| v.nil? ? ENV.delete(k) : (ENV[k] = v) }
+    @saved_env.each { |k, v| v.nil? ? ENV.delete(k) : (ENV[k] = v) }
     super
   end
 
@@ -123,6 +124,47 @@ class ConfigurationTest < Wurk::Test::UnitCase
   # in parallel with classes that mutate the Wurk::Web.config singleton.
   def test_web_delegates_to_web_config_singleton
     assert_same Wurk::Web.config, @config.web
+  end
+
+  # --- memory limit (SIDEKIQ_MAXMEM_MB, Ent §7.5) -----------------------
+
+  def test_memory_limit_defaults_to_nil_when_unset
+    assert_nil @config.memory_limit_mb
+    assert_nil @config.memory_limit_kb
+  end
+
+  def test_memory_limit_reads_sidekiq_maxmem_mb_env
+    ENV['SIDEKIQ_MAXMEM_MB'] = '1500'
+
+    assert_equal 1500, @config.memory_limit_mb
+    assert_equal 1500 * 1024, @config.memory_limit_kb
+  end
+
+  def test_memory_limit_prefers_wurk_native_env_over_sidekiq
+    ENV['SIDEKIQ_MAXMEM_MB'] = '1500'
+    ENV['WURK_MAXMEM_MB'] = '2000'
+
+    assert_equal 2000, @config.memory_limit_mb
+  end
+
+  def test_memory_limit_setter_overrides_env
+    ENV['SIDEKIQ_MAXMEM_MB'] = '1500'
+    @config.memory_limit_mb = 800
+
+    assert_equal 800, @config.memory_limit_mb
+    assert_equal 800 * 1024, @config.memory_limit_kb
+  end
+
+  def test_memory_limit_kb_disabled_when_zero
+    @config.memory_limit_mb = 0
+
+    assert_nil @config.memory_limit_kb, 'zero disables recycling'
+  end
+
+  def test_memory_limit_unparseable_env_disables_rather_than_raises
+    ENV['SIDEKIQ_MAXMEM_MB'] = 'not-a-number'
+
+    assert_nil @config.memory_limit_mb
   end
 
   # --- default capsule shortcuts ----------------------------------------

--- a/test/unit/swarm_test.rb
+++ b/test/unit/swarm_test.rb
@@ -36,6 +36,22 @@ class SwarmTest < Wurk::Test::UnitCase
     assert_equal 500_000, swarm.instance_variable_get(:@memory_limit)
   end
 
+  # #119: with no explicit memory_limit, the swarm picks up the config's
+  # SIDEKIQ_MAXMEM_MB-derived threshold (in KB) so the railtie / wurkswarm /
+  # demo entry points all honor it without each passing it through.
+  def test_initialize_defaults_memory_limit_from_config
+    @config.memory_limit_mb = 750
+    swarm = Wurk::Swarm.new(topology: topology, config: @config)
+
+    assert_equal 750 * 1024, swarm.instance_variable_get(:@memory_limit)
+  end
+
+  def test_initialize_memory_limit_nil_when_config_unset
+    swarm = Wurk::Swarm.new(topology: topology, config: @config)
+
+    assert_nil swarm.instance_variable_get(:@memory_limit)
+  end
+
   # --- boot validation --------------------------------------------------
 
   def test_boot_raises_on_empty_topology


### PR DESCRIPTION
Closes #119.

## What

Sidekiq Enterprise §7.5 recycles any swarm child whose RSS exceeds `SIDEKIQ_MAXMEM_MB`. Wurk already had the recycle mechanism (`Swarm#check_memory_pressure` / `recycle_if_bloated`, reading `/proc/<pid>/statm`), but **nothing ever fed it a limit** — `Swarm.new(memory_limit:)` defaulted to `nil`, so the feature never fired in any real boot.

- **`Configuration#memory_limit_mb`** (+ setter) reads `SIDEKIQ_MAXMEM_MB`, with `WURK_MAXMEM_MB` as the native alias. An explicit `config.memory_limit_mb = …` wins over the env; unparseable/empty env disables rather than raising.
- **`Configuration#memory_limit_kb`** converts MB→KB (the unit the swarm compares against `statm`, which is pages×4KB). `nil`/`0` disables recycling.
- **`Swarm.new`** defaults `memory_limit:` to `config.memory_limit_kb`, so the railtie, `wurkswarm`/`sidekiqswarm`, and the demo entrypoint all honor it **without each threading it through** — a single source of truth.

## Acceptance criteria (#119)

- [x] `SIDEKIQ_MAXMEM_MB=1500` causes a child exceeding ~1500 MB RSS to receive TERM and be respawned
- [x] With the env unset, behavior is unchanged (no recycling)
- [x] Integration test asserts a bloated child is recycled
- [x] Units confirmed: swarm compares KB; `statm` column is pages×4KB; MB→KB = ×1024

## Verification

- **Unit** (`configuration_test`): env read, `WURK_MAXMEM_MB` precedence, setter-over-env, MB→KB conversion, `nil`/`0`/unparseable → disabled.
- **Unit** (`swarm_test`): `Swarm.new` defaults `memory_limit` from `config.memory_limit_kb`; `nil` when unset.
- **Integration** (`swarm_boot_test`, real forks + real Redis): with a 1 MB limit, a booted child is TERMed and a **different** pid respawns to take its place (race-free Redis boot-log observer; the original child is confirmed dead).
- **Behavioral driver** through the real `SIDEKIQ_MAXMEM_MB` env var:

```
=== issue #119 SIDEKIQ_MAXMEM_MB behavioral verification ===
  [PASS] SIDEKIQ_MAXMEM_MB=1 -> config.memory_limit_kb == 1024
  [PASS] first child booted
  [PASS] bloated child recycled + a new child respawned
  derived_kb=1024  boot-log pids=["3245259", "3245298"]  original=3245259
```

Full `bin/rake test` (2139 runs) + `bin/rake test:parity` (20) green; touched/new files rubocop-clean.

## How to test in prod

```bash
# Recycle any worker child that grows past 1500 MB RSS:
SIDEKIQ_MAXMEM_MB=1500 bundle exec wurkswarm -e production
# (or WURK_MAXMEM_MB=1500; or set it on the Rails process that auto-forks the swarm)
```

Or in code:

```ruby
Sidekiq.configure_server { |config| config.memory_limit_mb = 1500 }
```

The swarm parent polls each child's RSS (every 10s) and `TERM`s — then respawns — any child over the threshold. Unset = no recycling (unchanged). Confirm via the parent log: `swarm: child <pid> RSS <n>KB >= <limit>KB; recycling`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced memory limit configuration to enable automatic child process recycling when memory thresholds are exceeded.
  * Support for `WURK_MAXMEM_MB` and `SIDEKIQ_MAXMEM_MB` environment variables for setting memory limits.
  * Memory limits can be configured and overridden programmatically.

* **Tests**
  * Added integration and unit test coverage for memory limit configuration and child process recycling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->