### PR TITLE
fix(web): redact encrypted job args in the dashboard as "<encrypted>" (#118)

### DIFF
--- a/lib/wurk/encryption.rb
+++ b/lib/wurk/encryption.rb
@@ -160,10 +160,15 @@ module Wurk
       # array with the last element replaced by the literal `"<encrypted>"`
       # when the job opted in. Cleartext preceding args are untouched so
       # operators can still triage on user_id / object_id / etc.
+      #
+      # Masks on the `encrypt` flag *or* an envelope-shaped last arg: a stored
+      # job hash doesn't always carry `encrypt` (it's a `sidekiq_options`, not
+      # persisted on every record), so envelope detection is the real guard —
+      # it keeps ciphertext out of the dashboard regardless of the flag.
       def redact_args(job)
         args = job['args'] || job[:args] || []
-        return args unless job['encrypt'] || job[:encrypt]
         return args if args.empty?
+        return args unless job['encrypt'] || job[:encrypt] || envelope?(args.last)
 
         args[0..-2] + ['<encrypted>']
       end

--- a/lib/wurk/job_record.rb
+++ b/lib/wurk/job_record.rb
@@ -105,10 +105,16 @@ module Wurk
       @display_class = active_job_wrapper? ? unwrap_class : klass
     end
 
+    # UI-facing args. Encrypted jobs (§4.7) get their envelope last arg
+    # masked as "<encrypted>" so ciphertext never reaches the dashboard;
+    # redaction keys off the envelope shape, so it fires whether or not the
+    # stored hash carried the `encrypt` flag. Cleartext preceding args stay
+    # visible for triage. Display-only — the stored payload is untouched.
     def display_args
       return @display_args if defined?(@display_args)
 
-      @display_args = active_job_wrapper? ? unwrap_args : args
+      base = active_job_wrapper? ? unwrap_args : args
+      @display_args = Wurk::Encryption.redact_args('args' => base, 'encrypt' => item['encrypt'])
     end
 
     # @api internal

--- a/test/engine/api_endpoints_test.rb
+++ b/test/engine/api_endpoints_test.rb
@@ -99,6 +99,52 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
     assert_empty json_body[:jobs]
   end
 
+  # --- §4.7 encrypted-arg redaction in the Web UI --------------------------
+  # The serializer/search paths funnel through JobRecord#display_args; these
+  # assert the rendered payload masks the envelope (not just redact_args in
+  # isolation) and never leaks ciphertext. Masking keys off the envelope
+  # SHAPE, so the pushed jobs deliberately omit the `encrypt` flag.
+
+  def test_queue_masks_encrypted_last_arg
+    push_encrypted_to_queue
+    get "/wurk/api/queues/#{@queue}"
+
+    assert_ok
+    job = json_body[:jobs].find { |j| j[:klass] == @class_name }
+    assert_equal [99, '<encrypted>'], job[:args]
+    assert_no_envelope_leak
+  end
+
+  def test_dead_masks_encrypted_last_arg
+    push_encrypted_to_zset('dead')
+    get '/wurk/api/dead'
+
+    assert_ok
+    entry = json_body[:entries].find { |e| e[:klass] == @class_name }
+    assert_equal [99, '<encrypted>'], entry[:args]
+    assert_no_envelope_leak
+  end
+
+  def test_search_masks_encrypted_last_arg
+    jid = push_encrypted_to_queue
+    get "/wurk/api/search?substr=#{jid}"
+
+    assert_ok
+    hit = json_body[:hits].find { |h| h[:jid] == jid }
+    refute_nil hit
+    assert_equal [99, '<encrypted>'], hit[:args]
+    assert_no_envelope_leak
+  end
+
+  def test_non_encrypted_args_render_unchanged
+    push_to_queue
+    get "/wurk/api/queues/#{@queue}"
+
+    assert_ok
+    job = json_body[:jobs].find { |j| j[:klass] == @class_name }
+    assert_equal [1, 2], job[:args]
+  end
+
   def test_retries_returns_paged_envelope
     push_to_zset('retry')
     get '/wurk/api/retries?count=5'
@@ -382,6 +428,42 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
       'error_class' => 'RuntimeError',
       'error_message' => 'boom'
     }
