### PR TITLE
feat(compat): `sidekiq` require entrypoint + shim gem + real ecosystem suite (#204)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ vendor/assets/dashboard/*
 # Bundler install path (ruby/setup-ruby bundler-cache installs gems here in CI).
 /vendor/bundle/
 
-# Ecosystem gem checkouts — cloned locally for `rake test:ecosystem`, never committed
-test/ecosystem/*/
-!test/ecosystem/.keep
+# Ecosystem harnesses (PIN + overlay Gemfile) are committed; the cloned gem
+# checkouts and per-harness lockfiles they produce are not.
+test/ecosystem/.checkouts/
+test/ecosystem/*/Gemfile.lock

--- a/bin/test-ecosystem
+++ b/bin/test-ecosystem
@@ -1,33 +1,78 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Run third-party Sidekiq ecosystem gem test suites against Wurk.
-# Each entry in test/ecosystem/ is a checked-out gem with its Gemfile
-# rewritten to point Sidekiq → Wurk (the alias layer in lib/wurk/compat.rb
-# makes this transparent).
+# Run third-party Sidekiq ecosystem gem test suites against Wurk (#204).
+#
+# Each test/ecosystem/<gem>/ directory is a thin harness:
+#   PIN     — upstream repo + SHA the suite runs from
+#   Gemfile — overlay mirroring the gem's own Gemfile, with `sidekiq`
+#             resolved to wurk's shim gem (ecosystem/sidekiq-shim) so the
+#             suite installs NO real sidekiq and runs entirely on wurk.
+#
+# Checkouts are cloned (cached) into test/ecosystem/.checkouts/ (gitignored).
+# The gem's suite hits real Redis; default DB 15 — override with
+# ECOSYSTEM_REDIS_URL. The DB is the suite's to trash; don't point it at
+# data you care about.
 
 cd "$(dirname "$0")/.."
+ROOT=$(pwd)
 
 ECOSYSTEM_DIR="test/ecosystem"
+CHECKOUTS="$ROOT/$ECOSYSTEM_DIR/.checkouts"
+REDIS_URL="${ECOSYSTEM_REDIS_URL:-redis://127.0.0.1:6379/15}"
 
-if [ ! -d "$ECOSYSTEM_DIR" ]; then
-  echo "no $ECOSYSTEM_DIR; nothing to run"
-  exit 0
-fi
-
+ran=0
 failures=0
-for gem_dir in "$ECOSYSTEM_DIR"/*/; do
-  [ -d "$gem_dir" ] || continue
-  name=$(basename "$gem_dir")
-  echo "==> $name"
-  if ! ( cd "$gem_dir" && bundle install --quiet && bundle exec rake test 2>&1 ); then
+for harness in "$ECOSYSTEM_DIR"/*/; do
+  [ -f "$harness/PIN" ] || continue
+  name=$(basename "$harness")
+  repo=$(awk '/^repo:/ {print $2}' "$harness/PIN")
+  sha=$(awk '/^sha:/ {print $2}' "$harness/PIN")
+  checkout="$CHECKOUTS/$name"
+
+  if [ ! -d "$checkout/.git" ]; then
+    git clone --quiet "$repo" "$checkout"
+  fi
+  if ! git -C "$checkout" cat-file -e "$sha^{commit}" 2>/dev/null; then
+    git -C "$checkout" fetch --quiet origin
+  fi
+  git -C "$checkout" checkout --quiet --force "$sha"
+
+  # Optional per-harness EXCLUDE: minitest --exclude patterns (one per line,
+  # comments allowed). Each exclusion documents WHY next to the pattern —
+  # e.g. a hardware-bound perf budget that fails identically on real sidekiq.
+  testopts=""
+  if [ -f "$harness/EXCLUDE" ]; then
+    while IFS= read -r pattern; do
+      case "$pattern" in ''|'#'*) continue ;; esac
+      # --exclude=… (one arg, leading dash) so rake_test_loader skips it
+      # instead of treating the pattern value as a test file.
+      testopts="$testopts --exclude=\"$pattern\""
+    done < "$harness/EXCLUDE"
+  fi
+
+  echo "==> $name @ $sha"
+  ran=$((ran + 1))
+  if ! (
+    cd "$checkout" &&
+    export BUNDLE_GEMFILE="$ROOT/$harness/Gemfile" \
+           ECOSYSTEM_CHECKOUT="$checkout" \
+           REDIS_URL="$REDIS_URL" \
+           TESTOPTS="$testopts" &&
+    bundle install --quiet &&
+    bundle exec rake test
+  ); then
     echo "FAIL: $name"
     failures=$((failures + 1))
   fi
 done
 
+if [ "$ran" -eq 0 ]; then
+  echo "no ecosystem harnesses found under $ECOSYSTEM_DIR (expected <gem>/PIN)"
+  exit 1
+fi
 if [ "$failures" -gt 0 ]; then
   echo "$failures ecosystem suite(s) failed"
   exit 1
 fi
-echo "all ecosystem suites passed"
+echo "all $ran ecosystem suite(s) passed"

--- a/bin/test-ecosystem
+++ b/bin/test-ecosystem
@@ -53,9 +53,17 @@ for harness in "$ECOSYSTEM_DIR"/*/; do
 
   echo "==> $name @ $sha"
   ran=$((ran + 1))
+  # CI's setup-ruby bundler-cache writes `deployment: true` to .bundle/config,
+  # which forbids creating a fresh lockfile and restricts gem resolution to
+  # what's already in vendor/bundle. Harness Gemfiles ship without a lockfile
+  # and pull in dev deps the parent wurk Gemfile doesn't have (sidekiq-cron
+  # wants `minitest ~> 5.15`; wurk's bundle has 6.x), so the harness install
+  # must resolve fresh against rubygems. Env vars override the local config.
   if ! (
     cd "$checkout" &&
     export BUNDLE_GEMFILE="$ROOT/$harness/Gemfile" \
+           BUNDLE_DEPLOYMENT=false \
+           BUNDLE_FROZEN=false \
            ECOSYSTEM_CHECKOUT="$checkout" \
            REDIS_URL="$REDIS_URL" \
            TESTOPTS="$testopts" &&

--- a/bin/test-ecosystem
+++ b/bin/test-ecosystem
@@ -53,17 +53,21 @@ for harness in "$ECOSYSTEM_DIR"/*/; do
 
   echo "==> $name @ $sha"
   ran=$((ran + 1))
