### PR TITLE
test: harden interrupt-repush completion clock vs full-suite load (#216)

### DIFF
--- a/test/integration/interrupt_handler_autoregister_test.rb
+++ b/test/integration/interrupt_handler_autoregister_test.rb
@@ -54,8 +54,16 @@ class InterruptHandlerAutoregisterTest < Wurk::Test::UnitCase
   # the regression check: a true wiring break (interrupt not re-pushed, or not
   # resumed) never writes @done_key, so the test still fails — just later — at
   # any timeout. The budget only absorbs scheduling latency, it can't mask a bug.
-  BOOT_TIMEOUT = 60.0
-  POLL_TIMEOUT = 60.0
+  #
+  # Under the dedicated `coverage (line+branch >= 90%)` CI gate, SimpleCov's
+  # per-line trace roughly doubles the wall-clock of every code path through
+  # lib/ — fork, child boot, BLMOVE, the interrupt re-push, the second fetch.
+  # 60s was hit on the dot on the coverage leg (recurrence of #216 there). Same
+  # scheduling-latency reasoning applies, just with a heavier multiplier; widen
+  # to 2× under COVERAGE so the budget tracks the actual load.
+  COVERAGE_LOAD = !ENV['COVERAGE'].nil?
+  BOOT_TIMEOUT = COVERAGE_LOAD ? 120.0 : 60.0
+  POLL_TIMEOUT = COVERAGE_LOAD ? 120.0 : 60.0
   POLL_INTERVAL = 0.1
   SHUTDOWN_TIMEOUT = 15
 

--- a/test/integration/interrupt_handler_autoregister_test.rb
+++ b/test/integration/interrupt_handler_autoregister_test.rb
@@ -41,15 +41,21 @@ end
 class InterruptHandlerAutoregisterTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  # Two separate clocks (#216): fork + child boot + first BLMOVE is the
-  # load-sensitive part — under the full parallel suite (NCPU parallel_fork
-  # workers, each integration test forking its own swarm) it alone can exceed
-  # 30s on a loaded machine. It gets its own generous budget, observed as the
-  # pushed job leaving the public queue. The completion clock then only times
-  # the interrupt → re-push → resume round trip, which is fast once the child
-  # is up — so it stays tight enough to catch a true wiring regression.
+  # Two separate clocks (#216): boot (fork + child boot + first BLMOVE),
+  # observed as the pushed job leaving the public queue, and completion (the
+  # interrupt → re-push → re-fetch → resume round trip), observed as @done_key.
+  # Both are load-sensitive: under the full parallel suite (NCPU parallel_fork
+  # workers, each integration test forking its own swarm) a single process's
+  # threads can be CPU-starved for tens of seconds. The completion round trip
+  # was originally budgeted tight (30s) on the assumption it's "fast once the
+  # child is up" — but it still needs the saturated child to get scheduled for
+  # a second fetch+execute, which on a loaded CI box can exceed 30s (#216
+  # recurrence). Give it the same generous budget as boot. This does NOT weaken
+  # the regression check: a true wiring break (interrupt not re-pushed, or not
+  # resumed) never writes @done_key, so the test still fails — just later — at
+  # any timeout. The budget only absorbs scheduling latency, it can't mask a bug.
   BOOT_TIMEOUT = 60.0
-  POLL_TIMEOUT = 30.0
+  POLL_TIMEOUT = 60.0
   POLL_INTERVAL = 0.1
   SHUTDOWN_TIMEOUT = 15
 


### PR DESCRIPTION
## What
`InterruptHandlerAutoregisterTest#test_interrupted_iterable_job_is_repushed_and_resumes_without_retry` flaked on `main` (CI run on a docs-only commit, 1 failure / 2309). Bumps the completion-wait budget from 30s → 60s.

## Root cause (not a logic bug)
The `InterruptHandler` re-push/resume wiring is correct. The failure is **full-suite CPU starvation**: under `NCPU` parallel_fork workers each forking a swarm, a single process's threads can be unscheduled for tens of seconds. #216 already widened the **boot** clock to 60s for this, but left the **completion** clock at 30s on the assumption the interrupt → re-push → re-fetch → resume round trip is "fast once the child is up." It isn't under worst-case load — that round trip still needs the starved child scheduled for a second fetch+execute.

## Why this doesn't mask real bugs
A true wiring regression (interrupt not re-pushed, or not resumed) **never** writes `@done_key`, so the test fails at *any* timeout — the budget only absorbs scheduling latency, it cannot hide a broken interrupt path. Same reasoning #216 applied to the boot clock.

## Verification
- Full suite green under `NCPU=4`: **2309 runs, 0 failures, 0 errors**.
- Interrupt test isolation loop: clean across many seeds.

Closes #216 (recurrence).

## How to test in prod
N/A — test-only change. Operators see no behavior difference; this only widens a CI timing budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Made interrupt-handler integration test timeouts load-sensitive to reduce flakiness under CPU contention.
  * Increased default timeouts and automatically widen them when coverage is enabled to absorb scheduling latency.
  * Expanded in-test documentation to clarify timeout behavior and preserve the integrity of the regression signal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->