### PR TITLE
fix(pro): Batch#on after first flush persists the callback instead of silently dropping it (#213)

### DIFF
--- a/docs/target/sidekiq-pro.md
+++ b/docs/target/sidekiq-pro.md
@@ -105,6 +105,7 @@ Rules:
 - Callbacks run as ordinary Sidekiq jobs on `callback_queue`; retry on failure like any job.
 - `:success` and `:death` are **not mutually exclusive** — death fires first, success never fires unless the dead job is manually retried to success.
 - Child `:success` fires before parent `:success`. Child `:complete` fires before parent `:complete`. No ordering between child `:success` and parent `:complete`.
+- **Wurk (#213):** `#on` after the first flush — following a `#jobs` call or on a batch reopened by bid — persists the callback to `b-<bid>` immediately (atomic server-side append), so it is never silently dropped. Registering on a batch whose Redis hash no longer exists raises `ArgumentError`; registering for an event that already fired logs a warning (the callback will never run).
 
 ### 2.5 `Sidekiq::Batch::Status`
 

--- a/lib/wurk/batch.rb
+++ b/lib/wurk/batch.rb
@@ -157,7 +157,9 @@ module Wurk
       raise ArgumentError, "invalid event #{event.inspect}" unless VALID_EVENTS.include?(sym)
       raise ArgumentError, 'callback options must be a Hash' unless options.is_a?(Hash)
 
-      @callbacks << [sym.to_s, callback_target(callback), options]
+      entry = [sym.to_s, callback_target(callback), options]
+      @callbacks << entry
+      persist_callback!(entry) if @flushed_once
       self
     end
 
@@ -222,6 +224,24 @@ module Wurk
     def flush_buffer(buffer)
       payloads = buffer.drain
       Wurk::Client.new.flush_batched(payloads) unless payloads.empty?
+    end
+
+    # Like `linger=`, anything registered after the first flush must reach
+    # Redis — `Callbacks.enqueue_callbacks` reads specs from the hash, so an
+    # in-memory-only append would silently never fire (#213). Covers both
+    # `on` after `#jobs` and batches reopened by bid. The append runs
+    # server-side (Lua) so concurrent registrations from different processes
+    # can't lose each other to a read-modify-write race.
+    def persist_callback!(entry)
+      event = entry[0]
+      fired = Wurk.redis do |conn|
+        Wurk::Lua::Loader.eval_cached(conn, :batch_append_callback,
+                                      keys: ["b-#{@bid}"], argv: [entry.to_json, event])
+      end
+      raise ArgumentError, "cannot register #{event} callback: batch #{@bid} no longer exists" if fired == -1
+      return unless fired == '1'
+
+      Wurk.logger.warn("batch #{@bid}: #{event} callback registered after #{event} already fired — it will never run")
     end
 
     # First flush writes the core hash, registers in the global `batches`

--- a/lib/wurk/lua.rb
+++ b/lib/wurk/lua.rb
@@ -149,6 +149,32 @@ module Wurk
       return 1
     LUA
 
+    # Pro Batch (§2.4): atomically append one callback triple to the
+    # `callbacks` JSON array on the batch hash. Server-side append (vs a
+    # Ruby read-modify-write) so two processes registering callbacks on the
+    # same reopened batch cannot lose each other's writes. Refuses to write
+    # when the batch hash is gone — resurrecting a bare hash would create a
+    # batch that can never fire anything.
+    # KEYS = [b-<bid>]
+    # ARGV = [callback triple JSON, event name]
+    # Returns -1 when the batch hash does not exist; otherwise the event's
+    # fired flag ("1", or nil when it has not fired yet).
+    BATCH_APPEND_CALLBACK = <<~LUA
+      if redis.call("exists", KEYS[1]) == 0 then
+        return -1
+      end
+      local raw = redis.call("hget", KEYS[1], "callbacks")
+      local list
+      if raw and raw ~= "" then
+        list = cjson.decode(raw)
+      else
+        list = {}
+      end
+      list[#list + 1] = cjson.decode(ARGV[1])
+      redis.call("hset", KEYS[1], "callbacks", cjson.encode(list))
+      return redis.call("hget", KEYS[1], ARGV[2])
+    LUA
+
     # Ent Unique (§3): atomic compare-and-delete of a lock key. Replaces the
     # two-command GET-then-DEL — between those calls the key can expire and a
     # fresh enqueue can grab it, and the bare DEL would then drop the new
@@ -220,6 +246,7 @@ module Wurk
       batch_ack_failed: BATCH_ACK_FAILED,
       batch_ack_complete: BATCH_ACK_COMPLETE,
       batch_invalidate: BATCH_INVALIDATE,
+      batch_append_callback: BATCH_APPEND_CALLBACK,
       fast_delete_job: FAST_DELETE_JOB,
       fast_delete_by_class: FAST_DELETE_BY_CLASS,
       release_if_owner: RELEASE_IF_OWNER

--- a/test/unit/batch_lifecycle_test.rb
+++ b/test/unit/batch_lifecycle_test.rb
@@ -432,6 +432,74 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
     assert_equal(1, @pool.with { |c| c.call('SCARD', "b-#{parent.bid}-pkids") })
   end
 
+  # --- #213: on() after first flush must persist --------------------------
+
+  def test_on_after_jobs_flush_persists_and_fires
+    batch = new_batch
+    batch.jobs { perform_one }
+    batch.on(:success, 'LateSuccess')
+
+    ack_success(batch.bid, jid_for(@queue, batch.bid))
+
+    assert_equal 1, callbacks_fired(event: 'success', bid: batch.bid),
+                 'callback registered after the first flush must persist and fire (#213)'
+  end
+
+  def test_on_reopened_batch_persists_and_fires
+    batch = new_batch
+    batch.jobs { perform_one }
+
+    Wurk::Batch.new(batch.bid).on(:complete, 'ReopenedComplete')
+    ack_success(batch.bid, jid_for(@queue, batch.bid))
+
+    assert_equal 1, callbacks_fired(event: 'complete', bid: batch.bid),
+                 'callback registered on a reopened batch must persist and fire (#213)'
+  end
+
+  def test_on_after_flush_preserves_earlier_callbacks
+    batch = new_batch(success: 'EarlySuccess')
+    batch.jobs { perform_one }
+    batch.on(:success, 'LateSuccess')
+
+    ack_success(batch.bid, jid_for(@queue, batch.bid))
+
+    assert_equal 2, callbacks_fired(event: 'success', bid: batch.bid)
+  end
+
+  def test_concurrent_reopeners_do_not_lose_each_others_callbacks
+    batch = new_batch
+    batch.jobs { perform_one }
+    # Both handles load the persisted spec list BEFORE either appends — a
+    # client-side read-modify-write would lose the first registration here.
+    reopen_a = Wurk::Batch.new(batch.bid)
+    reopen_b = Wurk::Batch.new(batch.bid)
+    reopen_a.on(:success, 'ReopenA')
+    reopen_b.on(:success, 'ReopenB')
+
+    ack_success(batch.bid, jid_for(@queue, batch.bid))
+
+    assert_equal 2, callbacks_fired(event: 'success', bid: batch.bid)
+  end
+
+  def test_on_unknown_batch_raises
+    ghost = Wurk::Batch.new('no-such-bid-213')
+
+    err = assert_raises(ArgumentError) { ghost.on(:success, 'Nope') }
+
+    assert_match(/no longer exists/, err.message)
+  end
+
+  def test_on_after_event_already_fired_does_not_enqueue_again
+    batch = new_batch(success: 'EarlySuccess')
+    batch.jobs { perform_one }
+    ack_success(batch.bid, jid_for(@queue, batch.bid))
+
+    batch.on(:success, 'TooLate')
+
+    assert_equal 1, callbacks_fired(event: 'success', bid: batch.bid),
+                 'registration after the event fired must not re-fire, only warn'
+  end
+
   private
 
   def track(batch)

--- a/test/unit/lua_test.rb
+++ b/test/unit/lua_test.rb
@@ -33,6 +33,7 @@ class LuaTest < Wurk::Test::UnitCase
     assert_equal(
       %i[zpopbyscore bulk_push reliable_schedule_promote
          batch_push batch_ack_success batch_ack_failed batch_ack_complete batch_invalidate
+         batch_append_callback
          fast_delete_job fast_delete_by_class release_if_owner
          limiter_concurrent_acquire limiter_concurrent_release
          limiter_bucket_acquire limiter_window_acquire limiter_leaky_acquire


### PR DESCRIPTION
Closes #213

## Problem

Batch callbacks were written to the `b-<bid>` hash only at first flush (`first_flush_hash`). `Batch#on` after that point appended to the in-memory `@callbacks` array and nothing else, so both of these silently never fired:

```ruby
b.jobs { ... }; b.on(:success, Foo)     # registered after the flush — lost
Wurk::Batch.new(bid).on(:success, Foo)  # reopened batch — lost
```

Silent data loss: no error, no warning, the callback just never runs.

## Fix

Persist, not raise (the `linger=` precedent at lib/wurk/batch.rb — it re-persists after first flush for exactly this reason; spec §2.4 now documents the choice):

- `Batch#on` persists post-flush registrations to the `b-<bid>` hash via a new `batch_append_callback` Lua script. The append is server-side because `callbacks` is a JSON **array**: two processes reopening the same batch and registering concurrently would lose one write under a Ruby read-modify-write. EVALSHA-cached like every other script.
- Registering on a batch whose Redis hash no longer exists raises `ArgumentError` (writing would resurrect a bare hash that can never fire).
- Registering for an event that already fired logs a warning — the callback can never run, but it is no longer *silent*.
- Pre-flush behavior is unchanged; wire format unchanged (same JSON array in the same hash field).

## Tests

- 6 new unit tests in `test/unit/batch_lifecycle_test.rb`: post-flush persist+fire, reopened-batch persist+fire, earlier callbacks preserved, concurrent-reopeners atomicity (fails under read-modify-write), unknown-bid raise, already-fired no-refire.
- `test/unit/lua_test.rb` registry expectation updated for the new script.
- Full suite (2267 runs), `test:parity` (23), `test:ecosystem`: all green.

## How to test in prod

In a Rails console against your real Redis:

```ruby
class WurkProbeJob
  include Sidekiq::Job
  def perform = sleep(20)
end

class LateCallback
  def on_success(status, opts) = Rails.logger.info("late callback fired for #{status.bid}")
end

b = Sidekiq::Batch.new
b.jobs { WurkProbeJob.perform_async }
b.on(:success, LateCallback)        # registered AFTER the jobs flush
puts b.bid
```

Verify the registration is durable before the job finishes:

```bash
redis-cli HGET b-<bid> callbacks   # must include "LateCallback" (old code: "[]")
```

When the job completes (~20s), the `late callback fired for <bid>` log line appears. Before this fix the hash field stayed `[]` and the callback never ran. Reopened-batch variant: `Sidekiq::Batch.new("<bid>").on(:success, LateCallback)` from a second console behaves identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Callbacks registered after batch processing now persist atomically to the batch state instead of being silently dropped.
  * Registering a callback on a non-existent batch now raises ArgumentError.
  * Registering for an event that already fired logs a warning and the callback will not run.

* **Documentation**
  * Clarified post-flush callback registration behavior in the docs.

* **Tests**
  * Added regression tests covering post-flush, reopened batches, concurrency, and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->