### PR TITLE
fix(pro): ancestor batch :success fires after a descendant's dead job is retried to success (#226)

### DIFF
--- a/lib/wurk/batch/callbacks.rb
+++ b/lib/wurk/batch/callbacks.rb
@@ -33,7 +33,7 @@ module Wurk
         return unless kids_finished?(bid)
 
         fire_complete(bid)
-        fire_success(bid) if pending.zero? && !death_fired?(bid)
+        fire_success(bid) if pending.zero? && !subtree_dead?(bid)
         propagate_to_parent(bid)
       end
 
@@ -146,6 +146,50 @@ module Wurk
         Wurk.redis { |conn| conn.call('HGET', "b-#{bid}", 'death') } == '1'
       end
 
+      # A batch's subtree is still dead while it carries the durable death
+      # mark OR any direct child does — deaths cascade up the parent chain,
+      # so a dead descendant keeps every ancestor's child marked. This gates
+      # `:success`, which must never fire while a job in the subtree is
+      # terminally dead (spec §2.4). The child check matters for the brief
+      # window where a batch with both its own dead job and a dead child has
+      # its OWN dead job retried to success: BATCH_PUSH (#212) clears that
+      # batch's own mark when its died set drains, but the child subtree is
+      # still dead, so `death_fired?` alone would wrongly let `:success` fire.
+      def subtree_dead?(bid)
+        death_fired?(bid) || any_child_dead?(bid)
+      end
+
+      # Recovery counterpart to cascade_death (#226). When a descendant's
+      # last dead job is manually retried back to success, the descendant
+      # clears its OWN death mark (#212, in BATCH_PUSH) — but every ancestor
+      # was marked by the death *cascade*, not by a jid in its own died set,
+      # so nothing here ever cleared them and the ancestor's `:success`
+      # stayed suppressed forever. Re-evaluate this batch: drop its durable
+      # death mark and `dead-batches` membership once its own died set is
+      # empty AND no child still carries a death mark. The `b-<bid>-death`
+      # notify dedup key is deliberately left intact, so a later re-death
+      # re-marks the batch (fire_death restores the flag before its own
+      # dedup guard) without ever re-enqueuing `:death`.
+      def clear_death_on_recovery(bid)
+        return unless death_fired?(bid)
+        return if own_died_remaining?(bid)
+        return if any_child_dead?(bid)
+
+        Wurk.redis do |conn|
+          conn.call('HDEL', "b-#{bid}", 'death')
+          conn.call('ZREM', 'dead-batches', bid)
+        end
+      end
+
+      def own_died_remaining?(bid)
+        Wurk.redis { |conn| conn.call('SCARD', "b-#{bid}-died") }.to_i.positive?
+      end
+
+      def any_child_dead?(bid)
+        kids = Wurk.redis { |conn| conn.call('SMEMBERS', "b-#{bid}-kids") }
+        kids.any? { |kid| death_fired?(kid) }
+      end
+
       # Per-callback rescue: one bad spec or a transient enqueue failure must
       # not strand the batch with the remaining callbacks for this event
       # un-enqueued. Log and move on so every other callback still fires.
@@ -196,6 +240,11 @@ module Wurk
         return if parent_bid.nil? || parent_bid.empty?
         return unless pkids_drained?(parent_bid, bid)
 
+        # A recovered child may have lifted the last death from the parent's
+        # subtree — clear the parent's cascaded mark before its gate runs, so
+        # `:success` can fire. Harmless on the death path: the dying child
+        # still carries its mark, so any_child_dead? keeps the parent dead.
+        clear_death_on_recovery(parent_bid)
         maybe_fire(parent_bid, pending: pending_for(parent_bid), live: live_for(parent_bid))
       end
 

--- a/test/unit/batch_lifecycle_test.rb
+++ b/test/unit/batch_lifecycle_test.rb
@@ -516,6 +516,42 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
                  'a second recovery still fires parent :success'
   end
 
