### PR TITLE
fix(ent): unique-lock lifecycle parity — own-jid re-push at promotion, release on automatic death (#205, #211)

### DIFF
--- a/lib/wurk/lua.rb
+++ b/lib/wurk/lua.rb
@@ -12,7 +12,7 @@ module Wurk
   #
   # `:zpopbyscore` is reproduced verbatim from sidekiq-free.md §1.8 and
   # MUST NOT diverge — parity tests will fail on a single byte change.
-  module Lua
+  module Lua # rubocop:disable Metrics/ModuleLength
     ZPOPBYSCORE = <<~LUA
       local key, now = KEYS[1], ARGV[1]
       local jobs = redis.call("zrange", key, "-inf", now, "byscore", "limit", 0, 1)
@@ -149,6 +149,22 @@ module Wurk
       return 1
     LUA
 
+    # Ent Unique (§3): atomic compare-and-delete of a lock key. Replaces the
+    # two-command GET-then-DEL — between those calls the key can expire and a
+    # fresh enqueue can grab it, and the bare DEL would then drop the new
+    # owner's lock. Shared by `Unique::ServerMiddleware#release` (normal
+    # success/start release) and `Unique::DEATH_HANDLER` (automatic-death
+    # release) so the two paths cannot drift.
+    # KEYS = [unique:<sha256>]
+    # ARGV = [owning jid]
+    # Returns 1 when the key was deleted, 0 otherwise.
+    RELEASE_IF_OWNER = <<~LUA
+      if redis.call("get", KEYS[1]) == ARGV[1] then
+        return redis.call("del", KEYS[1])
+      end
+      return 0
+    LUA
+
     # Pro Fast API (§11): server-side LRANGE+LREM to delete a single job by
     # jid from a queue list. Pure-Ruby Queue#find_job + JobRecord#delete is
     # O(N) round-trips; this is O(1) round-trip with O(N) Lua work.
@@ -205,7 +221,8 @@ module Wurk
       batch_ack_complete: BATCH_ACK_COMPLETE,
       batch_invalidate: BATCH_INVALIDATE,
       fast_delete_job: FAST_DELETE_JOB,
-      fast_delete_by_class: FAST_DELETE_BY_CLASS
+      fast_delete_by_class: FAST_DELETE_BY_CLASS,
+      release_if_owner: RELEASE_IF_OWNER
     }.merge(FILE_SCRIPTS).freeze
 
     # SHA1 of each script source — matches what `SCRIPT LOAD` returns.

--- a/lib/wurk/unique.rb
+++ b/lib/wurk/unique.rb
@@ -3,6 +3,7 @@
 require 'json'
 require 'digest'
 require_relative 'middleware'
+require_relative 'lua'
 
 module Wurk
   # Sidekiq Enterprise unique jobs. Best-effort dedup at enqueue time keyed
@@ -33,16 +34,24 @@ module Wurk
     # Ent parity: a job that dies automatically releases its lock so a
     # duplicate can enqueue immediately. Manual UI kills route through
     # `DeadSet#kill(notify_failure: false)`, which skips death handlers —
-    # those keep the lock (Ent wiki, Ent-Unique-Jobs). CAS on the owning
-    # jid mirrors ServerMiddleware#release.
+    # those keep the lock (Ent wiki, Ent-Unique-Jobs). Atomic CAS-DEL via
+    # the shared Lua script mirrors ServerMiddleware#release.
     DEATH_HANDLER = lambda do |job, _exception|
       next unless Wurk::Unique.enabled?
       next unless Wurk::Unique.coerce_ttl(job['unique_for'])
 
