### PR TITLE
fix(pro): batch :success fires after a dead job is manually retried to success (#212)

### DIFF
--- a/lib/wurk/batch/callbacks.rb
+++ b/lib/wurk/batch/callbacks.rb
@@ -41,14 +41,19 @@ module Wurk
         Wurk.redis { |conn| conn.call('SCARD', "b-#{bid}-pkids") }.to_i.zero?
       end
 
-      # Fired from Wurk::Batch::DeathHandler on the FIRST permanent death
-      # in the batch only. Subsequent deaths bump the counter but do not
-      # re-enqueue the callback.
+      # Fired from Wurk::Batch::DeathHandler whenever a death makes the died
+      # set go non-empty: the first death, or the first re-death after every
+      # dead jid was manually retried back into the live set (#212 — that
+      # retry's BATCH_PUSH cleared the death mark). The mark — durable `death`
+      # flag, `death_at`, `dead-batches` membership — is (re-)applied before
+      # the dedup guard so it is restored on re-death; the callback enqueue
+      # and parent cascade stay behind the guard so `:death` is enqueued at
+      # most once per batch.
       def fire_death(bid)
-        return unless dedup_set(bid, 'death')
-
         record_event(bid, 'death_at')
         Wurk.redis { |conn| conn.call('ZADD', 'dead-batches', Time.now.to_f.to_s, bid) }
+        return unless dedup_set(bid, 'death')
+
         enqueue_callbacks(bid, 'death')
         cascade_death(bid)
       end

--- a/lib/wurk/client.rb
+++ b/lib/wurk/client.rb
@@ -306,8 +306,9 @@ module Wurk
           eval_method,
           conn,
           :batch_push,
-          keys: ["b-#{j['bid']}", "b-#{j['bid']}-jids", "queue:#{j['queue']}", 'queues'],
-          argv: [j['queue'], j['jid'], Wurk.dump_json(j)]
+          keys: ["b-#{j['bid']}", "b-#{j['bid']}-jids", "queue:#{j['queue']}", 'queues',
+                 "b-#{j['bid']}-died", 'dead-batches'],
+          argv: [j['queue'], j['jid'], Wurk.dump_json(j), j['bid']]
         )
       end
     end

--- a/lib/wurk/lua.rb
+++ b/lib/wurk/lua.rb
@@ -58,13 +58,31 @@ module Wurk
 
     # Pro Batch: register a job into a batch and push it to its queue
     # atomically. Keeps total/pending in sync with the jids set.
-    # KEYS = [b-<bid>, b-<bid>-jids, queue_list, queues_set]
-    # ARGV = [queue_name, jid, job_json]
+    #
+    # A jid found in `b-<bid>-died` is a manual retry of a dead job (morgue
+    # "retry" / "add to queue") — it rejoins the live set without recounting:
+    # total and pending already include it, because a death never decrements
+    # pending. When that drains the died set the batch is no longer dead, so
+    # the durable `death` success-suppression flag clears and the bid leaves
+    # `dead-batches` — a later full drain can then fire `:success` (spec §2.4:
+    # success after the dead job is manually retried to success). The
+    # `b-<bid>-death` notify dedup key is untouched, so `:death` cannot
+    # re-fire.
+    # KEYS = [b-<bid>, b-<bid>-jids, queue_list, queues_set, b-<bid>-died, dead-batches]
+    # ARGV = [queue_name, jid, job_json, bid]
     # Returns 1.
     BATCH_PUSH = <<~LUA
-      redis.call("hincrby", KEYS[1], "total", 1)
-      redis.call("hincrby", KEYS[1], "pending", 1)
-      redis.call("sadd", KEYS[2], ARGV[2])
+      if redis.call("srem", KEYS[5], ARGV[2]) == 1 then
+        redis.call("sadd", KEYS[2], ARGV[2])
+        if redis.call("scard", KEYS[5]) == 0 then
+          redis.call("hdel", KEYS[1], "death")
+          redis.call("zrem", KEYS[6], ARGV[4])
+        end
+      else
+        redis.call("hincrby", KEYS[1], "total", 1)
+        redis.call("hincrby", KEYS[1], "pending", 1)
+        redis.call("sadd", KEYS[2], ARGV[2])
+      end
       redis.call("sadd", KEYS[4], ARGV[1])
       redis.call("lpush", KEYS[3], ARGV[3])
       return 1

--- a/test/unit/batch_lifecycle_test.rb
+++ b/test/unit/batch_lifecycle_test.rb
@@ -22,6 +22,7 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
     @class_name = "BatchLifeJob@#{Process.pid}-#{object_id}"
     @queue      = "blq-#{Process.pid}-#{object_id}"
     @cbq        = "blcb-#{Process.pid}-#{object_id}"
