### PR TITLE
fix(oss): Stats#queues + #queue_summaries sort by size descending (#214)

### DIFF
--- a/lib/wurk/stats.rb
+++ b/lib/wurk/stats.rb
@@ -49,7 +49,11 @@ module Wurk
       end
     end
 
-    # @return [Hash{String=>Integer}] queue name → LLEN.
+    # @return [Hash{String=>Integer}] queue name → LLEN, largest queue first.
+    # `SMEMBERS` order is arbitrary; Sidekiq sorts the name/size pairs by size
+    # descending before building the hash (Stats#queues, spec §19.1) — gems
+    # and dashboards reading this rely on that order. Match it exactly with
+    # `sort_by { |_, size| -size }`.
     def queues
       Wurk.redis do |conn|
         names = conn.call('SMEMBERS', Keys::QUEUES_SET)
@@ -58,11 +62,14 @@ module Wurk
         sizes = conn.pipelined do |pipe|
           names.each { |q| pipe.call('LLEN', Keys.queue(q)) }
         end
-        names.zip(sizes.map(&:to_i)).to_h
+        names.zip(sizes.map(&:to_i)).sort_by { |_, size| -size }.to_h
       end
     end
 
-    # @return [Array<QueueSummary>] one per known queue.
+    # @return [Array<QueueSummary>] one per known queue, largest first.
+    # Same size-descending order as Sidekiq's detailed queue list
+    # (`queue_summaries.sort_by { |qd| -qd.size }`) — this feeds the
+    # dashboard's queue table (api_controller#queues).
     def queue_summaries
       Wurk.redis do |conn|
         names = conn.call('SMEMBERS', Keys::QUEUES_SET)
@@ -75,7 +82,7 @@ module Wurk
             pipe.call('LRANGE', Keys.queue(q), -1, -1)
           end
         end
-        build_summaries(names, results, paused_set)
+        build_summaries(names, results, paused_set).sort_by { |qd| -qd.size }
       end
     end
 

--- a/test/unit/stats_test.rb
+++ b/test/unit/stats_test.rb
@@ -46,6 +46,10 @@ class StatsTest < Wurk::Test::UnitCase
     @pool.with do |conn|
       conn.call('DEL', "queue:#{@queue}")
       conn.call('SREM', 'queues', @queue)
+      (@probe_queues || []).each do |q|
+        conn.call('DEL', "queue:#{q}")
+        conn.call('SREM', 'queues', q)
+      end
       @zset_members.each { |set, members| members.each { |m| conn.call('ZREM', set, m) } }
       if @added_identity
         conn.call('SREM', 'processes', @identity)
@@ -244,6 +248,28 @@ class StatsTest < Wurk::Test::UnitCase
     assert_kind_of Array, Wurk::Stats.new.queue_summaries
   end
 
+  # --- #214: largest-queue-first ordering (Sidekiq parity) ----------------
+
+  # SMEMBERS order is arbitrary; Sidekiq's Stats#queues sorts by size
+  # descending. Push three of my own queues in non-monotonic size order and
+  # assert that, among just my queues (siblings push their own concurrently),
+  # the result lists them largest-first.
+  def test_queues_ordered_by_size_descending
+    sizes = order_probe_queues # { name => size }, sizes 1/3/2
+
+    ordered = Wurk::Stats.new.queues.keys & sizes.keys # & keeps result order
+
+    assert_equal sizes.keys.sort_by { |q| -sizes[q] }, ordered
+  end
+
+  def test_queue_summaries_ordered_by_size_descending
+    sizes = order_probe_queues
+
+    ordered = Wurk::Stats.new.queue_summaries.map(&:name) & sizes.keys
+
+    assert_equal sizes.keys.sort_by { |q| -sizes[q] }, ordered
+  end
+
   def test_default_queue_latency_returns_float
     assert_kind_of Float, Wurk::Stats.new.default_queue_latency
   end
@@ -427,6 +453,26 @@ class StatsTest < Wurk::Test::UnitCase
       c.call('SADD', 'queues', @queue)
       c.call('LPUSH', "queue:#{@queue}", payload)
     end
+  end
+
+  # Three of my own queues with distinct, non-monotonic sizes (1, 3, 2) so the
+  # descending sort is observable and not accidentally satisfied by insertion
+  # order. Returns { name => size }; teardown drops them via @probe_queues.
+  def order_probe_queues
+    @probe_queues ||= []
+    spec = { "stats-q-a-#{@ns}" => 1, "stats-q-b-#{@ns}" => 3, "stats-q-c-#{@ns}" => 2 }
+    spec.each do |name, count|
+      @probe_queues << name
+      @pool.with do |c|
+        c.call('SADD', 'queues', name)
+        count.times do
+          c.call('LPUSH', "queue:#{name}",
+                 Wurk.dump_json('class' => @class_name, 'args' => [], 'queue' => name,
+                                'jid' => SecureRandom.hex(12), 'enqueued_at' => ms_now))
+        end
+      end
+    end
+    spec
   end
 
   def add_zset_member(set, suffix)


### PR DESCRIPTION
## Summary

Closes #214. Sidekiq's `Stats#queues` and `Stats#queue_summaries` return queues **largest-first**; wurk zipped `SMEMBERS` order (arbitrary). Gems and dashboards that read `Sidekiq::Stats.new.queues` rely on the descending-size order, and wurk's own dashboard queue table (`api_controller#queues` → `queue_summaries`) rendered in no particular order.

## Fix

Both methods now sort by size descending, matching the sidekiq 8.1.6 oracle (`lib/sidekiq/api.rb`) **exactly**:

```ruby
# Stats#queues
names.zip(sizes.map(&:to_i)).sort_by { |_, size| -size }.to_h   # upstream: queues.zip(lengths).sort_by { |_, size| -size }.to_h
# Stats#queue_summaries
build_summaries(...).sort_by { |qd| -qd.size }                  # upstream: queue_summaries.sort_by { |qd| -qd.size }
```

The issue's "Done when" names only `Stats#queues`, but `queue_summaries` is the identical parity gap in the sibling method (Sidekiq sorts it too) and is what the dashboard actually renders — fixed both.

## Wire compat

No Redis key, JSON field, or sorted-set score change — pure result ordering.

## Tests

`test/unit/stats_test.rb`: two parity tests pushing three of my own queues in **non-monotonic** size order (1/3/2) and asserting that — among just my queues (parallel siblings push their own) — `queues` and `queue_summaries` list them largest-first. Both fail on `main`, pass here.

**Verification (run locally):** full suite `NCPU=4` → **2285 runs, 0 failures, 0 errors**; `test:parity` → 23, 0F/0E. Behavioral driver against real Redis (insertion order a/b/c, sizes 5/1/9 → must come back c/a/b): **4/4 pass on this branch, 4/4 fail on main**.

## How to test in prod

```ruby
# bin/rails runner / console — against your live Redis.
# Make two queues with different depths:
10.times { YourJob.set(queue: "low").perform_async }
100.times { YourJob.set(queue: "critical").perform_async }

Sidekiq::Stats.new.queues
#  => {"critical"=>100, "low"=>10, ...}   # largest first, like Sidekiq
Sidekiq::Stats.new.queue_summaries.map { |q| [q.name, q.size] }
#  => [["critical", 100], ["low", 10], ...]   # same order
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Queue listing and summary methods now consistently return results sorted by size in descending order (largest to smallest).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->