### PR TITLE
feat(web): per-queue size & latency historical gauges (#124, #126)

### DIFF
--- a/app/controllers/wurk/api/serializers.rb
+++ b/app/controllers/wurk/api/serializers.rb
@@ -127,6 +127,13 @@ module Wurk
         { at: row[:at], processed: row[:p], failed: row[:f], runtime_ms: row[:ms] }
       end
 
+      # One queue's size/latency gauge series (Wurk::Metrics::Query.queue_history).
+      # `points` are oldest→newest; `at` is epoch seconds at the bucket start,
+      # `size` is queue depth, `latency` is head-of-line wait in seconds.
+      def queue_history_series(row)
+        { name: row[:name], points: row[:points].map { |p| { at: p[:at], size: p[:size], latency: p[:latency] } } }
+      end
+
       def parse_options(raw)
         return {} if raw.nil? || raw.to_s.empty?
 

--- a/app/controllers/wurk/api_controller.rb
+++ b/app/controllers/wurk/api_controller.rb
@@ -228,6 +228,23 @@ module Wurk
       render json: { error: e.message }, status: :bad_request
     end
 
+    # Per-queue size/latency gauge time-series for the Metrics/Historical tab.
+    # `:bucket` is 1m/5m/1h; `?window=24h` (s/m/h/d) is clamped to the bucket's
+    # retention; optional `?queue=<name>` narrows to one queue. Each queue's
+    # `points` are Recharts-ready.
+    def queue_history
+      window = parse_window(params[:window])
+      queues = params[:queue].present? ? [params[:queue].to_s] : nil
+      series = ::Wurk::Web::Enterprise::Historical.queue_history(params[:bucket].to_s, window: window, queues: queues)
+      render json: {
+        bucket: params[:bucket].to_s,
+        window: window,
+        queues: series.map { |row| ::Wurk::Api::Serializers.queue_history_series(row) }
+      }
+    rescue ::ArgumentError => e
+      render json: { error: e.message }, status: :bad_request
+    end
+
     def search
       substr = params[:substr].to_s
       return render(json: { substr: substr, total: 0, hits: [] }) if substr.empty?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Wurk::Engine.routes.draw do
     get  'metrics',          to: 'api#metrics'
     get  'metrics/:klass',   to: 'api#metrics_for_job', as: :api_metrics_for_job, constraints: { klass: %r{[^/]+} }
     get  'history/:bucket',  to: 'api#history', as: :api_history
+    get  'queue-history/:bucket', to: 'api#queue_history', as: :api_queue_history
     get  'search',           to: 'api#search'
     get  'profiles',         to: 'api#profiles'
     get  'stream',           to: 'api#stream' # SSE

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,13 +17,256 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.3.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
         "@vitejs/plugin-react": "^6.0.0",
         "daisyui": "^5.5.20",
+        "jsdom": "^29.1.1",
         "tailwindcss": "^4.3.0",
         "typescript": "^6.0.0",
-        "vite": "^8.0.0"
+        "vite": "^8.0.0",
+        "vitest": "^4.1.8"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -58,6 +301,24 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@fortawesome/fontawesome-free": {
@@ -788,6 +1049,54 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -797,6 +1106,24 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3-array": {
@@ -862,6 +1189,20 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
@@ -914,6 +1255,182 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -922,6 +1439,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -934,6 +1458,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/csstype": {
@@ -1074,11 +1612,42 @@
         "url": "https://github.com/saadeghi/daisyui?sponsor=1"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1089,6 +1658,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.22.2",
@@ -1104,6 +1680,26 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-toolkit": {
       "version": "1.47.0",
       "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
@@ -1114,11 +1710,31 @@
         "benchmarks"
       ]
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1160,6 +1776,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/immer": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
@@ -1179,6 +1808,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
@@ -1187,6 +1823,54 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/lightningcss": {
@@ -1462,6 +2146,26 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1471,6 +2175,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
@@ -1490,6 +2201,40 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
+      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1538,6 +2283,38 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react": {
@@ -1674,6 +2451,16 @@
         "redux": "^5.0.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/reselect": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
@@ -1714,6 +2501,19 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -1726,6 +2526,13 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1735,6 +2542,27 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.3.0",
@@ -1763,6 +2591,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -1778,6 +2623,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.2"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tslib": {
@@ -1800,6 +2701,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/use-sync-external-store": {
@@ -1910,6 +2821,178 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build --outDir ../vendor/assets/dashboard --emptyOutDir",
     "preview": "vite preview",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^7.2.0",
@@ -19,12 +20,16 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-react": "^6.0.0",
     "daisyui": "^5.5.20",
+    "jsdom": "^29.1.1",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.0",
-    "vite": "^8.0.0"
+    "vite": "^8.0.0",
+    "vitest": "^4.1.8"
   }
 }

--- a/frontend/src/pages/Metrics.test.tsx
+++ b/frontend/src/pages/Metrics.test.tsx
@@ -35,14 +35,18 @@ function renderMetrics() {
 }
 
 // Route the component's three fetches by URL; the queue-history payload is the
-// one under test, the others return empty so the page renders.
-function mockFetch(queueHistory: unknown) {
+// one under test, the others return empty so the page renders. `queueOk: false`
+// drives the queue-history error path.
+function mockFetch(queueHistory: unknown, queueOk = true) {
   return vi.fn((url: string) => {
     let body: unknown = {};
-    if (url.includes('/queue-history/')) body = queueHistory;
-    else if (url.includes('/history/')) body = { bucket: '1m', window: 86400, series: [] };
+    let ok = true;
+    if (url.includes('/queue-history/')) {
+      body = queueHistory;
+      ok = queueOk;
+    } else if (url.includes('/history/')) body = { bucket: '1m', window: 86400, series: [] };
     else if (url.includes('/metrics')) body = { minutes: 60, top_jobs: [] };
-    return Promise.resolve({ json: () => Promise.resolve(body) } as Response);
+    return Promise.resolve({ ok, status: ok ? 200 : 400, json: () => Promise.resolve(body) } as Response);
   });
 }
 
@@ -95,5 +99,15 @@ describe('QueueGaugeCharts', () => {
 
     // Empty state is gone once there's data.
     expect(screen.queryByText(/No queue history yet/i)).toBeNull();
+  });
+
+  it('shows an error state (not the empty state) when the API fails', async () => {
+    vi.stubGlobal('fetch', mockFetch({ error: 'bucket must be one of …' }, false));
+
+    renderMetrics();
+
+    await waitFor(() => expect(screen.getByText('Error loading data')).toBeDefined());
+    expect(screen.queryByText(/No queue history yet/i)).toBeNull();
+    expect(screen.queryByText('Depth (jobs)')).toBeNull();
   });
 });

