### PR TITLE
chore: standardize Blacksmith runner, concurrency + job timeouts

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   bench:
     runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 45
     services:
       redis:
         image: redis:7.4
@@ -47,6 +48,7 @@ jobs:
   compare:
     if: github.event_name == 'pull_request'
     runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 45
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -40,6 +40,7 @@ env:
 jobs:
   authorize:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Verify actor is an approved deployer
         env:
@@ -60,6 +61,7 @@ jobs:
   build:
     needs: authorize
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # The required-reviewer gate lives here: under the Image Updater model the
     # pushed digest is the deploy trigger, so approval must pause the run BEFORE
     # the image ships, not after.

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   ecosystem:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 45
     services:
       redis:
         image: redis:7.4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   release:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
     services:
       redis:
         image: redis:7.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
     # via `include` to satisfy the required context while keeping the #29 matrix
     # (Ruby 3.2/3.3/3.4 × Rails 7.2/8.0).
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -75,6 +76,7 @@ jobs:
   parity:
     name: parity (oracle)
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
     services:
       redis:
         image: redis:7.4
@@ -106,6 +108,7 @@ jobs:
   coverage:
     name: coverage (line + branch >= 90%)
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
     services:
       redis:
         image: redis:7.4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ Skip step 3 → leaked sockets in children. Skip step 5 → children corrupt eac
 - **Never mock Redis** in integration or parity tests. Real Redis, unique namespace.
 - **Coverage gate.** SimpleCov **line** and **branch** coverage on `lib/` must both stay ≥90% (blocking; `minimum_coverage line: 90, branch: 90`). Branch was ratcheted from ~78% to ≥90% in #67 — keep new code at parity. The Cobertura report is still uploaded for per-file inspection. Coverage runs merge across the `minitest-parallel_fork` workers via `SimpleCov.at_fork`.
 - **CI** on GitHub Actions / Blacksmith runners. Benchmark bot comments deltas on every PR; >5% regression flags it.
+- **CI standard.** Runners are Blacksmith (`blacksmith-4vcpu-ubuntu-2404`; 8vcpu for bench — larger SKUs are deliberate, don't downsize). Every workflow declares a `concurrency` group with cancel-in-progress, and every job sets `timeout-minutes`. Deploy/publish workflows (deploy-demo, pages, release) never auto-cancel: `cancel-in-progress: false`.
 
 ## Platforms
 


### PR DESCRIPTION
## What
Adds per-job `timeout-minutes` to all 10 jobs across the 6 workflows and appends the org CI-standard note to `CLAUDE.md`. No concurrency, runner, or step changes.

## Why
Run 27345104330 (`test (3.4, 7.2)`) hung 24 minutes until manually cancelled — no job here sets `timeout-minutes`, so a hung job runs to GitHub's 6h default. Ceilings are sized to catch a hang, not bound runtime. Part of the org-wide Actions hygiene sweep (developerz-ai/infrastructure#300).

## Changes
- `bench.yml`: `bench` 45, `compare` 45 (recent successful runs finish in ~90s; 45 is hang-catch headroom for the double-run compare job)
- `deploy-demo.yml`: `authorize` 10, `build` 30
- `ecosystem.yml`: `ecosystem` 45
- `pages.yml`: `deploy` 10
- `release.yml`: `release` 30
- `test.yml`: `test` (matrix) 10, `parity` 10, `coverage` 10 (matrix jobs normally finish in ~90s)
- `CLAUDE.md`: CI-standard note appended to the testing section

## Verification
- `actionlint 1.7.12` on all 6 changed workflows: zero findings beyond the pre-existing `runner-label` complaint about Blacksmith labels (actionlint does not know third-party runner providers; those labels predate this change and are unchanged).
- Diff is purely additive (11 insertions, 0 deletions) — confirms concurrency blocks and runners are untouched.
- This PR's own CI run is the live proof the workflows still parse and trigger.
- Render-check (`kubectl kustomize`): N/A — no `stacks/**`; CI source-repo files only. Live test: N/A — CI-config only.

Closes developerz-ai/infrastructure#301


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added execution time limits to CI jobs across workflows to prevent runaway runs and improve CI reliability and resource usage.
* **Documentation**
  * Updated CI guidance to standardize runner/concurrency and per-job timeout recommendations, including exemptions for deploy/publish workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->