+  # Retry window race (raised in PR #227 review): after a child's dead job has
+  # been retried (BATCH_PUSH cleared the *child's* death mark and re-added the
+  # jid to child.live) but BEFORE the worker actually runs it, the parent's
+  # own job acks. The original death cascade already SREM'd the child from the
+  # parent's pkids set and BATCH_PUSH doesn't re-add it — so kids_finished?
+  # is true. But the parent's own cascaded death mark is untouched (BATCH_PUSH
+  # operates on the child bid only; clear_death_on_recovery only runs from a
+  # *successful* child drain via propagate_to_parent), so subtree_dead? is
+  # still true and :success must stay suppressed until the retried job
+  # actually succeeds.
+  def test_parent_own_ack_in_retry_window_keeps_success_suppressed # rubocop:disable Minitest/MultipleAssertions
+    parent, child = nested(parent_cbs: { success: 'ParentSuccess', death: 'ParentDeath' },
+                           child_cbs: { success: 'ChildSuccess' })
+    parent_jid = jid_for(@queue, parent.bid)
+    child_jid  = jid_for(@queue, child.bid)
+    kill(child.bid, child_jid)
+    retry_dead_job(child.bid, child_jid)
+
+    assert_nil(@pool.with { |c| c.call('HGET', "b-#{child.bid}", 'death') },
+               'BATCH_PUSH cleared the child mark — retry window has opened')
+    assert_equal('1', @pool.with { |c| c.call('HGET', "b-#{parent.bid}", 'death') },
+                 'BATCH_PUSH must not touch the parent — its cascaded mark stays set')
+
+    ack_success(parent.bid, parent_jid)
+
+    assert_equal 0, callbacks_fired(event: 'success', bid: parent.bid),
+                 ':success must not fire before the retried descendant job has actually succeeded'
+
+    ack_success(child.bid, child_jid)
+
+    assert_equal 1, callbacks_fired(event: 'success', bid: child.bid)
+    assert_equal 1, callbacks_fired(event: 'success', bid: parent.bid),
+                 ':success fires once the retried job acks and lifts the parent mark via propagate_to_parent'
+    assert_equal 1, callbacks_fired(event: 'death', bid: parent.bid), 'parent :death must not re-fire'
+  end
+
   # Mixed shape: a batch with BOTH its own dead job and a dead child. Retrying
   # only its own job (which drains its own died set and clears its own mark via
   # BATCH_PUSH) must not let :success fire while the child subtree is still

--- a/test/unit/batch_lifecycle_test.rb
+++ b/test/unit/batch_lifecycle_test.rb
@@ -393,6 +393,153 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
     assert_dead grand.bid, parent.bid
   end
 