+  end
+
+  # A crypto envelope shaped like Wurk::Encryption.encrypt's output. The
+  # ct/iv/tag base64 below double as canaries in assert_no_envelope_leak.
+  def encrypted_envelope
+    {
+      ::Wurk::Encryption::ENVELOPE_MARKER => true,
+      'v' => 1,
+      'iv' => 'aXYtY2FuYXJ5',
+      'ct' => 'Y3QtY2FuYXJ5',
+      'tag' => 'dGFnLWNhbmFyeQ=='
+    }
+  end
+
+  def push_encrypted_to_queue
+    payload = job_payload.merge('args' => [99, encrypted_envelope])
+    ::Wurk.redis do |c|
+      c.call('SADD', 'queues', @queue)
+      c.call('LPUSH', "queue:#{@queue}", ::Wurk.dump_json(payload))
+    end
+    payload['jid']
+  end
+
+  def push_encrypted_to_zset(name)
+    payload = job_payload.merge('args' => [99, encrypted_envelope])
+    ::Wurk.redis { |c| c.call('ZADD', name, ::Time.now.to_f.to_s, ::Wurk.dump_json(payload)) }
+    payload['jid']
+  end
+
+  # No part of the envelope — marker or any base64 field — may survive into
+  # a rendered Web UI payload.
+  def assert_no_envelope_leak
+    body = last_response.body
+    [::Wurk::Encryption::ENVELOPE_MARKER, 'aXYtY2FuYXJ5', 'Y3QtY2FuYXJ5', 'dGFnLWNhbmFyeQ=='].each do |marker|
+      refute_includes body, marker, "envelope fragment #{marker.inspect} leaked into Web UI payload"
+    end
   end
 
   def push_fire_history(lid, fired_at)

--- a/test/unit/encryption_test.rb
+++ b/test/unit/encryption_test.rb
@@ -510,6 +510,25 @@ class EncryptionTest < Wurk::Test::UnitCase
     assert_equal [1, '<encrypted>'], Wurk::Encryption.redact_args(job)
   end
 
+  # The stored job hash doesn't always carry `encrypt` (it's a sidekiq_option,
+  # not persisted on every record), so an envelope-shaped last arg is masked
+  # on shape alone via envelope? — otherwise ciphertext leaks into the Web UI.
+  def test_redact_args_masks_envelope_when_encrypt_flag_absent
+    job = { 'args' => [1, {
+      Wurk::Encryption::ENVELOPE_MARKER => true, 'v' => 1, 'iv' => 'aXY=', 'ct' => 'Y3Q=', 'tag' => 'dGFn'
+    }] }
+
+    assert_equal [1, '<encrypted>'], Wurk::Encryption.redact_args(job)
+  end
+
+  # A non-envelope Hash as the last arg (no flag) is left untouched — masking
+  # must not over-trigger on arbitrary hashes.
+  def test_redact_args_leaves_plain_hash_last_arg_untouched
+    job = { 'args' => [1, { 'user' => 'alice' }] }
+
+    assert_equal [1, { 'user' => 'alice' }], Wurk::Encryption.redact_args(job)
+  end
+
   # ---- helpers ---------------------------------------------------------
 
   private

--- a/test/unit/job_record_test.rb
+++ b/test/unit/job_record_test.rb
@@ -201,6 +201,24 @@ class JobRecordTest < Wurk::Test::UnitCase
     assert_same first, record.display_args
   end
 
+  # §4.7: an encryption envelope as the last arg renders as "<encrypted>" so
+  # ciphertext never reaches the dashboard. Keyed on envelope shape, so it
+  # fires even when the stored hash lacks the `encrypt` flag (as here).
+  def test_display_args_masks_encrypted_envelope_last_arg
+    item = base_item.merge('args' => [7, encryption_envelope])
+    record = Wurk::JobRecord.new(item, @qname)
+
+    assert_equal [7, '<encrypted>'], record.display_args
+  end
+
+  # Cleartext preceding args stay visible for triage; only the envelope hides.
+  def test_display_args_keeps_cleartext_preceding_encrypted_arg
+    item = base_item.merge('args' => ['user-42', 'order-7', encryption_envelope])
+    record = Wurk::JobRecord.new(item, @qname)
+
+    assert_equal ['user-42', 'order-7', '<encrypted>'], record.display_args
+  end
+
   # display_class memoization must survive a nil unwrap result so the second
   # call short-circuits even when the value is falsy-ish (here: plain klass).
   def test_display_class_memoizes_active_job_wrapper