+    @morgue     = "bldead-#{Process.pid}-#{object_id}"
     @bids       = []
   end
 
@@ -38,6 +39,7 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
         conn.call('DEL', "queue:#{q}")
         conn.call('SREM', 'queues', q)
       end
+      conn.call('DEL', @morgue)
     end
   ensure
     super
@@ -272,6 +274,82 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
     end
 
     assert_equal 0, Wurk::Batch::Status.new(batch.bid).failures
+  end
+
+  # --- #212: dead job manually retried to success ------------------------
+
+  # Spec §2.4: ":success never fires unless the dead job is manually retried
+  # to success." Full morgue round-trip: the job dies into the dead set, the
+  # operator hits "retry" (SortedEntry#retry → Client push → BATCH_PUSH), the
+  # retry succeeds, and the batch fires :success.
+  def test_dead_job_retried_from_morgue_to_success_fires_success # rubocop:disable Minitest/MultipleAssertions
+    batch = new_batch(success: 'S', complete: 'C', death: 'D')
+    batch.jobs { perform_one }
+    payload = queued(@queue).find { |j| j['bid'] == batch.bid }
+    jid = payload.fetch('jid')
+
+    morgue = Wurk::DeadSet.new(@morgue)
+    morgue.kill(JSON.dump(payload))
+
+    assert_equal 1, callbacks_fired(event: 'death', bid: batch.bid)
+    assert_equal 0, callbacks_fired(event: 'success', bid: batch.bid)
+
+    morgue.find_job(jid).retry
+    status = Wurk::Batch::Status.new(batch.bid)
+
+    assert_equal 1, status.total, 'manual retry must not recount total'
+    assert_equal 1, status.pending, 'manual retry must not recount pending'
+    assert_empty status.dead_jids
+    assert_nil(@pool.with { |c| c.call('ZSCORE', 'dead-batches', batch.bid) },
+               'recovered batch must leave dead-batches')
+
+    ack_success(batch.bid, jid)
+
+    assert_equal 1, callbacks_fired(event: 'success', bid: batch.bid)
+    assert_equal 1, callbacks_fired(event: 'death', bid: batch.bid), ':death must not re-fire'
+    assert_equal 0, Wurk::Batch::Status.new(batch.bid).pending
+  end
+
+  # With two dead jobs, retrying only one must keep :success suppressed —
+  # the death mark clears only when the died set fully drains.
+  def test_success_stays_suppressed_while_another_dead_jid_remains
+    batch = new_batch(success: 'S', death: 'D')
+    batch.jobs { 2.times { perform_one } }
+    jid_a, jid_b = jids_for(@queue, batch.bid)
+    kill(batch.bid, jid_a)
+    kill(batch.bid, jid_b)
+
+    retry_dead_job(batch.bid, jid_a)
+    ack_success(batch.bid, jid_a)
+
+    assert_equal 0, callbacks_fired(event: 'success', bid: batch.bid)
+    assert_equal('1', @pool.with { |c| c.call('HGET', "b-#{batch.bid}", 'death') })
+    refute_nil(@pool.with { |c| c.call('ZSCORE', 'dead-batches', batch.bid) })
+  end
+
+  # A retried dead job that dies again re-marks the batch dead (durable flag
+  # + dead-batches) without re-enqueuing :death; a second retry that finally
+  # succeeds still fires :success.
+  def test_re_death_after_recovery_re_marks_dead_without_refiring_death # rubocop:disable Minitest/MultipleAssertions
+    batch = new_batch(success: 'S', death: 'D')
+    batch.jobs { perform_one }
+    jid = jid_for(@queue, batch.bid)
+    kill(batch.bid, jid)
+
+    retry_dead_job(batch.bid, jid)
+    kill(batch.bid, jid)
+
+    assert_equal 1, callbacks_fired(event: 'death', bid: batch.bid), ':death enqueues at most once'
+    assert_equal('1', @pool.with { |c| c.call('HGET', "b-#{batch.bid}", 'death') },
+                 're-death must restore the durable death mark')
+    refute_nil(@pool.with { |c| c.call('ZSCORE', 'dead-batches', batch.bid) },
+               're-death must restore dead-batches membership')
+    assert_equal 0, callbacks_fired(event: 'success', bid: batch.bid)
+
+    retry_dead_job(batch.bid, jid)
+    ack_success(batch.bid, jid)
+
+    assert_equal 1, callbacks_fired(event: 'success', bid: batch.bid)
   end
 
   # --- nested death cascade ----------------------------------------------
@@ -628,6 +706,13 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
 
   def kill(bid, jid)
     Wurk::Batch::DeathHandler.call({ 'bid' => bid, 'jid' => jid }, RuntimeError.new('boom'))
