### PR TITLE
feat(web): per-loop execution history in the Periodic/Cron dashboard (#117)

### DIFF
--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -65,10 +65,15 @@
     "busy": "Live worker processes and the jobs they're currently running.",
     "batches": "Batched jobs and their progress, successes, and failures.",
     "limiters": "Rate limiters and their current usage.",
-    "cron": "Periodic (cron) jobs with their schedule and last run.",
+    "cron": "Periodic (cron) jobs with their schedule and last run — click a loop to see its execution history.",
     "metrics": "Throughput and failure history, with per-job execution stats.",
     "profiles": "Captured job profiles — open one in the Firefox profiler to inspect its flame graph.",
     "search": "Find a job across retries, scheduled, and dead by JID or class name."
+  },
+  "cron": {
+    "history_title": "Execution history",
+    "fired": "Fired",
+    "no_history": "No runs recorded yet"
   },
   "job": {
     "detail": "Job detail",

--- a/frontend/src/pages/Cron.tsx
+++ b/frontend/src/pages/Cron.tsx
@@ -1,11 +1,15 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { t } from '../i18n';
 import { PageHeader } from '../components/PageHeader';
-import { relativeTime, truncate } from '../utils';
+import Modal from '../components/Modal';
+import { relativeTime, isoTime, truncate } from '../utils';
 import { useMeta } from '../hooks/useMeta';
 import { SortableTh } from '../components/SortableTh';
 import { useSort, type Accessors } from '../hooks/useSort';
+
+// Newest-first [fired_at, jid] tuples from GET /wurk/api/cron/:lid/history.
+type HistoryEntry = [number, string];
 
 interface CronLoop {
   lid: string;
@@ -32,6 +36,7 @@ export default function Cron() {
   const qc = useQueryClient();
   const { data: meta } = useMeta();
   const readOnly = meta?.read_only ?? false;
+  const [historyLoop, setHistoryLoop] = useState<CronLoop | null>(null);
 
   useEffect(() => {
     document.title = `${t('nav.cron')} — Wurk`;
@@ -56,6 +61,16 @@ export default function Cron() {
   const enqueueNow = useMutation({
     mutationFn: (lid: string) => post(lid, 'enqueue'),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['cron'] }),
+  });
+
+  // Per-loop run history — fetched on demand when a row opens the modal.
+  const { data: history, isLoading: historyLoading } = useQuery<HistoryEntry[]>({
+    queryKey: ['cron-history', historyLoop?.lid],
+    queryFn: () =>
+      fetch(`/wurk/api/cron/${historyLoop!.lid}/history`)
+        .then((r) => r.json() as Promise<{ history: HistoryEntry[] }>)
+        .then((d) => d.history),
+    enabled: historyLoop !== null,
   });
 
   const { sorted, sort, toggle } = useSort(data ?? [], SORT);
@@ -87,7 +102,11 @@ export default function Cron() {
             </thead>
             <tbody>
               {sorted.map((loop) => (
-                <tr key={loop.lid}>
+                <tr
+                  key={loop.lid}
+                  className="row-clickable"
+                  onClick={() => setHistoryLoop(loop)}
+                >
                   <td style={{ fontFamily: 'monospace', fontSize: 12 }} title={loop.tz ?? undefined}>
                     {loop.schedule}
                   </td>
@@ -107,7 +126,7 @@ export default function Cron() {
                     )}
                   </td>
                   {!readOnly && (
-                    <td>
+                    <td onClick={(e) => e.stopPropagation()}>
                       <div style={{ display: 'flex', gap: '0.4rem' }}>
                         <button
                           className="btn btn-sm"
@@ -132,6 +151,43 @@ export default function Cron() {
           </table>
         </div>
       )}
+
+      <Modal
+        open={historyLoop !== null}
+        onClose={() => setHistoryLoop(null)}
+        title={
+          historyLoop
+            ? `${t('cron.history_title')} — ${truncate(historyLoop.klass, 40)}`
+            : t('cron.history_title')
+        }
+      >
+        {historyLoading ? (
+          <div className="empty-state"><span className="spinner" /></div>
+        ) : !history || history.length === 0 ? (
+          <div className="empty-state">{t('cron.no_history')}</div>
+        ) : (
+          <div className="table-wrapper">
+            <table>
+              <thead>
+                <tr>
+                  <th>{t('cron.fired')}</th>
+                  <th>{t('table.jid')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {history.map(([firedAt, jid], i) => (
+                  <tr key={`${jid}-${i}`}>
+                    <td style={{ color: 'var(--text-muted)' }} title={isoTime(firedAt)}>
+                      {relativeTime(firedAt)}
+                    </td>
+                    <td style={{ fontFamily: 'monospace', fontSize: 12 }}>{jid}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Modal>
     </div>
   );
 }

--- a/frontend/src/pages/Cron.tsx
+++ b/frontend/src/pages/Cron.tsx
@@ -64,7 +64,7 @@ export default function Cron() {
   });
 
   // Per-loop run history — fetched on demand when a row opens the modal.
-  const { data: history, isLoading: historyLoading } = useQuery<HistoryEntry[]>({
+  const { data: history, isLoading: historyLoading, isError: historyError } = useQuery<HistoryEntry[]>({
     queryKey: ['cron-history', historyLoop?.lid],
     queryFn: () =>
       fetch(`/wurk/api/cron/${historyLoop!.lid}/history`)
@@ -163,6 +163,8 @@ export default function Cron() {
       >
         {historyLoading ? (
           <div className="empty-state"><span className="spinner" /></div>
+        ) : historyError ? (
+          <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>
         ) : !history || history.length === 0 ? (
           <div className="empty-state">{t('cron.no_history')}</div>
         ) : (
@@ -175,8 +177,8 @@ export default function Cron() {
                 </tr>
               </thead>
               <tbody>
-                {history.map(([firedAt, jid], i) => (
-                  <tr key={`${jid}-${i}`}>
+                {history.map(([firedAt, jid]) => (
+                  <tr key={jid}>
                     <td style={{ color: 'var(--text-muted)' }} title={isoTime(firedAt)}>
                       {relativeTime(firedAt)}
                     </td>

--- a/test/engine/api_endpoints_test.rb
+++ b/test/engine/api_endpoints_test.rb
@@ -257,6 +257,37 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
     cleanup_cron_loop(lid)
   end
 
+  # #117: the Periodic page's history modal fetches this — [fired_at, jid]
+  # tuples, newest-first (LPUSH order), which the SPA renders as relative time
+  # + jid. (api_controller#cron_history)
+  def test_cron_history_returns_entries_newest_first
+    lid = seed_cron_loop
+    older = ::Time.now.to_i - 120
+    newer = ::Time.now.to_i - 10
+    push_fire_history(lid, older)
+    push_fire_history(lid, newer)
+
+    get "/wurk/api/cron/#{lid}/history"
+
+    assert_ok
+    assert_equal lid, json_body[:lid]
+    assert_equal [[newer, 'abc123'], [older, 'abc123']], json_body[:history]
+  ensure
+    ::Wurk.redis { |c| c.call('DEL', "#{::Wurk::Cron::HISTORY_PREFIX}#{lid}") }
+    cleanup_cron_loop(lid)
+  end
+
+  def test_cron_history_empty_for_loop_without_runs
+    lid = seed_cron_loop
+
+    get "/wurk/api/cron/#{lid}/history"
+
+    assert_ok
+    assert_empty json_body[:history]
+  ensure
+    cleanup_cron_loop(lid)
+  end
+
   def test_metrics_returns_top_jobs
     get '/wurk/api/metrics?minutes=5'
 


### PR DESCRIPTION
Closes #117.

## What

Sidekiq Enterprise §2.4 lists **Execution history view** as one of the three Periodic Web UI ops (the others — pause/unpause and Enqueue Now — Wurk already had in the UI). The backend + API existed (`GET /wurk/api/cron/:lid/history` → `[[fired_at, jid], ...]` newest-first), but the SPA never consumed them — the Cron table showed only Schedule / Last fire / Next fire.

- **`Cron.tsx`**: clicking a loop row opens a `Modal` that fetches that loop's history **on demand** (TanStack Query, keyed `['cron-history', lid]`, `enabled` only while the modal is open). Each run renders as relative fired-at (ISO timestamp on hover) + jid, **newest first** (matching the LPUSH/LIST order), with a loading spinner and an empty state. The Pause/Enqueue cell stops row-click propagation; history works in read-only mode (it's a read op).
- **i18n**: `cron.history_title` / `cron.fired` / `cron.no_history` (reuses `table.jid`); the Cron summary now hints the row is clickable. Other locales fall back to `en` (the bundle is `DeepPartial`).

## Acceptance criteria (#117)

- [x] Cron.tsx adds an affordance (row → modal) that fetches `/wurk/api/cron/:lid/history` on demand
- [x] Renders each entry as fired-at (relative) + jid, newest first, matching LIST order; empty state handled
- [x] i18n keys added; query keyed/`enabled` via TanStack Query; no console errors (clean `tsc -b`)
- [x] Engine test asserts the history affordance's data contract (entries newest-first + empty state)

## Verification

- `tsc -b` clean and `rake frontend:build` succeeds (both run in CI).
- **Engine tests** (`api_endpoints_test`): `cron_history` returns `[[newer, jid], [older, jid]]` newest-first, and `[]` for a loop with no runs — the exact shape/order the modal renders.
- Full `bin/rake test` (2141 runs) green.

> The frontend has no JS test runner (the gem ships precompiled assets; consumers never run Node), so rendering is covered by the type-check + build (CI) plus the endpoint-contract engine tests, rather than a DOM unit test.

## How to test in prod

Open the dashboard → **Cron**. Click any periodic loop row → a modal lists its recent runs (fired-at + jid), newest first. A loop that hasn't fired yet shows "No runs recorded yet". (Backed by `loop-history:{lid}`, which the periodic poller LPUSHes on each fire.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cron loops now support viewing execution history. Click any cron loop row to open a modal showing past fire events and run details.
* **Localization**
  * Updated English UI text for the summaries/cron area and added new cron-related copy for history, fired, and no-history states.
* **Tests**
  * Added automated tests verifying cron history responses for loops with and without runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->