### PR TITLE
docs(spec): document the `__wurk_enc__` crypto envelope marker (ent §4.4)

### DIFF
--- a/docs/target/sidekiq-ent.md
+++ b/docs/target/sidekiq-ent.md
@@ -420,11 +420,21 @@ Key sources: file, `ENV`, KMS — any callback that maps `Integer version → 32
 
 ### 4.4 On-wire format
 
-In Redis the job's last arg becomes a base64-encoded envelope, conceptually:
+In Redis the job's last arg becomes a JSON Hash envelope (not a base64 blob of a
+binary envelope — the args array stays valid JSON for inspectors):
 
 ```
-{ "v" => active_version, "iv" => b64(iv), "ct" => b64(ciphertext), "tag" => b64(gcm_tag) }
+{ "__wurk_enc__" => true, "v" => active_version, "iv" => b64(iv), "ct" => b64(ciphertext), "tag" => b64(gcm_tag) }
 ```
+
+The leading `__wurk_enc__ => true` marker is the authoritative envelope
+discriminator: detection (`Wurk::Encryption.envelope?`, used by both the server
+middleware and the Web UI redactor) keys off it, so a plain user Hash that
+happens to carry `v`/`iv`/`ct`/`tag` keys is never mistaken for ciphertext and
+fed to the cipher. wurk both writes and reads this format, so it is
+self-consistent; it is *not* wire-compatible with real Sidekiq Enterprise's
+crypto format (a base64 binary blob), which is a documented divergence — encrypted
+payloads do not round-trip Ent↔wurk regardless.
 
 Overhead: ~150 bytes + ~30% size growth from base64.
 


### PR DESCRIPTION
## What

Reconcile `docs/target/sidekiq-ent.md` §4.4 with the actual encryption implementation: the on-wire crypto envelope is `{__wurk_enc__: true, v, iv, ct, tag}`, but the spec listed only `{v, iv, ct, tag}`.

## Why

Found by a targeted Sidekiq-parity re-audit (round 3). [lib/wurk/encryption.rb](../blob/main/lib/wurk/encryption.rb) writes the `__wurk_enc__` marker and keys envelope detection (`Wurk::Encryption.envelope?`, used by both server middleware and the Web UI redactor) off it. The marker is a **deliberate design choice** — it prevents a plain user Hash that happens to carry `v`/`iv`/`ct`/`tag` keys from being mistaken for ciphertext and fed to the cipher. So the right reconciliation is doc→impl, not impl→doc.

Near-zero runtime impact: wurk's crypto format is self-consistent, and it's already a documented divergence from real Sidekiq Enterprise's binary blob format (encrypted payloads don't round-trip Ent↔wurk regardless).

## Scope

Docs only — no code change. The audit found the other 6 high-risk subsystems (JobRetry, Scheduled poller, Testing, Limiter, Client#push_bulk, Setter#perform_in) bit-faithful to spec.

## How to test in prod

N/A — documentation-only change to `docs/target/`. To confirm the documented format matches reality:

```ruby
Sidekiq::Enterprise::Crypto.enable(active_version: 1) { |v| OpenSSL::Cipher.new("aes-256-gcm").random_key }
# enqueue an `encrypt: true` job, then inspect the scheduled/retry payload:
Sidekiq.redis { |c| c.lrange("queue:default", 0, 0) }
# the last arg is a Hash with "__wurk_enc__" => true, "v", "iv", "ct", "tag"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Enterprise encryption documentation for Redis on-wire format, including the encrypted envelope structure and discriminator for envelope detection.
  * Clarified wire format divergence from standard Sidekiq Enterprise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->