@@ -317,5 +335,16 @@ class JobRecordTest < Wurk::Test::UnitCase
 
   def ms_now
     ::Process.clock_gettime(::Process::CLOCK_REALTIME, :millisecond)
+  end
+
+  # A crypto envelope shaped like Wurk::Encryption.encrypt's output.
+  def encryption_envelope
+    {
+      ::Wurk::Encryption::ENVELOPE_MARKER => true,
+      'v' => 1,
+      'iv' => 'aXY=',
+      'ct' => 'Y3Q=',
+      'tag' => 'dGFn'
+    }
   end
 end


### PR DESCRIPTION
Closes #118.

## Problem
`Wurk::Encryption.redact_args` (the §4.7 Web-UI masker) existed and was unit-tested but was **dead code** — no call site. The dashboard render path (`Api::Serializers#job_record`/`#sorted_entry` → `JobRecord#display_args`, and `Web::Search`) returned raw args, so an encrypted job's last arg leaked into the UI as the verbatim envelope:

```
{"__wurk_enc__":true,"v":1,"iv":"…","ct":"<base64 ciphertext>","tag":"…"}
```

…in Queues / Retries / Scheduled / Dead and Search. That defeats opting into encryption and breaks the §4.7 drop-in display contract (encrypted args must read `<encrypted>`).

## Fix
Wire redaction through **`JobRecord#display_args`** — the single chokepoint that `Api::Serializers#job_record`/`#sorted_entry` and `Web::Search` (queue_row + sorted_row) all funnel through, and that `SortedEntry < JobRecord` inherits. One change covers every view.

Masking keys off the envelope **shape** (`Encryption.envelope?`), not the `encrypt` flag — the flag isn't persisted on every stored job hash, so shape detection is the reliable guard. Cleartext preceding args stay visible for triage. **Display-only**: the stored Redis payload is never mutated, so wire-compat is preserved.

## Acceptance criteria
- [x] An enqueued/retried/scheduled/dead encrypted job shows its last arg as `"<encrypted>"`; cleartext preceding args remain visible.
- [x] No `ct` / `iv` / `tag` / `__wurk_enc__` ever appears in any Web-UI args payload.
- [x] **Engine/web test** asserts the *serializer output* masks the envelope (not just `redact_args` in isolation) — across queue / dead / search.
- [x] Non-encrypted jobs are unaffected (args render unchanged); non-envelope hashes are left alone.

## Tests
- `test/unit/encryption_test.rb` — `redact_args` masks an envelope with/without the `encrypt` flag; leaves a plain hash last-arg untouched.
- `test/unit/job_record_test.rb` — `display_args` masks an envelope last arg; keeps cleartext preceding args.
- `test/engine/api_endpoints_test.rb` — queue / dead / search endpoints render `["…","<encrypted>"]` and `assert_no_envelope_leak` (no marker or ct/iv/tag base64 in the response body).

Full suite (2149 runs, 0 failures), `test:parity`, and `test:ecosystem` all green locally. A behavioral driver pushing a real AES-256-GCM job confirmed the serialized output masks everywhere with zero leakage.

## How to test in prod
Encrypt a job's last arg, then confirm the dashboard hides it:

```ruby
# An encrypted worker (Sidekiq Enterprise crypto must be enabled)
class SecretJob
  include Sidekiq::Job
  sidekiq_options encrypt: true, queue: "default"
  def perform(public_id, secret); end
end

SecretJob.perform_async("user-42", { ssn: "123-45-6789" })
```

Open the dashboard → **Queues → default** (and **Dead** if it fails). The args column should read `user-42, <encrypted>` — **not** the `{"__wurk_enc__":…,"ct":"…"}` envelope. Search for the jid shows the same masked args. No restart needed; masking is on the read/render path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Encrypted job arguments now properly display as masked (`<encrypted>`) in the web UI across queue listings, dead letters, and search results.
  * Improved encryption detection to mask sensitive arguments more reliably, even without explicit encryption flags.

* **Tests**
  * Added comprehensive test coverage for encrypted argument masking across UI endpoints and scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->