+  end
+
+  # The morgue "retry" path without the morgue: re-push the dead job's
+  # payload through Wurk::Client, exactly what SortedEntry#retry does after
+  # removing the entry from the dead zset.
+  def retry_dead_job(bid, jid)
+    Wurk::Client.push('class' => @class_name, 'args' => [], 'queue' => @queue, 'bid' => bid, 'jid' => jid)
   end
 
   def build_server_middleware

--- a/test/unit/encryption_test.rb
+++ b/test/unit/encryption_test.rb
@@ -434,7 +434,8 @@ class EncryptionTest < Wurk::Test::UnitCase
   def test_decryption_failure_fires_death_handlers # rubocop:disable Metrics/AbcSize
     ENABLE_MUTEX.synchronize do
       fired = []
-      Wurk.configuration.death_handlers << ->(j, ex) { fired << [j['jid'], ex.class] }
+      handler = ->(j, ex) { fired << [j['jid'], ex.class] }
+      Wurk.configuration.death_handlers << handler
       Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
       env = Wurk::Encryption.encrypt('x')
       Wurk::Encryption.disable!
@@ -444,7 +445,11 @@ class EncryptionTest < Wurk::Test::UnitCase
       assert_raises(Wurk::JobRetry::Skip) { invoke_server(job) { :unreached } }
       assert_equal [[jid, Wurk::Encryption::KeyMissingError]], fired
     ensure
-      Wurk.configuration.death_handlers.clear
+      # Drop only the handler this test added; `.clear` would wipe
+      # Wurk::Batch::DeathHandler and Wurk::Unique::DEATH_HANDLER (registered
+      # at load time on the process-global config), leaking emptiness into
+      # whatever test the parallel-fork worker runs next.
+      Wurk.configuration.death_handlers.delete(handler) if handler
       drain_dead(jid)
     end
   end

--- a/test/unit/lua_test.rb
+++ b/test/unit/lua_test.rb
@@ -152,7 +152,9 @@ class LuaTest < Wurk::Test::UnitCase
     qset  = "#{@ns}:queues"
     @pool.with do |c|
       Wurk::Lua::Loader.eval_cached(
-        c, :batch_push, keys: [bkey, jids, list, qset], argv: ['default', 'JID1', '{"jid":"JID1"}']
+        c, :batch_push,
+        keys: [bkey, jids, list, qset, "#{@ns}:b-x-died", "#{@ns}:dead-batches"],
+        argv: ['default', 'JID1', '{"jid":"JID1"}', 'x']
       )
 
       assert_equal '1', c.call('HGET', bkey, 'total')
@@ -160,6 +162,62 @@ class LuaTest < Wurk::Test::UnitCase
       assert_equal 1, c.call('SISMEMBER', jids, 'JID1')
       assert_equal 1, c.call('LLEN', list)
       assert_equal 1, c.call('SISMEMBER', qset, 'default')
+      c.call('DEL', list)
+    end
+  end
+
+  # #212: pushing a jid found in the died set is a manual retry of a dead
+  # job — it rejoins the live set without recounting (total/pending already
+  # include it), and draining the died set clears the death mark so a later
+  # full drain can fire :success.
+  def test_batch_push_dead_jid_rejoins_live_set_without_recount # rubocop:disable Minitest/MultipleAssertions
+    bkey = "#{@ns}:b-dr"
+    jids = "#{@ns}:b-dr-jids"
+    died = "#{@ns}:b-dr-died"
+    dead = "#{@ns}:dead-batches"
+    list = "#{@ns}:queue:default"
+    @pool.with do |c|
+      c.call('HSET', bkey, 'total', 1, 'pending', 1, 'death', 1)
+      c.call('SADD', died, 'JID1')
+      c.call('ZADD', dead, 1, 'dr')
+
+      Wurk::Lua::Loader.eval_cached(
+        c, :batch_push,
+        keys: [bkey, jids, list, "#{@ns}:queues", died, dead],
+        argv: ['default', 'JID1', '{"jid":"JID1"}', 'dr']
+      )
+
+      assert_equal '1', c.call('HGET', bkey, 'total')
+      assert_equal '1', c.call('HGET', bkey, 'pending')
+      assert_equal 1, c.call('SISMEMBER', jids, 'JID1')
+      assert_equal 0, c.call('SCARD', died)
+      assert_nil c.call('HGET', bkey, 'death'), 'death suppression must clear when died drains'
+      assert_nil c.call('ZSCORE', dead, 'dr'), 'bid must leave dead-batches'
+      assert_equal 1, c.call('LLEN', list)
+      c.call('DEL', list)
+    end
+  end
+
+  def test_batch_push_dead_jid_keeps_death_mark_while_other_dead_jids_remain
+    bkey = "#{@ns}:b-dp"
+    jids = "#{@ns}:b-dp-jids"
+    died = "#{@ns}:b-dp-died"
+    dead = "#{@ns}:dead-batches"
+    list = "#{@ns}:queue:default"
+    @pool.with do |c|
+      c.call('HSET', bkey, 'total', 2, 'pending', 2, 'death', 1)
+      c.call('SADD', died, 'JID1', 'JID2')
+      c.call('ZADD', dead, 1, 'dp')
+
+      Wurk::Lua::Loader.eval_cached(
+        c, :batch_push,
+        keys: [bkey, jids, list, "#{@ns}:queues", died, dead],
+        argv: ['default', 'JID1', '{"jid":"JID1"}', 'dp']
+      )
+
+      assert_equal %w[JID2], c.call('SMEMBERS', died)
+      assert_equal '1', c.call('HGET', bkey, 'death'), 'death mark must persist while a dead jid remains'
+      refute_nil c.call('ZSCORE', dead, 'dp'), 'bid must stay in dead-batches'
       c.call('DEL', list)
     end
   end


