### PR TITLE
fix(pro): gate parent batch :complete/:success on running child batches (#209)

### DIFF
--- a/lib/wurk/batch/callbacks.rb
+++ b/lib/wurk/batch/callbacks.rb
@@ -15,15 +15,30 @@ module Wurk
     module Callbacks
       module_function
 
-      # Called from the server middleware after BATCH_ACK_SUCCESS. Fires
-      # `:complete` when live jids hit 0; fires `:success` when pending
-      # also hits 0 and there have been no deaths.
+      # Called from the server middleware after BATCH_ACK_SUCCESS (and from
+      # DeathHandler when a death drains the last live jid). Fires `:complete`
+      # when live jids hit 0; fires `:success` when pending also hits 0 and
+      # there have been no deaths.
+      #
+      # Both fires are additionally gated on `b-<bid>-pkids` being empty —
+      # children whose own subtree hasn't finished yet (#209). Spec §2.4:
+      # child `:complete`/`:success` fire before the parent's, so when the
+      # parent's *own* last job acks while a child batch is still running,
+      # nothing fires here; the last child's propagate_to_parent re-invokes
+      # this and fires then. The SREM in pkids_drained? happens before that
+      # re-invocation, so exactly one of the racing paths fires (dedup_set
+      # absorbs the overlap).
       def maybe_fire(bid, pending:, live:)
         return unless live.zero?
+        return unless kids_finished?(bid)
 
         fire_complete(bid)
         fire_success(bid) if pending.zero? && !death_fired?(bid)
         propagate_to_parent(bid)
+      end
+
+      def kids_finished?(bid)
+        Wurk.redis { |conn| conn.call('SCARD', "b-#{bid}-pkids") }.to_i.zero?
       end
 
       # Fired from Wurk::Batch::DeathHandler on the FIRST permanent death
@@ -166,10 +181,11 @@ module Wurk
         )
       end
 
-      # When a child batch's `:success` fires, decrement the parent's pkids
-      # set so the parent's own `:success` waits on the full subtree. When
-      # parent's pkids hits 0 *and* its own pending is 0, parent's success
-      # fires too.
+      # When a child batch finishes (its live jids hit 0 — by success or
+      # death), remove it from the parent's pkids set so the parent's own
+      # callbacks wait on the full subtree. When the parent's pkids hits 0,
+      # re-run the parent's maybe_fire: if its own counts are already at
+      # zero (the parent-acks-first race), this is what finally fires it.
       def propagate_to_parent(bid)
         parent_bid = parent_bid_for(bid)
         return if parent_bid.nil? || parent_bid.empty?

--- a/lib/wurk/batch/death_handler.rb
+++ b/lib/wurk/batch/death_handler.rb
@@ -29,8 +29,11 @@ module Wurk
         Wurk::Batch::Callbacks.fire_death(bid) if first_death == 1
         return unless live.zero?
 
-        Wurk::Batch::Callbacks.fire_complete(bid)
-        Wurk::Batch::Callbacks.propagate_to_parent(bid)
+        # Through the gated maybe_fire, not a direct fire_complete: this batch
+        # may still have running child batches, and spec §2.4 ordering says
+        # its `:complete` must wait for theirs (#209). `:success` stays
+        # suppressed regardless — the death above set the durable death flag.
+        Wurk::Batch::Callbacks.maybe_fire(bid, pending: Wurk::Batch::Callbacks.pending_for(bid), live: 0)
       end
     end
   end

--- a/test/engine/api_mutations_test.rb
+++ b/test/engine/api_mutations_test.rb
@@ -8,9 +8,16 @@ require_relative '../engine_test_helper'
 #
 # Like ApiEndpointsTest we talk to the engine via Rack::Test and read
 # `last_response` directly.
+#
+# Intra-class serial: many tests POST `/wurk/api/<set>/all/<cmd>`, and those
+# endpoints drain the *global* retry/scheduled/dead zsets (wire-compat with
+# Sidekiq — we can't namespace them per test). A parallel `test_all_retry_*`
+# can therefore re-enqueue another test's pushed jid before that test's
+# `test_all_kill_*` calls kill, so kill drains an empty zset and the jid lands
+# in a queue instead of dead. Exposed by COVERAGE-mode timing (CI failure on
+# #209) but pre-existing. Cross-class parallelism via minitest-parallel_fork
+# is unaffected — each worker still gets its own Redis DB.
 class ApiMutationsTest < Wurk::Test::EngineCase