--- a/frontend/src/pages/Metrics.test.tsx
+++ b/frontend/src/pages/Metrics.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import Metrics from './Metrics';
+
+// Stub Recharts so the per-queue chart logic (one <Line> per queue, pivoted
+// rows) is observable without a real layout — ResponsiveContainer renders
+// nothing under jsdom otherwise. Each Line exposes its dataKey as text.
+vi.mock('recharts', () => {
+  const Pass = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>;
+  return {
+    ResponsiveContainer: Pass,
+    LineChart: ({ children }: { children?: React.ReactNode }) => (
+      <div data-testid="linechart">{children}</div>
+    ),
+    Line: ({ dataKey }: { dataKey: string }) => <span data-testid="line">{dataKey}</span>,
+    BarChart: Pass,
+    Bar: () => null,
+    XAxis: () => null,
+    YAxis: () => null,
+    CartesianGrid: () => null,
+    Tooltip: () => null,
+    Legend: () => null,
+  };
+});
+
+function renderMetrics() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <Metrics />
+    </QueryClientProvider>
+  );
+}
+
+// Route the component's three fetches by URL; the queue-history payload is the
+// one under test, the others return empty so the page renders.
+function mockFetch(queueHistory: unknown) {
+  return vi.fn((url: string) => {
+    let body: unknown = {};
+    if (url.includes('/queue-history/')) body = queueHistory;
+    else if (url.includes('/history/')) body = { bucket: '1m', window: 86400, series: [] };
+    else if (url.includes('/metrics')) body = { minutes: 60, top_jobs: [] };
+    return Promise.resolve({ json: () => Promise.resolve(body) } as Response);
+  });
+}
+
+describe('QueueGaugeCharts', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch({ bucket: '1m', window: 86400, queues: [] }));
+  });
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('always renders the section heading', async () => {
+    renderMetrics();
+    expect(await screen.findByText('Queue Size & Latency')).toBeDefined();
+  });
+
+  it('shows the empty state when no queue history exists', async () => {
+    renderMetrics();
+    await waitFor(() =>
+      expect(screen.getByText(/No queue history yet/i)).toBeDefined()
+    );
+    expect(screen.queryByText('Depth (jobs)')).toBeNull();
+  });
+
+  it('renders a size and a latency chart with one line per queue', async () => {
+    const at = 1_781_000_000;
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        bucket: '1m',
+        window: 86400,
+        queues: [
+          { name: 'default', points: [{ at, size: 5, latency: 1.2 }] },
+          { name: 'critical', points: [{ at, size: 0, latency: 0 }] },
+        ],
+      })
+    );
+
+    renderMetrics();
+
+    // Both gauge charts render (size + latency).
+    await waitFor(() => expect(screen.getByText('Depth (jobs)')).toBeDefined());
+    expect(screen.getByText('Latency (seconds)')).toBeDefined();
+
+    // One <Line> per queue in each of the two charts → each queue name twice.
+    const lines = screen.getAllByTestId('line').map((n) => n.textContent);
+    expect(lines.filter((k) => k === 'default')).toHaveLength(2);
+    expect(lines.filter((k) => k === 'critical')).toHaveLength(2);
+
+    // Empty state is gone once there's data.
+    expect(screen.queryByText(/No queue history yet/i)).toBeNull();
+  });
+});

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -9,6 +9,7 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
+  Legend,
   ResponsiveContainer,
 } from 'recharts';
 import { t } from '../i18n';
@@ -41,6 +42,50 @@ interface HistoryResponse {
   bucket: string;
   window: number;
   series: HistoryPoint[];
+}
+
+// Matches Wurk::Api::Serializers.queue_history_series — one entry per queue,
+// each with a size/latency gauge sampled into the same time buckets as the
+// throughput chart (see Metrics::QueueRollup).
+interface QueueGaugePoint {
+  at: number;
+  size: number;
+  latency: number;
+}
+
+interface QueueSeries {
+  name: string;
+  points: QueueGaugePoint[];
+}
+
+interface QueueHistoryResponse {
+  bucket: string;
+  window: number;
+  queues: QueueSeries[];
+}
+
+// Distinct line colors per queue; the first reuses the accent so a
+// single-queue cluster matches the throughput chart's palette.
+const QUEUE_COLORS = [
+  'var(--accent)',
+  '#e0b341',
+  '#46b3a8',
+  '#d4737e',
+  '#8a7fd1',
+  '#5fa8d3',
+  '#c08457',
+  '#7bb274',
+] as const;
+
+const queueColor = (i: number) => QUEUE_COLORS[i % QUEUE_COLORS.length];
+
+// Hourly buckets span days, so show a date; sub-hour buckets show the clock.
+function bucketLabel(at: number, bucket: string): string {
+  const d = new Date(at * 1000);
+  const hh = String(d.getHours()).padStart(2, '0');
+  return bucket === '1h'
+    ? `${d.getMonth() + 1}/${d.getDate()} ${hh}:00`
+    : `${hh}:${String(d.getMinutes()).padStart(2, '0')}`;
 }
 
 const MINUTE_OPTIONS = [15, 30, 60, 120, 480] as const;
@@ -119,6 +164,95 @@ function HistoryCharts() {
   );
 }
 
