### PR TITLE
fix(oss): SortedEntry parity — retry/add_to_queue retry_count swap, death handlers on API kill (#206, #207)

### DIFF
--- a/lib/wurk/dead_set.rb
+++ b/lib/wurk/dead_set.rb
@@ -5,11 +5,16 @@ require_relative 'job_set'
 module Wurk
   # Capped ZSET of jobs that exhausted retries (the "morgue"). Bounded by
   # `dead_max_jobs` and `dead_timeout_in_seconds` config knobs — every
-  # `kill` trims both axes. Death handlers fire on retry-exhausted kills
-  # (notify_failure: true), not on user-initiated UI kills.
+  # `kill` trims both axes. Death handlers fire by default — including on
+  # API/UI kills, matching Sidekiq — unless `notify_failure: false`.
   #
   # Spec: docs/target/sidekiq-free.md §19.5, §17.2, §31.8.
   class DeadSet < JobSet
+    # Synthesized as the death-handler exception for kills without a real
+    # error. Byte-for-byte Sidekiq's message — Wurk::Unique::DEATH_HANDLER
+    # matches on it to keep the lock on manual kills (Ent parity), and
+    # ecosystem handlers may pattern-match it too.
+    API_KILL_MESSAGE = 'Job killed by API'
     # Optional `name` allows tests to operate on a namespaced ZSET; production
     # callers always use the default `'dead'` key (wire-compat with Sidekiq).
     def initialize(name = 'dead')
@@ -48,7 +53,7 @@ module Wurk
     def kill(message, opts = {}) # rubocop:disable Naming/PredicateMethod
       notify = opts.fetch(:notify_failure, true)
       do_trim = opts.fetch(:trim, true)
-      ex = opts[:ex] || RuntimeError.new('Job killed')
+      ex = opts[:ex] || RuntimeError.new(API_KILL_MESSAGE).tap { |e| e.set_backtrace(caller) }
 
       now = ::Process.clock_gettime(::Process::CLOCK_REALTIME)
       Wurk.redis { |conn| conn.call('ZADD', @name, now.to_s, message) }

--- a/lib/wurk/job_set.rb
+++ b/lib/wurk/job_set.rb
@@ -122,10 +122,10 @@ module Wurk
       count
     end
 
-    # Moves every job in this set to the dead set. `notify_failure: false`
-    # because this is a UI-initiated bulk action, not a retry-exhausted
-    # event. Returns the count of jobs moved.
-    def kill_all(notify_failure: false, ex: nil)
+    # Moves every job in this set to the dead set. Death handlers fire per
+    # entry by default — `each(&:kill)` equivalence with Sidekiq; pass
+    # `notify_failure: false` to suppress. Returns the count of jobs moved.
+    def kill_all(notify_failure: true, ex: nil)
       count = 0
       dead = DeadSet.new
       until size.zero?

--- a/lib/wurk/sorted_entry.rb
+++ b/lib/wurk/sorted_entry.rb
@@ -42,35 +42,37 @@ module Wurk
     # ZINCRBY to shift the score; positive deltas reschedule into the future.
     # Sidekiq passes the absolute target time; we compute the delta here so
     # the call survives clock skew between caller and Redis.
-    def reschedule(at) # rubocop:disable Naming/MethodParameterName
+    def reschedule(at)
       Wurk.redis { |conn| conn.call('ZINCRBY', @parent.name, at.to_f - @score, value) }
     end
 
-    # Removes this entry, decrements `retry_count` by one (so the worker treats
-    # the next attempt as a re-do, not a fresh retry), and re-enqueues via the
-    # client. Wire-compat with Sidekiq's "Retry now" UI action.
+    # Removes this entry and re-enqueues it via the client with the payload
+    # untouched. Backs the scheduled/dead "add to queue" actions — Sidekiq's
+    # add_to_queue does not touch `retry_count`.
     def add_to_queue
+      remove_job do |message|
+        Client.new.push(message)
+      end
+    end
+
+    # Same flow but decrements `retry_count` first: the count was already
+    # incremented when the job entered the retry set, and the next failure
+    # bumps it again — without the decrement a manual "Retry now" would
+    # consume an attempt. Wire-compat with Sidekiq's SortedEntry#retry.
+    def retry
       remove_job do |message|
         message['retry_count'] = message['retry_count'].to_i - 1 if message['retry_count']
         Client.new.push(message)
       end
     end
 
-    # Same flow as add_to_queue but keeps `retry_count` intact. Used for the
-    # "retry" action from the retry set (count was already incremented when
-    # the job entered retry; don't double-bump).
-    def retry
-      remove_job do |message|
-        Client.new.push(message)
-      end
-    end
-
     # Removes this entry from its parent set and writes it to the dead set.
-    # `notify_failure: false` because the kill is user-initiated (UI action),
-    # not a retry-exhausted event — death_handlers don't fire.
+    # Death handlers fire with the synthesized "Job killed by API" exception
+    # (Sidekiq's default) so error trackers and the batch death path observe
+    # API/UI kills.
     def kill
       remove_job do |message|
-        DeadSet.new.kill(Wurk.dump_json(message), notify_failure: false)
+        DeadSet.new.kill(Wurk.dump_json(message))
       end
     end
 

--- a/lib/wurk/unique.rb
+++ b/lib/wurk/unique.rb
@@ -32,13 +32,15 @@ module Wurk
     VALID_UNTIL = %i[success start].freeze
 
     # Ent parity: a job that dies automatically releases its lock so a
-    # duplicate can enqueue immediately. Manual UI kills route through
-    # `DeadSet#kill(notify_failure: false)`, which skips death handlers —
-    # those keep the lock (Ent wiki, Ent-Unique-Jobs). Atomic CAS-DEL via
-    # the shared Lua script mirrors ServerMiddleware#release.
-    DEATH_HANDLER = lambda do |job, _exception|
+    # duplicate can enqueue immediately. Manual API/UI kills keep the lock
+    # until TTL expiry (Ent wiki, Ent-Unique-Jobs) — they reach death
+    # handlers too (Sidekiq fires them on API kills), so we recognize the
+    # synthesized kill exception and skip the release for it. Atomic
+    # CAS-DEL via the shared Lua script mirrors ServerMiddleware#release.
+    DEATH_HANDLER = lambda do |job, exception|
       next unless Wurk::Unique.enabled?
       next unless Wurk::Unique.coerce_ttl(job['unique_for'])
+      next if exception.instance_of?(::RuntimeError) && exception.message == DeadSet::API_KILL_MESSAGE
 
       Wurk.redis { |conn| Wurk::Unique.release_if_owner(conn, Wurk::Unique.lock_key_for(job), job['jid']) }
     end

--- a/test/parity/sorted_entry_api_test.rb
+++ b/test/parity/sorted_entry_api_test.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'securerandom'
+
+# Parity test for the SortedEntry mutation API. Mirrors upstream Sidekiq's
+# api_test.rb expectations: `retry` decrements `retry_count` (the count was
+# bumped entering the retry set; the next failure re-bumps it), while
+# `add_to_queue` pushes the payload untouched — and `kill` fires death
+# handlers by default with the synthesized RuntimeError("Job killed by API").
+#
+# When this file diverges from upstream Sidekiq's tests, Wurk is wrong
+# unless the divergence is explicitly documented in
+# docs/target/sidekiq-free.md §19.
+class SortedEntryApiParityTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @ns           = "#{Process.pid}-#{object_id}"
+    @parent       = Wurk::RetrySet.new("retry-#{@ns}")
+    @pool         = Wurk.configuration.redis_pool
+    @dead_members = []
+    @queues       = []
+  end
+
+  def teardown
+    @pool.with do |c|
+      c.call('UNLINK', @parent.name)
+      @queues.each do |q|
+        c.call('DEL', "queue:#{q}")
+        c.call('SREM', 'queues', q)
+      end
+      c.call('ZREM', 'dead', *@dead_members) unless @dead_members.empty?
+    end
+  ensure
+    super
+  end
+
+  def test_retry_pushed_payload_matches_sidekiq
+    queue = unique_queue
+    entry = add_entry('retry_count' => 3, 'queue' => queue)
+
+    entry.retry
+
+    assert_equal 2, pushed_payload(queue)['retry_count']
+  end
+
+  def test_add_to_queue_pushed_payload_matches_sidekiq
+    queue = unique_queue
+    entry = add_entry('retry_count' => 3, 'queue' => queue)
+
+    entry.add_to_queue
+
+    assert_equal 3, pushed_payload(queue)['retry_count']
+  end
+
+  def test_kill_fires_death_handlers_with_api_exception
+    entry = add_entry
+    @dead_members << entry.value
+
+    ex = kill_and_capture_exception(entry)
+
+    assert_instance_of RuntimeError, ex
+    assert_equal 'Job killed by API', ex.message
+  end
+
+  private
+
+  # Kills the entry with a jid-keyed capture handler installed (the handler
+  # list is process-global and this class is parallel) and returns the
+  # exception the handlers observed for it.
+  def kill_and_capture_exception(entry)
+    received = {}
+    handler = ->(job, ex) { received[job['jid']] = ex }
+    Wurk.configuration.death_handlers << handler
+    entry.kill
+    received[entry.jid]
+  ensure
+    Wurk.configuration.death_handlers.delete(handler)
+  end
+
+  def add_entry(extra = {})
+    item = {
+      'class' => 'SortedEntryParityJob',
+      'args' => [],
+      'queue' => 'default',
+      'jid' => SecureRandom.hex(12),
+      'created_at' => Time.now.to_f
+    }.merge(extra)
+    payload = Wurk.dump_json(item)
+    @pool.with { |c| c.call('ZADD', @parent.name, 100.0, payload) }
+    Wurk::SortedEntry.new(@parent, 100.0, payload)
+  end
+
+  def pushed_payload(queue)
+    Wurk.load_json(@pool.with { |c| c.call('LRANGE', "queue:#{queue}", 0, 0) }.first)
+  end
+
+  def unique_queue
+    q = "sep-q-#{@ns}-#{@queues.size}"
+    @queues << q
+    q
+  end
+end

--- a/test/unit/dead_set_test.rb
+++ b/test/unit/dead_set_test.rb
@@ -73,6 +73,23 @@ class DeadSetTest < Wurk::Test::UnitCase
     assert_empty received
   end
 
+  # Sidekiq synthesizes RuntimeError("Job killed by API") with a backtrace
+  # when no `ex:` is given (#207). Keyed by jid — handlers are process-global
+  # and this class runs parallel.
+  def test_kill_synthesizes_api_kill_exception
+    received = {}
+    jid = "apim-#{@ns}"
+    Wurk.configuration.death_handlers << ->(job, ex) { received[job['jid']] = ex }
+
+    kill_payload(base_item('jid' => jid))
+
+    ex = received[jid]
+
+    assert_instance_of RuntimeError, ex
+    assert_equal Wurk::DeadSet::API_KILL_MESSAGE, ex.message
+    refute_nil ex.backtrace
+  end
+
   def test_kill_uses_provided_exception
     received_ex = nil
     Wurk.configuration.death_handlers << ->(_job, ex) { received_ex = ex }

--- a/test/unit/job_set_test.rb
+++ b/test/unit/job_set_test.rb
@@ -355,6 +355,35 @@ class JobSetTest < Wurk::Test::UnitCase
     @pool.with { |c| c.call('DEL', private_set) }
   end
 
+  # `each(&:kill)` equivalence with Sidekiq (#207): one death-handler call
+  # per entry by default.
+  def test_kill_all_fires_death_handlers_per_entry
+    private_set = seed_killable_set('kadh')
+
+    with_death_handler do |received|
+      private_job_set(private_set).kill_all
+
+      mine = received.select { |jid, _| jid.end_with?(@ns) }
+
+      assert_equal 2, mine.size
+      assert(mine.values.all? { |ex| ex.message == Wurk::DeadSet::API_KILL_MESSAGE })
+    end
+  ensure
+    @pool.with { |c| c.call('DEL', private_set) } if private_set
+  end
+
+  def test_kill_all_notify_false_skips_death_handlers
+    private_set = seed_killable_set('kanf')
+
+    with_death_handler do |received|
+      private_job_set(private_set).kill_all(notify_failure: false)
+
+      assert_empty(received.select { |jid, _| jid.end_with?(@ns) })
+    end
+  ensure
+    @pool.with { |c| c.call('DEL', private_set) } if private_set
+  end
+
   private
 
   def assert_drained(set_name, into_queue: nil, expected: nil, into_dead: nil)
@@ -401,6 +430,26 @@ class JobSetTest < Wurk::Test::UnitCase
 
   def test_private_set
     "wurktest-jobset-#{@ns}-#{rand(1_000_000)}"
+  end
+
+  # Two-entry private set whose jids end with @ns so handler captures can be
+  # filtered. Returns the set name; payloads are tracked for dead cleanup.
+  def seed_killable_set(prefix)
+    private_set = test_private_set
+    rows = (0...2).map { |i| [10 + i, "#{prefix}-#{i}-#{@ns}"] }
+    @dead_members.concat(seed_private(private_set, rows))
+    private_set
+  end
+
+  # Registers a jid-keyed capture handler for the block — keyed by jid
+  # because the handler list is process-global and this class is parallel.
+  def with_death_handler
+    received = {}
+    handler = ->(job, ex) { received[job['jid']] = ex }
+    Wurk.configuration.death_handlers << handler
+    yield received
+  ensure
+    Wurk.configuration.death_handlers.delete(handler)
   end
 
   def unique_queue

--- a/test/unit/sorted_entry_test.rb
+++ b/test/unit/sorted_entry_test.rb
@@ -140,7 +140,9 @@ class SortedEntryTest < Wurk::Test::UnitCase
     assert_equal(1, @pool.with { |c| c.call('LLEN', "queue:#{queue}") })
   end
 
-  def test_add_to_queue_decrements_retry_count
+  # Sidekiq's add_to_queue pushes the payload untouched — the decrement
+  # belongs to #retry (see #206).
+  def test_add_to_queue_keeps_retry_count
     queue = unique_queue
     entry = add_entry(item: base_item('retry_count' => 3, 'queue' => queue))
 
@@ -148,11 +150,11 @@ class SortedEntryTest < Wurk::Test::UnitCase
 
     raw = @pool.with { |c| c.call('LRANGE', "queue:#{queue}", 0, 0) }.first
 
-    assert_equal 2, Wurk.load_json(raw)['retry_count']
+    assert_equal 3, Wurk.load_json(raw)['retry_count']
   end
 
-  # No `retry_count` key ⇒ the decrement guard's else branch: enqueue the
-  # message unchanged, never inserting a retry_count field.
+  # No `retry_count` key ⇒ enqueue the message unchanged, never inserting
+  # a retry_count field.
   def test_add_to_queue_leaves_message_unchanged_without_retry_count
     queue = unique_queue
     entry = add_entry(item: base_item('queue' => queue))
@@ -181,7 +183,10 @@ class SortedEntryTest < Wurk::Test::UnitCase
     assert_equal(0, @pool.with { |c| c.call('LLEN', "queue:#{queue}") })
   end
 
-  def test_retry_removes_and_pushes_without_decrement
+  # The count was bumped when the job entered the retry set and the next
+  # failure bumps it again — Sidekiq decrements here so a manual "Retry now"
+  # doesn't consume an attempt (#206).
+  def test_retry_decrements_retry_count
     queue = unique_queue
     entry = add_entry(item: base_item('retry_count' => 3, 'queue' => queue))
 
@@ -189,7 +194,19 @@ class SortedEntryTest < Wurk::Test::UnitCase
 
     raw = @pool.with { |c| c.call('LRANGE', "queue:#{queue}", 0, 0) }.first
 
-    assert_equal 3, Wurk.load_json(raw)['retry_count']
+    assert_equal 2, Wurk.load_json(raw)['retry_count']
+  end
+
+  # No `retry_count` key ⇒ the decrement guard's else branch: push unchanged.
+  def test_retry_without_retry_count_pushes_unchanged
+    queue = unique_queue
+    entry = add_entry(item: base_item('queue' => queue))
+
+    entry.retry
+
+    raw = @pool.with { |c| c.call('LRANGE', "queue:#{queue}", 0, 0) }.first
+
+    refute Wurk.load_json(raw).key?('retry_count')
   end
 
   # --- kill --------------------------------------------------------------
@@ -204,7 +221,35 @@ class SortedEntryTest < Wurk::Test::UnitCase
     refute_nil(@pool.with { |c| c.call('ZSCORE', 'dead', entry.value) })
   end
 
+  # Sidekiq fires death handlers on API/UI kills by default, synthesizing
+  # RuntimeError("Job killed by API") with a backtrace (#207).
+  def test_kill_fires_death_handlers_by_default
+    entry = add_entry
+    @dead_members << entry.value
+
+    with_death_handler do |received|
+      entry.kill
+
+      ex = received[entry.jid]
+
+      assert_instance_of RuntimeError, ex
+      assert_equal Wurk::DeadSet::API_KILL_MESSAGE, ex.message
+      refute_nil ex.backtrace
+    end
+  end
+
   private
+
+  # Registers a jid-keyed capture handler for the block — keyed by jid
+  # because the handler list is process-global and this class is parallel.
+  def with_death_handler
+    received = {}
+    handler = ->(job, ex) { received[job['jid']] = ex }
+    Wurk.configuration.death_handlers << handler
+    yield received
+  ensure
+    Wurk.configuration.death_handlers.delete(handler)
+  end
 
   def add_entry(score: 100.0, jid: nil, item: nil)
     jid ||= SecureRandom.hex(12)

--- a/test/unit/unique_test.rb
+++ b/test/unit/unique_test.rb
@@ -462,6 +462,24 @@ class UniqueTest < Wurk::Test::UnitCase
     end
   end
 
+  # #207 × #211: API kills DO reach death handlers (OSS parity) while the
+  # unique lock is still retained — DEATH_HANDLER recognizes the synthesized
+  # "Job killed by API" exception and skips the release.
+  def test_api_kill_fires_other_death_handlers_but_keeps_lock
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      job = build_job(jid: 'kill-2', ttl: 600, queue: "kill2#{@suffix}")
+      key = seed_locked_retry_entry(job)
+
+      observe_death_handlers do |observed|
+        Wurk::RetrySet.new.find_job('kill-2').kill
+
+        assert_includes observed, ['kill-2', Wurk::DeadSet::API_KILL_MESSAGE]
+        assert_equal('kill-2', redis_call('GET', key))
+      end
+    end
+  end
+
   # ---- ServerMiddleware: lock release strategy -----------------------
 
   def test_server_middleware_no_op_when_disabled
@@ -652,6 +670,15 @@ class UniqueTest < Wurk::Test::UnitCase
 
   def redis_call(*args)
     Wurk.redis { |c| c.call(*args) }
+  end
+
+  def observe_death_handlers
+    observed = []
+    handler = ->(job, ex) { observed << [job['jid'], ex.message] }
+    Wurk.configuration.death_handlers << handler
+    yield observed
+  ensure
+    Wurk.configuration.death_handlers.delete(handler)
   end
 
   # Scripted fake connection for racing the SET NX / GET / SET NX sequence


### PR DESCRIPTION
## What

Two P1 OSS parity bugs in the sorted-set mutation API, both in the `SortedEntry`/`JobSet`/`DeadSet` surface:

### #206: `retry` and `add_to_queue` had `retry_count` handling swapped

Sidekiq's `SortedEntry#retry` decrements `retry_count` (the count was bumped when the job entered the retry set; the next failure re-bumps it — without the decrement a manual "Retry now" consumes an attempt and the job dies earlier). `add_to_queue` pushes the payload untouched. Wurk had it exactly inverted, with the rationale comments attached to the wrong methods.

### #207: API kill never fired death handlers

`SortedEntry#kill` passed `notify_failure: false` and `JobSet#kill_all` defaulted to `false`. Sidekiq fires death handlers on API kills **by default**, synthesizing `RuntimeError("Job killed by API")` with a backtrace. Error trackers, sidekiq-failures-style integrations, and Wurk's own batch death path never observed UI/API kills.

Both now fire by default; `DeadSet#kill` synthesizes Sidekiq's exact exception (`DeadSet::API_KILL_MESSAGE`).

### Interplay with #211 (Ent unique locks — shipped in #218)

API kills now reach death handlers, so `Unique::DEATH_HANDLER` recognizes the synthesized API-kill exception and **keeps** the lock — manual kills retain the lock per the Ent wiki, while automatic deaths (retries exhausted/discard) still release it. Covered by an explicit cross-issue test (`test_api_kill_fires_other_death_handlers_but_keeps_lock`) plus a driver regression scenario.

## Done when (quoted from the issues)

#206:
- [x] `SortedEntry#retry` decrements `retry_count` when present; `#add_to_queue` does not — `test_retry_decrements_retry_count`, `test_add_to_queue_keeps_retry_count`
- [x] Parity test asserting both pushed payloads match Sidekiq's — `test/parity/sorted_entry_api_test.rb`

#207:
- [x] `SortedEntry#kill` fires death handlers by default with `RuntimeError("Job killed by API")` semantics — `test_kill_fires_death_handlers_by_default`, `test_kill_synthesizes_api_kill_exception`
- [x] `kill_all` matches (`each(&:kill)` equivalence) — `test_kill_all_fires_death_handlers_per_entry` (+ `notify_failure: false` opt-out kept)
- [x] Parity test with a registered death handler — `test_kill_fires_death_handlers_with_api_exception`

## Wire compat

No Redis key, JSON field, or score format changes. Only payload-mutation logic (`retry_count` arithmetic) and death-handler invocation semantics.

## QA

Behavioral driver (6 scenarios, real Redis): on unfixed main F1–F3 FAIL / F4 PASS; on this branch **6/6 PASS**. Full suite 2252 runs / 0 failures, parity 23/23, ecosystem all green, rubocop clean. New unit + parity tests verified to fail against the unfixed lib.

## How to test in prod

```ruby
# 1. #206 — manual retry no longer consumes an attempt:
#    Find a job in the retry set (dashboard → Retries), note its retry count,
#    click "Retry now". On its next failure the count resumes from the same
#    attempt number instead of skipping one:
Sidekiq::RetrySet.new.first.item['retry_count']   # before and after — no net jump

# 2. #207 — death handlers observe kills (error trackers now see them):
Sidekiq.configure_server { |c| c.death_handlers << ->(job, ex) { Rails.logger.warn("DEAD: #{job['class']} #{ex.message}") } }
#    Kill a retrying job from the dashboard → log shows: DEAD: <JobClass> Job killed by API

# 3. Unique locks (Ent) — kill a retrying unique job from the dashboard,
#    then enqueue a duplicate: still blocked (returns nil), lock retained.
#    Let a unique job exhaust retries instead: duplicate enqueues immediately.
```

Closes #206. Closes #207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Death handlers now fire by default when jobs are killed via API.
  * Unique job locks are preserved during API kills.

* **Bug Fixes**
  * API-killed jobs now include proper exception messages and backtraces.
  * Retry count handling improved: `add_to_queue` preserves count; `retry` decrements it.

* **Tests**
  * Added comprehensive test coverage for death handler behavior during job kills and retry operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->