-  parallelize_me!
-
   def setup
     super
     @ns = "wurkmut:#{::Process.pid}:#{object_id}"

--- a/test/integration/batch_nested_callbacks_test.rb
+++ b/test/integration/batch_nested_callbacks_test.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Defined at the top level so Object.const_get resolves inside the forked
+# child (constant table is inherited; Minitest lexical scope is not).
+class Batch209FastWorker
+  include Wurk::Job
+
+  def perform(*); end
+end
+
+# Holds its thread until the test sets the release key, marking a running
+# sentinel first so the test knows the window is open. Owns its connection —
+# never share a socket across forks.
+class Batch209GatedWorker
+  include Wurk::Job
+
+  def perform(redis_url, running_key, release_key)
+    client = RedisClient.config(url: redis_url).new_client
+    client.call('SET', running_key, ::Process.pid.to_s, 'EX', 60)
+    deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + 20
+    until client.call('EXISTS', release_key) == 1
+      raise "#{release_key} never set — test driver lost?" if ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) > deadline
+
+      sleep 0.05
+    end
+  ensure
+    client&.close
+  end
+end
+
+# Real forks, real Redis, real perform. Issue #209 done-when: the parent
+# batch's `:complete`/`:success` must NOT fire while a child batch is still
+# running, even when the parent's own last job acks first (the pkids gate now
+# applies on the parent's own ack path, not just child→parent propagation).
+#
+# The child batch's only job blocks on a release key, pinning open the exact
+# race window: parent's own pending hits 0 in a real worker process while the
+# child batch is mid-flight. NEVER mock Redis here.
+class BatchNestedCallbacksTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  POLL_TIMEOUT = 15.0
+  POLL_INTERVAL = 0.05
+  # How long the parent's flags must HOLD at "not fired" once the race window
+  # is provably open before we believe the gate (vs. just winning a read race).
+  GATE_HOLD = 0.5
+
+  def setup
+    super
+    @ns = "batch209-#{Process.pid}-#{object_id}"
+    @queue_name = "#{@ns}-q"
+    @running_key = "#{@ns}-running"
+    @release_key = "#{@ns}-release"
+    @config = Wurk::Configuration.new
+    @config.logger = ::Logger.new(IO::NULL)
+    @config[:timeout] = 5
+    # Require-time registrations only touch the global Wurk.configuration;
+    # a fresh Configuration starts with a bare chain, and without the batch
+    # middleware the ack path never decrements pending.
+    @config.server_middleware.add(Wurk::Batch::ServerMiddleware)
+    @observer = RedisClient.config(url: Wurk::Test.redis_url).new_client
+  end
+
+  def teardown
+    @observer&.call('DEL', @running_key, @release_key,
+                    "queue:#{@queue_name}", private_queue_key(@queue_name))
+    @observer&.call('SREM', 'queues', @queue_name)
+    @observer&.close
+    @config&.reset_redis_pools!
+  ensure
+    super
+  end
+
+  def test_parent_callbacks_wait_for_running_child_batch_under_real_forks # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Minitest/MultipleAssertions
+    parent, child = enqueue_nested_batches
+    swarm = Wurk::Swarm.new(topology: topology, config: @config, shutdown_timeout: 5)
+    swarm.boot(install_signals: false)
+    supervisor = nil
+
+    begin
+      supervisor = Thread.new { swarm.supervise }
+
+      assert wait_until { window_open?(parent, child) },
+             'race window never opened: parent job acked + child job running ' \
+             "(parent pending=#{batch_field(parent, 'pending').inspect} " \
+             "child running=#{@observer.call('EXISTS', @running_key)})"
+
+      hold_deadline = monotonic_now + GATE_HOLD
+      while monotonic_now < hold_deadline
+        assert_nil batch_field(parent, 'complete'),
+                   'parent :complete fired while the child batch was still running (#209)'
+        assert_nil batch_field(parent, 'success'),
+                   'parent :success fired while the child batch was still running (#209)'
+        sleep POLL_INTERVAL
+      end
+
+      @observer.call('SET', @release_key, '1', 'EX', 60)
+
+      assert wait_until { batch_field(parent, 'success') == '1' },
+             "parent :success never fired after the child finished (within #{POLL_TIMEOUT}s)"
+      assert_equal '1', batch_field(parent, 'complete')
+      assert_equal '1', batch_field(child, 'success')
+
+      child_at  = batch_field(child, 'success_at').to_f
+      parent_at = batch_field(parent, 'success_at').to_f
+
+      assert_operator child_at, :<=, parent_at,
+                      'child :success must precede parent :success (spec §2.4)'
+    ensure
+      @observer.call('SET', @release_key, '1', 'EX', 60) # never strand the gated worker
+      swarm.shutdown(timeout: 5)
+      supervisor&.join(10)
+    end
+  end
+
+  private
+
+  def topology
+    # Concurrency 2: the gated job must not starve the parent's fast job.
+    Wurk::Topology.flat(count: 1, queues: [@queue_name], concurrency: 2)
+  end
+
+  # Parent batch: one fast own job + a nested child batch whose only job
+  # blocks until @release_key appears. Pushed through Wurk::Client so the
+  # batch client middleware stamps bids (same contract production uses).
+  def enqueue_nested_batches
+    parent = Wurk::Batch.new
+    child = nil
+    parent.jobs do
+      Wurk::Client.push('class' => Batch209FastWorker.name, 'args' => [],
+                        'queue' => @queue_name, 'retry' => false)
+      child = Wurk::Batch.new
+      child.jobs do
+        Wurk::Client.push('class' => Batch209GatedWorker.name,
+                          'args' => [Wurk::Test.redis_url, @running_key, @release_key],
+                          'queue' => @queue_name, 'retry' => false)
+      end
+    end
+    [parent, child]
+  end
+
+  # The #209 race window: the parent's own job has fully acked (pending 0)
+  # while the child batch's job is provably still inside perform.
+  def window_open?(parent, child)
+    batch_field(parent, 'pending').to_i.zero? &&
+      batch_field(child, 'pending').to_i == 1 &&
+      @observer.call('EXISTS', @running_key) == 1
+  end
+
+  def batch_field(batch, field)
+    @observer.call('HGET', "b-#{batch.bid}", field)
+  end
+
+  def wait_until
+    deadline = monotonic_now + POLL_TIMEOUT
+    until monotonic_now > deadline
+      return true if yield
+
+      sleep POLL_INTERVAL
+    end
+    false
+  end
+
+  def monotonic_now
+    ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+  end
+
+  def private_queue_key(queue_name)
+    Wurk::Fetcher::Reliable.private_queue_name("queue:#{queue_name}")
+  end
+end