-      key = Wurk::Unique.lock_key_for(job)
-      Wurk.redis do |conn|
-        conn.call('DEL', key) if conn.call('GET', key) == job['jid']
-      end
+      Wurk.redis { |conn| Wurk::Unique.release_if_owner(conn, Wurk::Unique.lock_key_for(job), job['jid']) }
+    end
+
+    # Atomic compare-and-delete of a unique lock key. Two-command
+    # GET-then-DEL is not a real CAS — the key can expire between the GET
+    # and DEL, letting a fresh enqueue grab it, and the bare DEL would
+    # then drop the new owner's lock. Routed through a single Lua script
+    # (`Wurk::Lua::RELEASE_IF_OWNER`) shared by `ServerMiddleware#release`
+    # (normal success/start release) and `DEATH_HANDLER` (automatic-death
+    # release) so the two paths cannot drift.
+    def self.release_if_owner(conn, key, jid)
+      Wurk::Lua::Loader.eval_cached(conn, :release_if_owner, keys: [key], argv: [jid])
     end
 
     # `Sidekiq::Enterprise.unique!` flips this on. The middleware pair is
@@ -256,13 +265,13 @@ module Wurk
         VALID_UNTIL.include?(sym) ? sym : DEFAULT_UNTIL
       end
 
-      # CAS DEL: only drop the key if the owning JID still matches ours.
-      # Prevents a long-overdue retry from releasing a fresh lock held by
-      # a re-enqueued duplicate after the original TTL expired.
+      # Atomic CAS-DEL: only drop the key if the owning JID still matches
+      # ours. Prevents a long-overdue retry from releasing a fresh lock
+      # held by a re-enqueued duplicate after the original TTL expired.
+      # Shares the Lua script with `DEATH_HANDLER` so both release paths
+      # have identical semantics.
       def release(key, jid)
-        redis_pool.with do |conn|
-          conn.call('DEL', key) if conn.call('GET', key) == jid
-        end
+        redis_pool.with { |conn| Wurk::Unique.release_if_owner(conn, key, jid) }
       rescue StandardError => e
         Wurk.logger&.warn { "Wurk::Unique release failed: #{e.class}: #{e.message}" }
       end

--- a/lib/wurk/unique.rb
+++ b/lib/wurk/unique.rb
@@ -16,6 +16,10 @@ module Wurk
   #     *before* invoking perform; a duplicate can be enqueued while the
   #     first is running.
   #
+  # A job that dies *automatically* (retries exhausted / discarded) releases
+  # its lock via a death handler; manual UI kills keep the lock until TTL
+  # expiry (Ent wiki, Ent-Unique-Jobs).
+  #
   # Wire-compat (§3.9): single-key Redis layout — `unique:<sha256>` STRING
   # holding the owning JID. Scheduled jobs extend the TTL by the delay so
   # the lock covers the entire wait+execution window (§3.4).
@@ -25,6 +29,21 @@ module Wurk
     KEY_PREFIX = 'unique:'
     DEFAULT_UNTIL = :success
     VALID_UNTIL = %i[success start].freeze
+
+    # Ent parity: a job that dies automatically releases its lock so a
+    # duplicate can enqueue immediately. Manual UI kills route through
+    # `DeadSet#kill(notify_failure: false)`, which skips death handlers —
+    # those keep the lock (Ent wiki, Ent-Unique-Jobs). CAS on the owning
+    # jid mirrors ServerMiddleware#release.
+    DEATH_HANDLER = lambda do |job, _exception|
+      next unless Wurk::Unique.enabled?
+      next unless Wurk::Unique.coerce_ttl(job['unique_for'])
+
+      key = Wurk::Unique.lock_key_for(job)
+      Wurk.redis do |conn|
+        conn.call('DEL', key) if conn.call('GET', key) == job['jid']
+      end
+    end
 
     # `Sidekiq::Enterprise.unique!` flips this on. The middleware pair is
     # always loaded (so worker `sidekiq_options unique_for:` is a no-op
@@ -91,6 +110,8 @@ module Wurk
           unless Wurk.configuration.client_middleware.exists?(ClientMiddleware)
         Wurk.configuration.server_middleware.add(ServerMiddleware) \
           unless Wurk.configuration.server_middleware.exists?(ServerMiddleware)