+  # --- #226: descendant dead job retried to success lifts ancestor suppression
+
+  # Spec §2.4 across the parent chain: a child's job dies (cascading :death up
+  # to the parent), the operator retries it to success, the child fires
+  # :success, and the parent fires :success once its own work is done too.
+  def test_nested_descendant_recovery_fires_ancestor_success # rubocop:disable Minitest/MultipleAssertions
+    parent, child = nested(parent_cbs: { success: 'ParentSuccess', death: 'ParentDeath' },
+                           child_cbs: { success: 'ChildSuccess', death: 'ChildDeath' })
+    child_jid = jid_for(@queue, child.bid)
+    kill(child.bid, child_jid)
+
+    assert_equal 1, callbacks_fired(event: 'death', bid: parent.bid), 'child death cascades :death to the parent'
+    assert_dead parent.bid, child.bid
+
+    retry_dead_job(child.bid, child_jid)
+    ack_success(child.bid, child_jid)
+
+    assert_equal 1, callbacks_fired(event: 'success', bid: child.bid)
+    assert_equal 0, callbacks_fired(event: 'success', bid: parent.bid),
+                 'parent :success still waits on its own pending job'
+
+    ack_success(parent.bid, jid_for(@queue, parent.bid))
+
+    assert_equal 1, callbacks_fired(event: 'success', bid: parent.bid),
+                 'parent :success fires once the recovered subtree and its own work are done'
+    assert_equal 1, callbacks_fired(event: 'death', bid: parent.bid), 'parent :death must not re-fire'
+    assert_nil(@pool.with { |c| c.call('ZSCORE', 'dead-batches', parent.bid) }, 'recovered parent leaves dead-batches')
+  end
+
+  # A parent with two dead children must keep :success suppressed until BOTH
+  # recover — recovering only one leaves the parent's subtree still dead.
+  def test_ancestor_stays_suppressed_while_other_descendant_dead # rubocop:disable Minitest/MultipleAssertions
+    parent = new_batch(success: 'ParentSuccess', death: 'ParentDeath')
+    child_a = child_b = nil
+    parent.jobs do
+      perform_one # parent's own job — without it the parent gets an Empty marker
+      child_a = new_batch
+      child_a.jobs { perform_one }
+      child_b = new_batch
+      child_b.jobs { perform_one }
+    end
+    parent_jid = jid_for(@queue, parent.bid)
+    a_jid = jid_for(@queue, child_a.bid)
+    b_jid = jid_for(@queue, child_b.bid)
+    kill(child_a.bid, a_jid)
+    kill(child_b.bid, b_jid)
+
+    assert_equal 1, callbacks_fired(event: 'death', bid: parent.bid)
+
+    retry_dead_job(child_a.bid, a_jid)
+    ack_success(child_a.bid, a_jid)
+    ack_success(parent.bid, parent_jid)
+
+    assert_equal 0, callbacks_fired(event: 'success', bid: parent.bid),
+                 'parent stays suppressed while child_b is still dead'
+    assert_equal('1', @pool.with { |c| c.call('HGET', "b-#{parent.bid}", 'death') },
+                 'parent keeps its death mark while a descendant is dead')
+
+    retry_dead_job(child_b.bid, b_jid)
+    ack_success(child_b.bid, b_jid)
+
+    assert_equal 1, callbacks_fired(event: 'success', bid: parent.bid),
+                 'parent :success fires once every descendant has recovered'
+    assert_equal 1, callbacks_fired(event: 'death', bid: parent.bid)
+  end
+
+  # The clear walks the full chain: a leaf recovery must lift suppression on
+  # every ancestor up to the root.
+  def test_deep_recovery_fires_success_through_every_ancestor # rubocop:disable Minitest/MultipleAssertions
+    grand = new_batch(success: 'GrandSuccess', death: 'GrandDeath')
+    parent = child = nil
+    grand.jobs do
+      perform_one
+      parent = new_batch(success: 'ParentSuccess')
+      parent.jobs do
+        perform_one
+        child = new_batch(success: 'ChildSuccess')
+        child.jobs { perform_one }
+      end
+    end
+    child_jid = jid_for(@queue, child.bid)
+    kill(child.bid, child_jid)
+
+    assert_equal 1, callbacks_fired(event: 'death', bid: grand.bid), 'death cascades to the root'
+
+    retry_dead_job(child.bid, child_jid)
+    ack_success(child.bid, child_jid)
+    ack_success(parent.bid, jid_for(@queue, parent.bid))
+    ack_success(grand.bid, jid_for(@queue, grand.bid))
+
+    assert_equal 1, callbacks_fired(event: 'success', bid: child.bid)
+    assert_equal 1, callbacks_fired(event: 'success', bid: parent.bid)
+    assert_equal 1, callbacks_fired(event: 'success', bid: grand.bid),
+                 'leaf recovery lifts suppression all the way to the root'
+    assert_nil(@pool.with { |c| c.call('ZSCORE', 'dead-batches', grand.bid) })
+  end
+
+  # A descendant that dies again after recovery must re-mark every ancestor
+  # dead (durable flag + dead-batches) without re-enqueuing :death anywhere.
+  def test_descendant_re_death_re_marks_ancestors_without_refiring_death # rubocop:disable Minitest/MultipleAssertions
+    parent, child = nested(parent_cbs: { success: 'ParentSuccess', death: 'ParentDeath' },
+                           child_cbs: { death: 'ChildDeath' })
+    child_jid = jid_for(@queue, child.bid)
+
+    kill(child.bid, child_jid)
+    retry_dead_job(child.bid, child_jid)
+    kill(child.bid, child_jid)
+
+    assert_equal 1, callbacks_fired(event: 'death', bid: child.bid), 'child :death enqueues at most once'
+    assert_equal 1, callbacks_fired(event: 'death', bid: parent.bid), 'parent :death enqueues at most once'
+    assert_equal('1', @pool.with { |c| c.call('HGET', "b-#{parent.bid}", 'death') },
+                 're-death restores the parent death mark')
+    refute_nil(@pool.with { |c| c.call('ZSCORE', 'dead-batches', parent.bid) },
+               're-death restores parent dead-batches membership')
+
+    retry_dead_job(child.bid, child_jid)
+    ack_success(child.bid, child_jid)
+    ack_success(parent.bid, jid_for(@queue, parent.bid))
+
+    assert_equal 1, callbacks_fired(event: 'success', bid: parent.bid),
+                 'a second recovery still fires parent :success'
+  end
+
+  # Mixed shape: a batch with BOTH its own dead job and a dead child. Retrying
+  # only its own job (which drains its own died set and clears its own mark via
+  # BATCH_PUSH) must not let :success fire while the child subtree is still
+  # dead — subtree_dead? catches the still-dead child.
+  def test_own_recovery_stays_suppressed_while_child_subtree_dead
+    parent, child = nested(parent_cbs: { success: 'ParentSuccess', death: 'ParentDeath' })
+    parent_jid = jid_for(@queue, parent.bid)
+    child_jid  = jid_for(@queue, child.bid)
+    kill(child.bid, child_jid)
+    kill(parent.bid, parent_jid)
+
+    retry_dead_job(parent.bid, parent_jid)
+    ack_success(parent.bid, parent_jid)
+
+    assert_equal 0, callbacks_fired(event: 'success', bid: parent.bid),
+                 "parent's own recovery must not fire :success while the child is dead"
+
+    retry_dead_job(child.bid, child_jid)
+    ack_success(child.bid, child_jid)
+
+    assert_equal 1, callbacks_fired(event: 'success', bid: parent.bid),
+                 'parent :success fires once the child subtree also recovers'
+  end
+
   # --- per-callback rescue ----------------------------------------------
 
   def test_failing_callback_enqueue_does_not_strand_remaining_callbacks


