### PR TITLE
fix(pro): scheduled-job expires_in uses schedule time as clock origin (#208)

### DIFF
--- a/lib/wurk/job_util.rb
+++ b/lib/wurk/job_util.rb
@@ -116,13 +116,17 @@ module Wurk
 
     # Pro `expires_in:` → absolute epoch-float `expiry` resolved once at push,
     # so the server middleware doesn't redo the math. Spec: sidekiq-pro.md §7.
+    # For scheduled jobs the clock origin is `at` (epoch seconds), not
+    # `created_at` (epoch millis) — otherwise any delay > expires_in makes the
+    # job born-expired: perform_in(2h) + expires_in: 1h must expire at 3h.
     # nil.respond_to?(:to_f) is true on modern Ruby (returns 0.0), so we must
     # gate on a non-nil duration before coercing.
     def stamp_expiry(item)
       d = item['expires_in']
-      return if d.nil?
+      return if d.nil? || !d.respond_to?(:to_f)
 
-      item['expiry'] ||= (item['created_at'].to_f / 1000.0) + d.to_f if d.respond_to?(:to_f)
+      origin = item['at'] ? item['at'].to_f : (item['created_at'].to_f / 1000.0)
+      item['expiry'] ||= origin + d.to_f
     end
 
     def report_unsafe(item, offender, mode)

--- a/test/unit/middleware_expiry_test.rb
+++ b/test/unit/middleware_expiry_test.rb
@@ -257,6 +257,28 @@ class MiddlewareExpiryTest < Wurk::Test::UnitCase
     assert_in_delta((created_at_ms / 1000.0) + 3600, item['expiry'], 0.001)
   end
 
+  # Spec §7: "perform_in(2.hours) + expires_in: 1.hour ⇒ expires 3h after
+  # enqueue" — for scheduled jobs the clock origin is `at`, not `created_at`.
+  def test_client_stamps_expiry_from_at_for_scheduled_jobs
+    created_at_ms = 1_700_000_000_000
+    at = (created_at_ms / 1000.0) + 7200
+    item = { 'created_at' => created_at_ms, 'expires_in' => 3600, 'at' => at, 'class' => 'X', 'args' => [] }
+    Stamper.new.stamp(item)
+
+    assert_in_delta(at + 3600, item['expiry'], 0.001)
+  end
+
+  def test_scheduled_job_is_not_born_expired
+    # The #208 regression: delay (2h) > expires_in (1h) used to stamp an
+    # expiry 1h *before* the job's own run time, so promotion always dropped it.
+    created_at_ms = 1_700_000_000_000
+    at = (created_at_ms / 1000.0) + 7200
+    item = { 'created_at' => created_at_ms, 'expires_in' => 3600, 'at' => at, 'class' => 'X', 'args' => [] }
+    Stamper.new.stamp(item)
+
+    assert_operator item['expiry'], :>, at, 'scheduled job must not expire before its own run time'
+  end
+
   def test_client_does_not_overwrite_caller_supplied_expiry
     item = {
       'created_at' => 1_700_000_000_000,
@@ -320,7 +342,27 @@ class MiddlewareExpiryTest < Wurk::Test::UnitCase
     end
   end
 
+  def test_client_push_scheduled_job_stamps_expiry_from_at
+    with_expiry_job(3600) do |klass, queue, pool|
+      at = ::Process.clock_gettime(::Process::CLOCK_REALTIME) + 7200
+      jid = Wurk::Client.new.push('class' => klass, 'args' => [], 'queue' => queue, 'at' => at)
+
+      expiry = fetch_scheduled_expiry(pool, jid)
+
+      assert_in_delta at + 3600, expiry, 0.01
+    end
+  end
+
   private
+
+  def fetch_scheduled_expiry(pool, jid)
+    raw = pool.with { |c| c.call('ZRANGE', 'schedule', 0, -1) }
+              .find { |m| JSON.parse(m)['jid'] == jid }
+
+    refute_nil raw, 'expected the scheduled payload in the schedule set'
+    pool.with { |c| c.call('ZREM', 'schedule', raw) }
+    JSON.parse(raw)['expiry']
+  end
 
   def with_expiry_job(duration)
     klass_name = "ExpiryJob_#{Process.pid}_#{object_id}"


### PR DESCRIPTION
Closes #208.

## Summary

`JobUtil#stamp_expiry` computed `expiry = created_at + expires_in`, ignoring `at`. For any scheduled job with `delay > expires_in`, the stamped expiry landed *before* the job's own run time — the Expiry middleware then dropped it the moment the scheduler promoted it. Every `perform_in(delay)` job with `expires_in < delay` silently never ran.

Per the authoritative spec (docs/target/sidekiq-pro.md §7):

> "For scheduled jobs the clock starts at enqueue, not at schedule time, i.e. `perform_in(2.hours)` + `expires_in: 1.hour` ⇒ **expires 3h after enqueue**."

The clock origin is now `at` (epoch seconds) when present, falling back to `created_at` (epoch millis) for immediate jobs. Wire format unchanged — `expiry` stays an absolute epoch-float stamped once at push.

## Done when (from #208)

- [x] `stamp_expiry` uses `at` as the clock origin when present (matching spec §7's 3h example)
- [x] Test: `perform_in(2h, expires_in: 1h)` job executes when promoted at 2h and expires at 3h

## QA evidence

Behavioral driver (`tmp/expiry_208_qa.rb`, real Redis DB 14):

```
perform_in(2h) + expires_in: 1h stamps expiry = at + 1h (3h after enqueue)   PASS
scheduled expiry is AFTER the job's own run time (not born-expired)          PASS
job with delay(1.2s) > expires_in(0.5s) EXECUTES when promoted on time      PASS
same job is still DROPPED once at + expires_in has passed                    PASS
immediate (non-scheduled) job still stamps expiry = created_at + d           PASS
ALL 5 CHECKS PASSED
```

Driver sanity-checked against the unfixed code: 3/5 checks fail there (expiry lands 3600s before the run time).

Suites: full `bin/rake test` (2255 runs, 0 failures), `test:parity` (23 runs, 0 failures), `test:ecosystem` (all passed).

## How to test in prod

```ruby
# Rails console on a host with the worker running:
class ExpiryProbeJob
  include Sidekiq::Job
  def perform(tag) = Rails.logger.info("ExpiryProbeJob ran: #{tag}")
end

# delay (120s) > expires_in (60s) — before this fix the job was silently
# discarded at promotion; now it must run at ~T+120s:
ExpiryProbeJob.set(expires_in: 60).perform_in(120, "delayed-2m-expires-1m")

# Confirm the stamped expiry is AFTER the run time:
job = Sidekiq::ScheduledSet.new.find { |j| j.klass == "ExpiryProbeJob" }
job["expiry"] - job.at.to_f   # => 60.0  (was -60.0 before the fix)
```

After ~2 minutes, `grep "ExpiryProbeJob ran" log/production.log` shows the job executed. Expiry still enforced: a job whose `at + expires_in` has passed is skipped and counted in the dashboard's expired stat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed expiry time calculation for scheduled jobs—now correctly computed from the scheduled execution time rather than creation time, preventing premature expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->