+        handlers = Wurk.configuration.death_handlers
+        handlers << DEATH_HANDLER unless handlers.include?(DEATH_HANDLER)
       end
     end
 
@@ -172,7 +193,17 @@ module Wurk
         pool.with do |conn|
           return yield if conn.call('SET', key, job['jid'], 'NX', 'EX', ttl) == 'OK'
 
-          log_duplicate(job, conn.call('GET', key))
+          holder = conn.call('GET', key)
+          # The job's own jid holding the lock is a re-push, not a duplicate:
+          # scheduled/retry promotion re-runs this chain while the
+          # enqueue-time lock is still live (§3.4/§3.7) — dropping here would
+          # silently lose the job.
+          return yield if holder == job['jid']
+          # nil holder: the lock expired between the failed SET NX and the
+          # GET — re-acquire instead of dropping.
+          return yield if holder.nil? && conn.call('SET', key, job['jid'], 'NX', 'EX', ttl) == 'OK'
+
+          log_duplicate(job, holder)
         end
         nil
       end

--- a/test/unit/lua_test.rb
+++ b/test/unit/lua_test.rb
@@ -33,7 +33,7 @@ class LuaTest < Wurk::Test::UnitCase
     assert_equal(
       %i[zpopbyscore bulk_push reliable_schedule_promote
          batch_push batch_ack_success batch_ack_failed batch_ack_complete batch_invalidate
-         fast_delete_job fast_delete_by_class
+         fast_delete_job fast_delete_by_class release_if_owner
          limiter_concurrent_acquire limiter_concurrent_release
          limiter_bucket_acquire limiter_window_acquire limiter_leaky_acquire
          limiter_points_acquire limiter_points_refund].sort,

--- a/test/unit/unique_test.rb
+++ b/test/unit/unique_test.rb
@@ -23,6 +23,7 @@ class UniqueTest < Wurk::Test::UnitCase
     Wurk::Unique.disable!
     Wurk.configuration.client_middleware.remove(Wurk::Unique::ClientMiddleware)
     Wurk.configuration.server_middleware.remove(Wurk::Unique::ServerMiddleware)
+    Wurk.configuration.death_handlers.delete(Wurk::Unique::DEATH_HANDLER)
   ensure
     super
   end
@@ -297,6 +298,167 @@ class UniqueTest < Wurk::Test::UnitCase
     end
   end
 
+  # ---- ClientMiddleware: own-jid re-push (#205) -----------------------
+
+  def test_client_middleware_own_jid_repush_proceeds
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      job = build_job(jid: 'repush-1', ttl: 600)
+      track_key(job)
+
+      assert invoke_client(job)
+      assert invoke_client(job), 'promotion re-push of the lock holder must not be dropped'
+      assert_equal('repush-1', Wurk.redis { |c| c.call('GET', Wurk::Unique.lock_key_for(job)) })
+    end
+  end
+
+  def test_unique_scheduled_job_survives_promotion
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      queue = "promo#{@suffix}"
+      jid = Wurk::Client.push('class' => 'PromoJob', 'args' => [1], 'queue' => queue,
+                              'unique_for' => 3600, 'at' => ::Time.now.to_f - 1)
+      track_key('class' => 'PromoJob', 'queue' => queue, 'args' => [1])
+
+      refute_nil jid
+      drain_sorted_set(Wurk::Keys::SCHEDULE)
+
+      assert_equal 1, redis_call('LLEN', "queue:#{queue}")
+      assert_equal 0, redis_call('ZCARD', Wurk::Keys::SCHEDULE)
+    end
+  end
+
+  def test_unique_retry_job_survives_promotion
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      queue = "rpromo#{@suffix}"
+      job = build_job(jid: 'retry-promo-1', ttl: 3600, queue: queue)
+      seed_locked_retry_entry(job)
+
+      drain_sorted_set(Wurk::Keys::RETRY)
+
+      assert_equal 1, redis_call('LLEN', "queue:#{queue}")
+      assert_equal 0, redis_call('ZCARD', Wurk::Keys::RETRY)
+    end
+  end
+
+  def test_client_middleware_reacquires_when_lock_expires_mid_check
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      # First SET NX loses, GET sees the lock already expired (nil), the
+      # retried SET NX wins — the push must proceed, not drop.
+      pool = stub_pool(set_results: [nil, 'OK'], get_result: nil)
+      job = build_job(jid: 'race-1', ttl: 60)
+
+      assert Wurk::Unique::ClientMiddleware.new.call(nil, job, job['queue'], pool) { true }
+    end
+  end
+
+  def test_client_middleware_drops_when_reacquire_also_loses
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      # Lock expired before GET but a competitor re-took it before our
+      # retried SET NX — duplicate semantics apply.
+      pool = stub_pool(set_results: [nil, nil], get_result: nil)
+      job = build_job(jid: 'race-2', ttl: 60)
+
+      refute Wurk::Unique::ClientMiddleware.new.call(nil, job, job['queue'], pool) { true }
+    end
+  end
+
+  # ---- Death handler: lock release on automatic death (#211) ----------
+
+  def test_enable_registers_death_handler_once
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      Wurk::Unique.enable!
+
+      count = Wurk.configuration.death_handlers.count(Wurk::Unique::DEATH_HANDLER)
+
+      assert_equal 1, count
+    end
+  end
+
+  def test_automatic_death_releases_lock
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      job = build_job(jid: 'dead-1', ttl: 600)
+      track_key(job)
+
+      assert invoke_client(job)
+      die_unretryable(job)
+
+      assert_nil redis_call('GET', Wurk::Unique.lock_key_for(job))
+    end
+  end
+
+  def test_automatic_death_allows_fresh_duplicate
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      job = build_job(jid: 'dead-a', ttl: 600)
+      track_key(job)
+
+      assert invoke_client(job)
+      die_unretryable(job)
+
+      assert invoke_client(build_job(jid: 'dead-b', ttl: 600)),
+             'a fresh duplicate must enqueue immediately after the holder dies'
+    end
+  end
+
+  def test_death_handler_retains_foreign_lock
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      job = build_job(jid: 'dh-cas', ttl: 600)
+      key = Wurk::Unique.lock_key_for(job)
+      Wurk.redis { |c| c.call('SET', key, 'someone-else', 'EX', 600) }
+      track_key(job)
+
+      Wurk::Unique::DEATH_HANDLER.call(job, RuntimeError.new('boom'))
+
+      assert_equal('someone-else', Wurk.redis { |c| c.call('GET', key) })
+    end
+  end
+
+  def test_death_handler_noop_without_unique_for
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      job = { 'class' => 'X', 'queue' => 'q', 'args' => [], 'jid' => 'nfu-1' }
+      key = Wurk::Unique.lock_key_for(job)
+      Wurk.redis { |c| c.call('SET', key, 'nfu-1', 'EX', 60) }
+      @keys << key
+
+      Wurk::Unique::DEATH_HANDLER.call(job, RuntimeError.new('boom'))
+
+      assert_equal('nfu-1', redis_call('GET', key))
+    end
+  end
+
+  def test_death_handler_noop_when_disabled
+    job = build_job(jid: 'dh-off', ttl: 600)
+    key = Wurk::Unique.lock_key_for(job)
+    Wurk.redis { |c| c.call('SET', key, 'dh-off', 'EX', 600) }
+    track_key(job)
+
+    Wurk::Unique::DEATH_HANDLER.call(job, RuntimeError.new('boom'))
+
+    assert_equal('dh-off', Wurk.redis { |c| c.call('GET', key) })
+  end
+
+  def test_manual_ui_kill_retains_lock
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      job = build_job(jid: 'kill-1', ttl: 600, queue: "kill#{@suffix}")
+      key = seed_locked_retry_entry(job)
+
+      Wurk::RetrySet.new.find_job('kill-1').kill
+
+      assert_equal('kill-1', redis_call('GET', key),
+                   'a user-initiated UI kill must keep the unique lock (Ent parity)')
+      assert_equal 1, redis_call('ZCARD', Wurk::Keys::DEAD)
+    end
+  end
+
   # ---- ServerMiddleware: lock release strategy -----------------------
 
   def test_server_middleware_no_op_when_disabled
@@ -483,6 +645,50 @@ class UniqueTest < Wurk::Test::UnitCase
 
   def track_key(job)
     @keys << Wurk::Unique.lock_key_for(job)
+  end
+
+  def redis_call(*args)
+    Wurk.redis { |c| c.call(*args) }
+  end
+
+  # Scripted fake connection for racing the SET NX / GET / SET NX sequence
+  # deterministically — a real lock expiry between those calls can't be
+  # forced against live Redis.
+  def stub_pool(set_results:, get_result:)
+    conn = Object.new
+    conn.define_singleton_method(:call) do |*args|
+      args.first == 'SET' ? set_results.shift : get_result
+    end
+    pool = Object.new
+    pool.define_singleton_method(:with) { |&blk| blk.call(conn) }
+    pool
+  end
+
+  def drain_sorted_set(sset)
+    Wurk::Scheduled::Enq.new(Wurk.configuration).enqueue_jobs([sset])
+  end
+
+  # Simulate a failed `unique_until: :success` job: the enqueue-time lock is
+  # still held by its own jid while the payload waits in `retry`. Returns the
+  # lock key (tracked for teardown).
+  def seed_locked_retry_entry(job)
+    key = Wurk::Unique.lock_key_for(job)
+    @keys << key
+    Wurk.redis do |c|
+      c.call('SET', key, job['jid'], 'EX', 3600)
+      c.call('ZADD', Wurk::Keys::RETRY, (::Time.now.to_f - 1).to_s, Wurk.dump_json(job))
+    end
+    key
+  end
+
+  # Drive a no-retry failure through JobRetry#global so the job dies
+  # automatically (death handlers fire, as in retries-exhausted).
+  def die_unretryable(job)
+    job['retry'] = false
+    retrier = Wurk::JobRetry.new(Wurk.configuration)
+    assert_raises(Wurk::JobRetry::Handled) do
+      retrier.global(Wurk.dump_json(job), job['queue']) { raise 'boom' }
+    end
   end
 
   def with_logger(logger)

--- a/test/unit/unique_test.rb
+++ b/test/unit/unique_test.rb
@@ -450,12 +450,15 @@ class UniqueTest < Wurk::Test::UnitCase
       Wurk::Unique.enable!
       job = build_job(jid: 'kill-1', ttl: 600, queue: "kill#{@suffix}")
       key = seed_locked_retry_entry(job)
+      # FLUSHDB only runs per test class, so the DEAD zset can already hold
+      # entries from earlier `die_unretryable` tests — assert the delta.
+      before = redis_call('ZCARD', Wurk::Keys::DEAD)
 
       Wurk::RetrySet.new.find_job('kill-1').kill
 
       assert_equal('kill-1', redis_call('GET', key),
                    'a user-initiated UI kill must keep the unique lock (Ent parity)')
-      assert_equal 1, redis_call('ZCARD', Wurk::Keys::DEAD)
+      assert_equal before + 1, redis_call('ZCARD', Wurk::Keys::DEAD)
     end
   end
 


### PR DESCRIPTION
## What

Two tightly-coupled Ent unique-jobs parity bugs in the lock lifecycle, both in `lib/wurk/unique.rb`:

### #205 (P0): unique jobs silently LOST at schedule/retry promotion

`ClientMiddleware#acquire_or_drop` dropped any push whose `SET NX` lost — **even when the existing holder was the job's own jid**. Scheduled promotion (`Scheduled::Enq#drain_set`) and retry promotion re-push the same payload through the client chain while the enqueue-time lock is guaranteed live (TTL = `unique_for` + delay, spec §3.4), so:

- every unique `perform_in`/`perform_at` job vanished at its scheduled time
- any `unique_until: :success` job that failed once was permanently lost (never reached the dead set)

**Fix:** holder == own jid is treated as a re-acquisition and the push proceeds. A nil holder (lock expired between the failed `SET NX` and the `GET`) retries the acquisition once instead of dropping.

### #211 (P2): unique lock not released when a job dies

No death handler touched `unique:*` keys, so a retry-exhausted job kept its lock until TTL expiry — duplicates stayed blocked long after the job was dead, diverging from Ent ("Sidekiq will remove the lock for any job which automatically dies").

**Fix:** `Unique.enable!` registers a death handler that CAS-releases the lock (`GET == jid → DEL`, mirroring `ServerMiddleware#release`). Manual UI kills route through `DeadSet#kill(notify_failure: false)` which skips death handlers, so they retain the lock — per the Ent wiki.

## Done when (quoted from the issues)

#205:
- [x] A unique `perform_in` job is enqueued to its queue at promotion (default `Enq` path) — `test_unique_scheduled_job_survives_promotion`
- [x] A failing `unique_until: :success` job goes through the normal retry pipeline — `test_unique_retry_job_survives_promotion`
- [x] Regression test for the holder==own-jid re-push case — `test_client_middleware_own_jid_repush_proceeds`

#211:
- [x] Retry-exhausted unique job releases its lock; a fresh duplicate can enqueue immediately — `test_automatic_death_releases_lock`, `test_automatic_death_allows_fresh_duplicate`
- [x] Manual UI kill does NOT release the lock (Ent parity) — `test_manual_ui_kill_retains_lock`
- [x] Test for both paths — plus CAS/foreign-lock, disabled, no-`unique_for`, and mid-check-expiry race coverage

## Wire compat

No Redis key, JSON field, or score format changes — same `unique:<sha256>` STRING holding the owning JID, same TTL math. Only the client-side acquire decision and a new death handler.

## QA

Behavioral driver (5 scenarios, real Redis): on unfixed main F1–F3 FAIL / F4–F5 PASS; on this branch **5/5 PASS** (true duplicates are still dropped — no regression). Full suite 2246 runs / 0 failures, parity 20/20, ecosystem all green, rubocop clean.

## How to test in prod

```ruby
# 1. Enable unique jobs (initializer) and enqueue a scheduled unique job:
Sidekiq::Enterprise.unique!
jid = AuditJob.set(wait: 30).perform_async(42)   # AuditJob: sidekiq_options unique_for: 1.hour

# 2. Wait ~35s, then confirm the job RAN instead of vanishing:
#    dashboard → Queues/Busy, or:
Sidekiq::Queue.new('default').size                # job visible until a worker picks it up

# 3. Death-release: make a unique job raise with retry: 0, then immediately re-enqueue:
FailingUniqueJob.perform_async(1)                 # dies → lock released
FailingUniqueJob.perform_async(1)                 # returns a fresh jid (pre-fix: nil for up to unique_for)

# 4. Manual-kill retention: kill a retrying unique job from the dashboard UI,
#    then try to enqueue a duplicate — it should still be blocked (returns nil).
```

Closes #205. Closes #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic release of uniqueness locks when jobs die now correctly frees locks for new jobs.
  * Re-pushes from the same job are no longer treated as duplicates.
  * Improved behavior when lock expiry races occur during enqueue.

* **Tests**
  * Expanded tests covering lock lifetime, re-push, race conditions, and death-handler behavior.

* **Documentation**
  * Clarified how automatic deaths release uniqueness locks and how manual kills retain them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->