--- a/test/unit/batch_lifecycle_test.rb
+++ b/test/unit/batch_lifecycle_test.rb
@@ -432,6 +432,66 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
     assert_equal(1, @pool.with { |c| c.call('SCARD', "b-#{parent.bid}-pkids") })
   end
 
+  # --- #209: parent gated on running child batches ------------------------
+
+  def test_parent_callbacks_wait_when_parent_acks_before_child # rubocop:disable Minitest/MultipleAssertions
+    parent, child = nested(parent_cbs: { success: 'ParentSuccess', complete: 'ParentComplete' },
+                           child_cbs: { success: 'ChildSuccess' })
+
+    # The #209 race: the parent's own last job acks while the child batch
+    # still has a pending job — nothing may fire on the parent yet.
+    ack_success(parent.bid, jid_for(@queue, parent.bid))
+
+    assert_equal 0, callbacks_fired(event: 'complete', bid: parent.bid),
+                 'parent :complete must wait for running child batches'
+    assert_equal 0, callbacks_fired(event: 'success', bid: parent.bid),
+                 'parent :success must wait for running child batches'
+
+    ack_success(child.bid, jid_for(@queue, child.bid))
+
+    assert_equal 1, callbacks_fired(event: 'success', bid: child.bid)
+    assert_equal 1, callbacks_fired(event: 'complete', bid: parent.bid)
+    assert_equal 1, callbacks_fired(event: 'success', bid: parent.bid)
+  end
+
+  def test_parent_fires_when_child_acks_first_then_parent
+    parent, child = nested(parent_cbs: { success: 'ParentSuccess', complete: 'ParentComplete' })
+    ack_success(child.bid, jid_for(@queue, child.bid))
+
+    assert_equal 0, callbacks_fired(event: 'success', bid: parent.bid),
+                 'parent must still wait for its own job'
+
+    ack_success(parent.bid, jid_for(@queue, parent.bid))
+
+    assert_equal 1, callbacks_fired(event: 'complete', bid: parent.bid)
+    assert_equal 1, callbacks_fired(event: 'success', bid: parent.bid)
+  end
+
+  def test_child_events_recorded_before_parent_under_parent_first_ack_order
+    parent, child = nested(parent_cbs: { success: 'ParentSuccess' }, child_cbs: { success: 'ChildSuccess' })
+    ack_success(parent.bid, jid_for(@queue, parent.bid))
+    ack_success(child.bid, jid_for(@queue, child.bid))
+
+    child_at  = @pool.with { |c| c.call('HGET', "b-#{child.bid}", 'success_at') }.to_f
+    parent_at = @pool.with { |c| c.call('HGET', "b-#{parent.bid}", 'success_at') }.to_f
+
+    assert_operator child_at, :<=, parent_at, 'child :success must precede parent :success (spec §2.4)'
+  end
+
+  def test_parent_complete_after_own_job_death_waits_for_running_child
+    parent, child = nested(parent_cbs: { complete: 'ParentComplete', success: 'ParentSuccess' })
+    kill(parent.bid, jid_for(@queue, parent.bid))
+
+    assert_equal 0, callbacks_fired(event: 'complete', bid: parent.bid),
+                 'parent :complete must wait for the running child even on the death path'
+
+    ack_success(child.bid, jid_for(@queue, child.bid))
+
+    assert_equal 1, callbacks_fired(event: 'complete', bid: parent.bid)
+    assert_equal 0, callbacks_fired(event: 'success', bid: parent.bid),
+                 'death must keep suppressing parent :success'
+  end
+
   private
 
   def track(batch)