+// Per-queue size + head-of-line latency gauges over the selected window
+// (Sidekiq Ent Historical tab, §5.2). One line per queue in each of the two
+// charts; the range selector mirrors the throughput chart's buckets.
+function QueueGaugeCharts() {
+  const [range, setRange] = useState(0);
+  const { bucket, window } = HISTORY_RANGES[range];
+
+  const { data, isLoading, isError } = useQuery<QueueHistoryResponse>({
+    queryKey: ['queue-history', bucket, window],
+    queryFn: () =>
+      fetch(`/wurk/api/queue-history/${bucket}?window=${window}`).then(
+        (r) => r.json() as Promise<QueueHistoryResponse>
+      ),
+    refetchInterval: 30000,
+  });
+
+  const queues = data?.queues ?? [];
+  // Every queue shares the same gap-filled bucket timestamps, so pivot to wide
+  // rows keyed by timestamp with one column per queue for Recharts.
+  const ats = queues[0]?.points.map((p) => p.at) ?? [];
+  const rowsFor = (field: 'size' | 'latency') =>
+    ats.map((at, i) => {
+      const row: Record<string, number | string> = { label: bucketLabel(at, bucket) };
+      queues.forEach((q) => {
+        row[q.name] = q.points[i]?.[field] ?? 0;
+      });
+      return row;
+    });
+  const hasData = queues.some((q) => q.points.some((p) => p.size > 0 || p.latency > 0));
+
+  const chart = (rows: ReturnType<typeof rowsFor>, decimals: boolean) => (
+    <ResponsiveContainer width="100%" height={240}>
+      <LineChart data={rows} margin={{ top: 4, right: 16, left: 0, bottom: 4 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+        <XAxis dataKey="label" tick={{ fill: 'var(--text-muted)', fontSize: 11 }} minTickGap={48} />
+        <YAxis tick={{ fill: 'var(--text-muted)', fontSize: 11 }} allowDecimals={decimals} />
+        <Tooltip contentStyle={tooltipStyle} />
+        <Legend wrapperStyle={{ fontSize: 12 }} />
+        {queues.map((q, i) => (
+          <Line
+            key={q.name}
+            type="monotone"
+            dataKey={q.name}
+            stroke={queueColor(i)}
+            strokeWidth={2}
+            dot={false}
+          />
+        ))}
+      </LineChart>
+    </ResponsiveContainer>
+  );
+
+  return (
+    <div className="card" style={{ marginBottom: '1.5rem' }}>
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '1rem' }}>
+        <div className="section-title">Queue Size &amp; Latency</div>
+        <select
+          className="select"
+          style={{ marginInlineStart: 'auto' }}
+          value={range}
+          onChange={(e) => setRange(Number(e.target.value))}
+          aria-label="Queue history range"
+        >
+          {HISTORY_RANGES.map((r, i) => (
+            <option key={r.label} value={i}>{r.label}</option>
+          ))}
+        </select>
+      </div>
+
+      {isLoading && <div className="empty-state"><span className="spinner" /></div>}
+      {isError && <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>}
+      {data && !hasData && <div className="empty-state">No queue history yet — charts fill in as queues build up.</div>}
+
+      {data && hasData && (
+        <>
+          <div className="section-subtitle" style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 4 }}>
+            Depth (jobs)
+          </div>
+          {chart(rowsFor('size'), false)}
+          <div className="section-subtitle" style={{ fontSize: 12, color: 'var(--text-muted)', margin: '1rem 0 4px' }}>
+            Latency (seconds)
+          </div>
+          {chart(rowsFor('latency'), true)}
+        </>
+      )}
+    </div>
+  );
+}
+
 export default function Metrics() {
   const [minutes, setMinutes] = useState(60);
 
@@ -162,6 +296,8 @@ export default function Metrics() {
       </PageHeader>
 
       <HistoryCharts />
+
+      <QueueGaugeCharts />
 
       {isLoading && (
         <div className="empty-state"><span className="spinner" /></div>

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -173,10 +173,16 @@ function QueueGaugeCharts() {
 
   const { data, isLoading, isError } = useQuery<QueueHistoryResponse>({
     queryKey: ['queue-history', bucket, window],
-    queryFn: () =>
-      fetch(`/wurk/api/queue-history/${bucket}?window=${window}`).then(
-        (r) => r.json() as Promise<QueueHistoryResponse>
-      ),
+    // Throw on a non-OK response so react-query's `isError` fires instead of an
+    // error payload (which has no `queues`) falling through to the empty state.
+    queryFn: async () => {
+      const r = await fetch(`/wurk/api/queue-history/${bucket}?window=${window}`);
+      if (!r.ok) {
+        const err = (await r.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(err?.error ?? `queue-history request failed (${r.status})`);
+      }
+      return r.json() as Promise<QueueHistoryResponse>;
+    },
     refetchInterval: 30000,
   });
 

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,14 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+// Dedicated test config — kept out of vite.config.ts so the build's
+// manifest-generator plugin (apply: "build") never runs under the test runner.
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    include: ['src/**/*.test.{ts,tsx}'],
+  },
+});

--- a/lib/wurk/launcher.rb
+++ b/lib/wurk/launcher.rb
@@ -10,6 +10,7 @@ require_relative 'scheduled'
 require_relative 'leader'
 require_relative 'cron'
 require_relative 'metrics/rollup'
+require_relative 'metrics/queue_rollup'
 require_relative 'fetcher/reaper'
 
 module Wurk
@@ -41,7 +42,7 @@ module Wurk
     # (Sidekiq's drop-in surface). The single source of truth is Heartbeat.
     BEAT_PAUSE = Heartbeat::BEAT_PAUSE
 
-    attr_accessor :managers, :poller, :cron_poller, :metrics_rollup
+    attr_accessor :managers, :poller, :cron_poller, :metrics_rollup, :queue_rollup
 
     def initialize(config, embedded: false)
       @config = config
@@ -51,6 +52,7 @@ module Wurk
       @poller = build_poller
       @cron_poller = build_cron_poller
       @metrics_rollup = build_metrics_rollup
+      @queue_rollup = build_queue_rollup
       @leader = build_leader
       @reaper = build_reaper
       @started_at = nil
@@ -81,6 +83,7 @@ module Wurk
       @leader&.start
       @cron_poller&.start
       @metrics_rollup&.start
+      @queue_rollup&.start
       @managers.each(&:start)
       @reaper.start
       boot_reclaim
@@ -115,6 +118,7 @@ module Wurk
       # releasing the lock so no tick races a follower's promotion.
       @cron_poller&.terminate
       @metrics_rollup&.terminate
+      @queue_rollup&.terminate
       @reaper&.stop
       # CAS-release the cluster lock now (planned shutdown) so a follower can
       # take over immediately instead of waiting out the TTL.
@@ -246,6 +250,13 @@ module Wurk
     # with `config.metrics_rollup_interval`.
     def build_metrics_rollup
       Wurk::Metrics::Rollup.new(@config)
+    end
+
+    # Leader-only per-queue gauge sampler. Like the metrics rollup, every
+    # process runs one but only the leader writes the `qm|…` size/latency
+    # buckets the Historical tab's per-queue charts read.
+    def build_queue_rollup
+      Wurk::Metrics::QueueRollup.new(@config)
     end
 
     # Every worker process campaigns for the single cluster lock (`dear-leader`);

--- a/lib/wurk/metrics/query.rb
+++ b/lib/wurk/metrics/query.rb
@@ -74,9 +74,13 @@ module Wurk
         names = queue_names(queues)
         return [] if names.empty?
 
-        hashes = pipeline_hgetall(starts.map { |s| Wurk::Metrics::QueueRollup.bucket_key(bucket, s) })
-                 .map { |h| h.is_a?(::Array) ? h.each_slice(2).to_h : (h || {}) }
+        hashes = queue_bucket_hashes(bucket, starts)
         names.map { |name| { name: name, points: queue_points(name, starts, hashes) } }
+      end
+
+      def queue_bucket_hashes(bucket, starts)
+        pipeline_hgetall(starts.map { |s| Wurk::Metrics::QueueRollup.bucket_key(bucket, s) })
+          .map { |h| h.is_a?(::Array) ? h.each_slice(2).to_h : (h || {}) }
       end
 
       MAX_QUEUE_SERIES = 25

--- a/lib/wurk/metrics/query.rb
+++ b/lib/wurk/metrics/query.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
+require_relative '../keys'
 require_relative 'history'
 require_relative 'rollup'
+require_relative 'queue_rollup'
 
 module Wurk
   module Metrics
@@ -57,6 +59,39 @@ module Wurk
         starts = bucket_starts(now, step, clamp_history_window!(window_seconds, ttl))
         rows = pipeline_hmget(starts.map { |s| Wurk::Metrics::Rollup.bucket_key(bucket, s) }, %w[p f ms])
         starts.zip(rows).map { |at, (p, f, ms)| { at: at, p: p.to_i, f: f.to_i, ms: ms.to_i } }
+      end
+
+      # Per-queue size/latency gauge time-series written by
+      # Metrics::QueueRollup. `bucket` is '1m'/'5m'/'1h'; `window_seconds` is
+      # clamped to the bucket's retention. Returns one entry per live queue
+      # (or the explicit `queues:` list) — `[{name:, points: [{at:, size:,
+      # latency:}, …]}, …]` — oldest→newest, gap-filled with zeros so a chart
+      # has a continuous x-axis. Capped at MAX_QUEUE_SERIES queues to bound the
+      # payload; the cap is logged-free because queue cardinality is small.
+      def queue_history(bucket, window_seconds, queues: nil, now: ::Time.now)
+        step, ttl = bucket_spec!(bucket)
+        starts = bucket_starts(now, step, clamp_history_window!(window_seconds, ttl))
+        names = queue_names(queues)
+        return [] if names.empty?
+
+        hashes = pipeline_hgetall(starts.map { |s| Wurk::Metrics::QueueRollup.bucket_key(bucket, s) })
+                 .map { |h| h.is_a?(::Array) ? h.each_slice(2).to_h : (h || {}) }
+        names.map { |name| { name: name, points: queue_points(name, starts, hashes) } }
+      end
+
+      MAX_QUEUE_SERIES = 25
+
+      def queue_names(queues)
+        names = queues || Wurk.redis { |c| c.call('SMEMBERS', Wurk::Keys::QUEUES_SET) }
+        names.sort.first(MAX_QUEUE_SERIES)
+      end
+
+      def queue_points(name, starts, hashes)
+        size_field = "#{name}|#{Wurk::Metrics::QueueRollup::SIZE_KIND}"
+        lat_field  = "#{name}|#{Wurk::Metrics::QueueRollup::LAT_KIND}"
+        starts.zip(hashes).map do |at, hash|
+          { at: at, size: hash[size_field].to_i, latency: (hash[lat_field] || 0).to_f }
+        end
       end
 
       def bucket_spec!(bucket)

--- a/lib/wurk/metrics/queue_rollup.rb
+++ b/lib/wurk/metrics/queue_rollup.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require_relative '../component'
+require_relative '../keys'
+require_relative '../job_record'
+require_relative 'rollup'
+
+module Wurk
+  module Metrics
+    # Leader-only background thread that snapshots each queue's current depth
+    # (LLEN) and head-of-line latency into compact per-queue gauge buckets the
+    # dashboard's "queue size / latency over time" charts read directly:
+    #
+    #   qm|1m|<epoch>   HASH {<queue>|sz, <queue>|lt}   TTL 24h
+    #   qm|5m|<epoch>   HASH {<queue>|sz, <queue>|lt}   TTL 7d
+    #   qm|1h|<epoch>   HASH {<queue>|sz, <queue>|lt}   TTL 30d
+    #
+    # Unlike Metrics::Rollup (which SUMS counters rolled up from a source),
+    # size and latency are GAUGES — point-in-time values — so each tick samples
+    # "now" and writes it to the current bucket at every resolution. Within a
+    # coarse (5m/1h) bucket the per-minute ticks overwrite, so the bucket holds
+    # the latest sample in its window (a "last value" downsample, which is the
+    # right summary for a gauge). Leader-gated so N workers don't each sample
+    # the same queues every minute. `<epoch>` is the UTC start-of-bucket.
+    #
+    # Spec: docs/target/sidekiq-ent.md §5.2 (sidekiq.queue.size /
+    # sidekiq.queue.latency gauges), §7 Historical tab.
+    class QueueRollup
+      include Component
+
+      PREFIX = 'qm'
+      SIZE_KIND = 'sz'
+      LAT_KIND = 'lt'
+
+      # Mirror Metrics::Rollup retention so the dashboard's range selector
+      # (24h·1m / 7d·5m / 30d·1h) maps 1:1 to both the throughput and the
+      # queue-gauge series.
+      BUCKETS = Wurk::Metrics::Rollup::BUCKETS
+
+      DEFAULT_TICK_SECONDS = 60
+
+      def self.bucket_key(bucket, epoch)
+        "#{PREFIX}|#{bucket}|#{epoch}"
+      end
+
+      def initialize(config)
+        @config = config
+        @done = false
+        @mutex = ::Mutex.new
+        @sleeper = ::ConditionVariable.new
+        @tick_interval = config[:metrics_rollup_interval] || DEFAULT_TICK_SECONDS
+        @thread = nil
+      end
+
+      def start
+        @thread ||= safe_thread('queue-metrics') do # rubocop:disable Naming/MemoizedInstanceVariableName
+          wait
+          until @done
+            tick
+            wait
+          end
+        end
+      end
+
+      def terminate
+        @mutex.synchronize do
+          @done = true
+          @sleeper.signal
+        end
+      end
+
+      # Leader-gated: only the elected leader samples, so N workers don't each
+      # HSET the same buckets every minute.
+      def tick(now: ::Time.now)
+        return unless leader?
+
+        sample(now)
+      rescue StandardError => e
+        handle_exception(e, { context: 'queue-metrics' })
+      end
+
+      # One sampling pass, bypassing the leader gate and the sleep loop. Public
+      # so deterministic specs and a manual "sample now" can drive it directly.
+      def sample(now = ::Time.now)
+        gauges = queue_gauges
+        return if gauges.empty?
+
+        fields = gauges.flat_map do |name, (size, lat)|
+          ["#{name}|#{SIZE_KIND}", size, "#{name}|#{LAT_KIND}", lat]
+        end
+        BUCKETS.each do |bucket, (step, ttl)|
+          key = self.class.bucket_key(bucket, (now.to_i / step) * step)
+          redis do |c|
+            c.call('HSET', key, *fields)
+            c.call('EXPIRE', key, ttl)
+          end
+        end
+        nil
+      end
+
+      private
+
+      # [[queue_name, [size, latency_seconds]], ...] for every live queue. The
+      # latency is the head-of-line wait — the tail of the LIST is the oldest
+      # job — in seconds, rounded for compact storage.
+      def queue_gauges
+        now_ms = real_ms
+        redis do |c|
+          names = c.call('SMEMBERS', Keys::QUEUES_SET)
+          next [] if names.empty?
+
+          raw = c.pipelined do |p|
+            names.each do |q|
+              p.call('LLEN', Keys.queue(q))
+              p.call('LRANGE', Keys.queue(q), -1, -1)
+            end
+          end
+          names.each_with_index.map do |name, i|
+            [name, [raw[i * 2].to_i, head_latency(raw[(i * 2) + 1], now_ms)]]
+          end
+        end
+      end
+
+      def head_latency(lrange_result, now_ms)
+        payload = lrange_result.is_a?(::Array) ? lrange_result.first : lrange_result
+        return 0.0 if payload.nil?
+
+        Wurk::JobRecord.latency_from(Wurk.load_json(payload)['enqueued_at'], now_ms).round(2)
+      rescue ::JSON::ParserError
+        0.0
+      end
+
+      def wait
+        @mutex.synchronize do
+          @sleeper.wait(@mutex, @tick_interval) unless @done
+        end
+      end
+    end
+  end
+end

--- a/lib/wurk/metrics/queue_rollup.rb
+++ b/lib/wurk/metrics/queue_rollup.rb
@@ -109,14 +109,20 @@ module Wurk
           names = c.call('SMEMBERS', Keys::QUEUES_SET)
           next [] if names.empty?
 
-          raw = c.pipelined do |p|
-            names.each do |q|
-              p.call('LLEN', Keys.queue(q))
-              p.call('LRANGE', Keys.queue(q), -1, -1)
-            end
-          end
+          raw = pipelined_queue_reads(c, names)
           names.each_with_index.map do |name, i|
             [name, [raw[i * 2].to_i, head_latency(raw[(i * 2) + 1], now_ms)]]
+          end
+        end
+      end
+
+      # Per queue: LLEN (depth) then LRANGE tail (head-of-line job), in one
+      # round trip. Results interleave [len, [tail], len, [tail], …].
+      def pipelined_queue_reads(conn, names)
+        conn.pipelined do |p|
+          names.each do |q|
+            p.call('LLEN', Keys.queue(q))
+            p.call('LRANGE', Keys.queue(q), -1, -1)
           end
         end
       end

--- a/lib/wurk/metrics/queue_rollup.rb
+++ b/lib/wurk/metrics/queue_rollup.rb
@@ -121,12 +121,17 @@ module Wurk
         end
       end
 
+      # A single malformed tail payload (bad JSON, or valid JSON of the wrong
+      # shape) yields 0.0 for that queue rather than bubbling up and skipping
+      # the whole sampling pass for every queue.
       def head_latency(lrange_result, now_ms)
         payload = lrange_result.is_a?(::Array) ? lrange_result.first : lrange_result
         return 0.0 if payload.nil?
 
-        Wurk::JobRecord.latency_from(Wurk.load_json(payload)['enqueued_at'], now_ms).round(2)
-      rescue ::JSON::ParserError
+        parsed = Wurk.load_json(payload)
+        enqueued_at = parsed.is_a?(::Hash) ? parsed['enqueued_at'] : nil
+        Wurk::JobRecord.latency_from(enqueued_at, now_ms).round(2)
+      rescue ::JSON::ParserError, ::TypeError, ::ArgumentError
         0.0
       end
 

--- a/lib/wurk/web/enterprise.rb
+++ b/lib/wurk/web/enterprise.rb
@@ -132,6 +132,14 @@ module Wurk
         def history(bucket, window:, now: ::Time.now)
           Wurk::Metrics::Query.history(bucket, window, now: now)
         end
+
+        # Per-queue size/latency gauge time-series for the Historical tab.
+        # `bucket` is '1m'/'5m'/'1h'; `window` is in seconds (clamped to the
+        # bucket's retention). `queues:` narrows to one queue (else every live
+        # queue). Returns `[{name:, points: [{at:, size:, latency:}, …]}, …]`.
+        def queue_history(bucket, window:, queues: nil, now: ::Time.now)
+          Wurk::Metrics::Query.queue_history(bucket, window, queues: queues, now: now)
+        end
       end
     end
   end

--- a/test/engine/api_endpoints_test.rb
+++ b/test/engine/api_endpoints_test.rb
@@ -370,6 +370,40 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
     assert_match(/bucket/, json_body[:error])
   end
 
+  def test_queue_history_returns_per_queue_gauge_series
+    name = "qmqh-#{@ns}"
+    epoch, key = seed_queue_metric(name, size: 8, latency: 4.5)
+    get '/wurk/api/queue-history/1m?window=24h'
+
+    assert_ok
+    row = json_body[:queues].find { |q| q[:name] == name }
+    refute_nil row, 'seeded queue should appear in the series'
+    point = row[:points].find { |p| p[:at] == epoch }
+
+    assert_equal 8, point[:size]
+    assert_in_delta 4.5, point[:latency], 0.001
+  ensure
+    cleanup_queue_metric(name, key)
+  end
+
+  def test_queue_history_supports_single_queue_filter
+    name = "qmqf-#{@ns}"
+    _epoch, key = seed_queue_metric(name, size: 3, latency: 1.0)
+    get "/wurk/api/queue-history/1m?window=1h&queue=#{name}"
+
+    assert_ok
+    assert_equal [name], json_body[:queues].map { |q| q[:name] }
+  ensure
+    cleanup_queue_metric(name, key)
+  end
+
+  def test_queue_history_rejects_unknown_bucket
+    get '/wurk/api/queue-history/9z?window=1h'
+
+    assert_equal 400, last_response.status
+    assert_match(/bucket/, json_body[:error])
+  end
+
   # The SSE stream emits one `event: stats` tick and closes when
   # `?max_duration=0` is supplied. Production callers omit the param and the
   # loop runs until `STREAM_MAX_DURATION`.
@@ -527,6 +561,21 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
     key = "jr|1m|#{epoch}"
     ::Wurk.redis { |c| c.call('HSET', key, 'p', processed, 'f', failed, 'ms', ms) }
     [epoch, key]
+  end
+
+  def seed_queue_metric(name, size:, latency:)
+    minutes_back = 1 + ((::Process.pid ^ object_id) % 1000)
+    epoch = ((::Time.now.to_i / 60) * 60) - (minutes_back * 60)
+    key = "qm|1m|#{epoch}"
+    ::Wurk.redis do |c|
+      c.call('SADD', 'queues', name)
+      c.call('HSET', key, "#{name}|sz", size, "#{name}|lt", latency)
+    end
+    [epoch, key]
+  end
+
+  def cleanup_queue_metric(name, key)
+    ::Wurk.redis { |c| c.call('DEL', key); c.call('SREM', 'queues', name) } if key
   end
 
   def seed_cron_loop

--- a/test/engine/api_endpoints_test.rb
+++ b/test/engine/api_endpoints_test.rb
@@ -111,6 +111,7 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
 
     assert_ok
     job = json_body[:jobs].find { |j| j[:klass] == @class_name }
+
     assert_equal [99, '<encrypted>'], job[:args]
     assert_no_envelope_leak
   end
@@ -121,6 +122,7 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
 
     assert_ok
     entry = json_body[:entries].find { |e| e[:klass] == @class_name }
+
     assert_equal [99, '<encrypted>'], entry[:args]
     assert_no_envelope_leak
   end
@@ -131,6 +133,7 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
 
     assert_ok
     hit = json_body[:hits].find { |h| h[:jid] == jid }
+
     refute_nil hit
     assert_equal [99, '<encrypted>'], hit[:args]
     assert_no_envelope_leak
@@ -142,6 +145,7 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
 
     assert_ok
     job = json_body[:jobs].find { |j| j[:klass] == @class_name }
+
     assert_equal [1, 2], job[:args]
   end
 
@@ -378,10 +382,10 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
     assert_ok
     row = json_body[:queues].find { |q| q[:name] == name }
     refute_nil row, 'seeded queue should appear in the series'
+
     point = row[:points].find { |p| p[:at] == epoch }
 
-    assert_equal 8, point[:size]
-    assert_in_delta 4.5, point[:latency], 0.001
+    assert_equal({ at: epoch, size: 8, latency: 4.5 }, point)
   ensure
     cleanup_queue_metric(name, key)
   end
@@ -392,7 +396,7 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
     get "/wurk/api/queue-history/1m?window=1h&queue=#{name}"
 
     assert_ok
-    assert_equal [name], json_body[:queues].map { |q| q[:name] }
+    assert_equal([name], json_body[:queues].map { |q| q[:name] })
   ensure
     cleanup_queue_metric(name, key)
   end
@@ -495,6 +499,7 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
   # a rendered Web UI payload.
   def assert_no_envelope_leak
     body = last_response.body
+
     [::Wurk::Encryption::ENVELOPE_MARKER, 'aXYtY2FuYXJ5', 'Y3QtY2FuYXJ5', 'dGFnLWNhbmFyeQ=='].each do |marker|
       refute_includes body, marker, "envelope fragment #{marker.inspect} leaked into Web UI payload"
     end
@@ -575,7 +580,12 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
   end
 
   def cleanup_queue_metric(name, key)
-    ::Wurk.redis { |c| c.call('DEL', key); c.call('SREM', 'queues', name) } if key
+    return unless key
+
+    ::Wurk.redis do |c|
+      c.call('DEL', key)
+      c.call('SREM', 'queues', name)
+    end
   end
 
   def seed_cron_loop

--- a/test/unit/metrics_query_test.rb
+++ b/test/unit/metrics_query_test.rb
@@ -23,15 +23,7 @@ class MetricsQueryTest < Wurk::Test::UnitCase
         c.call('DEL', *keys) unless keys.empty?
         break if cursor == '0'
       end
-      # Per-class fields only — never DEL the shared minute/rollup buckets,
-      # other parallel tests for the same minute will lose their writes.
-      [@now, @now - 60, @now - 120].each do |t|
-        [Wurk::Metrics::History.minute_key(t), Wurk::Metrics::History.rollup_key(t)].each do |key|
-          [@klass_a, @klass_b].each do |kls|
-            c.call('HDEL', key, "#{kls}|p", "#{kls}|f", "#{kls}|ms", "#{kls}|x", "#{kls}nodelim")
-          end
-        end
-      end
+      delete_class_fields(c)
       # The queue_history tests SADD this suite's queues to the shared `queues`
       # set; remove them so queue_history(queues: nil) can't read a leftover.
       mine = c.call('SMEMBERS', 'queues').select { |q| q.include?(@suffix) }
@@ -39,6 +31,18 @@ class MetricsQueryTest < Wurk::Test::UnitCase
     end
   ensure
     super
+  end
+
+  # Per-class fields only — never DEL the shared minute/rollup buckets, or
+  # other parallel tests for the same minute will lose their writes.
+  def delete_class_fields(conn)
+    [@now, @now - 60, @now - 120].each do |t|
+      [Wurk::Metrics::History.minute_key(t), Wurk::Metrics::History.rollup_key(t)].each do |key|
+        [@klass_a, @klass_b].each do |kls|
+          conn.call('HDEL', key, "#{kls}|p", "#{kls}|f", "#{kls}|ms", "#{kls}|x", "#{kls}nodelim")
+        end
+      end
+    end
   end
 
   # ---- caps ---------------------------------------------------------------
@@ -235,14 +239,10 @@ class MetricsQueryTest < Wurk::Test::UnitCase
     write_qm('1m', @now, "#{q1}|sz" => 5, "#{q1}|lt" => 12.5, "#{q2}|sz" => 2, "#{q2}|lt" => 0)
 
     series = Wurk::Metrics::Query.queue_history('1m', 300, queues: [q1, q2], now: @now)
-    a = series.find { |s| s[:name] == q1 }
+    points = series.find { |s| s[:name] == q1 }[:points]
 
-    assert_equal 5, a[:points].size # window 300 / 60 = 5 points, gap-filled
-    last = a[:points].last
-
-    assert_equal((@now.to_i / 60) * 60, last[:at])
-    assert_equal 5, last[:size]
-    assert_in_delta 12.5, last[:latency], 0.001
+    assert_equal 5, points.size # window 300 / 60 = 5 points, gap-filled
+    assert_equal({ at: (@now.to_i / 60) * 60, size: 5, latency: 12.5 }, points.last)
   end
 
   def test_queue_history_gap_fills_missing_buckets_with_zeros

--- a/test/unit/metrics_query_test.rb
+++ b/test/unit/metrics_query_test.rb
@@ -222,4 +222,71 @@ class MetricsQueryTest < Wurk::Test::UnitCase
   def test_pipeline_hmget_empty_keys_returns_empty
     assert_equal [], Wurk::Metrics::Query.pipeline_hmget([], %w[p f ms])
   end
+
+  # ---- queue_history reader (per-queue size/latency gauges) ----------------
+
+  def test_queue_history_returns_per_queue_size_and_latency_series
+    q1 = "Qa#{@suffix}"
+    q2 = "Qb#{@suffix}"
+    write_qm('1m', @now, "#{q1}|sz" => 5, "#{q1}|lt" => 12.5, "#{q2}|sz" => 2, "#{q2}|lt" => 0)
+
+    series = Wurk::Metrics::Query.queue_history('1m', 300, queues: [q1, q2], now: @now)
+    a = series.find { |s| s[:name] == q1 }
+
+    assert_equal 5, a[:points].size # window 300 / 60 = 5 points, gap-filled
+    last = a[:points].last
+
+    assert_equal((@now.to_i / 60) * 60, last[:at])
+    assert_equal 5, last[:size]
+    assert_in_delta 12.5, last[:latency], 0.001
+  end
+
+  def test_queue_history_gap_fills_missing_buckets_with_zeros
+    series = Wurk::Metrics::Query.queue_history('1m', 300, queues: ["Qz#{@suffix}"], now: @now)
+    points = series.first[:points]
+
+    assert_equal 5, points.size
+    assert(points.all? { |p| p[:size].zero? && p[:latency].zero? })
+  end
+
+  def test_queue_history_rejects_unknown_bucket
+    assert_raises(ArgumentError) { Wurk::Metrics::Query.queue_history('2m', 300, queues: ['x'], now: @now) }
+  end
+
+  def test_queue_history_clamps_window_to_bucket_retention
+    series = Wurk::Metrics::Query.queue_history('1m', 48 * 3600, queues: ["Qc#{@suffix}"], now: @now)
+
+    assert_operator series.first[:points].size, :<=, 24 * 60
+  end
+
+  def test_queue_history_reads_live_queue_set_when_queues_nil
+    q1 = "Qlive#{@suffix}"
+    Wurk.redis { |c| c.call('SADD', 'queues', q1) }
+    write_qm('1m', @now, "#{q1}|sz" => 7, "#{q1}|lt" => 3.0)
+
+    series = Wurk::Metrics::Query.queue_history('1m', 120, now: @now)
+    row = series.find { |s| s[:name] == q1 }
+
+    refute_nil row, 'queue from the live `queues` set should be charted'
+    assert_equal 7, row[:points].last[:size]
+  end
+
+  def test_queue_history_caps_queue_count
+    names = (0...30).map { |i| format('Qcap%<s>s_%<i>02d', s: @suffix, i: i) }
+    Wurk.redis { |c| c.call('SADD', 'queues', *names) }
+
+    series = Wurk::Metrics::Query.queue_history('1m', 120, now: @now)
+
+    assert_operator series.size, :<=, Wurk::Metrics::Query::MAX_QUEUE_SERIES
+  end
+
+  private
+
+  # Write a per-queue gauge bucket directly so the reader tests don't depend on
+  # the sampler's wall-clock latency math.
+  def write_qm(bucket, at, fields)
+    step = Wurk::Metrics::QueueRollup::BUCKETS[bucket][0]
+    key = Wurk::Metrics::QueueRollup.bucket_key(bucket, (at.to_i / step) * step)
+    Wurk.redis { |c| c.call('HSET', key, *fields.flatten) }
+  end
 end

--- a/test/unit/metrics_query_test.rb
+++ b/test/unit/metrics_query_test.rb
@@ -32,6 +32,10 @@ class MetricsQueryTest < Wurk::Test::UnitCase
           end
         end
       end
+      # The queue_history tests SADD this suite's queues to the shared `queues`
+      # set; remove them so queue_history(queues: nil) can't read a leftover.
+      mine = c.call('SMEMBERS', 'queues').select { |q| q.include?(@suffix) }
+      c.call('SREM', 'queues', *mine) unless mine.empty?
     end
   ensure
     super

--- a/test/unit/metrics_queue_rollup_test.rb
+++ b/test/unit/metrics_queue_rollup_test.rb
@@ -81,16 +81,15 @@ class MetricsQueueRollupTest < Wurk::Test::UnitCase
   def test_sample_tolerates_a_malformed_queue_payload
     Wurk.redis do |c|
       c.call('SADD', 'queues', @q1, @q2)
-      c.call('LPUSH', "queue:#{@q1}", 'not-json{')         # bad JSON
+      c.call('LPUSH', "queue:#{@q1}", 'not-json{') # bad JSON
       c.call('LPUSH', "queue:#{@q2}", Wurk.dump_json([1, 2])) # valid JSON, wrong shape
     end
     @qr.sample(@at)
     h = bucket_hash('1m')
+    fields = ["#{@q1}|sz", "#{@q1}|lt", "#{@q2}|sz", "#{@q2}|lt"]
 
-    assert_equal '1', h["#{@q1}|sz"]
-    assert_equal '0.0', h["#{@q1}|lt"]
-    assert_equal '1', h["#{@q2}|sz"]
-    assert_equal '0.0', h["#{@q2}|lt"]
+    assert_equal({ "#{@q1}|sz" => '1', "#{@q1}|lt" => '0.0', "#{@q2}|sz" => '1', "#{@q2}|lt" => '0.0' },
+                 h.slice(*fields))
   end
 
   def test_tick_samples_when_leader
@@ -142,7 +141,8 @@ class MetricsQueueRollupTest < Wurk::Test::UnitCase
       c.call('SADD', 'queues', name)
       depth.times do |i|
         age = i.zero? ? head_age_s : 0
-        c.call('LPUSH', "queue:#{name}", Wurk.dump_json('class' => 'J', 'args' => [], 'enqueued_at' => ::Time.now.to_f - age))
+        c.call('LPUSH', "queue:#{name}",
+               Wurk.dump_json('class' => 'J', 'args' => [], 'enqueued_at' => ::Time.now.to_f - age))
       end
     end
   end

--- a/test/unit/metrics_queue_rollup_test.rb
+++ b/test/unit/metrics_queue_rollup_test.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'securerandom'
+require 'wurk/metrics/queue_rollup'
+require 'wurk/metrics/query'
+
+# QueueRollup samples per-queue depth + head-of-line latency into time buckets
+# (`qm|<bucket>|<epoch>` HASH, `<queue>|sz` / `<queue>|lt` fields). Like the
+# cluster-total rollup these buckets are keyed only by time, so each test picks
+# a unique minute-aligned epoch (PID:object_id) and unique queue names, then
+# DELs exactly its own keys on teardown.
+class MetricsQueueRollupTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @epoch_min = ((2_000_000_000 + ((Process.pid % 100_000) * 100_000) + (object_id % 100_000)) / 60) * 60
+    @at = ::Time.at(@epoch_min).utc
+    @q1 = "qmq-#{SecureRandom.hex(5)}-a"
+    @q2 = "qmq-#{SecureRandom.hex(5)}-b"
+    @qr = Wurk::Metrics::QueueRollup.new(Wurk.configuration)
+  end
+
+  def teardown
+    Wurk.redis do |c|
+      keys = Wurk::Metrics::QueueRollup::BUCKETS.map do |bucket, (step, _ttl)|
+        Wurk::Metrics::QueueRollup.bucket_key(bucket, (@epoch_min / step) * step)
+      end
+      c.call('DEL', *keys, "queue:#{@q1}", "queue:#{@q2}")
+      c.call('SREM', 'queues', @q1, @q2)
+    end
+  ensure
+    super
+  end
+
+  def test_sample_writes_size_for_each_queue_at_every_resolution
+    seed_queue(@q1, depth: 3)
+    seed_queue(@q2, depth: 1)
+    @qr.sample(@at)
+
+    Wurk::Metrics::QueueRollup::BUCKETS.each_key do |bucket|
+      h = bucket_hash(bucket)
+
+      assert_equal '3', h["#{@q1}|sz"], "#{bucket} size for #{@q1}"
+      assert_equal '1', h["#{@q2}|sz"], "#{bucket} size for #{@q2}"
+    end
+  end
+
+  def test_sample_records_head_of_line_latency
+    # Tail of the LIST is the oldest waiting job; seed it ~90s old.
+    seed_queue(@q1, depth: 1, head_age_s: 90)
+    @qr.sample(@at)
+
+    latency = bucket_hash('1m')["#{@q1}|lt"].to_f
+
+    assert_operator latency, :>=, 85, 'head-of-line latency should reflect the oldest job'
+    assert_operator latency, :<=, 200
+  end
+
+  def test_sample_sets_per_bucket_retention_ttls
+    seed_queue(@q1, depth: 1)
+    @qr.sample(@at)
+
+    Wurk::Metrics::QueueRollup::BUCKETS.each do |bucket, (step, ttl)|
+      actual = Wurk.redis { |c| c.call('TTL', Wurk::Metrics::QueueRollup.bucket_key(bucket, (@epoch_min / step) * step)) }
+
+      assert_operator actual, :>, ttl - 120, "#{bucket} ttl too low"
+      assert_operator actual, :<=, ttl, "#{bucket} ttl too high"
+    end
+  end
+
+  def test_sample_is_a_noop_when_no_queues
+    @qr.sample(@at) # nothing seeded
+
+    assert_empty bucket_hash('1m')
+  end
+
+  def test_tick_samples_when_leader
+    seed_queue(@q1, depth: 2)
+    @qr.define_singleton_method(:leader?) { true }
+    @qr.tick(now: @at)
+
+    assert_equal '2', bucket_hash('1m')["#{@q1}|sz"]
+  end
+
+  def test_tick_is_leader_gated
+    seed_queue(@q1, depth: 2)
+    @qr.define_singleton_method(:leader?) { false }
+    @qr.tick(now: @at)
+
+    assert_empty bucket_hash('1m')
+  end
+
+  # Exercises the spawned-thread `until @done` loop without a fixed sleep.
+  # rubocop:disable Metrics/AbcSize
+  def test_start_loop_samples_until_terminated
+    config = Wurk::Configuration.new
+    config.logger = ::Logger.new(IO::NULL)
+    config[:metrics_rollup_interval] = 0.01
+    qr = Wurk::Metrics::QueueRollup.new(config)
+    qr.define_singleton_method(:leader?) { true }
+    qr.define_singleton_method(:sample) { |_now = ::Time.now| @ticks = (@ticks || 0) + 1 }
+
+    qr.start
+    poll_until(2.0) { qr.instance_variable_get(:@ticks).to_i.positive? }
+    qr.terminate
+
+    assert_operator qr.instance_variable_get(:@ticks).to_i, :>, 0
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  private
+
+  def poll_until(timeout)
+    deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + timeout
+    sleep(0.005) until yield || ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) > deadline
+  end
+
+  # Push `depth` jobs; the head-of-line job (LIST tail, oldest) is `head_age_s`
+  # seconds old. Enqueue with LPUSH so the tail is the oldest, matching the
+  # client's FIFO convention (Queue#latency reads the tail).
+  def seed_queue(name, depth:, head_age_s: 0)
+    Wurk.redis do |c|
+      c.call('SADD', 'queues', name)
+      depth.times do |i|
+        age = i.zero? ? head_age_s : 0
+        c.call('LPUSH', "queue:#{name}", Wurk.dump_json('class' => 'J', 'args' => [], 'enqueued_at' => ::Time.now.to_f - age))
+      end
+    end
+  end
+
+  def bucket_hash(bucket)
+    step = Wurk::Metrics::QueueRollup::BUCKETS[bucket][0]
+    raw = Wurk.redis { |c| c.call('HGETALL', Wurk::Metrics::QueueRollup.bucket_key(bucket, (@epoch_min / step) * step)) }
+    raw.is_a?(::Array) ? raw.each_slice(2).to_h : raw
+  end
+end

--- a/test/unit/metrics_queue_rollup_test.rb
+++ b/test/unit/metrics_queue_rollup_test.rb
@@ -76,6 +76,23 @@ class MetricsQueueRollupTest < Wurk::Test::UnitCase
     assert_empty bucket_hash('1m')
   end
 
+  # A malformed tail payload on one queue must not abort the whole pass: that
+  # queue records latency 0.0 and the healthy queue is still sampled.
+  def test_sample_tolerates_a_malformed_queue_payload
+    Wurk.redis do |c|
+      c.call('SADD', 'queues', @q1, @q2)
+      c.call('LPUSH', "queue:#{@q1}", 'not-json{')         # bad JSON
+      c.call('LPUSH', "queue:#{@q2}", Wurk.dump_json([1, 2])) # valid JSON, wrong shape
+    end
+    @qr.sample(@at)
+    h = bucket_hash('1m')
+
+    assert_equal '1', h["#{@q1}|sz"]
+    assert_equal '0.0', h["#{@q1}|lt"]
+    assert_equal '1', h["#{@q2}|sz"]
+    assert_equal '0.0', h["#{@q2}|lt"]
+  end
+
   def test_tick_samples_when_leader
     seed_queue(@q1, depth: 2)
     @qr.define_singleton_method(:leader?) { true }


### PR DESCRIPTION
Closes #124. Closes #126.

Sidekiq Enterprise §5.2 emits per-queue `sidekiq.queue.size` / `sidekiq.queue.latency` gauges, and the Historical tab (§7) charts them over a recent window. wurk captured only per-job-**class** throughput — no per-queue dimension was persisted or queryable. This adds it end to end. #126 (charts) depends on #124 (the series), so they ship together.

## Backend (#124 — the data)
- **`Metrics::QueueRollup`** — a leader-gated sampler thread (mirrors `Metrics::Rollup`). Each tick snapshots every live queue's depth (`LLEN`) + head-of-line latency (tail of the LIST, exactly like `Queue#latency`) into gauge buckets `qm|{1m,5m,1h}|<epoch>` with `<queue>|sz` / `<queue>|lt` fields, at all three resolutions, with 24h/7d/30d retention. Size/latency are **gauges**, so a tick samples "now" and overwrites the current bucket (last-value downsample) rather than summing counters.
- **`Query.queue_history`** + **`Enterprise::Historical.queue_history`** readers — gap-filled, window-clamped, `MAX_QUEUE_SERIES`-capped; mirror the existing `history` reader.
- **`GET /wurk/api/queue-history/:bucket?window=&queue=`** + a `queue_history_series` serializer.
- Launcher builds/starts/terminates the sampler alongside the metrics rollup (leader-gated, so only one process writes).

## Frontend (#126 — the charts)
- **`QueueGaugeCharts`** on the Metrics page: stacked **Depth** + **Latency** line charts, one line per queue, the same `24h·1m / 7d·5m / 30d·1h` range selector as the throughput chart, and an empty state.

## Acceptance criteria
**#124**
- [x] Periodic capture of each queue's size + head-of-line latency into time-buckets.
- [x] A query API returning per-queue size/latency series over a window.
- [x] Metrics page renders per-queue gauges over the recent window.
- [x] Tests covering capture + query for ≥2 queues.

**#126**
- [x] Per-queue size & latency charts over the selected window.
- [x] Window/bucket selector applies to the queue charts.
- [x] Empty-state handling when no queue history yet.
- [x] Render test for the new charts.

## Tests
- `test/unit/metrics_queue_rollup_test.rb` — capture for 2+ queues, head-of-line latency, per-bucket TTLs, leader gating, thread loop.
- `test/unit/metrics_query_test.rb` — `queue_history` series, gap-fill, window clamp, bad bucket, live-queue-set path, queue cap.
- `test/engine/api_endpoints_test.rb` — endpoint returns per-queue gauge series, single-queue filter, bad bucket → 400.
- **First frontend test runner** (vitest + testing-library): `frontend/src/pages/Metrics.test.tsx` asserts the empty state and one `<Line>` per queue across both charts.
- Full suite **2165 runs, 0 failures**, coverage gate, `test:parity`, `test:ecosystem`, and `tsc -b && vite build` all green locally.

**Wire-compat:** only adds new `qm|…` keys; no existing Redis key or job JSON changed.

## How to test in prod
Per-queue gauges are captured automatically once a worker boots (the leader samples every ~minute). Enqueue some jobs to spread depth/latency across a few queues:

```ruby
1000.times { SomeJob.set(queue: "default").perform_async }
50.times   { SomeJob.set(queue: "critical").perform_async }
```

Open the dashboard → **Metrics** → **Queue Size & Latency**. After a couple of minutes you'll see a line per queue in both the Depth and Latency charts; the `24h·1m / 7d·5m / 30d·1h` selector switches the window. New JSON: `GET /wurk/api/queue-history/1m?window=24h`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-queue historical depth and latency charts with time-window selection and optional queue filtering; a new JSON API provides the chart data and periodic sampling runs server-side.

* **Tests**
  * Extensive unit and integration tests covering queue metric sampling, retention/edge cases, API responses (including errors/filters), and frontend chart/error/empty states.

* **Chores**
  * Frontend test tooling and scripts added to run the new test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->