### PR DESCRIPTION
## Summary

Follow-up to #212 / PR #225, which fixed the single-batch case: a dead job manually retried to success now clears the batch's own death mark and lets `:success` fire. The **nested** case was still blocked one level up.

When a child batch's job dies, `Callbacks.cascade_death` fires `:death` on every ancestor, setting each ancestor's durable `death` flag (`b-<bid>` hash) and `dead-batches` membership. If the dead job is later retried to success, the *child's* mark clears (its jid was in the child's `b-<bid>-died` set, drained by BATCH_PUSH), but the ancestors' flags were set by the cascade — not by a jid in their own `died` sets — so nothing ever cleared them. `death_fired?` then suppressed every ancestor's `:success` forever, even though the whole subtree eventually succeeded.

Closes #226.

## Fix

All in Ruby — **BATCH_PUSH Lua and the Redis key schema are untouched** (no new keys, no JSON-format change; only reads of existing `died`/`kids`/`dead-batches` keys plus the same `HDEL death` / `ZREM dead-batches` clear #212 already uses).

- **`clear_death_on_recovery(bid)`** — the recovery counterpart to `cascade_death`. Clears a batch's durable `death` flag and `dead-batches` membership once its own `died` set is empty **AND** no child in `b-<bid>-kids` still carries a death mark. Wired into `propagate_to_parent`, so a recovered descendant lifts suppression level by level up to the root. The `b-<bid>-death` notify dedup key is deliberately left intact, so a later re-death re-marks the batch (via `fire_death`'s pre-dedup `record_event`) **without ever re-enqueuing `:death`**.
- **`:success` gate hardened** from `!death_fired?` to `!subtree_dead?` (`death_fired? || any_child_dead?`). This covers the mixed shape where a batch has both its own dead job and a dead child: retrying only its own job drains its own `died` set and clears its own mark in BATCH_PUSH, but the child subtree is still dead — `any_child_dead?` keeps `:success` suppressed.

