### PR TITLE
feat(ent): write/read the history:metrics capped stream (#125)

### DIFF
--- a/app/controllers/wurk/api_controller.rb
+++ b/app/controllers/wurk/api_controller.rb
@@ -228,6 +228,17 @@ module Wurk
       render json: { error: e.message }, status: :bad_request
     end
 
+    # Ent §5.3 Historical snapshots from the capped `history:metrics` stream.
+    # `?limit=N` (default 1000) most-recent points, oldest→newest, each
+    # `{at:, processed:, failures:, …}`. Fields are read generically so a
+    # migrated Sidekiq Ent stream renders as-is.
+    def history_snapshots
+      limit = ::Wurk::Api::Pagination.clamp_int(
+        params[:limit], 1, ::Wurk::History::STREAM_CAP, ::Wurk::History::STREAM_DEFAULT_LIMIT
+      )
+      render json: { snapshots: ::Wurk::Web::Enterprise::Historical.snapshots(limit: limit) }
+    end
+
     # Per-queue size/latency gauge time-series for the Metrics/Historical tab.
     # `:bucket` is 1m/5m/1h; `?window=24h` (s/m/h/d) is clamped to the bucket's
     # retention; optional `?queue=<name>` narrows to one queue. Each queue's

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Wurk::Engine.routes.draw do
     get  'cron/:lid/history', to: 'api#cron_history', as: :api_cron_history
     get  'metrics',          to: 'api#metrics'
     get  'metrics/:klass',   to: 'api#metrics_for_job', as: :api_metrics_for_job, constraints: { klass: %r{[^/]+} }
+    get  'history/snapshots', to: 'api#history_snapshots', as: :api_history_snapshots
     get  'history/:bucket',  to: 'api#history', as: :api_history
     get  'queue-history/:bucket', to: 'api#queue_history', as: :api_queue_history
     get  'search',           to: 'api#search'

--- a/frontend/src/pages/Metrics.test.tsx
+++ b/frontend/src/pages/Metrics.test.tsx
@@ -37,11 +37,13 @@ function renderMetrics() {
 // Route the component's three fetches by URL; the queue-history payload is the
 // one under test, the others return empty so the page renders. `queueOk: false`
 // drives the queue-history error path.
-function mockFetch(queueHistory: unknown, queueOk = true) {
+function mockFetch(queueHistory: unknown, queueOk = true, snapshots: unknown[] = []) {
   return vi.fn((url: string) => {
     let body: unknown = {};
     let ok = true;
-    if (url.includes('/queue-history/')) {
+    // /history/snapshots must be matched before the /history/ rollup route.
+    if (url.includes('/history/snapshots')) body = { snapshots };
+    else if (url.includes('/queue-history/')) {
       body = queueHistory;
       ok = queueOk;
     } else if (url.includes('/history/')) body = { bucket: '1m', window: 86400, series: [] };
@@ -109,5 +111,35 @@ describe('QueueGaugeCharts', () => {
     await waitFor(() => expect(screen.getByText('Error loading data')).toBeDefined());
     expect(screen.queryByText(/No queue history yet/i)).toBeNull();
     expect(screen.queryByText('Depth (jobs)')).toBeNull();
+  });
+});
+
+describe('HistoricalSnapshots', () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('shows the empty state when the history:metrics stream is empty', async () => {
+    vi.stubGlobal('fetch', mockFetch({ bucket: '1m', window: 86400, queues: [] }, true, []));
+    renderMetrics();
+
+    expect(await screen.findByText('Historical Snapshots')).toBeDefined();
+    await waitFor(() => expect(screen.getByText(/No snapshots yet/i)).toBeDefined());
+  });
+
+  it('charts the backlog gauge fields and hides the cumulative counters', async () => {
+    const snapshots = [{ at: 1_781_000_000, processed: 100, failures: 2, enqueued: 5, dead: 1 }];
+    vi.stubGlobal('fetch', mockFetch({ bucket: '1m', window: 86400, queues: [] }, true, snapshots));
+    renderMetrics();
+
+    const lines = (await screen.findAllByTestId('line')).map((n) => n.textContent);
+
+    // backlog gauges charted…
+    expect(lines).toContain('enqueued');
+    expect(lines).toContain('dead');
+    // …cumulative counters are not (HistoryCharts shows throughput instead).
+    expect(lines).not.toContain('processed');
+    expect(lines).not.toContain('failures');
   });
 });

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -164,6 +164,71 @@ function HistoryCharts() {
   );
 }
 
+// Ent §5.3 Historical snapshots from the capped `history:metrics` stream. One
+// point per periodic snapshot; a line per numeric field. The two cumulative
+// counters (processed/failures) are charted by HistoryCharts already, so this
+// "backlog over time" view hides them — but any other numeric field (incl. a
+// migrated Ent install's own fields) renders generically.
+interface Snapshot {
+  at: number;
+  [field: string]: number;
+}
+
+const CUMULATIVE_FIELDS = new Set(['processed', 'failures']);
+
+function HistoricalSnapshots() {
+  const { data, isLoading, isError } = useQuery<{ snapshots: Snapshot[] }>({
+    queryKey: ['history-snapshots'],
+    queryFn: async () => {
+      const r = await fetch('/wurk/api/history/snapshots?limit=1000');
+      if (!r.ok) throw new Error(`history snapshots request failed (${r.status})`);
+      return r.json() as Promise<{ snapshots: Snapshot[] }>;
+    },
+    refetchInterval: 30000,
+  });
+
+  const snapshots = data?.snapshots ?? [];
+  const fields = Array.from(
+    new Set(
+      snapshots.flatMap((s) =>
+        Object.keys(s).filter((k) => k !== 'at' && !CUMULATIVE_FIELDS.has(k) && typeof s[k] === 'number')
+      )
+    )
+  );
+  const rows = snapshots.map((s) => {
+    const d = new Date(s.at * 1000);
+    return { ...s, label: `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}` };
+  });
+  const hasData = snapshots.length > 0 && fields.length > 0;
+
+  return (
+    <div className="card" style={{ marginBottom: '1.5rem' }}>
+      <div className="section-title" style={{ marginBottom: '1rem' }}>Historical Snapshots</div>
+
+      {isLoading && <div className="empty-state"><span className="spinner" /></div>}
+      {isError && <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>}
+      {data && !hasData && (
+        <div className="empty-state">No snapshots yet — enable <code>config.retain_history</code> to record history.</div>
+      )}
+
+      {data && hasData && (
+        <ResponsiveContainer width="100%" height={260}>
+          <LineChart data={rows} margin={{ top: 4, right: 16, left: 0, bottom: 4 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+            <XAxis dataKey="label" tick={{ fill: 'var(--text-muted)', fontSize: 11 }} minTickGap={48} />
+            <YAxis tick={{ fill: 'var(--text-muted)', fontSize: 11 }} allowDecimals={false} />
+            <Tooltip contentStyle={tooltipStyle} />
+            <Legend wrapperStyle={{ fontSize: 12 }} />
+            {fields.map((f, i) => (
+              <Line key={f} type="monotone" dataKey={f} stroke={queueColor(i)} strokeWidth={2} dot={false} />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  );
+}
+
 // Per-queue size + head-of-line latency gauges over the selected window
 // (Sidekiq Ent Historical tab, §5.2). One line per queue in each of the two
 // charts; the range selector mirrors the throughput chart's buckets.
@@ -302,6 +367,8 @@ export default function Metrics() {
       </PageHeader>
 
       <HistoryCharts />
+
+      <HistoricalSnapshots />
 
       <QueueGaugeCharts />
 

--- a/lib/wurk/history.rb
+++ b/lib/wurk/history.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'component'
+require_relative 'keys'
 require_relative 'stats'
 require_relative 'metrics/statsd'
 
@@ -26,18 +27,45 @@ module Wurk
   # The block receives the raw dogstatsd client `s` (quacks like
   # `Datadog::Statsd`: gauge/count/histogram/batch) and writes fully-qualified
   # `sidekiq.*` metric names itself, matching Sidekiq Ent. Leader-gated via the
-  # cluster `dear-leader` lock so exactly one process emits per cluster. No-op
-  # when no dogstatsd client is configured (nothing to emit to).
+  # cluster `dear-leader` lock so exactly one process emits per cluster.
+  #
+  # Every snapshot is also appended to the capped Redis stream
+  # `history:metrics` (§5.3) — the same key a migrated Sidekiq Ent install
+  # uses — so the dashboard's Historical view has a data source independent of
+  # any external statsd, and pre-existing Ent stream data renders without
+  # rewrite. The stream write happens whenever the snapshotter runs; the
+  # dogstatsd emit is skipped only when no client is configured.
   #
   # Aliased as `Sidekiq::History` (drop-in contract).
-  # Spec: docs/target/sidekiq-ent.md §5.1–§5.2.
+  # Spec: docs/target/sidekiq-ent.md §5.1–§5.3.
   class History
     include Component
+
+    # Stream field → Stats reader. Single source for both the `history:metrics`
+    # stream entry and the default §5.2 statsd gauge set (which prefixes
+    # `sidekiq.`). Order is the display order.
+    SNAPSHOT_FIELDS = {
+      'processed' => :processed,
+      'failures' => :failed,
+      'enqueued' => :enqueued,
+      'retries' => :retry_size,
+      'dead' => :dead_size,
+      'scheduled' => :scheduled_size,
+      'busy' => :workers_size
+    }.freeze
+
+    # Approximate cap on retained snapshots (XADD MAXLEN ~). At the default 30s
+    # interval this is ~3.5 days of history; older points age out. `~` lets
+    # Redis trim in whole macro-nodes, so the actual length can briefly exceed
+    # the cap — matching Ent's best-effort retention.
+    STREAM_CAP = 10_000
+    STREAM_DEFAULT_LIMIT = 1000
 
     def initialize(config)
       @config = config
       @interval = config.history_interval
       @collector = config.history_collector
+      @stream_cap = config[:history_stream_cap] || STREAM_CAP
       @done = false
       @mutex = ::Mutex.new
       @sleeper = ::ConditionVariable.new
@@ -73,27 +101,68 @@ module Wurk
 
     # One snapshot, bypassing the leader gate and the sleep loop. Public so
     # deterministic specs and a manual "snapshot now" can drive it directly.
+    # Always appends to the `history:metrics` stream (the dashboard's source);
+    # additionally emits to dogstatsd when a client is configured.
     def snapshot
-      client = Wurk::Metrics::Statsd.client
-      return if client.nil?
-
-      @collector ? @collector.call(client) : default_snapshot(client)
+      values = collect_values
+      record_stream(values)
+      emit_statsd(values)
       nil
+    end
+
+    # Most-recent snapshots from the `history:metrics` stream, oldest→newest.
+    # Each point is `{ at: <epoch seconds>, <field>: <numeric>, … }`. Fields are
+    # read generically, so a migrated Sidekiq Ent install's entries render
+    # without rewrite regardless of which fields they carry.
+    def self.recent(limit: STREAM_DEFAULT_LIMIT)
+      count = limit.to_i.clamp(1, STREAM_CAP)
+      entries = Wurk.redis { |c| c.call('XREVRANGE', Keys::HISTORY_METRICS, '+', '-', 'COUNT', count) }
+      entries.reverse.map { |entry_id, fields| parse_entry(entry_id, fields) }
+    end
+
+    def self.parse_entry(entry_id, fields)
+      pairs = fields.is_a?(::Array) ? fields.each_slice(2).to_h : fields
+      point = { at: stream_epoch(entry_id) }
+      pairs.each { |field, value| point[field.to_sym] = numeric(value) }
+      point
+    end
+
+    # Redis stream IDs are "<ms>-<seq>"; the ms half is the snapshot time.
+    def self.stream_epoch(entry_id)
+      entry_id.to_s.split('-', 2).first.to_i / 1000.0
+    end
+
+    # Coerce a stream field to Int/Float for charting; leave non-numeric Ent
+    # fields (e.g. a label) untouched so nothing is silently dropped.
+    def self.numeric(value)
+      float = Float(value)
+      (float % 1).zero? ? float.to_i : float
+    rescue ::ArgumentError, ::TypeError
+      value
     end
 
     private
 
-    # §5.2 default gauge set. Names carry the `sidekiq.` prefix so a dashboard
-    # built for Sidekiq Ent reads them unchanged.
-    def default_snapshot(client)
+    def collect_values
       stats = Wurk::Stats.new
-      client.gauge('sidekiq.processed', stats.processed)
-      client.gauge('sidekiq.failures',  stats.failed)
-      client.gauge('sidekiq.enqueued',  stats.enqueued)
-      client.gauge('sidekiq.retries',   stats.retry_size)
-      client.gauge('sidekiq.dead',      stats.dead_size)
-      client.gauge('sidekiq.scheduled', stats.scheduled_size)
-      client.gauge('sidekiq.busy',      stats.workers_size)
+      SNAPSHOT_FIELDS.transform_values { |reader| stats.public_send(reader) }
+    end
+
+    def record_stream(values)
+      fields = values.flat_map { |field, value| [field, value] }
+      redis do |c|
+        c.call('XADD', Keys::HISTORY_METRICS, 'MAXLEN', '~', @stream_cap, '*', *fields)
+      end
+    end
+
+    # §5.2 default gauge set carries the `sidekiq.` prefix so a dashboard built
+    # for Sidekiq Ent reads it unchanged. A custom collector replaces it.
+    def emit_statsd(values)
+      client = Wurk::Metrics::Statsd.client
+      return if client.nil?
+      return @collector.call(client) if @collector
+
+      values.each { |field, value| client.gauge("sidekiq.#{field}", value) }
     end
 
     def wait

--- a/lib/wurk/keys.rb
+++ b/lib/wurk/keys.rb
@@ -29,6 +29,11 @@ module Wurk
     # Live process identities (heartbeat membership).
     PROCESSES      = 'processes'
 
+    # Ent Historical Metrics: capped Redis stream of periodic snapshots written
+    # by Wurk::History (§5.3). Same key a migrated Sidekiq Ent install uses, so
+    # its existing data renders without rewrite. Spec: sidekiq-ent.md §5.3, §10.
+    HISTORY_METRICS = 'history:metrics'
+
     # Profiles (v8.0+): ZSET of `<token>-<jid>` keys, score = expiry epoch;
     # each member also has a `<token>-<jid>` HASH holding the profile blob.
     # Spec: docs/target/sidekiq-free.md §1.7.

--- a/lib/wurk/web/enterprise.rb
+++ b/lib/wurk/web/enterprise.rb
@@ -140,6 +140,12 @@ module Wurk
         def queue_history(bucket, window:, queues: nil, now: ::Time.now)
           Wurk::Metrics::Query.queue_history(bucket, window, queues: queues, now: now)
         end
+
+        # Ent §5.3 Historical snapshots from the `history:metrics` stream,
+        # oldest→newest. Returns `[{at:, processed:, failures:, …}, …]`.
+        def snapshots(limit: Wurk::History::STREAM_DEFAULT_LIMIT)
+          Wurk::History.recent(limit: limit)
+        end
       end
     end
   end

--- a/test/engine/api_endpoints_test.rb
+++ b/test/engine/api_endpoints_test.rb
@@ -374,6 +374,18 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
     assert_match(/bucket/, json_body[:error])
   end
 
+  def test_history_snapshots_returns_stream_points
+    ::Wurk.redis { |c| c.call('XADD', 'history:metrics', '*', 'processed', '5', 'enqueued', '3') }
+    get '/wurk/api/history/snapshots?limit=10'
+
+    assert_ok
+    point = json_body[:snapshots].last
+
+    assert_equal({ processed: 5, enqueued: 3 }, point.slice(:processed, :enqueued))
+  ensure
+    ::Wurk.redis { |c| c.call('DEL', 'history:metrics') }
+  end
+
   def test_queue_history_returns_per_queue_gauge_series
     name = "qmqh-#{@ns}"
     epoch, key = seed_queue_metric(name, size: 8, latency: 4.5)
@@ -381,6 +393,7 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
 
     assert_ok
     row = json_body[:queues].find { |q| q[:name] == name }
+
     refute_nil row, 'seeded queue should appear in the series'
 
     point = row[:points].find { |p| p[:at] == epoch }

--- a/test/unit/history_test.rb
+++ b/test/unit/history_test.rb
@@ -36,6 +36,9 @@ class HistoryTest < Wurk::Test::UnitCase
     sidekiq.dead sidekiq.scheduled sidekiq.busy
   ].freeze
 
+  # The same metrics as stream fields (no `sidekiq.` prefix), as symbols.
+  STREAM_FIELDS = Wurk::History::SNAPSHOT_FIELDS.keys.map(&:to_sym).freeze
+
   def setup
     super
     @prev_builder = Wurk.configuration.dogstatsd
@@ -109,10 +112,12 @@ class HistoryTest < Wurk::Test::UnitCase
     assert_equal [['sidekiq.custom', 7]], fake.gauges
   end
 
-  def test_snapshot_is_a_noop_without_a_dogstatsd_client
+  def test_snapshot_skips_statsd_but_still_records_the_stream_without_a_client
     Wurk.configuration.dogstatsd = nil
 
-    assert_nil history.snapshot
+    history.snapshot
+
+    assert_equal(1, Wurk.redis { |c| c.call('XLEN', Wurk::Keys::HISTORY_METRICS) })
   end
 
   # --- leader gate ------------------------------------------------------
@@ -153,12 +158,64 @@ class HistoryTest < Wurk::Test::UnitCase
     assert_operator snapshotter.instance_variable_get(:@snaps).to_i, :>, 0
   end
 
+  # --- history:metrics stream (§5.3) -----------------------------------
+
+  def test_snapshot_appends_the_section_5_2_fields_to_the_stream
+    seed_queue('hq', 4)
+
+    history.snapshot
+    point = Wurk::History.recent.last
+
+    assert_equal STREAM_FIELDS.sort, (point.keys - [:at]).sort
+    assert_equal 4, point[:enqueued]
+  end
+
+  def test_recent_returns_points_oldest_to_newest
+    3.times do |i|
+      seed_queue("hq#{i}", i + 1)
+      history.snapshot
+    end
+    points = Wurk::History.recent
+
+    assert_equal 3, points.size
+    assert_equal(points.map { |p| p[:at] }.sort, points.map { |p| p[:at] })
+  end
+
+  def test_recent_clamps_to_the_requested_count
+    5.times { history.snapshot }
+
+    assert_equal 2, Wurk::History.recent(limit: 2).size
+  end
+
+  # AC: a migrated Ent install's entries render without rewrite — fields are
+  # read generically (numeric coerced, non-numeric kept).
+  def test_recent_tolerates_foreign_ent_stream_fields
+    Wurk.redis { |c| c.call('XADD', Wurk::Keys::HISTORY_METRICS, '*', 'processed', '999', 'odd_field', '12', 'label', 'x') }
+    point = Wurk::History.recent.last
+
+    assert_equal 999, point[:processed]
+    assert_equal 12, point[:odd_field]
+    assert_equal 'x', point[:label]
+  end
+
+  def test_stream_is_capped_by_maxlen
+    snapshotter = history(cap: 10)
+    200.times { snapshotter.snapshot }
+    xlen = Wurk.redis { |c| c.call('XLEN', Wurk::Keys::HISTORY_METRICS) }
+
+    assert_operator xlen, :<, 200, 'MAXLEN ~ should trim the stream'
+  end
+
   private
 
   # A History built on a throwaway config so retain_history never mutates the
-  # process-global Wurk.configuration.
-  def history(interval: 30, &collector)
+  # process-global Wurk.configuration. The config's Redis is pinned to this
+  # worker's test DB (a fresh Configuration would otherwise default to DB 0,
+  # which tests must never touch) so the stream write lands where recent() reads.
+  def history(interval: 30, cap: nil, &collector)
     config = Wurk::Configuration.new
+    config.redis = { url: Wurk::Test.redis_url }
+    config[:history_stream_cap] = cap if cap
     config.retain_history(interval, &collector)
     Wurk::History.new(config)
   end


### PR DESCRIPTION
Closes #125. Builds on #123 (the §5 snapshotter), now on `main`.

Sidekiq Ent 8.0+ keeps the last N history snapshots in a capped Redis stream `history:metrics` (§5.3) — a required key prefix for migration parity (§10 checklist line 808). wurk had no such key.

## What's added
- **`Wurk::History`** now computes `Stats` once and **`XADD`s each snapshot to `history:metrics`** (`MAXLEN ~ cap`) on every run — **independent of statsd**, so the dashboard has a history source even with no external client. The dogstatsd emit is unchanged (skipped only when no client is configured).
- **`Wurk::History.recent(limit:)`** reads the stream (`XREVRANGE`, oldest→newest), parsing fields **generically** (numeric coercion, non-numeric kept) so a **migrated Ent install's entries render without rewrite**. Cap is config-tunable (`history_stream_cap`) for tests.
- **`GET /wurk/api/history/snapshots`** + `Enterprise::Historical.snapshots` + `Keys::HISTORY_METRICS`.
- **Metrics page → "Historical Snapshots"** chart: a line per backlog gauge (`enqueued/retries/dead/scheduled/busy`), hiding the cumulative counters the throughput chart already shows; renders any other numeric field (incl. migrated Ent fields) generically; empty state.

## Acceptance criteria
- [x] The §5 snapshotter appends each snapshot to a capped `history:metrics` stream (`XADD MAXLEN ~ N`).
- [x] The Historical tab renders from `history:metrics` when present.
- [x] Existing `history:metrics` data from a migrated Ent install renders without rewrite (generic, tolerant parse).
- [x] Tests asserting key name, cap behavior, and read path.

## Note on the entry schema
§5.3/§10 name the `history:metrics` key but don't pin a per-entry field schema, so writes use the §5.2 short field names (`processed`, `failures`, `enqueued`, …) and **reads are tolerant** — every numeric field of each entry renders, whatever a migrated Ent stream carries. Cap uses `MAXLEN ~` (approximate, best-effort like Ent).

## Tests
- `test/unit/history_test.rb` — stream append + §5.2 fields, `MAXLEN` cap trims, `recent` oldest→newest + count clamp, **foreign-Ent-field tolerance**, statsd skipped-but-stream-written without a client.
- `test/engine/api_endpoints_test.rb` — `/history/snapshots` returns stream points.
- `frontend/src/pages/Metrics.test.tsx` — empty state + backlog lines rendered, cumulative counters hidden.
- Full suite **2185, 0 failures**, coverage, `test:parity`, `test:ecosystem`, `tsc`/build + vitest, and RuboCop on new files all green locally.

A behavioral driver confirmed the real path end-to-end, and the chart was visually verified (sine-wave backlog over the last hour, cumulative counters hidden, no console errors).

## How to test in prod
Enable the snapshotter (#123); the stream fills automatically:

```ruby
Sidekiq.configure_server { |c| c.retain_history(30) }   # dogstatsd optional
```

Open the dashboard → **Metrics → Historical Snapshots**: a line per backlog gauge over time. Migrating from Sidekiq Ent? Your existing `history:metrics` stream renders as-is — no rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Historical Snapshots chart section to the Metrics page for tracking backlog metrics over time
  * New `/api/history/snapshots` endpoint to retrieve stored historical metric snapshots with configurable retrieval limits
  * Backend infrastructure now persists historical metric snapshots to Redis for querying and dashboard visualization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->