### PR TITLE
feat(web): render third-party Web-extension views natively in the dashboard (#187)

### DIFF
--- a/app/controllers/wurk/extensions_controller.rb
+++ b/app/controllers/wurk/extensions_controller.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'wurk/web/extension'
+
+module Wurk
+  # Serves third-party Web extensions (#187): `ext/:name/*subpath` runs the
+  # registered extension's matched route and returns its rendered HTML for the
+  # SPA's Extension page to embed; `ext-assets/:name/*file` serves files from
+  # the extension's `asset_paths`.
+  #
+  # Inherits DashboardController so an /ext/* URL that is actually the SPA's
+  # client-side route (no extension registered under that name — e.g. a browser
+  # refresh on /wurk/ext/<tab>/) falls through to the SPA shell instead of 404.
+  class ExtensionsController < DashboardController
+    # Extension forms carry no Rails CSRF token. Parity with Sidekiq's own
+    # CSRF model instead (spec §25.1): unsafe methods must be same-origin per
+    # Sec-Fetch-Site; cross-site requests are denied. GETs are unaffected.
+    skip_forgery_protection
+    before_action :verify_same_origin!, unless: -> { request.get? || request.head? }
+
+    def show
+      result = Web::Extension::Renderer.call(
+        name: params[:name], method: request.request_method,
+        subpath: "/#{params[:subpath]}", env: request.env, mount: request.script_name
+      )
+      return index unless result # not an extension → SPA client route; let React handle it
+
+      respond_with(result)
+    end
+
+    def asset
+      file, cache_for = Web::Extension::Renderer.asset_file(params[:name], params[:file])
+      return head :not_found unless file
+
+      response.headers['Cache-Control'] = "public, max-age=#{cache_for}"
+      send_file file, disposition: 'inline'
+    end
+
+    private
+
+    def respond_with((status, headers, body))
+      return redirect_to(headers['Location'], allow_other_host: false) if status == 302
+
+      # Extension output is host-registered server code, same trust model as
+      # Sidekiq::Web rendering its extensions — not user input.
+      render html: body.html_safe, layout: false, status: status # rubocop:disable Rails/OutputSafety
+    end
+
+    def verify_same_origin!
+      site = request.headers['Sec-Fetch-Site']
+      head :forbidden unless site.nil? || site == 'same-origin'
+    end
+  end
+end

--- a/app/controllers/wurk/extensions_controller.rb
+++ b/app/controllers/wurk/extensions_controller.rb
@@ -43,7 +43,7 @@ module Wurk
 
       # Extension output is host-registered server code, same trust model as
       # Sidekiq::Web rendering its extensions — not user input.
-      render html: body.html_safe, layout: false, status: status # rubocop:disable Rails/OutputSafety
+      render html: body.html_safe, layout: false, status: status
     end
 
     def verify_same_origin!

--- a/app/controllers/wurk/extensions_controller.rb
+++ b/app/controllers/wurk/extensions_controller.rb
@@ -46,9 +46,11 @@ module Wurk
       render html: body.html_safe, layout: false, status: status
     end
 
+    # Spec §25.1: unsafe methods require `Sec-Fetch-Site: same-origin` — a
+    # missing header is denied too, like stock Sidekiq (a non-browser client
+    # must spoof the header deliberately; a cookie-carrying browser can't).
     def verify_same_origin!
-      site = request.headers['Sec-Fetch-Site']
-      head :forbidden unless site.nil? || site == 'same-origin'
+      head :forbidden unless request.headers['Sec-Fetch-Site'] == 'same-origin'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,16 @@ Wurk::Engine.routes.draw do
   get 'profiles/:key/data', to: 'profiles#data', as: :profile_data, constraints: { key: %r{[^/]+} }
   get 'profiles/:key',      to: 'profiles#show', as: :profile,      constraints: { key: %r{[^/]+} }
 
+  # Third-party Web extensions (#187): server-rendered route + assets. The SPA's
+  # Extension page fetches `ext/:name/<subpath>` and embeds the returned HTML;
+  # `format: false` keeps dots in subpaths/filenames out of Rails' format logic.
+  # An /ext URL with no matching registered extension falls through to the SPA
+  # shell inside the controller (it's the SPA's own /ext/:tab client route).
+  match 'ext/:name(/*subpath)', to: 'extensions#show', via: %i[get post], as: :extension,
+                                format: false, defaults: { subpath: '' }, constraints: { name: %r{[^/]+} }
+  get 'ext-assets/:name/*file', to: 'extensions#asset', as: :extension_asset,
+                                format: false, constraints: { name: %r{[^/]+} }
+
   # SPA catch-all — let React Router handle the rest.
   get '*path', to: 'dashboard#index', constraints: ->(req) { req.format == :html }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,7 +76,7 @@ Wurk::Engine.routes.draw do
   # `format: false` keeps dots in subpaths/filenames out of Rails' format logic.
   # An /ext URL with no matching registered extension falls through to the SPA
   # shell inside the controller (it's the SPA's own /ext/:tab client route).
-  match 'ext/:name(/*subpath)', to: 'extensions#show', via: %i[get post], as: :extension,
+  match 'ext/:name(/*subpath)', to: 'extensions#show', via: %i[get post put patch delete], as: :extension,
                                 format: false, defaults: { subpath: '' }, constraints: { name: %r{[^/]+} }
   get 'ext-assets/:name/*file', to: 'extensions#asset', as: :extension_asset,
                                 format: false, constraints: { name: %r{[^/]+} }

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -155,24 +155,39 @@ end
 
 A registered tab whose path isn't one Wurk already renders natively surfaces in
 the left-nav (read from `GET /api/meta`). Clicking it opens an in-dashboard
-**Extension** page that embeds the extension's own path (`/<mount>/<index>`) in an
-iframe. `custom_job_info_rows` render as extra rows in the job-detail modal.
+**Extension** page that renders the extension's view **natively**: the
+extension's Sinatra-style routes and ERB views are executed server-side and the
+resulting HTML is embedded in the page. `custom_job_info_rows` render as extra
+rows in the job-detail modal.
 
-**Supported subset (important).** Wurk's dashboard is a **precompiled React
-SPA**, not Sidekiq's server-rendered ERB UI. So:
+**How native rendering works.** Sidekiq extensions declare routes in
+`registered(app)` (`app.get "/locks" do … erb :index end`) and ship ERB
+templates under `root_dir/views`. Wurk captures those routes at registration
+and serves them Sidekiq-Web-compatibly — no Sinatra involved:
 
-- **Registration is accepted and no-op-safe** — requiring a gem that calls
-  `register`/`register_extension` (or mutates `tabs`) never crashes boot.
-- **Tabs surface in the nav** and open an Extension page that iframes the
-  extension's path. If the host mounts the gem's own Rack app reachable at that
-  path, its view renders in the frame; otherwise the frame shows a short
-  "not rendered here" note (no recursive dashboard nesting).
-- **`custom_job_info_rows` render** in the job-detail modal — each registered
-  callable (`call(job)`) or `add_pair(job)` object contributes a `label/value`
-  row.
-- **Sidekiq's ERB extension views are _not_ rendered natively.** Sidekiq
-  extensions ship ERB templates rendered by a Sinatra app; wurk has no such
-  render path, so the gem's own templates aren't compiled into the SPA bundle.
+- `GET/POST /<mount>/ext/<name>/<subpath>` matches the extension's route
+  (route params like `/locks/:digest` included), runs the block in a
+  `WebHelpers`-compatible context (`h`, `t`, `truncate`, `root_path`,
+  `asset_path`, `redis`, `params`, `redirect`, `erb`, …), and returns the
+  rendered HTML. Links and forms inside the view are intercepted by the SPA so
+  navigation stays in-page; `redirect` (e.g. delete → list) is followed
+  transparently.
+- `GET /<mount>/ext-assets/<name>/<file>` serves files from the extension's
+  `asset_paths` (with `Cache-Control` from `cache_for`, path-traversal
+  rejected), so a view's `<link href="<%= asset_path('app.css') %>">` works.
+- Locale strings load from `root_dir/locales/en.yml` and resolve through the
+  `t` helper; missing keys degrade to the humanized key, never raise.
+- CSRF matches Sidekiq's model: non-`GET` extension requests must be
+  same-origin per `Sec-Fetch-Site`; cross-site requests are denied.
+- Tabs added by bare `tabs["Label"] = "path"` mutation have no extension to
+  render; those fall back to an Extension page that iframes the tab's own path
+  (if the host mounts something reachable there, it renders in the frame).
+- Registration stays no-op-safe — a gem calling `register`/`register_extension`
+  (or mutating `tabs`) never crashes boot.
 
-Rendering Sidekiq's ERB extension views natively in the dashboard is tracked as
-a follow-up (#187).
+**Scope note.** This renders extensions registered against wurk's
+`Sidekiq::Web` alias. Gems that literally `require "sidekiq"` still can't load
+against wurk (wurk intentionally does not depend on — or install — the sidekiq
+gem; the consumer app shouldn't either, since wurk's native unique-jobs / cron /
+batches / limiter replace the common ecosystem gems). A `require "sidekiq"`
+compatibility shim is tracked, deliberately deferred, in #204.

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -132,10 +132,12 @@ export default function Nav({ open, onClose }: NavProps) {
           )}
           {customTabs.map((tab) => (
             <li key={tab.path}>
-              {/* In-SPA route: /ext/:tab renders an Extension page that embeds
-                  the extension's own path in an iframe. */}
+              {/* In-SPA route: /ext/:tab renders an Extension page (native
+                  server-rendered view, or an iframe for bare tabs[]= tabs).
+                  Registered index paths end in "/" ("locks/"); strip it so the
+                  route param round-trips to the same tab. */}
               <NavLink
-                to={`/ext/${tab.path}`}
+                to={`/ext/${tab.path.replace(/\/+$/, '')}`}
                 onClick={onClose}
                 className="wurk-navlink"
                 style={({ isActive }) => ({

--- a/frontend/src/hooks/useMeta.ts
+++ b/frontend/src/hooks/useMeta.ts
@@ -1,11 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
 
 // A dashboard tab registered by a third-party gem via
-// Sidekiq::Web.register_extension. wurk surfaces it in the nav as a link to its
-// path; the extension's own server-rendered view is not injected into the SPA.
+// Sidekiq::Web.register_extension. When ext_name is present, the Extension page
+// fetches the extension's server-rendered view from /wurk/ext/<ext_name>/* and
+// embeds it natively; tabs added by bare `tabs[]=` mutation have no extension
+// to render (ext_name null) and fall back to an iframe of their own path.
 export interface CustomTab {
   name: string;
   path: string;
+  ext_name?: string | null;
 }
 
 export interface Meta {

--- a/frontend/src/pages/Extension.test.tsx
+++ b/frontend/src/pages/Extension.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import Extension from './Extension';
+
+// Regression for the trailing-slash mismatch: registered index paths keep
+// Sidekiq's trailing slash ("locks/") while the /ext/:tab route param has
+// none. The tab must still resolve to its extension (native server-rendered
+// embed), not fall back to the iframe "not rendered here" page.
+
+function mockFetch(meta: unknown, extHtml: string) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes('/api/meta')) {
+      return { ok: true, status: 200, json: async () => meta, text: async () => '' } as Response;
+    }
+    return { ok: true, status: 200, json: async () => ({}), text: async () => extHtml } as Response;
+  });
+}
+
+function renderAt(path: string) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/ext/:tab" element={<Extension />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('Extension', () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('matches a registered tab whose index path has a trailing slash', async () => {
+    const fetchMock = mockFetch(
+      { read_only: false, read_only_message: null, custom_tabs: [{ name: 'Demo Locks', path: 'locks/', ext_name: 'demo_locks' }] },
+      '<h2>Demo Locks</h2><td>WelcomeEmailJob</td>'
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderAt('/ext/locks');
+
+    await waitFor(() => expect(screen.getByText('WelcomeEmailJob')).toBeTruthy());
+    const extCalls = fetchMock.mock.calls.map((c) => String(c[0])).filter((u) => u.includes('/ext/'));
+    expect(extCalls).toContain('/wurk/ext/demo_locks/locks');
+  });
+
+  it('falls back to the iframe embed for a bare tabs[]= tab (no ext_name)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({ read_only: false, read_only_message: null, custom_tabs: [{ name: 'Legacy', path: 'legacy', ext_name: null }] }, '')
+    );
+
+    renderAt('/ext/legacy');
+
+    await waitFor(() => expect(screen.getByTitle('Legacy')).toBeTruthy());
+    expect(screen.getByTitle('Legacy').getAttribute('src')).toBe('/wurk/legacy?wurk_ext_embed=1');
+  });
+});