## Done when (from #226)

- [x] Child batch job dies → parent `:death` fires → dead job retried to success → child fires `:success` → parent fires `:success` once all its other work is done
- [x] Ancestor with a *different* still-dead descendant keeps `:success` suppressed
- [x] `:death` never re-enqueues per batch
- [x] Lifecycle tests covering the nested recovery chain (2-deep, 3-deep, two-sibling, re-death, mixed own+child)

## Tests

`test/unit/batch_lifecycle_test.rb`, new `#226` section:
- `test_nested_descendant_recovery_fires_ancestor_success` — child dies → cascade `:death` → retry to success → child `:success` → parent `:success` after its own job; `:death` not re-fired; parent leaves `dead-batches`.
- `test_ancestor_stays_suppressed_while_other_descendant_dead` — two dead children; recovering one keeps the parent suppressed; recovering both fires it.
- `test_deep_recovery_fires_success_through_every_ancestor` — leaf recovery lifts suppression all the way to the root (3-deep).
- `test_descendant_re_death_re_marks_ancestors_without_refiring_death` — re-death restores the ancestor mark + `dead-batches` without re-enqueuing `:death`; a second recovery still fires `:success`.
- `test_own_recovery_stays_suppressed_while_child_subtree_dead` — mixed own-job + dead-child shape.

**QA driver** (`/tmp/wurk_qa_226.rb`, real Redis, self-cleaning): **14/14 pass on this branch; 4 fail on `main`** (`parent :success FIRED got=0 want=1`, `parent left dead-batches got=true`, `fires once all recovered got=0`, `second recovery fires :success got=0`).

Full suite: `2282 runs, 0 failures, 0 errors` (NCPU=4).

## How to test in prod

```ruby
# Rails console / bin/rails runner — uses your live Redis, cleans up after itself.
parent = Sidekiq::Batch.new
parent.description = "226 verify"
parent.on(:success, "SomeCallbackClass")   # any class with on_success
parent.on(:death,   "SomeCallbackClass")   # and on_death
child_bid = nil
parent.jobs do
  HardJob.perform_async                     # parent's own job
  child = Sidekiq::Batch.new
  child.on(:success, "SomeCallbackClass")
  child.jobs { HardJob.perform_async }      # a job you can make raise
  child_bid = child.bid
end

# 1. Let the CHILD's job exhaust retries (or kill it from the Retries page).
#    → :death cascades: parent appears under "Dead batches",
#      Sidekiq::Batch::Status.new(parent.bid).data["death"] == 1
# 2. Fix the issue, then hit "Retry" on that job in the Dead (morgue) page.
# 3. Let the retry succeed, then let the parent's own job succeed:
Sidekiq::Batch::Status.new(parent.bid).data
#    → success_at is set, the parent is gone from "Dead batches",
#      and your parent on_success ran. :death did NOT fire a second time.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Success notifications for hierarchical batches no longer fire while any descendant subtree remains marked dead; suppression is now based on subtree state.

* **New Features**
  * Durable death marks are cleared when a subtree fully recovers, allowing completion notifications to fire again once all descendant work finishes.

* **Tests**
  * Added end-to-end scenarios covering nested recovery, race windows, re-death, and ancestor suppression behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->