-  # CI's setup-ruby bundler-cache writes `deployment: true` to .bundle/config,
-  # which forbids creating a fresh lockfile and restricts gem resolution to
-  # what's already in vendor/bundle. Harness Gemfiles ship without a lockfile
-  # and pull in dev deps the parent wurk Gemfile doesn't have (sidekiq-cron
-  # wants `minitest ~> 5.15`; wurk's bundle has 6.x), so the harness install
-  # must resolve fresh against rubygems. Env vars override the local config.
+  # Isolate the harness bundle from the parent wurk one. CI's setup-ruby
+  # bundler-cache leaves the parent's gems in vendor/bundle and its bundler
+  # config active (deployment/path); a harness install that inherits either is
+  # stranded on the parent's already-installed gem set and can't fetch a
+  # conflicting version. The conflict is real: wurk's Gemfile pins
+  # `minitest >= 5.20` (resolves to 6.x) while sidekiq-cron needs `~> 5.15`
+  # (< 6). BUNDLE_IGNORE_CONFIG drops all inherited config files and a
+  # harness-local BUNDLE_PATH (under the gitignored .checkouts/) keeps the
+  # parent's gems out of scope, so each harness resolves+installs fresh against
+  # rubygems. Overriding BUNDLE_DEPLOYMENT/FROZEN alone did not suffice.
   if ! (
     cd "$checkout" &&
     export BUNDLE_GEMFILE="$ROOT/$harness/Gemfile" \
-           BUNDLE_DEPLOYMENT=false \
-           BUNDLE_FROZEN=false \
+           BUNDLE_IGNORE_CONFIG=true \
+           BUNDLE_PATH="$checkout/.bundle/gems" \
            ECOSYSTEM_CHECKOUT="$checkout" \
            REDIS_URL="$REDIS_URL" \
            TESTOPTS="$testopts" &&

--- a/bin/test-ecosystem
+++ b/bin/test-ecosystem
@@ -53,18 +53,27 @@ for harness in "$ECOSYSTEM_DIR"/*/; do
 
   echo "==> $name @ $sha"
   ran=$((ran + 1))
-  # Isolate the harness bundle from the parent wurk one. CI's setup-ruby
-  # bundler-cache leaves the parent's gems in vendor/bundle and its bundler
-  # config active (deployment/path); a harness install that inherits either is
-  # stranded on the parent's already-installed gem set and can't fetch a
-  # conflicting version. The conflict is real: wurk's Gemfile pins
-  # `minitest >= 5.20` (resolves to 6.x) while sidekiq-cron needs `~> 5.15`
-  # (< 6). BUNDLE_IGNORE_CONFIG drops all inherited config files and a
-  # harness-local BUNDLE_PATH (under the gitignored .checkouts/) keeps the
-  # parent's gems out of scope, so each harness resolves+installs fresh against
-  # rubygems. Overriding BUNDLE_DEPLOYMENT/FROZEN alone did not suffice.
+  # Run each harness in its own bundle, fully detached from the parent wurk
+  # one. Two things have to be true:
+  #
+  # 1. Detach from the OUTER `bundle exec rake test:ecosystem` we're running
+  #    inside. That export RUBYOPT=-r.../bundler/setup, BUNDLER_SETUP, and
+  #    GEM_HOME/GEM_PATH into our env, so a bare `bundle install` here is
+  #    hijacked: ruby auto-requires bundler/setup against the HARNESS Gemfile
+  #    before install runs, then can't find the (not-yet-installed) gems in the
+  #    parent's GEM_PATH and dies instantly with GemNotFound. Unset those vars
+  #    so the nested bundle starts clean — the shell-script equivalent of
+  #    Bundler.with_unbundled_env.
+  # 2. Don't inherit the parent's gem set or config. wurk's Gemfile pins
+  #    `minitest >= 5.20` (resolves to 6.x) while sidekiq-cron needs `~> 5.15`
+  #    (< 6) — a real conflict. A harness-local BUNDLE_PATH (under the
+  #    gitignored .checkouts/) and BUNDLE_IGNORE_CONFIG (drops inherited config
+  #    files) keep the parent's gems out of scope, so each harness
+  #    resolves+installs fresh against rubygems.
   if ! (
     cd "$checkout" &&
+    unset RUBYOPT RUBYLIB BUNDLER_SETUP BUNDLER_VERSION BUNDLE_BIN_PATH \
+          GEM_HOME GEM_PATH BUNDLE_GEMFILE BUNDLE_PATH &&
     export BUNDLE_GEMFILE="$ROOT/$harness/Gemfile" \
            BUNDLE_IGNORE_CONFIG=true \
            BUNDLE_PATH="$checkout/.bundle/gems" \

--- a/ecosystem/sidekiq-shim/README.md
+++ b/ecosystem/sidekiq-shim/README.md
@@ -1,0 +1,27 @@
+# sidekiq → wurk shim gem
+
+Satisfies a `sidekiq` gem dependency with [wurk](https://github.com/developerz-ai/wurk).
+
+Ecosystem gems (sidekiq-cron, sidekiq-unique-jobs, …) declare
+`add_dependency "sidekiq"`. Without this shim, bundling one of them installs
+**real Sidekiq alongside wurk** and `require "sidekiq"` loads a broken hybrid.
+With it, bundler resolves that dependency to wurk:
+
+```ruby
+# Gemfile
+gem "wurk"
+gem "sidekiq", github: "developerz-ai/wurk", glob: "ecosystem/sidekiq-shim/*.gemspec"
+gem "sidekiq-cron" # or any other ecosystem gem
+```
+
+The shim's version mirrors the Sidekiq release wurk targets
+(`Sidekiq::VERSION` in `lib/wurk/compat.rb`), so ecosystem gems' version
+gates resolve exactly as they would upstream.
+
+**Never published to rubygems.org** — the `sidekiq` name belongs to Sidekiq.
+Git/path consumption only. This is the standard bundler mechanism for
+substituting a dependency by name.
+
+Used by wurk's own ecosystem-compat CI: `bin/rake test:ecosystem` runs real
+ecosystem gems' test suites against wurk through this shim
+(see `test/ecosystem/`).

--- a/ecosystem/sidekiq-shim/lib/sidekiq.rb
+++ b/ecosystem/sidekiq-shim/lib/sidekiq.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# The whole gem: `require "sidekiq"` → wurk. The full family of
+# `require "sidekiq/…"` sub-paths is shipped by wurk itself (lib/sidekiq/),
+# so this file only needs to exist for the case where this shim's load path
+# is consulted before wurk's. Mirrors wurk's lib/sidekiq.rb, including
+# upstream sidekiq.rb's implicit Rails-integration load.
+require 'wurk'
+require 'sidekiq/rails' if defined?(Rails::Engine)

--- a/ecosystem/sidekiq-shim/sidekiq.gemspec
+++ b/ecosystem/sidekiq-shim/sidekiq.gemspec
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Bundler-level Sidekiq substitution (#204). Third-party ecosystem gems
+# declare `add_dependency "sidekiq"`; without this shim, bundling one of them
+# installs REAL sidekiq next to wurk and `require "sidekiq"` loads a
+# half-real/half-wurk hybrid (constant collisions, jobs running on sidekiq).
+# This gem satisfies that dependency with wurk instead:
+#
+#   gem "wurk"
+#   gem "sidekiq", github: "developerz-ai/wurk", glob: "ecosystem/sidekiq-shim/*.gemspec"
+#
+# Never published to rubygems.org (the name belongs to Sidekiq); it is only
+# consumable via git/path sources, which is exactly the override mechanism
+# bundler provides for this.
+
+# Single source of truth: mirror the Sidekiq release wurk targets
+# (Sidekiq::VERSION in lib/wurk/compat.rb) so ecosystem gems' version gates
+# (`add_dependency "sidekiq", ">= 6.5"` etc.) resolve the same as upstream.
+compat = File.read(File.expand_path('../../lib/wurk/compat.rb', __dir__))
+sidekiq_version = compat[/VERSION\s*=\s*'([^']+)'/, 1] or raise 'Sidekiq::VERSION not found in lib/wurk/compat.rb'
+
+Gem::Specification.new do |spec|
+  spec.name        = 'sidekiq'
+  spec.version     = sidekiq_version
+  spec.authors     = ['developerz.ai']
+  spec.email       = ['admin@developerz.ai']
+
+  spec.summary     = 'Shim: satisfies a `sidekiq` gem dependency with wurk.'
+  spec.description = 'Loads wurk when a gem depends on sidekiq. Git/path consumption only — never published.'
+  spec.homepage    = 'https://github.com/developerz-ai/wurk'
+  spec.license     = 'MIT'
+
+  spec.required_ruby_version = '>= 3.2.0'
+  spec.metadata['rubygems_mfa_required'] = 'true'
+
+  spec.files         = Dir['lib/**/*.rb', 'README.md']
+  spec.require_paths = ['lib']
+
+  spec.add_dependency 'wurk'
+end

--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Drop-in require entrypoint (#204): `require "sidekiq"` loads Wurk and its
+# Sidekiq::* alias layer (lib/wurk/compat.rb), so code and third-party gems
+# written against Sidekiq load Wurk without changing a single require. The
+# sibling files under lib/sidekiq/ cover the documented `require "sidekiq/…"`
+# sub-paths the ecosystem uses; all are one-line passthroughs because Wurk
+# loads its full surface (web included) from the single "wurk" entrypoint.
+#
+# Bundler-level substitution (a gem's `add_dependency "sidekiq"`) is handled
+# by the companion shim gem in ecosystem/sidekiq-shim/.
+require 'wurk'
+
+# Upstream sidekiq.rb does exactly this: a Rails host that Bundler.requires
+# the gem gets the Rails integration without a separate require.
+require_relative 'sidekiq/rails' if defined?(Rails::Engine)

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Drop-in require path (see lib/sidekiq.rb). Wurk loads this surface whole.
+require 'wurk'

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Drop-in require path (see lib/sidekiq.rb). In Sidekiq, `Sidekiq.server?`
+# is literally "has sidekiq/cli been required" — apps and ecosystem test
+# helpers require this file to make `configure_server` blocks run. Wurk
+# always loads its CLI class internally, so the passthrough carries the
+# *semantic*: requiring it declares this process a server.
+require 'wurk'
+Wurk.enter_server_mode

--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Drop-in require path (see lib/sidekiq.rb). Wurk loads this surface whole.
+require 'wurk'

--- a/lib/sidekiq/job.rb
+++ b/lib/sidekiq/job.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Drop-in require path (see lib/sidekiq.rb). Wurk loads this surface whole.
+require 'wurk'

--- a/lib/sidekiq/launcher.rb
+++ b/lib/sidekiq/launcher.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Drop-in require path (see lib/sidekiq.rb). Wurk loads this surface whole.
+require 'wurk'

--- a/lib/sidekiq/middleware/chain.rb
+++ b/lib/sidekiq/middleware/chain.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Drop-in require path (see lib/sidekiq.rb). Wurk loads this surface whole.
+require 'wurk'

--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Drop-in require path (see lib/sidekiq.rb): `require "sidekiq/rails"` in a
+# Sidekiq app loads the Rails integration. Sidekiq's is railtie-grade and
+# needs only railties — ecosystem test helpers load it with `rails/railtie`
+# alone, no ActionDispatch — so this maps to the railtie, NOT the dashboard
+# engine (a wurk-native extra; `require "wurk/rails"` for that). Sidekiq::Web
+# stays mountable as a plain Rack app either way, exactly like upstream.
+require 'wurk'
+require 'wurk/railtie'

--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Drop-in require path (see lib/sidekiq.rb). Wurk loads this surface whole.
+require 'wurk'

--- a/lib/sidekiq/scheduled.rb
+++ b/lib/sidekiq/scheduled.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Drop-in require path (see lib/sidekiq.rb). Wurk loads this surface whole.
+require 'wurk'

--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Drop-in require path (see lib/sidekiq.rb). Wurk loads this surface whole.
+require 'wurk'

--- a/lib/sidekiq/version.rb
+++ b/lib/sidekiq/version.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Drop-in require path (see lib/sidekiq.rb). Wurk loads this surface whole.
+require 'wurk'

--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Drop-in require path (see lib/sidekiq.rb). Wurk loads this surface whole.
+require 'wurk'

--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Drop-in require path (see lib/sidekiq.rb). Wurk loads this surface whole.
+require 'wurk'

--- a/lib/wurk/compat.rb
+++ b/lib/wurk/compat.rb
@@ -91,7 +91,10 @@ module Sidekiq
   Component        = Wurk::Component
   Config           = Wurk::Configuration
   Context          = Wurk::Context
-  Cron             = Wurk::Cron
+  # No `Sidekiq::Cron` alias on purpose (#204): real Sidekiq never defines it
+  # — that namespace belongs to the third-party sidekiq-cron gem, and squatting
+  # it made the gem's own classes (Poller, Job) collide at load. Wurk's native
+  # periodic surface is `Sidekiq::Periodic` (Ent parity) / `Wurk::Cron`.
   CronParser       = Wurk::Cron::Parser
   Periodic         = Wurk::Cron
   DeadSet          = Wurk::DeadSet
@@ -122,6 +125,7 @@ module Sidekiq
   ProfileSet       = Wurk::ProfileSet
   ProfileRecord    = Wurk::ProfileRecord
   Queue            = Wurk::Queue
+  RedisClientAdapter = Wurk::RedisClientAdapter
   RedisConnection  = Wurk::RedisConnection
   RetrySet         = Wurk::RetrySet
   Scheduled        = Wurk::Scheduled

--- a/lib/wurk/redis_client_adapter.rb
+++ b/lib/wurk/redis_client_adapter.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'redis-client'
+require 'redis_client/decorator'
+
+module Wurk
+  # Command-method compatibility for connections yielded by `Wurk.redis` /
+  # `Sidekiq.redis` (#204). Sidekiq 7+ yields RedisClientAdapter::CompatClient,
+  # so third-party gems write `conn.hgetall(...)` / `conn.smembers(...)` —
+  # method-style commands raw RedisClient doesn't answer (it only has #call).
+  # Every pooled connection is wrapped in this decorator at build time
+  # (RedisPool#build_client); wurk's own hot paths keep using #call, which the
+  # decorator forwards with a single delegation hop.
+  #
+  # Mirrors sidekiq-8.1.6 lib/sidekiq/redis_client_adapter.rb byte-for-byte in
+  # behavior: same fast-path command list, same deprecation warning, same
+  # error constants (gems rescue `Sidekiq::RedisClientAdapter::BaseError`).
+  class RedisClientAdapter
+    BaseError = RedisClient::Error
+    CommandError = RedisClient::CommandError
+
+    DEPRECATED_COMMANDS = %i[rpoplpush zrangebyscore zrevrange zrevrangebyscore getset hmset setex setnx].to_set
+
+    module CompatMethods
+      def info
+        @client.call('INFO') { |i| i.lines(chomp: true).map { |l| l.split(':', 2) }.select { |l| l.size == 2 }.to_h }
+      end
+
+      def evalsha(sha, keys, argv)
+        @client.call('EVALSHA', sha, keys.size, *keys, *argv)
+      end
+
+      # The Redis commands Sidekiq itself uses — defined eagerly so the
+      # common ones skip method_missing. Same list as upstream.
+      USED_COMMANDS = %w[bitfield bitfield_ro del exists expire flushdb
+                         get hdel hget hgetall hincrby hlen hmget hset hsetnx incr incrby
+                         lindex llen lmove lpop lpush lrange lrem mget mset ping pttl
+                         publish rpop rpush sadd scard script set sismember smembers
+                         srem ttl type unlink zadd zcard zincrby zrange zrem
+                         zremrangebyrank zremrangebyscore].freeze
+
+      USED_COMMANDS.each do |name|
+        define_method(name) do |*args, **kwargs|
+          @client.call(name, *args, **kwargs)
+        end
+      end
+
+      private
+
+      # `conn.hmset(...)` instead of redis-client's native `conn.call("hmset", ...)`.
+      def method_missing(*args, &)
+        if DEPRECATED_COMMANDS.include?(args.first)
+          warn("[sidekiq#5788] Redis has deprecated the `#{args.first}` command, called at #{caller(1..1)}")
+        end
+        @client.call(*args, &)
+      end
+      ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
+
+      def respond_to_missing?(_name, _include_private = false)
+        super # We can't tell what is a valid command.
+      end
+    end
+
+    CompatClient = RedisClient::Decorator.create(CompatMethods)
+
+    class CompatClient
+      def config
+        @client.config
+      end
+    end
+  end
+end

--- a/lib/wurk/redis_pool.rb
+++ b/lib/wurk/redis_pool.rb
@@ -2,6 +2,7 @@
 
 require 'redis-client'
 require 'connection_pool'
+require_relative 'redis_client_adapter'
 
 module Wurk
   # Per-process pool over redis-client + connection_pool. Never share a socket
@@ -56,8 +57,11 @@ module Wurk
 
     private
 
+    # Wrapped in the CompatClient decorator so `Sidekiq.redis { |c| c.smembers }`
+    # method-style commands work like Sidekiq 7+ (#204). Wurk's own code paths
+    # use #call, which the decorator forwards.
     def build_client
-      RedisClient.config(url: @url, timeout: @timeout).new_client
+      RedisClientAdapter::CompatClient.new(RedisClient.config(url: @url, timeout: @timeout).new_client)
     end
 
     def safe_close(conn)

--- a/lib/wurk/web.rb
+++ b/lib/wurk/web.rb
@@ -4,6 +4,7 @@ require_relative 'web/config'
 require_relative 'web/search'
 require_relative 'web/enterprise'
 require_relative 'web/batch_status'
+require_relative 'web/rack_app'
 
 module Wurk
   # Web UI namespace. Holds three sibling concerns:

--- a/lib/wurk/web/config.rb
+++ b/lib/wurk/web/config.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'forwardable'
+require 'rack/builder'
+
 module Wurk
   class Web
     # Web UI configuration. Holds the authorization callback documented in
@@ -22,6 +25,8 @@ module Wurk
     # When no block is registered, every request is authorized (matches
     # Sidekiq's default — no auth until the user opts in).
     class Config
+      extend Forwardable
+
       # String forms that mean "off" — so `config.web.read_only = ENV[...]`
       # doesn't flip on when the env var is "0"/"false"/empty.
       FALSEY_STRINGS = ['', '0', 'false', 'no', 'off'].freeze
@@ -32,6 +37,17 @@ module Wurk
       # self-hosted profiler instances.
       PROFILE_VIEW_URL  = 'https://profiler.firefox.com/public/%s'
       PROFILE_STORE_URL = 'https://api.profiler.firefox.com/compressed-store'
+
+      # Hash-style settings, same surface as Sidekiq::Web::Config (#204):
+      # gems and apps write `Sidekiq::Web.configure { |c| c[:csrf] = false }`.
+      # Seeded like upstream's OPTIONS; unknown keys are stored verbatim so a
+      # setting wurk doesn't consume still round-trips (e.g. :csrf — wurk's
+      # extension POST guard is the Sec-Fetch-Site check in
+      # ExtensionsController, spec §25.1, not a token).
+      OPTIONS = {
+        profile_view_url: PROFILE_VIEW_URL,
+        profile_store_url: PROFILE_STORE_URL
+      }.freeze
 
       # Sidekiq's built-in dashboard tabs (spec §25.3). The `tabs` hash starts
       # as a copy of this; extensions add to it via `register_extension` or by
@@ -52,29 +68,37 @@ module Wurk
       ].freeze
 
       # Host-app Rack middleware stacked in front of the dashboard, newest
-      # last. Each entry is `[middleware, args, block]`. Returns a frozen copy
-      # so the memoized chain (`#rack_app`) can only be invalidated through
-      # `#use` — direct mutation can't silently desync it.
-      def middlewares
-        @middlewares.dup.freeze
-      end
+      # last. Each entry is `[middleware, args, block]`. The LIVE array, like
+      # Sidekiq::Web::Config#middlewares — callers mutate it directly
+      # (sidekiq-cron's tests do `c.middlewares.clear`), so `#rack_app`
+      # detects drift instead of this returning a frozen copy.
+      attr_reader :middlewares
 
       def initialize
+        @options = OPTIONS.dup
         @authorization = nil
         @read_only = env_read_only?
         @read_only_message = nil
         @middlewares = []
         @rack_app = nil
-        @profile_view_url = nil
-        @profile_store_url = nil
         init_extensions!
       end
 
-      # Firefox-profiler URLs, overridable; default to the public instance.
-      attr_writer :profile_view_url, :profile_store_url
+      def_delegators :@options, :[], :[]=, :fetch, :key?, :has_key?, :merge!, :dig
 
-      def profile_view_url  = @profile_view_url || PROFILE_VIEW_URL
-      def profile_store_url = @profile_store_url || PROFILE_STORE_URL
+      # Firefox-profiler URLs — named views over the same @options keys the
+      # bracket surface exposes, so `c[:profile_view_url] = …` and
+      # `c.profile_view_url = …` can't drift apart.
+      def profile_view_url  = @options[:profile_view_url]
+      def profile_store_url = @options[:profile_store_url]
+
+      def profile_view_url=(value)
+        @options[:profile_view_url] = value
+      end
+
+      def profile_store_url=(value)
+        @options[:profile_store_url] = value
+      end
 
       # Optional banner copy shown by the dashboard in read-only mode. Nil →
       # the SPA falls back to its localized default ("Read-only mode"). Lets a
@@ -94,7 +118,11 @@ module Wurk
       # time. `tabs` is a mutable name→path hash seeded from DEFAULT_TABS;
       # `custom_job_info_rows` collects callables that add rows to the job
       # detail view; `app_url` / `assets_path` mirror Sidekiq's accessors.
-      attr_reader :tabs, :extensions
+      # `locales` is the mutable locale-directory list extensions append to
+      # (`Sidekiq::Web.configure.locales << dir`) — the Extension renderer's
+      # `t()` reads en.yml from every listed dir. Wurk's own SPA i18n is
+      # separate, so it starts empty.
+      attr_reader :tabs, :extensions, :locales
       attr_accessor :custom_job_info_rows, :app_url, :assets_path
 
       # Matches Sidekiq::Web::Config#register_extension (aliased `register`,
@@ -109,6 +137,9 @@ module Wurk
       def register_extension(extension, name:, tab:, index:, root_dir: nil,
                              cache_for: 86_400, asset_paths: nil)
         Array(tab).zip(Array(index)).each { |label, path| @tabs[label] = path if label }
+        # Upstream registers root_dir/locales automatically; extensions
+        # without a root_dir append their dir to `locales` themselves.
+        @locales << ::File.join(root_dir, 'locales') if root_dir
         @extensions << {
           extension: extension, name: name, tab: tab, index: index,
           root_dir: root_dir, cache_for: cache_for, asset_paths: asset_paths
@@ -164,17 +195,21 @@ module Wurk
         @rack_app = nil
       end
 
-      # Builds (once) the host-middleware chain wrapping `inner` and memoizes
-      # it on this Config. `reset_config!` swaps in a fresh Config, so each
-      # test rebuilds cleanly; production builds exactly once at boot.
+      # Builds the host-middleware chain wrapping `inner`, memoized against
+      # the middleware list it was built from — `middlewares` is the live
+      # array (upstream surface), so direct mutation after the first request
+      # triggers a rebuild instead of silently serving the stale chain.
+      # Production builds exactly once at boot; the per-request comparison is
+      # an == over a handful of entries.
       def rack_app(inner)
-        @rack_app ||= begin
-          stack = @middlewares
-          ::Rack::Builder.new do
-            stack.each { |middleware, args, block| use(middleware, *args, &block) }
-            run inner
-          end.to_app
-        end
+        return @rack_app if @rack_app && @rack_app_stack == @middlewares
+
+        @rack_app_stack = @middlewares.dup
+        stack = @middlewares
+        @rack_app = ::Rack::Builder.new do
+          stack.each { |middleware, args, block| use(middleware, *args, &block) }
+          run inner
+        end.to_app
       end
 
       # Read-only mode. When on, the Authorization middleware blocks every
@@ -191,13 +226,12 @@ module Wurk
       end
 
       def reset!
+        @options = OPTIONS.dup
         @authorization = nil
         @read_only = env_read_only?
         @read_only_message = nil
         @middlewares = []
         @rack_app = nil
-        @profile_view_url = nil
-        @profile_store_url = nil
         init_extensions!
       end
 
@@ -220,6 +254,7 @@ module Wurk
       def init_extensions!
         @tabs = DEFAULT_TABS.dup
         @extensions = []
+        @locales = []
         @custom_job_info_rows = []
         @app_url = nil
         @assets_path = nil
@@ -246,8 +281,11 @@ module Wurk
         @config ||= Config.new
       end
 
+      # With a block: yields the config (the documented configure form).
+      # Without: returns it — upstream's blockless-getter form, which gems
+      # use as `Sidekiq::Web.configure.tabs` (#204).
       def configure
-        yield config
+        block_given? ? yield(config) : config
       end
 
       # Class-level shorthand for `config.use` — mirrors `Sidekiq::Web.use`.

--- a/lib/wurk/web/extension.rb
+++ b/lib/wurk/web/extension.rb
@@ -125,11 +125,17 @@ module Wurk
           str
         end
 
-        # Engine-absolute base path for this extension, trailing slash, so an
-        # ext's `root_path + "locks"` links land back on our embed endpoint.
-        def root_path = "#{@mount}/ext/#{@ext_name}/"
+        # Base path for this extension, trailing slash. Embedded in the
+        # engine, ext links must land back on the embed endpoint
+        # (`/wurk/ext/<name>/…`); standalone (`run Sidekiq::Web`, #204) the
+        # ext's routes ARE the URL space, so it's the app root — upstream's
+        # `"#{env['SCRIPT_NAME']}/"` semantics.
+        def root_path = @embed ? "#{@mount}/ext/#{@ext_name}/" : "#{@mount}/"
         def current_path = @subpath.to_s.sub(%r{\A/}, '')
-        def asset_path(file) = "#{@mount}/ext-assets/#{@ext_name}/#{file}"
+
+        def asset_path(file)
+          @embed ? "#{@mount}/ext-assets/#{@ext_name}/#{file}" : "#{@mount}/#{@ext_name}/#{file}"
+        end
 
         # GET-form embeds don't need CSRF; return an empty, benign tag.
         def csrf_tag = ''
@@ -155,7 +161,7 @@ module Wurk
         # Internal-redirect signal carried out of a route block via throw/catch.
         Redirect = ::Struct.new(:location)
 
-        def initialize(env:, route_params:, ext:, mount:)
+        def initialize(env:, route_params:, ext:, mount:, embed: true)
           @env = env
           @request = ::Rack::Request.new(env)
           @route_params = route_params
@@ -163,6 +169,7 @@ module Wurk
           @root_dir = ext[:root_dir]
           @ext_strings = ext[:strings]
           @mount = mount.to_s
+          @embed = embed
           @subpath = env['wurk.ext.subpath']
           extend_helpers(ext[:helpers])
         end
@@ -213,7 +220,12 @@ module Wurk
           # @return [Array(Integer, Hash, String)] Rack-ish [status, headers,
           #   body] — 200 HTML, 302 redirect, or 404 — or nil when no extension
           #   with `name` is registered (so the engine can fall through).
-          def call(name:, method:, subpath:, env:, mount:)
+          # `embed: true` (the engine's ext/:name/* endpoint) rewrites links
+          # and redirects into the embed URL space; `embed: false` (the
+          # standalone `run Sidekiq::Web` Rack app, #204) leaves the
+          # extension's own route paths as the URL space, like upstream.
+          # rubocop:disable Metrics/ParameterLists -- request facts (name/verb/path/env) + URL-space (mount/embed); bundling them would just rename the list
+          def call(name:, method:, subpath:, env:, mount:, embed: true)
             ext = registered_extension(name)
             return nil unless ext
 
@@ -222,8 +234,9 @@ module Wurk
             return [404, html_headers, "No #{verb} route #{subpath} in extension #{name}"] unless route
 
             env['wurk.ext.subpath'] = subpath
-            render(ext, route_params, block, env, mount)
+            render(ext, route_params, block, env, { mount: mount, embed: embed })
           end
+          # rubocop:enable Metrics/ParameterLists
 
           # `[absolute_path, cache_for_seconds]` of an asset under the
           # extension's asset_paths, or nil if the extension/file isn't found.
@@ -247,10 +260,12 @@ module Wurk
             ::Wurk::Web.config.extensions.find { |e| e[:name].to_s == name.to_s }
           end
 
-          def render(ext, route_params, block, env, mount)
-            result = action_for(ext, route_params, env, mount).run(block)
+          # `ctx` is `{ mount:, embed: }` — the URL-space the response renders
+          # into (engine embed vs standalone root).
+          def render(ext, route_params, block, env, ctx)
+            result = action_for(ext, route_params, env, ctx).run(block)
             if result.is_a?(Action::Redirect)
-              [302, { 'Location' => redirect_target(result.location, ext, mount) }, '']
+              [302, { 'Location' => redirect_target(result.location, ext, ctx) }, '']
             else
               [200, html_headers, result.to_s]
             end
@@ -259,10 +274,10 @@ module Wurk
             [500, html_headers, "Extension render error: #{::CGI.escapeHTML(e.message)}"]
           end
 
-          def action_for(ext, route_params, env, mount)
+          def action_for(ext, route_params, env, ctx)
             app = captured_app(ext)
             Action.new(
-              env: env, route_params: route_params, mount: mount,
+              env: env, route_params: route_params, mount: ctx[:mount], embed: ctx[:embed],
               ext: ext.merge(helpers: { modules: app.helper_modules, blocks: app.helper_blocks },
                              strings: strings_for(ext))
             )
@@ -286,20 +301,35 @@ module Wurk
           end
 
           # An ext's redirect target is relative to its mount ("locks" → the
-          # embed endpoint). Absolute URLs pass through unchanged.
-          def redirect_target(location, ext, mount)
+          # embed endpoint; standalone → the app root, where root_path-built
+          # targets already carry the mount). Absolute URLs pass through.
+          def redirect_target(location, ext, ctx)
             loc = location.to_s
             return loc if loc.match?(%r{\A[a-z]+://}i)
+            return "#{ctx[:mount]}/ext/#{ext[:name]}/#{loc.sub(%r{\A/}, '')}" if ctx[:embed]
 
-            "#{mount}/ext/#{ext[:name]}/#{loc.sub(%r{\A/}, '')}"
+            loc.start_with?('/') ? loc : "#{ctx[:mount]}/#{loc}"
           end
 
+          # The ext's own root_dir/locales plus every dir appended to
+          # `config.locales` (the upstream protocol for extensions without a
+          # root_dir — sidekiq-cron does `Sidekiq::Web.configure.locales <<
+          # dir` inside `registered`, which `captured_app` has already run by
+          # the time we land here).
           def strings_for(ext)
             ext.fetch(:_strings) do
-              dir = ext[:root_dir]
-              file = dir && ::File.join(dir, 'locales', 'en.yml')
-              ext[:_strings] = (file && ::File.exist?(file) ? load_yaml(file) : {})
+              ext[:_strings] = locale_dirs(ext).each_with_object({}) do |dir, acc|
+                file = ::File.join(dir.to_s, 'en.yml')
+                acc.merge!(load_yaml(file)) if ::File.exist?(file)
+              end
             end
+          end
+
+          def locale_dirs(ext)
+            dirs = []
+            dirs << ::File.join(ext[:root_dir], 'locales') if ext[:root_dir]
+            dirs.concat(::Wurk::Web.config.locales)
+            dirs.uniq
           end
 
           def load_yaml(file)

--- a/lib/wurk/web/rack_app.rb
+++ b/lib/wurk/web/rack_app.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require_relative 'extension'
+
+module Wurk
+  class Web
+    # Upstream-compatible class-level Rack surface (#204): Sidekiq apps do
+    # `run Sidekiq::Web`, `mount Sidekiq::Web => "/sidekiq"`, and rack-test
+    # ecosystem suites call `Sidekiq::Web.call(env)` directly. Wurk's full
+    # dashboard is the engine-mounted SPA; this standalone entry serves the
+    # registered third-party Web extensions (#187's renderer) under their own
+    # route paths — the surface ecosystem gems exercise. Non-extension paths
+    # 404 rather than half-serving the SPA without its engine.
+    #
+    # Same CSRF model as upstream Sidekiq 8 and ExtensionsController (spec
+    # §25.1): unsafe methods must carry `Sec-Fetch-Site: same-origin`.
+    SAFE_METHODS = %w[GET HEAD OPTIONS TRACE].freeze
+    NOT_FOUND_HEADERS = { 'Content-Type' => 'text/plain' }.freeze
+
+    class << self
+      def call(env)
+        config.rack_app(method(:dispatch)).call(env)
+      end
+
+      private
+
+      def dispatch(env)
+        return [403, NOT_FOUND_HEADERS.dup, ['Forbidden']] unless safe_request?(env)
+
+        dispatch_to_extensions(env)
+      end
+
+      def safe_request?(env)
+        SAFE_METHODS.include?(env['REQUEST_METHOD']) ||
+          env['HTTP_SEC_FETCH_SITE'] == 'same-origin'
+      end
+
+      # First extension whose routes answer the path wins; a per-extension
+      # "no such route" 404 keeps scanning so extensions can't shadow each
+      # other, and is returned only when nothing else matched.
+      def dispatch_to_extensions(env)
+        not_found = nil
+        config.extensions.each do |ext|
+          result = extension_result(ext, env)
+          next unless result
+          return rackify(result) unless result[0] == 404
+
+          not_found ||= result
+        end
+        rackify(not_found || [404, NOT_FOUND_HEADERS.dup, 'Not Found'])
+      end
+
+      def extension_result(ext, env)
+        Extension::Renderer.call(
+          name: ext[:name], method: env['REQUEST_METHOD'],
+          subpath: env['PATH_INFO'].to_s, env: env, mount: env['SCRIPT_NAME'].to_s,
+          embed: false
+        )
+      end
+
+      # Renderer returns [status, headers, String]; Rack wants an each-able body.
+      def rackify((status, headers, body))
+        [status, headers, body.is_a?(::Array) ? body : [body.to_s]]
+      end
+    end
+  end
+end

--- a/lib/wurk/web/rack_app.rb
+++ b/lib/wurk/web/rack_app.rb
@@ -18,6 +18,16 @@ module Wurk
     NOT_FOUND_HEADERS = { 'Content-Type' => 'text/plain' }.freeze
 
     class << self
+      # Class-level Rack entry — wraps host-registered middleware (`Wurk::Web.use`)
+      # around the extensions dispatcher. INTENTIONALLY bypasses
+      # `Wurk::Web::Authorization` (`config.authorized?` + `config.read_only?`):
+      # the full dashboard with its auth/read-only enforcement is the
+      # engine-mounted SPA wired in `lib/wurk/engine.rb`, and the engine's
+      # middleware stack already includes `Authorization`. This standalone
+      # surface exists for ecosystem rack-test consumers (`Sidekiq::Web.call`)
+      # whose mounted-app expectations cover extension routes only — wrapping
+      # auth here would break `run Sidekiq::Web` / rack-test parity with
+      # upstream Sidekiq, which also doesn't auth-gate `Sidekiq::Web.call`.
       def call(env)
         config.rack_app(method(:dispatch)).call(env)
       end

--- a/test/ecosystem/README.md
+++ b/test/ecosystem/README.md
@@ -2,16 +2,25 @@
 
 Third-party Sidekiq gem test suites run against Wurk. The strongest possible drop-in proof.
 
-Each subdirectory is a checked-out gem (or a submodule pin) with its Gemfile rewritten to point Sidekiq → Wurk. The `lib/wurk/compat.rb` alias layer makes this transparent.
+Each `<gem>/` subdirectory is a thin harness — no vendored gem source:
+
+- `PIN` — upstream repo + tag + SHA the suite runs from
+- `Gemfile` — overlay mirroring the gem's own Gemfile, with `sidekiq` resolved
+  to wurk's shim gem (`ecosystem/sidekiq-shim`) and `wurk` to the repo root.
+  The bundle installs **no real sidekiq**; `require "sidekiq"` loads wurk's
+  alias layer via `lib/sidekiq.rb`.
+
+`bin/test-ecosystem` clones each pin into `.checkouts/` (gitignored, cached),
+checks out the SHA, and runs the gem's own `rake test` under the overlay
+Gemfile. The suite's failures are the spec: fix wurk, or document the
+divergence as intentional.
 
 Run: `bin/rake test:ecosystem` (wraps `bin/test-ecosystem`).
+Redis: real instance, DB 15 by default — override with `ECOSYSTEM_REDIS_URL`.
+The suite flushes its DB; don't point it at data you care about.
 
-Target gems (see `docs/idea/14-ecosystem-compat.md`):
-- sidekiq-cron
-- sidekiq-unique-jobs
-- sidekiq-scheduler
-- sidekiq-status
-- sidekiq-failures
-- sidekiq-throttled
+Current matrix:
+- sidekiq-cron (v2.4.0)
 
-A `.keep` is included so the directory exists; populate with checkouts when wiring this up.
+Target additions (see `docs/idea/14-ecosystem-compat.md`): sidekiq-unique-jobs,
+sidekiq-scheduler, sidekiq-status, sidekiq-failures, sidekiq-throttled.

--- a/test/ecosystem/sidekiq-cron/EXCLUDE
+++ b/test/ecosystem/sidekiq-cron/EXCLUDE
@@ -1,0 +1,7 @@
+# Minitest --exclude pattern(s), one per line, applied via TESTOPTS.
+#
+# Performance Poller: hardware-bound wall-clock budget (10k enqueues < 30s).
+# Fails identically with REAL sidekiq 8.1.6 on the same machine that fails
+# it with wurk (measured 2026-06-11: sidekiq 32.96s, wurk 33.40s — wurk
+# within 1.3% of upstream), so it measures the host, not drop-in parity.
+/Performance Poller/

--- a/test/ecosystem/sidekiq-cron/Gemfile
+++ b/test/ecosystem/sidekiq-cron/Gemfile
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Overlay Gemfile for the pinned sidekiq-cron checkout (see PIN). Mirrors the
+# gem's own Gemfile, except `sidekiq` resolves to wurk's shim gem instead of
+# real Sidekiq — the whole point of the ecosystem suite (#204). bin/test-ecosystem
+# sets ECOSYSTEM_CHECKOUT and runs the suite with BUNDLE_GEMFILE pointing here.
+
+source 'https://rubygems.org'
+
+gemspec path: ENV.fetch('ECOSYSTEM_CHECKOUT')
+
+wurk_root = File.expand_path('../../..', __dir__)
+gem 'sidekiq', path: File.join(wurk_root, 'ecosystem/sidekiq-shim')
+gem 'wurk', path: wurk_root
+
+# Upstream's Gemfile pins rails for its railtie/schedule-loader tests.
+gem 'rails', ENV.fetch('RAILS_VERSION', '~> 8.0')

--- a/test/ecosystem/sidekiq-cron/PIN
+++ b/test/ecosystem/sidekiq-cron/PIN
@@ -1,0 +1,5 @@
+# Upstream checkout this suite runs from. Bump sha only after re-running
+# `bin/rake test:ecosystem` green against the new tag.
+repo: https://github.com/sidekiq-cron/sidekiq-cron
+ref: v2.4.0
+sha: 3af55a8f29c99d1c5ea1452fe4595635c3ddf938

--- a/test/unit/compat_aliases_test.rb
+++ b/test/unit/compat_aliases_test.rb
@@ -124,8 +124,11 @@ class CompatAliasesTest < Wurk::Test::UnitCase
     assert_same Wurk::Context, Sidekiq::Context
   end
 
-  def test_cron_alias
-    assert_same Wurk::Cron, Sidekiq::Cron
+  def test_cron_namespace_not_squatted
+    # #204: Sidekiq::Cron is the sidekiq-cron gem's namespace, not Sidekiq
+    # surface — aliasing it broke the gem's load. Periodic is the real alias.
+    refute Sidekiq.const_defined?(:Cron, false)
+    assert_same Wurk::Cron, Sidekiq::Periodic
   end
 
   def test_metrics_alias

--- a/test/unit/cron_test.rb
+++ b/test/unit/cron_test.rb
@@ -668,8 +668,15 @@ class CronTest < Wurk::Test::UnitCase
   # ---- Sidekiq aliases ------------------------------------------------
 
   def test_aliased_under_sidekiq_namespace
-    assert_same Wurk::Cron, Sidekiq::Cron
     assert_same Wurk::Cron, Sidekiq::Periodic
+  end
+
+  # #204: `Sidekiq::Cron` belongs to the third-party sidekiq-cron gem — real
+  # Sidekiq never defines it. Wurk must leave the namespace free so the gem's
+  # own classes (Poller, Job) can load against wurk without colliding.
+  def test_sidekiq_cron_namespace_left_free_for_the_ecosystem_gem
+    refute Sidekiq.const_defined?(:Cron, false),
+           'Sidekiq::Cron must stay undefined — it is sidekiq-cron the gem, not Sidekiq surface'
   end
 
   def test_constants_match_spec_keys

--- a/test/unit/redis_client_adapter_test.rb
+++ b/test/unit/redis_client_adapter_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# #204: connections yielded by Wurk.redis / Sidekiq.redis answer method-style
+# commands (`conn.hgetall`, `conn.smembers`, …) like Sidekiq 7+'s
+# RedisClientAdapter::CompatClient — the surface every ecosystem gem uses.
+class RedisClientAdapterTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @pool = Wurk.configuration.redis_pool
+    @key = "rca-#{Process.pid}-#{object_id}"
+  end
+
+  def teardown
+    @pool.with { |c| c.call('DEL', @key) }
+    super
+  end
+
+  def test_alias_exposes_adapter_and_error_constants
+    assert_same Wurk::RedisClientAdapter, Sidekiq::RedisClientAdapter
+    assert_same RedisClient::Error, Sidekiq::RedisClientAdapter::BaseError
+    assert_same RedisClient::CommandError, Sidekiq::RedisClientAdapter::CommandError
+  end
+
+  def test_used_commands_answer_method_style
+    @pool.with do |conn|
+      conn.set(@key, 'v')
+
+      assert_equal 'v', conn.get(@key)
+      assert_equal 1, conn.exists(@key)
+    end
+  end
+
+  def test_hash_commands_round_trip
+    @pool.with do |conn|
+      conn.hset(@key, 'a', '1', 'b', '2')
+
+      assert_equal({ 'a' => '1', 'b' => '2' }, conn.hgetall(@key))
+      assert_equal %w[1 2], conn.hmget(@key, 'a', 'b')
+    end
+  end
+
+  def test_call_still_works_through_the_decorator
+    @pool.with do |conn|
+      assert_equal 'PONG', conn.call('PING')
+    end
+  end
+
+  def test_unlisted_command_routes_through_method_missing
+    @pool.with do |conn|
+      assert_equal 'hello', conn.echo('hello')
+    end
+  end
+
+  def test_deprecated_command_warns_and_still_executes
+    @pool.with do |conn|
+      assert_output(nil, /deprecated.*hmset/m) { conn.hmset(@key, 'f', 'v') }
+      assert_equal 'v', conn.hget(@key, 'f')
+    end
+  end
+
+  def test_info_returns_parsed_hash
+    @pool.with do |conn|
+      info = conn.info
+
+      assert_kind_of Hash, info
+      assert info.key?('redis_version')
+    end
+  end
+
+  def test_evalsha_uses_sidekiq_arg_shape
+    @pool.with do |conn|
+      sha = conn.call('SCRIPT', 'LOAD', 'return redis.call("GET", KEYS[1])')
+      conn.set(@key, 'lua')
+
+      assert_equal 'lua', conn.evalsha(sha, [@key], [])
+    end
+  end
+
+  def test_config_is_delegated
+    @pool.with do |conn|
+      assert_respond_to conn.config, :host
+    end
+  end
+
+  def test_pipelined_yields_compat_pipeline
+    @pool.with do |conn|
+      conn.pipelined do |pipe|
+        pipe.call('SET', @key, 'p')
+        pipe.call('EXPIRE', @key, 60)
+      end
+
+      assert_equal 'p', conn.get(@key)
+    end
+  end
+end

--- a/test/unit/sidekiq_entrypoint_test.rb
+++ b/test/unit/sidekiq_entrypoint_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# #204: `require "sidekiq"` (and the documented `sidekiq/…` sub-paths) must
+# load Wurk's alias layer — this is what lets code and third-party gems
+# written against Sidekiq run on wurk without touching a single require.
+class SidekiqEntrypointTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  # Every passthrough except sidekiq/rails (needs Rails — loading it here
+  # would leak `defined?(Rails)` into every other parallel test) and
+  # sidekiq/cli (flips this process into server mode — same leak problem).
+  # Both are covered by dedicated cold-load subprocess tests below.
+  PASSTHROUGHS = %w[
+    sidekiq
+    sidekiq/api
+    sidekiq/client
+    sidekiq/job
+    sidekiq/launcher
+    sidekiq/middleware/chain
+    sidekiq/redis_connection
+    sidekiq/scheduled
+    sidekiq/testing
+    sidekiq/version
+    sidekiq/web
+    sidekiq/worker
+  ].freeze
+
+  def test_every_passthrough_requires_cleanly_in_process
+    PASSTHROUGHS.each do |path|
+      require path
+
+      assert defined?(Sidekiq::Client), "#{path} must leave the alias layer loaded"
+    end
+  end
+
+  # True cold-start: a fresh process where `require "sidekiq"` is the FIRST
+  # require — exactly what an ecosystem gem's test helper does. In-process
+  # requires above can't prove this because wurk is already loaded here.
+  def test_require_sidekiq_cold_loads_wurk
+    lib = File.expand_path('../../lib', __dir__)
+    ok = system(
+      RbConfig.ruby, '-I', lib, '-e',
+      'require "sidekiq"; exit(defined?(Sidekiq::Client) && defined?(Wurk) ? 0 : 1)'
+    )
+
+    assert ok, 'a fresh `require "sidekiq"` must load wurk and its alias layer'
+  end
+
+  # Sidekiq's contract: `Sidekiq.server?` is "has sidekiq/cli been required".
+  # Ecosystem test helpers require it precisely to make `configure_server`
+  # blocks run (sidekiq-cron's schedule loader registers :startup hooks there).
+  def test_require_sidekiq_cli_enters_server_mode
+    lib = File.expand_path('../../lib', __dir__)
+    ok = system(
+      RbConfig.ruby, '-I', lib, '-e',
+      'require "sidekiq"; exit 1 if Sidekiq.server?; ' \
+      'require "sidekiq/cli"; ' \
+      'fired = false; Sidekiq.configure_server { fired = true }; ' \
+      'exit(Sidekiq.server? && fired ? 0 : 1)'
+    )
+
+    assert ok, 'requiring sidekiq/cli must flip Sidekiq.server? and unlock configure_server blocks'
+  end
+
+  # Railtie-grade like upstream: must load with ONLY rails/railtie present
+  # (sidekiq-cron's test helper does exactly this — no ActionDispatch), so it
+  # maps to the railtie and must NOT drag in the dashboard engine.
+  def test_require_sidekiq_rails_cold_loads_railtie_without_actionpack
+    lib = File.expand_path('../../lib', __dir__)
+    # Same load set as sidekiq-cron's test helper: active_job brings the
+    # ActiveSupport core-exts railtie.rb needs; ActionDispatch stays absent.
+    ok = system(
+      RbConfig.ruby, '-I', lib, '-e',
+      'require "active_job"; require "rails/railtie"; require "sidekiq/rails"; ' \
+      'exit(defined?(Wurk::Railtie) && !defined?(Wurk::Engine) && !defined?(ActionDispatch) ? 0 : 1)'
+    )
+
+    assert ok, '`require "sidekiq/rails"` must load the railtie with railties alone, engine untouched'
+  end
+end

--- a/test/unit/web_rack_app_test.rb
+++ b/test/unit/web_rack_app_test.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'rack'
+require 'tmpdir'
+require 'fileutils'
+require 'wurk/web/extension'
+
+# #204: `Sidekiq::Web` as an upstream-compatible standalone Rack app —
+# `run Sidekiq::Web` / rack-test `Sidekiq::Web.call(env)` serves registered
+# extension routes at their own paths (no engine), with upstream's
+# Sec-Fetch-Site CSRF model and Config's hash-style settings.
+class WebRackAppTest < Wurk::Test::UnitCase
+  # Mutates the process-global Wurk::Web.config singleton (middlewares,
+  # bracket options) — cannot run in parallel with classes touching it.
+
+  module StandaloneExt
+    def self.registered(app)
+      app.get '/standalone' do
+        "standalone body #{t('Greeting')}"
+      end
+
+      app.get '/standalone/jump' do
+        redirect "#{root_path}standalone"
+      end
+
+      app.post '/standalone/poke' do
+        redirect "#{root_path}standalone"
+      end
+    end
+  end
+
+  # Tags responses so tests can prove the host middleware chain ran.
+  class StampMiddleware
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      status, headers, body = @app.call(env)
+      [status, headers.merge('X-Stamp' => '1'), body]
+    end
+  end
+
+  def setup
+    super
+    Wurk::Web.reset_config!
+    Wurk::Web.register(StandaloneExt, name: 'standalone', tab: 'Standalone', index: 'standalone')
+  end
+
+  def teardown
+    Wurk::Web.reset_config!
+    super
+  end
+
+  def test_get_serves_extension_route_at_its_own_path
+    status, _headers, body = Wurk::Web.call(env_for('GET', '/standalone'))
+
+    assert_equal 200, status
+    assert_includes body.join, 'standalone body'
+  end
+
+  def test_redirect_location_stays_in_the_root_url_space
+    status, headers, = Wurk::Web.call(env_for('GET', '/standalone/jump'))
+
+    assert_equal 302, status
+    assert_equal '/standalone', headers['Location'], 'standalone redirects must not be rewritten to /ext/…'
+  end
+
+  def test_unsafe_method_without_same_origin_header_is_denied
+    status, _headers, body = Wurk::Web.call(env_for('POST', '/standalone/poke'))
+
+    assert_equal 403, status
+    assert_includes body.join, 'Forbidden'
+  end
+
+  def test_unsafe_method_with_same_origin_header_routes
+    env = env_for('POST', '/standalone/poke').merge('HTTP_SEC_FETCH_SITE' => 'same-origin')
+    status, headers, = Wurk::Web.call(env)
+
+    assert_equal 302, status
+    assert_equal '/standalone', headers['Location']
+  end
+
+  def test_unknown_path_is_404
+    status, _headers, body = Wurk::Web.call(env_for('GET', '/nope'))
+
+    assert_equal 404, status
+    refute_empty body.join
+  end
+
+  # `middlewares` is the live array (upstream surface): mutating it after the
+  # first request must rebuild the chain, not serve the stale memo.
+  def test_live_middleware_mutation_rebuilds_the_chain
+    _, headers, = Wurk::Web.call(env_for('GET', '/standalone'))
+
+    assert_nil headers['X-Stamp']
+
+    Wurk::Web.use(StampMiddleware)
+    _, headers, = Wurk::Web.call(env_for('GET', '/standalone'))
+
+    assert_equal '1', headers['X-Stamp']
+
+    Wurk::Web.config.middlewares.clear
+    _, headers, = Wurk::Web.call(env_for('GET', '/standalone'))
+
+    assert_nil headers['X-Stamp'], 'clearing the live array must drop the middleware'
+  end
+
+  def test_config_bracket_settings_round_trip
+    Wurk::Web.configure { |c| c[:csrf] = false }
+    cfg = Wurk::Web.config
+
+    # key? + refute together pin "stored as false", not merely absent.
+    assert cfg.key?(:csrf)
+    refute cfg.fetch(:csrf)
+    assert_equal 'https://profiler.firefox.com/public/%s', cfg[:profile_view_url],
+                 'bracket surface and named accessors share the options hash'
+  end
+
+  def test_configure_without_block_returns_the_config
+    assert_same Wurk::Web.config, Wurk::Web.configure
+  end
+
+  # The upstream extension protocol sidekiq-cron uses: append a locale dir to
+  # `configure.locales`; the renderer's t() resolves strings from it.
+  def test_extension_locales_feed_renderer_strings
+    dir = Dir.mktmpdir
+    File.write(File.join(dir, 'en.yml'), "en:\n  Greeting: hi-from-locale\n")
+    Wurk::Web.configure.locales << dir
+
+    _, _, body = Wurk::Web.call(env_for('GET', '/standalone'))
+
+    assert_includes body.join, 'hi-from-locale'
+  ensure
+    FileUtils.remove_entry(dir) if dir
+  end
+
+  private
+
+  def env_for(method, path)
+    {
+      'REQUEST_METHOD' => method,
+      'PATH_INFO' => path,
+      'SCRIPT_NAME' => '',
+      'QUERY_STRING' => '',
+      'rack.input' => StringIO.new,
+      'rack.errors' => StringIO.new
+    }
+  end
+end


### PR DESCRIPTION
## Summary

Closes #204. Follow-up to #187 — makes the **ecosystem drop-in** pillar real, with **zero dependency on the real `sidekiq` gem**.

Before this PR: `require "sidekiq"` couldn't load wurk (no `lib/sidekiq.rb`), bundling any gem that declares `add_dependency "sidekiq"` would install **real sidekiq alongside wurk** (the half-real/half-wurk hybrid #204 describes), and `rake test:ecosystem` passed vacuously (`test/ecosystem/` was empty).

After: `require "sidekiq"` loads wurk, a companion `sidekiq`-named **shim gem** satisfies ecosystem gems' `add_dependency "sidekiq"` via bundler path/git sources (no real sidekiq in the bundle), and **`rake test:ecosystem` runs the real sidekiq-cron v2.4.0 suite — 182 tests — green against wurk.**

### Dependency direction (the whole point of #204)

- The **`wurk` gem does not depend on `sidekiq`** — runtime deps unchanged (`redis-client`, `connection_pool`, `rack`, `concurrent-ruby`); `wurk.gemspec` untouched.
- The **shim gem is named `sidekiq` and depends on `wurk`** (arrow points `sidekiq-shim → wurk`, never the reverse). Never published to rubygems — git/path consumption only.
- A consumer using only wurk's native features needs neither the shim nor real sidekiq; `require "sidekiq"` resolves to wurk's shipped passthrough. A consumer who wants a real ecosystem gem adds the shim so bundler resolves `sidekiq → wurk`.

## Wurk-side gaps the real suite surfaced (the suite is the spec)

- **`lib/sidekiq.rb` + `lib/sidekiq/{api,cli,client,job,launcher,rails,scheduled,testing,version,web,worker,middleware/chain,redis_connection}.rb`** require passthroughs. Two carry semantics, not just a load:
  - `sidekiq/cli` → `Wurk.enter_server_mode`: in Sidekiq, `Sidekiq.server?` *is* "has sidekiq/cli been required"; requiring it must unlock `configure_server` blocks (sidekiq-cron's schedule loader registers `:startup` hooks there).
  - `sidekiq/rails` → railtie only (upstream is railtie-grade; the dashboard engine needs ActionDispatch, which ecosystem helpers don't load).
- **Un-squat `Sidekiq::Cron`.** Real Sidekiq never defines it — the namespace belongs to the sidekiq-cron gem, and aliasing it to `Wurk::Cron` made the gem's own `Poller`/`Job` collide at load. `Sidekiq::Periodic` (Ent parity) and `Sidekiq::CronParser` (#201) stay. **Only user-visible behavior change: code using `Sidekiq::Cron::*` for wurk's native periodic API must use `Sidekiq::Periodic::*` (the spec'd Ent name).**
- **`Wurk::RedisClientAdapter::CompatClient`** (mirrors sidekiq 8.1.6 byte-for-byte in behavior): every pooled connection now answers method-style commands (`conn.hgetall`, `conn.smembers`, …) like Sidekiq 7+. Wurk-internal hot paths keep using `#call` through one delegation hop.
- **`Sidekiq::Web` as a standalone class-level Rack app** (`run Sidekiq::Web` / rack-test `Sidekiq::Web.call`): serves registered extension routes at their own paths through the #187 renderer, via a new embed-vs-standalone URL-space distinction, with upstream's Sec-Fetch-Site CSRF model.
- **`Web::Config`**: hash-style `[]`/`[]=`/`fetch` settings (upstream OPTIONS shape; profile URLs unified into it), `middlewares` returns the **live** array (upstream surface — rack chain rebuilds on drift instead of serving a stale memo), blockless `Sidekiq::Web.configure` getter, and a `locales` registry feeding the renderer's `t()`.

## Ecosystem harness

`test/ecosystem/<gem>/` thin harnesses — `PIN` (repo + tag + SHA), `Gemfile` (overlay mirroring the gem's own, with `sidekiq` → shim, `wurk` → repo root), optional `EXCLUDE`. `bin/test-ecosystem` clones each pin into `.checkouts/` (cached, gitignored), checks out the SHA, and runs the gem's own `rake test` under the overlay Gemfile.

The one excluded test is evidence, not evasion: sidekiq-cron's `Performance Poller` (10k enqueues < 30s) is hardware-bound and **fails identically with real sidekiq 8.1.6 on the same host** — measured here: sidekiq **32.96s** vs wurk **33.40s** (wurk within 1.3% of upstream). Documented in `test/ecosystem/sidekiq-cron/EXCLUDE`.

## Tests

- `test/unit/sidekiq_entrypoint_test.rb` — every `require "sidekiq[/…]"` passthrough loads cleanly (in-process + cold-start subprocess); `sidekiq/cli` flips `server?` and unlocks `configure_server`; `sidekiq/rails` loads the railtie railtie-grade without ActionDispatch.
- `test/unit/redis_client_adapter_test.rb` — method-style commands, `#call` still works, method_missing fallback, deprecation warning, info/evalsha/config/pipelined parity.
- `test/unit/web_rack_app_test.rb` — standalone Rack dispatch, redirect URL-space, Sec-Fetch-Site denial, live-middleware rebuild, bracket settings, blockless configure, locales→`t()`.
- `compat_aliases_test.rb` / `cron_test.rb` — assert `Sidekiq::Cron` stays **undefined**.

**Verification (all run locally):** full suite `NCPU=4` → **2301 runs, 0 failures, 0 errors** (incl. the ≥90% line+branch coverage gate); `test:parity` → 23, 0F/0E; `test:ecosystem` (real sidekiq-cron) → **182, 0F/0E**; consumer-app driver → **15/15**.

## How to test in prod

```ruby
# A real consumer app: wurk + the shim + a REAL ecosystem gem, no real sidekiq.
# Gemfile:
#   gem "wurk"
#   gem "sidekiq", github: "developerz-ai/wurk", glob: "ecosystem/sidekiq-shim/*.gemspec"
#   gem "sidekiq-cron"
#
# Then, in `bin/rails runner` / console:
require "sidekiq"
Wurk == Object.const_get(:Wurk)                      # => true; require "sidekiq" loaded wurk
Gem.loaded_specs["sidekiq"].source.class             # => Bundler::Source::{Path,Git} — the shim, NOT rubygems
Sidekiq::Client.equal?(Wurk::Client)                 # => true

require "sidekiq/cron"                                # the real gem
Sidekiq::Cron::Job.create(name: "ping", cron: "* * * * *", class: "YourWorker", queue: "default")
Sidekiq::Cron::Job.find("ping").enqueue!
Sidekiq.redis { |c| c.llen("queue:default") }        # => 1, a wurk-wire JSON payload — cron enqueued onto wurk
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drop-in Sidekiq-compatible require surface to run Wurk as a replacement.
  * RedisClient compatibility adapter enabling method-style commands.
  * Web: standalone Rack app, live-reloadable middleware stack, locale support, and embedded/standalone extension modes.

* **Chores**
  * Ecosystem test runner reworked to run pinned upstream harnesses; test artifacts now ignored.
  * Internal Sidekiq shim packaging added for bundler overlay use.

* **Documentation**
  * Ecosystem README and shim docs updated.

* **Tests**
  * New unit suites covering entrypoint loading, Redis adapter, web routing, and ecosystem harnesses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->