### PR DESCRIPTION
Closes #209

## Problem

`Wurk::Batch::Callbacks.maybe_fire` fired the parent batch's `:complete`/`:success` as soon as the parent's **own** live/pending counters hit zero. The `b-<bid>-pkids` gate only existed on the child→parent propagation path, so when the parent's last own job acked while a child batch was still running, the parent's callbacks fired early — violating spec §2.4 ("All jobs in batch **(and all descendant batches)** succeeded"; child events fire before parent events).

## Fix

- `maybe_fire` now returns early unless `SCARD b-<bid>-pkids == 0`. When the parent acks first, nothing fires; the last finishing child's `propagate_to_parent` re-invokes `maybe_fire` and fires then. The pkids `SREM` happens before that re-invocation, so exactly one of the racing paths fires (`dedup_set` absorbs any overlap).
- `DeathHandler` routes through the same gated `maybe_fire` instead of calling `fire_complete` directly, so a parent-job death also waits for running children before `:complete` (and `:success` stays suppressed via the durable death flag).

## Tests

- 4 new unit tests in `test/unit/batch_lifecycle_test.rb`: parent-acks-first deferral, child-acks-first unchanged, `success_at` ordering (§2.4), and the death-path deferral.
- New integration test `test/integration/batch_nested_callbacks_test.rb`: real swarm fork + real Redis; the child batch's job blocks on a release key to hold the race window open while the parent's own job acks in a real worker, asserting the parent's flags stay unfired for the whole window.
- Full suite (2266 runs), `test:parity` (23 runs), `test:ecosystem`: all green. Integration test passed 4/4 consecutive runs.

## How to test in prod

In a Rails console (or any process with Wurk loaded) against your real Redis:

```ruby
class WurkProbeJob
  include Sidekiq::Job
  def perform(sleep_s = 0) = sleep(sleep_s)
end

parent = Sidekiq::Batch.new
parent.on(:success, ->(status, _) { Rails.logger.info("parent success #{status.bid}") })
child = nil
parent.jobs do
  WurkProbeJob.perform_async(0)    # parent's own job: finishes immediately
  child = Sidekiq::Batch.new
  child.jobs { WurkProbeJob.perform_async(30) }  # child job: still running
end
```

Then watch the batch hashes while the child job sleeps:

```bash
redis-cli HGETALL b-<parent-bid>   # success/complete must be ABSENT while the child runs
redis-cli HGETALL b-<child-bid>    # pending=1 during the sleep
```

After ~30s the child finishes; `b-<child-bid> success_at` must be ≤ `b-<parent-bid> success_at`, and the parent's `success`/`complete` flip to `1` only then. Before this fix, the parent's `success=1` appeared the moment its own job acked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Parent batch callbacks (complete and success) now wait for running child batches to finish before firing, preserving correct callback ordering even on parent death.

* **Tests**
  * Added integration and unit tests covering nested batch callback gating, real fork/Redis scenarios, ordering of success/complete timestamps, and test isolation improvements (removed problematic parallelization).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->