--- a/frontend/src/pages/Extension.tsx
+++ b/frontend/src/pages/Extension.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { PageHeader } from '../components/PageHeader';
 import { useMeta } from '../hooks/useMeta';
@@ -30,15 +30,21 @@ function NativeExtension({ extName, indexPath, title }: { extName: string; index
   const base = `/wurk/ext/${extName}/`;
   const [html, setHtml] = useState<string | null>(null);
   const [error, setError] = useState(false);
+  // Monotonic request id: a response only lands if it's still the latest, so
+  // rapid link clicks can't resolve out of order and show stale HTML.
+  const seq = useRef(0);
 
   const load = useCallback(
     async (path: string, init?: RequestInit) => {
+      const id = ++seq.current;
       try {
         const res = await fetch(base + path, init);
+        const text = await res.text();
+        if (id !== seq.current) return;
         setError(!res.ok && res.status !== 404);
-        setHtml(await res.text());
+        setHtml(text);
       } catch {
-        setError(true);
+        if (id === seq.current) setError(true);
       }
     },
     [base]
@@ -68,7 +74,7 @@ function NativeExtension({ extName, indexPath, title }: { extName: string; index
     e.preventDefault();
     const data = new FormData(form);
     if ((form.method || 'get').toUpperCase() === 'GET') {
-      const qs = new URLSearchParams(data as unknown as Record<string, string>).toString();
+      const qs = new URLSearchParams(Array.from(data.entries()) as [string, string][]).toString();
       void load(`${url.pathname.slice(base.length)}${qs ? `?${qs}` : ''}`);
     } else {
       void load(url.pathname.slice(base.length) + url.search, { method: 'POST', body: data });

--- a/frontend/src/pages/Extension.tsx
+++ b/frontend/src/pages/Extension.tsx
@@ -14,7 +14,10 @@ import { t } from '../i18n';
 export default function Extension() {
   const { tab = '' } = useParams();
   const { data: meta } = useMeta();
-  const entry = meta?.custom_tabs?.find((tab_) => tab_.path === tab);
+  // Registered index paths keep Sidekiq's trailing slash ("locks/") but the
+  // route param never has one — compare them normalized.
+  const norm = (p: string) => p.replace(/\/+$/, '');
+  const entry = meta?.custom_tabs?.find((tab_) => norm(tab_.path) === norm(tab));
   const name = entry?.name ?? tab;
 
   if (entry?.ext_name) {

--- a/frontend/src/pages/Extension.tsx
+++ b/frontend/src/pages/Extension.tsx
@@ -1,24 +1,101 @@
+import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { PageHeader } from '../components/PageHeader';
 import { useMeta } from '../hooks/useMeta';
 import { t } from '../i18n';
 
 // Renders a third-party extension tab registered via
-// Sidekiq::Web.register_extension. wurk's dashboard is a precompiled React SPA
-// with no server-side ERB render path, so we embed the extension's own path in
-// an iframe (carrying ?wurk_ext_embed=1). If the host mounts the gem's Rack app
-// there it renders; otherwise the SPA itself answers that path and main.tsx —
-// seeing the embed flag inside an iframe — paints a small "not rendered" stub
-// instead of recursively nesting the whole dashboard.
+// Sidekiq::Web.register_extension. When the tab maps to a registered extension
+// (ext_name from /api/meta), its routes/ERB views are server-rendered by
+// Wurk::Web::Extension::Renderer at /wurk/ext/<name>/* and embedded here
+// natively — links and forms inside the view are intercepted so navigation
+// stays on this page (#187). Tabs without an extension (bare `tabs[]=`
+// mutation) keep the old iframe embed of their own path.
 export default function Extension() {
   const { tab = '' } = useParams();
   const { data: meta } = useMeta();
-  const name = meta?.custom_tabs?.find((tab_) => tab_.path === tab)?.name ?? tab;
-  const src = `/wurk/${tab}?wurk_ext_embed=1`;
+  const entry = meta?.custom_tabs?.find((tab_) => tab_.path === tab);
+  const name = entry?.name ?? tab;
+
+  if (entry?.ext_name) {
+    return <NativeExtension key={entry.ext_name} extName={entry.ext_name} indexPath={tab} title={name} />;
+  }
+  return <IframeExtension tab={tab} title={name} />;
+}
+
+function NativeExtension({ extName, indexPath, title }: { extName: string; indexPath: string; title: string }) {
+  const base = `/wurk/ext/${extName}/`;
+  const [html, setHtml] = useState<string | null>(null);
+  const [error, setError] = useState(false);
+
+  const load = useCallback(
+    async (path: string, init?: RequestInit) => {
+      try {
+        const res = await fetch(base + path, init);
+        setError(!res.ok && res.status !== 404);
+        setHtml(await res.text());
+      } catch {
+        setError(true);
+      }
+    },
+    [base]
+  );
+
+  useEffect(() => {
+    void load(indexPath.replace(/\/+$/, ''));
+  }, [load, indexPath]);
+
+  // Keep extension-internal navigation inside this page: anchors and forms
+  // whose target resolves under our embed base are fetched instead of
+  // navigating the whole browser away from the SPA. Redirects (delete → list)
+  // are followed by fetch transparently.
+  const onClick = (e: React.MouseEvent) => {
+    const a = (e.target as HTMLElement).closest('a');
+    if (!a?.getAttribute('href')) return;
+    const url = new URL(a.href, window.location.origin);
+    if (url.origin !== window.location.origin || !url.pathname.startsWith(base)) return;
+    e.preventDefault();
+    void load(url.pathname.slice(base.length) + url.search);
+  };
+
+  const onSubmit = (e: React.FormEvent) => {
+    const form = e.target as HTMLFormElement;
+    const url = new URL(form.getAttribute('action') || window.location.href, window.location.origin);
+    if (url.origin !== window.location.origin || !url.pathname.startsWith(base)) return;
+    e.preventDefault();
+    const data = new FormData(form);
+    if ((form.method || 'get').toUpperCase() === 'GET') {
+      const qs = new URLSearchParams(data as unknown as Record<string, string>).toString();
+      void load(`${url.pathname.slice(base.length)}${qs ? `?${qs}` : ''}`);
+    } else {
+      void load(url.pathname.slice(base.length) + url.search, { method: 'POST', body: data });
+    }
+  };
 
   return (
     <>
-      <PageHeader icon="fa-puzzle-piece" title={name} summary={t('extension.summary')}>
+      <PageHeader icon="fa-puzzle-piece" title={title} summary={t('extension.summary')} />
+      {error && <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>}
+      {html === null && !error && <div className="empty-state"><span className="spinner" /></div>}
+      {html !== null && !error && (
+        <div
+          className="card ext-view"
+          onClick={onClick}
+          onSubmit={onSubmit}
+          // Extension HTML is rendered server-side from host-registered gem
+          // code — the same trust model as Sidekiq::Web rendering it.
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      )}
+    </>
+  );
+}
+
+function IframeExtension({ tab, title }: { tab: string; title: string }) {
+  const src = `/wurk/${tab}?wurk_ext_embed=1`;
+  return (
+    <>
+      <PageHeader icon="fa-puzzle-piece" title={title} summary={t('extension.summary')}>
         <a className="btn btn-sm" href={`/wurk/${tab}`} target="_blank" rel="noopener noreferrer">
           <i className="fa-solid fa-arrow-up-right-from-square" style={{ marginInlineEnd: '0.4rem' }} />
           {t('extension.open')}
@@ -26,7 +103,7 @@ export default function Extension() {
       </PageHeader>
 
       <iframe
-        title={name}
+        title={title}
         src={src}
         style={{
           width: '100%',

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -990,3 +990,38 @@ tbody tr:last-child td {
   background: var(--surface-hover);
 }
 .chip:active { transform: translateY(1px); }
+
+/* Server-rendered Web-extension views (#187). Extension ERB ships its own
+   plain markup (tables/forms/links), so give the common elements just enough
+   theme styling to sit in the dashboard without shipping Sidekiq's CSS. */
+.ext-view { overflow-x: auto; }
+.ext-view table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.ext-view th,
+.ext-view td { padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--border); text-align: start; }
+.ext-view th { color: var(--text-muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; }
+.ext-view a { color: var(--accent); }
+.ext-view h1, .ext-view h2, .ext-view h3 { margin: 0.5rem 0; }
+.ext-view form { display: inline-flex; gap: 0.5rem; align-items: center; margin: 0.5rem 0; }
+.ext-view input[type='text'],
+.ext-view input[type='search'],
+.ext-view input[type='number'],
+.ext-view select {
+  background: var(--surface-strong);
+  border: 1px solid var(--border-strong);
+  color: var(--text);
+  border-radius: 6px;
+  padding: 0.35rem 0.6rem;
+  font-size: 13px;
+}
+.ext-view input[type='submit'],
+.ext-view button {
+  background: var(--surface-strong);
+  border: 1px solid var(--border-strong);
+  color: var(--text);
+  border-radius: 6px;
+  padding: 0.35rem 0.75rem;
+  font-size: 13px;
+  cursor: pointer;
+}
+.ext-view input[type='submit']:hover,
+.ext-view button:hover { border-color: var(--accent); }

--- a/lib/wurk/web/config.rb
+++ b/lib/wurk/web/config.rb
@@ -100,12 +100,11 @@ module Wurk
       # Matches Sidekiq::Web::Config#register_extension (aliased `register`,
       # spec §25.2): `tab` is the label(s), `index` the path(s), `name` the
       # asset namespace. `tab`/`index` are zipped into the `tabs` hash
-      # (label => path), so the tab surfaces in the SPA nav via /api/meta. It
-      # does NOT invoke the extension's server-side routes/views: wurk's
-      # dashboard is a precompiled React SPA with no Sinatra/ERB render path, so
-      # an ext's own view can't be injected (documented divergence — registration
-      # is accepted no-op-safe so requiring the gem never crashes boot). Yields
-      # self to an optional block for further config, and returns self.
+      # (label => path) so the tab surfaces in the SPA nav via /api/meta, and
+      # the extension's `registered(app)` routes/ERB views are served by
+      # Wurk::Web::Extension::Renderer under `ext/:name/*` (#187) — the SPA's
+      # Extension page embeds the rendered HTML. Yields self to an optional
+      # block for further config, and returns self.
       # rubocop:disable Metrics/ParameterLists -- signature matches Sidekiq::Web::Config#register_extension (spec §25.2)
       def register_extension(extension, name:, tab:, index:, root_dir: nil,
                              cache_for: 86_400, asset_paths: nil)
@@ -121,13 +120,24 @@ module Wurk
       alias register register_extension
 
       # Tabs the SPA should render in the nav: everything registered beyond the
-      # Sidekiq defaults and wurk's own native pages, as `{ name:, path: }`.
+      # Sidekiq defaults and wurk's own native pages, as `{ name:, path:,
+      # ext_name: }`. `ext_name` ties the tab back to a registered extension so
+      # the Extension page can fetch its server-rendered view from
+      # `ext/:ext_name/*`; nil for tabs added by bare `tabs[]=` mutation (the
+      # SPA falls back to the iframe embed for those).
       def custom_tabs
         @tabs.filter_map do |name, path|
           next if DEFAULT_TABS.key?(name) || NATIVE_TAB_PATHS.include?(path.to_s)
 
-          { name: name, path: path.to_s }
+          { name: name, path: path.to_s, ext_name: extension_for_index(path)&.dig(:name)&.to_s }
         end
+      end
+
+      # The registered extension whose `index` covers `path` ("locks/" and
+      # "locks" are the same index).
+      def extension_for_index(path)
+        norm = path.to_s.delete_suffix('/')
+        @extensions.find { |e| Array(e[:index]).any? { |i| i.to_s.delete_suffix('/') == norm } }
       end
 
       # Evaluate the registered `custom_job_info_rows` against a job (spec

--- a/lib/wurk/web/config.rb
+++ b/lib/wurk/web/config.rb
@@ -127,7 +127,9 @@ module Wurk
       # SPA falls back to the iframe embed for those).
       def custom_tabs
         @tabs.filter_map do |name, path|
-          next if DEFAULT_TABS.key?(name) || NATIVE_TAB_PATHS.include?(path.to_s)
+          # Same trailing-slash normalization as extension_for_index, so a
+          # native path registered as "cron/" doesn't duplicate the native tab.
+          next if DEFAULT_TABS.key?(name) || NATIVE_TAB_PATHS.include?(path.to_s.delete_suffix('/'))
 
           { name: name, path: path.to_s, ext_name: extension_for_index(path)&.dig(:name)&.to_s }
         end

--- a/lib/wurk/web/extension.rb
+++ b/lib/wurk/web/extension.rb
@@ -77,13 +77,24 @@ module Wurk
         private
 
         def compile(path)
-          return /\A#{Regexp.escape(path[0..-2])}.*\z/ if path.end_with?('*')
+          return /\A#{::Regexp.escape(path[0..-2])}.*\z/ if path.end_with?('*')
 
-          pattern = path.gsub(NAMED) do
-            @keys << ::Regexp.last_match(2).to_sym
-            "/#{::Regexp.last_match(1)}([^/?#]+)"
-          end
-          %r{\A#{pattern}/?\z}
+          %r{\A#{escaped_pattern(path)}/?\z}
+        end
+
+        # Escape every literal fragment so route text like ".json" or "+"
+        # matches itself instead of acting as a regex metacharacter.
+        def escaped_pattern(path)
+          pattern = +''
+          pos = 0
+          path.scan(NAMED) { pos = append_param(pattern, path, pos, ::Regexp.last_match) }
+          pattern << ::Regexp.escape(path[pos..])
+        end
+
+        def append_param(pattern, path, pos, match)
+          @keys << match[2].to_sym
+          pattern << ::Regexp.escape(path[pos...match.begin(0)]) << "/#{::Regexp.escape(match[1])}([^/?#]+)"
+          match.end(0)
         end
       end
 

--- a/lib/wurk/web/extension.rb
+++ b/lib/wurk/web/extension.rb
@@ -1,0 +1,302 @@
+# frozen_string_literal: true
+
+require 'erb'
+require 'cgi'
+require 'securerandom'
+
+module Wurk
+  class Web
+    # Server-side renderer for third-party Web extensions (spec §25, #187).
+    #
+    # Sidekiq extensions register Sinatra-style routes + ERB views via
+    # `Sidekiq::Web.register(Ext, name:, tab:, index:, root_dir:, asset_paths:)`,
+    # where `Ext.registered(app)` calls `app.get "/path" do … end` and
+    # `app.helpers SomeModule`. wurk's dashboard is a React SPA with no Sinatra
+    # render path, so this module provides a minimal, Sidekiq-Web-compatible
+    # renderer: it captures the routes, runs the matched block in an `Action`
+    # context (a `WebHelpers` subset + the ext's own helpers + `erb`), and
+    # returns the rendered HTML for the SPA's Extension page to embed.
+    #
+    # It does NOT depend on the `sidekiq` gem — extensions registered through
+    # wurk's own `Sidekiq::Web.register` alias render unchanged. (Running a
+    # real third-party gem unmodified additionally needs the shim in #204.)
+    module Extension
+      # Captures the routes + helpers an extension declares in `registered`.
+      # Quacks like the slice of `Sidekiq::Web::Application` extensions touch.
+      class App
+        attr_reader :routes, :helper_modules, :helper_blocks
+
+        HTTP_METHODS = %i[get post put patch delete head].freeze
+
+        def initialize
+          @routes = []          # [[method_string, Route, block], …]
+          @helper_modules = []
+          @helper_blocks = []
+        end
+
+        HTTP_METHODS.each do |verb|
+          define_method(verb) do |path, &block|
+            @routes << [verb.to_s.upcase, Route.new(path), block]
+          end
+        end
+
+        # Sidekiq extensions add helpers via `app.helpers(Mod)` and/or a block.
+        def helpers(*mods, &block)
+          @helper_modules.concat(mods)
+          @helper_blocks << block if block
+          self
+        end
+
+        # Sinatra settings calls some extensions make — accepted no-op.
+        def set(*); end
+        def settings = self
+        def configure(*) = (yield self if block_given?)
+      end
+
+      # Compiles a Sinatra-style path ("/locks/:digest") into a matcher that
+      # extracts Symbol-keyed route params. A trailing "*" matches the rest.
+      class Route
+        NAMED = %r{/([^/]*):([^./:$]+)}
+
+        attr_reader :path
+
+        def initialize(path)
+          @path = path.to_s
+          @keys = []
+          @regex = compile(@path)
+        end
+
+        # Returns a `{key => value}` Hash of route params, or nil if no match.
+        def match(path)
+          m = @regex.match(path)
+          return nil unless m
+
+          @keys.each_with_index.to_h { |k, i| [k, m[i + 1] && CGI.unescape(m[i + 1])] }
+        end
+
+        private
+
+        def compile(path)
+          return %r{\A#{Regexp.escape(path[0..-2])}.*\z} if path.end_with?('*')
+
+          pattern = path.gsub(NAMED) do
+            @keys << ::Regexp.last_match(2).to_sym
+            "/#{::Regexp.last_match(1)}([^/?#]+)"
+          end
+          %r{\A#{pattern}/?\z}
+        end
+      end
+
+      # The `WebHelpers` subset real extension views/routes call. Mixed into
+      # every `Action`. Anything an exotic gem needs beyond this can be added
+      # incrementally; the common surface (escaping, paths, time, i18n) is here.
+      module Helpers
+        def h(text) = ::CGI.escapeHTML(text.to_s)
+
+        # Truncate long text (display safety) — mirrors Sidekiq's default cap.
+        def truncate(text, max = 2000)
+          str = text.to_s
+          str.size > max ? "#{str[0, max]}…" : str
+        end
+
+        # Best-effort arg display, matching Sidekiq's `to_display`.
+        def to_display(arg)
+          str = arg.inspect
+          str.size > 100 ? "#{str[0, 100]}…" : str
+        end
+
+        # i18n: look up the extension's own locale strings if present, else the
+        # humanized key (so a missing translation degrades, never raises).
+        def t(key, options = {})
+          val = (@ext_strings || {}).dig(*key.to_s.split('.'))
+          str = val.is_a?(::String) ? val : key.to_s.tr('_', ' ').capitalize
+          options.each { |k, v| str = str.gsub("%{#{k}}", v.to_s) }
+          str
+        end
+
+        # Engine-absolute base path for this extension, trailing slash, so an
+        # ext's `root_path + "locks"` links land back on our embed endpoint.
+        def root_path = "#{@mount}/ext/#{@ext_name}/"
+        def current_path = @subpath.to_s.sub(%r{\A/}, '')
+        def asset_path(file) = "#{@mount}/ext-assets/#{@ext_name}/#{file}"
+
+        # GET-form embeds don't need CSRF; return an empty, benign tag.
+        def csrf_tag = ''
+        def csp_nonce = (@csp_nonce ||= ::SecureRandom.hex(8))
+
+        # `<time>` element like Sidekiq's relative_time; JS upgrades it client-side.
+        def relative_time(time)
+          t = time.is_a?(::Time) ? time : ::Time.at(time.to_f)
+          iso = t.utc.iso8601
+          %(<time class="ltr" dir="ltr" title="#{iso}" datetime="#{iso}">#{iso}</time>)
+        end
+
+        def redis(&) = ::Wurk.redis(&)
+        def product_version = ::Wurk::VERSION
+        def number_with_delimiter(num) = num.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse
+      end
+
+      # Per-request render context: instance-evals a matched route block, then
+      # renders ERB with the block's ivars + helpers in scope.
+      class Action
+        include Helpers
+
+        # Internal-redirect signal carried out of a route block via throw/catch.
+        Redirect = ::Struct.new(:location)
+
+        def initialize(env:, route_params:, ext:, mount:)
+          @env = env
+          @request = ::Rack::Request.new(env)
+          @route_params = route_params
+          @ext_name = ext[:name].to_s
+          @root_dir = ext[:root_dir]
+          @ext_strings = ext[:strings]
+          @mount = mount.to_s
+          @subpath = env['wurk.ext.subpath']
+          extend_helpers(ext[:helpers])
+        end
+
+        attr_reader :env, :request
+
+        def params = @params ||= symbolize(@request.params).merge(@route_params)
+        def url_params(key) = @request.params[key.to_s]
+        def route_params(key = nil) = key ? @route_params[key.to_sym] : @route_params
+        def session = (@env['rack.session'] ||= {})
+        def logger = ::Wurk.logger
+        def redirect(location) = throw(:wurk_ext_halt, Redirect.new(location))
+
+        # Render an ERB template. `content` is either the template String (the
+        # common path — the ext's own helper reads the file) or a Symbol naming
+        # a `*.erb` under the ext's root_dir/views.
+        def erb(content, _options = {})
+          template = content.is_a?(::Symbol) ? read_view(content) : content.to_s
+          ::ERB.new(template, trim_mode: '-').result(binding)
+        end
+
+        # Run the route block in this context, capturing redirects. Returns the
+        # rendered HTML String, or a Redirect.
+        def run(block)
+          catch(:wurk_ext_halt) { instance_exec(&block) }
+        end
+
+        private
+
+        def read_view(name)
+          raise ::ArgumentError, "extension #{@ext_name} has no root_dir" unless @root_dir
+
+          ::File.read(::File.join(@root_dir, 'views', "#{name}.erb"))
+        end
+
+        def extend_helpers(helpers)
+          Array(helpers && helpers[:modules]).each { |mod| extend(mod) }
+          Array(helpers && helpers[:blocks]).each { |blk| instance_eval(&blk) if blk }
+        end
+
+        def symbolize(hash) = hash.to_h.transform_keys(&:to_sym)
+      end
+
+      # Ties it together: finds a registered extension by name, captures its
+      # routes once (`registered(app)`), matches the request, and renders.
+      class Renderer
+        class << self
+          # @return [Array(Integer, Hash, String)] Rack-ish [status, headers,
+          #   body] — 200 HTML, 302 redirect, or 404 — or nil when no extension
+          #   with `name` is registered (so the engine can fall through).
+          def call(name:, method:, subpath:, env:, mount:)
+            ext = registered_extension(name)
+            return nil unless ext
+
+            verb = method.to_s.upcase
+            route, block, route_params = match_route(ext, verb, subpath)
+            return [404, html_headers, "No #{verb} route #{subpath} in extension #{name}"] unless route
+
+            env['wurk.ext.subpath'] = subpath
+            render(ext, route_params, block, env, mount)
+          end
+
+          # `[absolute_path, cache_for_seconds]` of an asset under the
+          # extension's asset_paths, or nil if the extension/file isn't found.
+          # The expand_path prefix check rejects `../` traversal out of the dir.
+          def asset_file(name, file)
+            ext = registered_extension(name)
+            return nil unless ext
+
+            Array(ext[:asset_paths]).each do |dir|
+              path = ::File.expand_path(::File.join(dir, file.to_s))
+              return [path, ext[:cache_for] || 86_400] if path.start_with?("#{::File.expand_path(dir)}/") && ::File.file?(path)
+            end
+            nil
+          end
+
+          private
+
+          def registered_extension(name)
+            ::Wurk::Web.config.extensions.find { |e| e[:name].to_s == name.to_s }
+          end
+
+          def render(ext, route_params, block, env, mount)
+            app = captured_app(ext)
+            action = Action.new(
+              env: env, route_params: route_params, mount: mount,
+              ext: ext.merge(helpers: { modules: app.helper_modules, blocks: app.helper_blocks },
+                             strings: strings_for(ext))
+            )
+            result = action.run(block)
+            if result.is_a?(Action::Redirect)
+              [302, { 'Location' => redirect_target(result.location, ext, mount) }, '']
+            else
+              [200, html_headers, result.to_s]
+            end
+          rescue ::StandardError => e
+            ::Wurk.configuration.handle_exception(e, context: 'web-extension-render')
+            [500, html_headers, "Extension render error: #{::CGI.escapeHTML(e.message)}"]
+          end
+
+          def match_route(ext, verb, subpath)
+            captured_app(ext).routes.each do |meth, route, block|
+              next unless meth == verb
+
+              params = route.match(subpath)
+              return [route, block, params] if params
+            end
+            [nil, nil, nil]
+          end
+
+          # Capture the ext's routes/helpers once; memoize on the config entry.
+          def captured_app(ext)
+            ext[:_app] ||= App.new.tap do |app|
+              ext[:extension].registered(app) if ext[:extension].respond_to?(:registered)
+            end
+          end
+
+          # An ext's redirect target is relative to its mount ("locks" → the
+          # embed endpoint). Absolute URLs pass through unchanged.
+          def redirect_target(location, ext, mount)
+            loc = location.to_s
+            return loc if loc.match?(%r{\A[a-z]+://}i)
+
+            "#{mount}/ext/#{ext[:name]}/#{loc.sub(%r{\A/}, '')}"
+          end
+
+          def strings_for(ext)
+            ext.fetch(:_strings) do
+              dir = ext[:root_dir]
+              file = dir && ::File.join(dir, 'locales', 'en.yml')
+              ext[:_strings] = (file && ::File.exist?(file) ? load_yaml(file) : {})
+            end
+          end
+
+          def load_yaml(file)
+            require 'yaml'
+            data = ::YAML.safe_load_file(file)
+            data.is_a?(::Hash) ? (data.values.first || data) : {}
+          rescue ::StandardError
+            {}
+          end
+
+          def html_headers = { 'Content-Type' => 'text/html; charset=utf-8' }
+        end
+      end
+    end
+  end
+end

--- a/lib/wurk/web/extension.rb
+++ b/lib/wurk/web/extension.rb
@@ -29,7 +29,7 @@ module Wurk
         HTTP_METHODS = %i[get post put patch delete head].freeze
 
         def initialize
-          @routes = []          # [[method_string, Route, block], …]
+          @routes = [] # [[method_string, Route, block], …]
           @helper_modules = []
           @helper_blocks = []
         end
@@ -77,7 +77,7 @@ module Wurk
         private
 
         def compile(path)
-          return %r{\A#{Regexp.escape(path[0..-2])}.*\z} if path.end_with?('*')
+          return /\A#{Regexp.escape(path[0..-2])}.*\z/ if path.end_with?('*')
 
           pattern = path.gsub(NAMED) do
             @keys << ::Regexp.last_match(2).to_sym
@@ -223,7 +223,9 @@ module Wurk
 
             Array(ext[:asset_paths]).each do |dir|
               path = ::File.expand_path(::File.join(dir, file.to_s))
-              return [path, ext[:cache_for] || 86_400] if path.start_with?("#{::File.expand_path(dir)}/") && ::File.file?(path)
+              next unless path.start_with?("#{::File.expand_path(dir)}/") && ::File.file?(path)
+
+              return [path, ext[:cache_for] || 86_400]
             end
             nil
           end
@@ -235,13 +237,7 @@ module Wurk
           end
 
           def render(ext, route_params, block, env, mount)
-            app = captured_app(ext)
-            action = Action.new(
-              env: env, route_params: route_params, mount: mount,
-              ext: ext.merge(helpers: { modules: app.helper_modules, blocks: app.helper_blocks },
-                             strings: strings_for(ext))
-            )
-            result = action.run(block)
+            result = action_for(ext, route_params, env, mount).run(block)
             if result.is_a?(Action::Redirect)
               [302, { 'Location' => redirect_target(result.location, ext, mount) }, '']
             else
@@ -250,6 +246,15 @@ module Wurk
           rescue ::StandardError => e
             ::Wurk.configuration.handle_exception(e, context: 'web-extension-render')
             [500, html_headers, "Extension render error: #{::CGI.escapeHTML(e.message)}"]
+          end
+
+          def action_for(ext, route_params, env, mount)
+            app = captured_app(ext)
+            Action.new(
+              env: env, route_params: route_params, mount: mount,
+              ext: ext.merge(helpers: { modules: app.helper_modules, blocks: app.helper_blocks },
+                             strings: strings_for(ext))
+            )
           end
 
           def match_route(ext, verb, subpath)

--- a/test/dummy/config/initializers/zz_custom_tab_preview.rb
+++ b/test/dummy/config/initializers/zz_custom_tab_preview.rb
@@ -18,18 +18,12 @@ if ENV['WURK_DEMO'] == '1'
 
     def self.registered(app)
       app.get '/locks' do
-        @locks = redis { |c| c.call('HGETALL', KEY) }
-        if @locks.empty?
-          redis { |c| c.call('HSET', KEY, *SEED.flatten) }
-          @locks = SEED.dup
-        end
+        @locks = DemoLocksExt.seeded_locks
         erb :index
       end
 
       app.get '/locks/:digest' do
-        @digest = route_params(:digest)
-        @job = redis { |c| c.call('HGET', KEY, @digest) }
-        @since = Time.at(Time.now.to_i - (@digest.sum % 3600))
+        @digest, @job, @since = DemoLocksExt.lock_detail(route_params(:digest))
         erb :show
       end
 
@@ -37,6 +31,19 @@ if ENV['WURK_DEMO'] == '1'
         redis { |c| c.call('HDEL', KEY, route_params(:digest)) }
         redirect 'locks'
       end
+    end
+
+    def self.lock_detail(digest)
+      job = Wurk.redis { |c| c.call('HGET', KEY, digest) }
+      [digest, job, Time.at(Time.now.to_i - (digest.sum % 3600))]
+    end
+
+    def self.seeded_locks
+      locks = Wurk.redis { |c| c.call('HGETALL', KEY) }
+      return locks unless locks.empty?
+
+      Wurk.redis { |c| c.call('HSET', KEY, *SEED.flatten) }
+      SEED.dup
     end
   end
 

--- a/test/dummy/config/initializers/zz_custom_tab_preview.rb
+++ b/test/dummy/config/initializers/zz_custom_tab_preview.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Demo Web extension (WURK_DEMO=1): a Sidekiq-style "Locks" tab in the shape
+# real gems use (sidekiq-unique-jobs et al.) — `registered(app)` routes, ERB
+# views + locale strings + CSS from root_dir/asset_paths, route params, and a
+# POST → redirect flow — all rendered natively by the #187 extension renderer.
+# Registered through the `Sidekiq::Web.register` drop-in alias on purpose.
+if ENV['WURK_DEMO'] == '1'
+  module DemoLocksExt
+    ROOT = File.expand_path('../../lib/demo_ext', __dir__)
+    KEY = 'demo:locks'
+    SEED = {
+      '3f2a09c1d4e5' => 'WelcomeEmailJob',
+      '9b81e7aa0c44' => 'NightlyReportJob',
+      'c57d1f02b9e3' => 'SyncInventoryJob',
+      '71ee5b6d28f0' => 'ChargeSubscriptionJob'
+    }.freeze
+
+    def self.registered(app)
+      app.get '/locks' do
+        @locks = redis { |c| c.call('HGETALL', KEY) }
+        if @locks.empty?
+          redis { |c| c.call('HSET', KEY, *SEED.flatten) }
+          @locks = SEED.dup
+        end
+        erb :index
+      end
+
+      app.get '/locks/:digest' do
+        @digest = route_params(:digest)
+        @job = redis { |c| c.call('HGET', KEY, @digest) }
+        @since = Time.at(Time.now.to_i - (@digest.sum % 3600))
+        erb :show
+      end
+
+      app.post '/locks/:digest/delete' do
+        redis { |c| c.call('HDEL', KEY, route_params(:digest)) }
+        redirect 'locks'
+      end
+    end
+  end
+
+  Sidekiq::Web.register(
+    DemoLocksExt,
+    name: 'demo_locks',
+    tab: ['Demo Locks'],
+    index: ['locks/'],
+    root_dir: DemoLocksExt::ROOT,
+    asset_paths: [File.join(DemoLocksExt::ROOT, 'assets')]
+  )
+end

--- a/test/dummy/lib/demo_ext/assets/demo_ext.css
+++ b/test/dummy/lib/demo_ext/assets/demo_ext.css
@@ -1,0 +1,5 @@
+.demo-locks-subtitle { color: var(--muted, #9aa4b2); }
+.demo-locks { width: 100%; border-collapse: collapse; }
+.demo-locks th, .demo-locks td { padding: 0.5rem 0.75rem; text-align: start; border-bottom: 1px solid var(--border, #2a3140); }
+.demo-locks-release { cursor: pointer; padding: 0.25rem 0.75rem; border-radius: 0.375rem; border: 1px solid var(--danger, #e5484d); background: transparent; color: var(--danger, #e5484d); }
+.demo-locks-release:hover { background: var(--danger, #e5484d); color: #fff; }

--- a/test/dummy/lib/demo_ext/locales/en.yml
+++ b/test/dummy/lib/demo_ext/locales/en.yml
@@ -1,0 +1,11 @@
+en:
+  title: Demo Locks
+  subtitle: "A Sidekiq-style Web extension rendered natively by the dashboard (issue #187). ERB views, locale strings, and this page's CSS all come from the extension itself."
+  digest: Digest
+  job: Held by
+  release: Release
+  empty: No locks held.
+  lock: Lock
+  held_by: Held by
+  not_found: This lock no longer exists (already released?).
+  back: All locks

--- a/test/dummy/lib/demo_ext/views/index.erb
+++ b/test/dummy/lib/demo_ext/views/index.erb
@@ -1,0 +1,25 @@
+<link rel="stylesheet" href="<%= asset_path('demo_ext.css') %>">
+<h2><%= t('title') %></h2>
+<p class="demo-locks-subtitle"><%= t('subtitle') %></p>
+<table class="demo-locks">
+  <thead>
+    <tr><th><%= t('digest') %></th><th><%= t('job') %></th><th></th></tr>
+  </thead>
+  <tbody>
+    <% @locks.each do |digest, job| %>
+      <tr>
+        <td><a href="<%= root_path %>locks/<%= h digest %>"><code><%= h digest %></code></a></td>
+        <td><%= h job %></td>
+        <td>
+          <form method="post" action="<%= root_path %>locks/<%= h digest %>/delete">
+            <%= csrf_tag %>
+            <button type="submit" class="demo-locks-release"><%= t('release') %></button>
+          </form>
+        </td>
+      </tr>
+    <% end %>
+    <% if @locks.empty? %>
+      <tr><td colspan="3"><%= t('empty') %></td></tr>
+    <% end %>
+  </tbody>
+</table>

--- a/test/dummy/lib/demo_ext/views/show.erb
+++ b/test/dummy/lib/demo_ext/views/show.erb
@@ -1,0 +1,8 @@
+<link rel="stylesheet" href="<%= asset_path('demo_ext.css') %>">
+<h2><%= t('lock') %> <code><%= h @digest %></code></h2>
+<% if @job %>
+  <p><%= t('held_by') %> <strong><%= h @job %></strong> · <%= relative_time(@since) %></p>
+<% else %>
+  <p><%= t('not_found') %></p>
+<% end %>
+<p><a href="<%= root_path %>locks">&larr; <%= t('back') %></a></p>

--- a/test/engine/extensions_test.rb
+++ b/test/engine/extensions_test.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require_relative '../engine_test_helper'
+
+# Drives the Web-extension endpoints (#187) against the booted dummy app:
+# `GET/POST /wurk/ext/:name/*` renders the registered extension's route and
+# `GET /wurk/ext-assets/:name/*` serves its asset_paths. Registers a synthetic
+# extension under a per-test unique name and removes it in teardown.
+class ExtensionsTest < Wurk::Test::EngineCase
+  parallelize_me!
+
+  FIXTURE_DIR = File.expand_path('../fixtures/demo_ext', __dir__)
+
+  module EngineExt
+    def self.registered(app)
+      app.get '/list' do
+        erb '<table class="ext-table"><tr><td><%= h(url_params("q") || "all") %></td></tr></table>'
+      end
+      app.get '/list/clear' do
+        redirect 'list'
+      end
+      app.post '/list' do
+        erb '<p>posted</p>'
+      end
+    end
+  end
+
+  def setup
+    super
+    @name = "engext-#{::Process.pid}-#{object_id}"
+    ::Wurk::Web.config.register_extension(
+      EngineExt,
+      name: @name, tab: ["Eng #{@name}"], index: ["eng-#{@name}/"],
+      asset_paths: [File.join(FIXTURE_DIR, 'assets')], cache_for: 60
+    )
+  end
+
+  def teardown
+    ::Wurk::Web.config.extensions.reject! { |e| e[:name] == @name }
+    ::Wurk::Web.config.tabs.delete("Eng #{@name}")
+  ensure
+    super
+  end
+
+  def test_renders_a_registered_extension_route
+    get "/wurk/ext/#{@name}/list?q=needle"
+
+    assert_ok
+    assert_includes last_response.body, '<td>needle</td>'
+    assert_includes last_response.content_type, 'text/html'
+  end
+
+  def test_extension_redirect_stays_under_the_embed_base
+    get "/wurk/ext/#{@name}/list/clear"
+
+    assert_equal 302, last_response.status
+    assert_includes last_response.headers['Location'], "/wurk/ext/#{@name}/list"
+  end
+
+  def test_unknown_route_renders_404_body
+    get "/wurk/ext/#{@name}/nope"
+
+    assert_equal 404, last_response.status
+  end
+
+  def test_unregistered_name_falls_through_to_the_spa_shell
+    get '/wurk/ext/some-client-tab/'
+
+    assert_ok
+    assert_includes last_response.body, 'wurk-root' # the SPA shell, not a 404
+  end
+
+  def test_post_route_dispatches_same_origin
+    post "/wurk/ext/#{@name}/list", {}, { 'HTTP_SEC_FETCH_SITE' => 'same-origin' }
+
+    assert_ok
+    assert_includes last_response.body, 'posted'
+  end
+
+  def test_cross_site_post_is_forbidden
+    post "/wurk/ext/#{@name}/list", {}, { 'HTTP_SEC_FETCH_SITE' => 'cross-site' }
+
+    assert_equal 403, last_response.status
+  end
+
+  def test_serves_extension_assets_with_cache_control
+    get "/wurk/ext-assets/#{@name}/app.css"
+
+    assert_ok
+    assert_includes last_response.body, 'rebeccapurple'
+    assert_includes last_response.headers['Cache-Control'], 'max-age=60'
+  end
+
+  def test_asset_traversal_is_not_found
+    get "/wurk/ext-assets/#{@name}/..%2Fviews%2Fhello.erb"
+
+    assert_equal 404, last_response.status
+  end
+
+  def test_meta_custom_tabs_include_ext_name
+    get '/wurk/api/meta'
+
+    assert_ok
+    tab = json_body[:custom_tabs].find { |t| t[:name] == "Eng #{@name}" }
+
+    refute_nil tab
+    assert_equal @name, tab[:ext_name]
+  end
+
+  private
+
+  def json_body = ::JSON.parse(last_response.body, symbolize_names: true)
+
+  def assert_ok
+    assert_equal 200, last_response.status, "non-200 response: body=#{last_response.body[0, 500]}"
+  end
+end

--- a/test/engine/extensions_test.rb
+++ b/test/engine/extensions_test.rb
@@ -22,6 +22,12 @@ class ExtensionsTest < Wurk::Test::EngineCase
       app.post '/list' do
         erb '<p>posted</p>'
       end
+      app.put '/list' do
+        erb '<p>put</p>'
+      end
+      app.delete '/list' do
+        erb '<p>deleted</p>'
+      end
     end
   end
 
@@ -81,6 +87,26 @@ class ExtensionsTest < Wurk::Test::EngineCase
     post "/wurk/ext/#{@name}/list", {}, { 'HTTP_SEC_FETCH_SITE' => 'cross-site' }
 
     assert_equal 403, last_response.status
+  end
+
+  def test_post_without_fetch_metadata_is_forbidden
+    post "/wurk/ext/#{@name}/list"
+
+    assert_equal 403, last_response.status
+  end
+
+  def test_put_routes_dispatch_same_origin
+    put "/wurk/ext/#{@name}/list", {}, { 'HTTP_SEC_FETCH_SITE' => 'same-origin' }
+
+    assert_ok
+    assert_includes last_response.body, 'put'
+  end
+
+  def test_delete_routes_dispatch_same_origin
+    delete "/wurk/ext/#{@name}/list", {}, { 'HTTP_SEC_FETCH_SITE' => 'same-origin' }
+
+    assert_ok
+    assert_includes last_response.body, 'deleted'
   end
 
   def test_serves_extension_assets_with_cache_control

--- a/test/engine/web_authorization_test.rb
+++ b/test/engine/web_authorization_test.rb
@@ -125,8 +125,8 @@ class WebAuthorizationTest < Wurk::Test::EngineCase
   end
 
   # A third-party extension registering a tab surfaces it in /api/meta, which
-  # the SPA nav reads (spec §25.2). The registration is no-op-safe — requiring
-  # the gem doesn't crash boot even though wurk can't render its view.
+  # the SPA nav reads (spec §25.2), including the ext_name the Extension page
+  # uses to fetch the server-rendered view (#187).
   def test_meta_exposes_registered_custom_tabs
     Wurk::Web.configure { |c| c.register_extension(Object, name: 'locks', tab: 'Locks', index: 'locks') }
 
@@ -134,6 +134,6 @@ class WebAuthorizationTest < Wurk::Test::EngineCase
 
     assert_equal 200, last_response.status
     assert_includes JSON.parse(last_response.body)['custom_tabs'],
-                    { 'name' => 'Locks', 'path' => 'locks' }
+                    { 'name' => 'Locks', 'path' => 'locks', 'ext_name' => 'locks' }
   end
 end

--- a/test/fixtures/demo_ext/assets/app.css
+++ b/test/fixtures/demo_ext/assets/app.css
@@ -1,0 +1,1 @@
+.demo-ext { color: rebeccapurple; }

--- a/test/fixtures/demo_ext/locales/en.yml
+++ b/test/fixtures/demo_ext/locales/en.yml
@@ -1,0 +1,2 @@
+en:
+  greeting: "Hello from fixture"

--- a/test/fixtures/demo_ext/views/hello.erb
+++ b/test/fixtures/demo_ext/views/hello.erb
@@ -1,0 +1,3 @@
+<h1><%= t('greeting') %></h1>
+<p class="who"><%= h(@who) %></p>
+<a href="<%= root_path %>items/7">item</a>

--- a/test/unit/web_config_test.rb
+++ b/test/unit/web_config_test.rb
@@ -214,13 +214,13 @@ class WebConfigTest < Wurk::Test::UnitCase
     Wurk::Web.config.register_extension(Object, name: 'locks', tab: 'Locks', index: 'locks')
 
     assert_equal 'locks', Wurk::Web.config.tabs['Locks']
-    assert_includes Wurk::Web.config.custom_tabs, { name: 'Locks', path: 'locks' }
+    assert_includes Wurk::Web.config.custom_tabs, { name: 'Locks', path: 'locks', ext_name: 'locks' }
   end
 
   def test_register_is_an_alias_for_register_extension
     Wurk::Web.config.register(Object, name: 'status', tab: 'Status', index: 'status')
 
-    assert_includes Wurk::Web.config.custom_tabs, { name: 'Status', path: 'status' }
+    assert_includes Wurk::Web.config.custom_tabs, { name: 'Status', path: 'status', ext_name: 'status' }
   end
 
   def test_register_extension_returns_self_for_chaining
@@ -258,7 +258,8 @@ class WebConfigTest < Wurk::Test::UnitCase
   def test_tabs_hash_is_directly_mutable
     Wurk::Web.config.tabs['Expiry'] = 'expiry'
 
-    assert_includes Wurk::Web.config.custom_tabs, { name: 'Expiry', path: 'expiry' }
+    # Bare tabs[]= mutation registers no extension, so there's nothing to render (ext_name nil).
+    assert_includes Wurk::Web.config.custom_tabs, { name: 'Expiry', path: 'expiry', ext_name: nil }
   end
 
   def test_custom_job_info_rows_is_a_mutable_array

--- a/test/unit/web_extension_test.rb
+++ b/test/unit/web_extension_test.rb
@@ -155,7 +155,32 @@ class WebExtensionTest < Wurk::Test::UnitCase
     assert_nil Wurk::Web::Extension::Renderer.asset_file(@name, 'nope.css')
   end
 
+  # --- route compilation ---------------------------------------------------
+
+  def test_route_literals_with_regex_metacharacters_match_literally
+    route = Wurk::Web::Extension::Route.new('/jobs/:jid.json')
+
+    assert_equal({ jid: 'abc' }, route.match('/jobs/abc.json'))
+    assert_nil route.match('/jobs/abcXjson')
+  end
+
+  def test_route_plus_sign_is_literal_not_a_quantifier
+    route = Wurk::Web::Extension::Route.new('/foo+bar')
+
+    refute_nil route.match('/foo+bar')
+    assert_nil route.match('/foooo+bar')
+  end
+
   # --- custom_tabs wiring ------------------------------------------------------
+
+  def test_native_tab_path_with_trailing_slash_stays_out_of_custom_tabs
+    label = "Native #{@name}"
+    Wurk::Web.config.tabs[label] = 'cron/'
+
+    assert_nil(Wurk::Web.config.custom_tabs.find { |t| t[:name] == label })
+  ensure
+    Wurk::Web.config.tabs.delete(label)
+  end
 
   def test_custom_tabs_carry_the_extension_name
     tab = Wurk::Web.config.custom_tabs.find { |t| t[:name] == "Demo #{@name}" }

--- a/test/unit/web_extension_test.rb
+++ b/test/unit/web_extension_test.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'rack'
+require 'wurk/web/extension'
+
+# Pins the Web-extension renderer (#187): Sinatra-style route capture from
+# `Ext.registered(app)`, the Action context (params/erb/redirect + the
+# WebHelpers subset), and Renderer dispatch (render / redirect rewrite / 404 /
+# unknown-ext nil / asset lookup with traversal guard).
+#
+# Registers into the process-global Wurk::Web.config under a per-test unique
+# name and removes it in teardown, so parallel test classes never collide.
+class WebExtensionTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  FIXTURE_DIR = File.expand_path('../fixtures/demo_ext', __dir__)
+
+  # A synthetic extension exercising the surface real gems use
+  # (sidekiq-unique-jobs shape: helpers + list/detail/delete routes). The
+  # nested `def` inside `app.helpers` is the documented Sidekiq extension
+  # idiom, and the route count is the fixture's whole point — both cops are
+  # off for this faithful replica.
+  # rubocop:disable Lint/NestedMethodDefinition, Metrics/AbcSize
+  module DemoExt
+    def self.registered(app)
+      app.helpers do
+        def shout(text) = text.to_s.upcase
+      end
+      app.get '/hello' do
+        @who = url_params('who') || 'world'
+        erb :hello
+      end
+      app.get '/inline' do
+        erb '<p><%= shout("hi") %>-<%= h("<x>") %></p>'
+      end
+      app.get '/items/:id' do
+        erb '<p>item <%= h(route_params(:id)) %> of <%= h(params[:id]) %></p>'
+      end
+      app.get '/away' do
+        redirect 'hello'
+      end
+      app.get '/external' do
+        redirect 'https://example.com/elsewhere'
+      end
+      app.get '/boom' do
+        raise 'kaboom'
+      end
+      app.post '/things' do
+        erb '<p>made <%= h(url_params("name")) %></p>'
+      end
+    end
+  end
+  # rubocop:enable Lint/NestedMethodDefinition, Metrics/AbcSize
+
+  def setup
+    super
+    @name = "demo-#{::Process.pid}-#{object_id}"
+    Wurk::Web.config.register_extension(
+      DemoExt,
+      name: @name, tab: ["Demo #{@name}"], index: ["demo-#{@name}/"],
+      root_dir: FIXTURE_DIR, asset_paths: [File.join(FIXTURE_DIR, 'assets')], cache_for: 123
+    )
+  end
+
+  def teardown
+    Wurk::Web.config.extensions.reject! { |e| e[:name] == @name }
+    Wurk::Web.config.tabs.delete("Demo #{@name}")
+  ensure
+    super
+  end
+
+  # --- rendering ---------------------------------------------------------
+
+  def test_renders_an_erb_view_from_root_dir_with_helpers_and_locale
+    status, _headers, body = render_call('GET', '/hello', query: 'who=din')
+
+    assert_equal 200, status
+    # locales/en.yml translation + url_params-through-h, in document order.
+    assert_match(%r{<h1>Hello from fixture</h1>.*<p class="who">din</p>}m, body)
+    assert_includes body, 'href="/wurk/ext/' # root_path rewritten to the embed base
+  end
+
+  def test_renders_inline_template_with_extension_helpers
+    status, _headers, body = render_call('GET', '/inline')
+
+    assert_equal 200, status
+    assert_equal '<p>HI-&lt;x&gt;</p>', body.strip
+  end
+
+  def test_route_params_are_extracted_and_merged_into_params
+    _status, _headers, body = render_call('GET', '/items/42')
+
+    assert_equal '<p>item 42 of 42</p>', body.strip
+  end
+
+  def test_post_routes_dispatch
+    status, _headers, body = render_call('POST', '/things', query: 'name=widget')
+
+    assert_equal 200, status
+    assert_includes body, 'made widget'
+  end
+
+  # --- redirects -----------------------------------------------------------
+
+  def test_relative_redirect_is_rewritten_to_the_embed_base
+    status, headers, = render_call('GET', '/away')
+
+    assert_equal 302, status
+    assert_equal "/wurk/ext/#{@name}/hello", headers['Location']
+  end
+
+  def test_absolute_redirect_passes_through
+    _status, headers, = render_call('GET', '/external')
+
+    assert_equal 'https://example.com/elsewhere', headers['Location']
+  end
+
+  # --- dispatch edges --------------------------------------------------------
+
+  def test_unknown_route_is_404
+    status, _headers, body = render_call('GET', '/nope')
+
+    assert_equal 404, status
+    assert_includes body, 'No GET route'
+  end
+
+  def test_unknown_extension_returns_nil_for_spa_fallthrough
+    assert_nil Wurk::Web::Extension::Renderer.call(
+      name: 'not-registered', method: 'GET', subpath: '/x', env: env_for('GET', ''), mount: '/wurk'
+    )
+  end
+
+  def test_route_block_raise_is_a_500_not_an_exception
+    status, _headers, body = render_call('GET', '/boom')
+
+    assert_equal 500, status
+    assert_includes body, 'kaboom'
+  end
+
+  # --- assets ----------------------------------------------------------------
+
+  def test_asset_file_resolves_with_cache_for
+    path, cache_for = Wurk::Web::Extension::Renderer.asset_file(@name, 'app.css')
+
+    assert_equal File.join(FIXTURE_DIR, 'assets', 'app.css'), path
+    assert_equal 123, cache_for
+  end
+
+  def test_asset_file_blocks_directory_traversal
+    assert_nil Wurk::Web::Extension::Renderer.asset_file(@name, '../views/hello.erb')
+  end
+
+  def test_asset_file_missing_is_nil
+    assert_nil Wurk::Web::Extension::Renderer.asset_file(@name, 'nope.css')
+  end
+
+  # --- custom_tabs wiring ------------------------------------------------------
+
+  def test_custom_tabs_carry_the_extension_name
+    tab = Wurk::Web.config.custom_tabs.find { |t| t[:name] == "Demo #{@name}" }
+
+    assert_equal @name, tab[:ext_name]
+    assert_equal "demo-#{@name}/", tab[:path]
+  end
+
+  private
+
+  def render_call(method, subpath, query: '')
+    Wurk::Web::Extension::Renderer.call(
+      name: @name, method: method, subpath: subpath,
+      env: env_for(method, query), mount: '/wurk'
+    )
+  end
+
+  def env_for(method, query)
+    { 'REQUEST_METHOD' => method, 'QUERY_STRING' => query, 'rack.input' => ::StringIO.new }
+  end
+end


### PR DESCRIPTION
Closes #187

## What

Sidekiq Web extensions (Sinatra-style `registered(app)` routes + ERB views) now render **natively inside the dashboard SPA** — no host-side Rack mounting, no iframe for registered extensions.

- **`Wurk::Web::Extension`** (`lib/wurk/web/extension.rb`) — a minimal Sidekiq-Web-compatible renderer with zero Sinatra/sidekiq dependency:
  - `App` captures the routes + helpers an extension declares in `registered(app)`.
  - `Route` compiles Sinatra-style paths (`/locks/:digest`, trailing `*`) with symbol route params.
  - `Helpers` is the `Sidekiq::WebHelpers` subset real extension views call (`h`, `t`, `truncate`, `to_display`, `root_path`, `asset_path`, `relative_time`, `redis`, `csrf_tag`, …); locale strings load from the extension's `locales/en.yml`, missing keys degrade instead of raising.
  - `Action` instance-execs the matched route block and renders ERB (string or `:view_name` from `root_dir/views`) with the block's ivars in scope; `redirect` is carried out via throw/catch.
- **`ExtensionsController`** — `GET/POST /wurk/ext/:name/*subpath` renders the matched route; `GET /wurk/ext-assets/:name/*file` serves `asset_paths` files (`Cache-Control` from `cache_for`, `../` traversal rejected). CSRF mirrors Sidekiq: non-GET must be same-origin per `Sec-Fetch-Site`. Unknown `/ext/*` URLs fall through to the SPA shell (browser refresh works).
- **SPA `Extension` page** — tabs with a registered extension (`ext_name` in `/api/meta`) fetch and embed the server-rendered HTML; in-view links/forms are intercepted so navigation stays in-page and redirects follow transparently. Bare `tabs[]=` tabs keep the old iframe fallback.
- **Fix:** registered index paths keep Sidekiq's trailing slash (`locks/`) but the route param has none — tab matching is now normalized (this was the "tab renders nothing" bug found in local QA).
- **Demo:** `WURK_DEMO=1` registers a "Demo Locks" extension in the dummy app via the `Sidekiq::Web.register` drop-in alias — ERB views, locale strings, CSS asset, route params, POST→redirect, all through the new renderer.
- **Docs:** `docs/dashboard.md` "Custom tabs / Web extensions" rewritten for native rendering, with a scope note pointing at #204.

## Scope note (per #204)

This renders extensions registered against wurk's `Sidekiq::Web` alias. Gems that literally `require "sidekiq"` still need the deliberately-deferred compat shim (#204) — wurk does not and must not depend on the sidekiq gem, and the product direction is that consumer apps don't depend on sidekiq-ecosystem gems at all (wurk's native unique jobs / cron / batches / limiter replace them). Hence the issue's "real gem ecosystem test" acceptance bullet is delivered as a synthetic in-repo extension + the tracked #204 decision.

## Tests

- `test/unit/web_extension_test.rb` — 13 tests: route compile/match, helpers, ERB render, redirect, asset lookup + traversal guard.
- `test/engine/extensions_test.rb` — 9 tests against the booted dummy app: render, route params, redirect base, POST, 404s, assets, Sec-Fetch-Site CSRF.
- `frontend/src/pages/Extension.test.tsx` — native-match (incl. trailing-slash regression) + iframe-fallback.
- Full suite: **2223 runs, 0 failures** · frontend: **8/8** · rubocop clean.

## How to test in prod

Register any Sidekiq-style extension in an initializer (or just use a gem that calls `Sidekiq::Web.register` on load):

```ruby
# config/initializers/wurk_ext.rb — same call real gems make
Sidekiq::Web.register(
  MyExt, name: "myext", tab: ["My Ext"], index: ["myext/"],
  root_dir: Rails.root.join("lib/my_ext").to_s,
  asset_paths: [Rails.root.join("lib/my_ext/assets").to_s]
)
```

Then:

```sh
# tab is advertised to the SPA
curl -s https://<host>/wurk/api/meta | jq .custom_tabs
# extension view renders server-side (HTML, 200)
curl -si https://<host>/wurk/ext/myext/myext | head -20
# extension assets are served with caching
curl -si https://<host>/wurk/ext-assets/myext/app.css | head -10
# cross-site POSTs are rejected (CSRF parity)
curl -si -X POST -H "Sec-Fetch-Site: cross-site" https://<host>/wurk/ext/myext/anything | head -1   # → 403
```

In the browser: the tab appears under **Extensions** in the left nav; clicking it renders the extension's view in-page (links/forms stay inside the dashboard). To eyeball it without writing an extension, boot the dummy app with `WURK_DEMO=1` and open the **Demo Locks** tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard tabs can render native server-side extensions (with asset endpoints and SPA fallbacks).
* **Frontend**
  * Extension page now loads server-rendered HTML (or falls back to iframe), normalizes trailing slashes, and intercepts in-view navigation.
  * Themed styles added for extension views.
* **Security**
  * Non-GET/HEAD extension requests require same-origin fetch metadata.
* **Documentation**
  * Docs updated to explain routing, helpers, locale/CSRF behavior, and SPA interception.
* **Tests**
  * Extensive tests added for routing, rendering, asset serving, and same-origin enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->