### PR DESCRIPTION
## Summary

Sidekiq Pro spec §2.4: ":success and :death are not mutually exclusive — death fires first, success never fires **unless the dead job is manually retried to success**." In Wurk that path was impossible — once any batch job died, `:success` was permanently suppressed even after the operator retried the dead job from the morgue and it succeeded.

Closes #212.

### Actual mechanism (differs slightly from the issue's theory)

The issue predicted the success-ack would hit the `[-1, -1]` short-circuit. In reality `Client#raw_push` routes **every** bid-carrying payload through `BATCH_PUSH`, so the morgue retry re-added the jid to the live set and re-incremented `total`/`pending` (double count). The success ack then took the normal path — but `pending` could never drain to 0 (the death never decremented it, and the retry re-incremented it), and the durable `death` flag suppressed `:success` regardless. Two independent blocks, both fixed at the `BATCH_PUSH` chokepoint:

1. **`BATCH_PUSH` (lib/wurk/lua.rb)** — a pushed jid found in `b-<bid>-died` is a manual retry of a dead job: it rejoins the live set **without** recounting (`total`/`pending` already include it, since a death never decrements `pending`). When that drains the died set, the batch is no longer dead: the durable `death` suppression flag clears and the bid leaves `dead-batches`. The `b-<bid>-death` notify dedup key is untouched, so `:death` cannot re-fire.
2. **`Callbacks.fire_death`** — the death mark (`death` flag, `death_at`, `dead-batches` membership) now (re-)applies *before* the notify dedup guard, so a retried job that dies **again** re-marks the batch dead — while the dedup guard still caps the `:death` callback at one enqueue per batch.

### Done when (from #212)

- [x] Dead batch job → manual retry (morgue "retry") → succeeds → batch fires `:success`
- [x] `:death` still fires exactly once
- [x] Test covering die → manual retry → success

### Tests

- `lua_test.rb`: died-jid re-push rejoins live set without recount + clears the death mark when died drains; mark persists while another dead jid remains.
- `batch_lifecycle_test.rb`: full morgue round-trip (`DeadSet#kill` → `SortedEntry#retry` → success → `:success` fires, `:death` exactly once); partial-recovery suppression (second dead jid keeps `:success` suppressed); re-death after recovery re-marks dead without re-firing `:death`, and a second retry to success still fires `:success`.

QA driver (`/tmp/wurk_qa_212.rb`, output in PR conversation): 14/14 checks pass on this branch; 7 fail on main including `:success FIRED got=0 want=1`.

## How to test in prod

```ruby
# Rails console / bin/rails runner — uses your live Redis, cleans up after itself.
batch = Sidekiq::Batch.new
batch.description = "212 verify"
batch.on(:success, "SomeCallbackClass")   # any class with on_success
batch.on(:death,   "SomeCallbackClass")   # and on_death
batch.jobs { HardJob.perform_async }      # a job you can make raise

# 1. Let the job exhaust retries (or kill it from the dashboard "Retries" page).
#    → :death fires, batch appears under "Dead batches",
#      Sidekiq::Batch::Status.new(batch.bid).dead_jids == [jid]
# 2. Fix the underlying issue, then hit "Retry" on the job in the Dead (morgue) page.
# 3. When the retry succeeds:
Sidekiq::Batch::Status.new(batch.bid).data
#    → pending: 0, dead_jids: [], success_at set — and your on_success ran.
#    The batch is gone from "Dead batches"; :death did NOT fire a second time.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
