### PR TITLE
fix(cron): enqueue ActiveJob cron targets via the AJ adapter (1.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Wurk are recorded here. Format: [Keep a Changelog](https:
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-06-11
+
+### Fixed
+- **Cron / Periodic** — a cron loop targeting an `ActiveJob` class now enqueues it through the ActiveJob adapter (`perform_later` → `Sidekiq::ActiveJob::Wrapper`) instead of pushing it as a bare Sidekiq worker. Previously the poller did a raw `client.push('class' => "MyActiveJob")`, so the processor would call `MyActiveJob.new.perform` and skip all of ActiveJob (callbacks, argument deserialization, retries). Matches sidekiq-cron behavior. An explicit cron `queue:` still overrides; otherwise the job's own `queue_as` is respected.
+
 ## [1.0.0] - 2026-06-11
 
 First stable release. Wurk is a 100% drop-in replacement for Sidekiq, Sidekiq

--- a/lib/wurk/cron.rb
+++ b/lib/wurk/cron.rb
@@ -574,12 +574,41 @@ module Wurk
       end
 
       def enqueue!(loop_obj)
+        aj = active_job_class(loop_obj.klass)
+        return enqueue_active_job(aj, loop_obj) if aj
+
         @client.push(
           'class' => loop_obj.klass,
           'args' => loop_obj.args,
           'queue' => loop_obj.queue,
           'retry' => loop_obj.retry_value
         )
+      end
+
+      # Resolve a loop's class name to an ActiveJob::Base subclass, or nil when
+      # ActiveJob isn't loaded (standalone wurk) or the class isn't one.
+      # sidekiq-cron parity: a cron loop targeting an ActiveJob must enqueue
+      # through the AJ adapter so the job runs via Sidekiq::ActiveJob::Wrapper
+      # with full callbacks/serialization — a bare `client.push('class' => …)`
+      # would make the processor call `Klass.new.perform`, skipping all of AJ.
+      def active_job_class(name)
+        return nil unless defined?(::ActiveJob::Base)
+
+        const = name.split('::').inject(::Object) { |mod, c| mod.const_get(c) }
+        const if const.is_a?(::Class) && const < ::ActiveJob::Base
+      rescue ::NameError
+        nil
+      end
+
+      # Enqueue via the AJ adapter (→ wurk). Only override the queue when the
+      # loop set one explicitly; otherwise the job's own `queue_as` wins. AJ's
+      # `retry_on`/`discard_on` govern retries, so the Sidekiq `retry` option
+      # doesn't apply here. Returns the wurk jid (provider_job_id) so the fire
+      # history records it; nil if a before_enqueue callback halted the push.
+      def enqueue_active_job(klass, loop_obj)
+        target = loop_obj.queue == 'default' ? klass : klass.set(queue: loop_obj.queue)
+        job = target.perform_later(*loop_obj.args)
+        job.provider_job_id if job.respond_to?(:provider_job_id)
       end
 
       def read_fire_marks(lid)

--- a/lib/wurk/version.rb
+++ b/lib/wurk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wurk
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/test/unit/cron_test.rb
+++ b/test/unit/cron_test.rb
@@ -2,6 +2,8 @@
 
 require_relative '../test_helper'
 require 'tzinfo'
+require 'active_job'
+require 'active_job/queue_adapters/wurk_adapter'
 
 class CronTest < Wurk::Test::UnitCase
   parallelize_me!
@@ -388,6 +390,22 @@ class CronTest < Wurk::Test::UnitCase
     job = enqueue_via_leader_tick(klass: "CronTest::Pollee#{@suffix}", queue: "cron-q-#{@suffix}", args: [1, 2])
 
     assert_equal "CronTest::Pollee#{@suffix}", job['class']
+  end
+
+  # A cron loop targeting an ActiveJob class must enqueue through the AJ wrapper
+  # (perform_later → Sidekiq::ActiveJob::Wrapper), NOT as a bare worker — a raw
+  # `client.push('class' => AJClass)` would make the processor call
+  # `AJClass.new.perform` and skip all of ActiveJob. sidekiq-cron parity.
+  def test_poller_enqueues_active_job_via_wrapper_when_leader
+    queue = "cron-aj-#{@suffix}"
+    klass = build_cron_active_job(queue)
+    job = enqueue_via_leader_tick(klass: klass.name, queue: queue, args: [])
+
+    assert_equal 'Sidekiq::ActiveJob::Wrapper', job['class'],
+                 'ActiveJob cron target must enqueue through the AJ wrapper, not as a bare worker'
+    assert_equal klass.name, job['wrapped']
+  ensure
+    Object.send(:remove_const, klass.name.to_sym) if klass.respond_to?(:name) && klass.name
   end
 
   def test_poller_enqueues_args_when_leader
@@ -1096,6 +1114,20 @@ class CronTest < Wurk::Test::UnitCase
     # Pretend this process holds the cluster lock.
     poller.define_singleton_method(:leader?) { true }
     poller
+  end
+
+  # Named ActiveJob subclass wired to the wurk adapter. AJ serialization needs
+  # a real (non-anonymous) constant, so const_set a unique name; the test's
+  # ensure-block removes it.
+  def build_cron_active_job(queue)
+    klass = Class.new(::ActiveJob::Base) do
+      def perform(*); end
+    end
+    klass.queue_as(queue)
+    klass.queue_adapter = :wurk
+    name = "CronAJ_#{Process.pid}_#{object_id}_#{rand(1 << 32)}"
+    Object.const_set(name, klass)
+    klass
   end
 
   def enqueue_via_leader_tick(klass:, queue:, args:)


### PR DESCRIPTION
## What
A `config.periodic` / cron loop whose class is an **ActiveJob** subclass now enqueues it through `perform_later` (→ `Sidekiq::ActiveJob::Wrapper`) instead of a raw `client.push('class' => "MyActiveJob")`.

## Why
The raw push made the processor call `MyActiveJob.new.perform` directly — skipping all of ActiveJob (callbacks, argument deserialization, retry/discard). sidekiq-cron handles ActiveJob targets correctly, so this was a drop-in parity gap. Found while migrating a real app (all-ActiveJob) onto wurk cron.

## Behavior
- ActiveJob class → `perform_later` via the configured adapter.
- Explicit cron `queue:` still overrides; otherwise the job's own `queue_as` wins.
- Plain Sidekiq workers unchanged (raw push path).
- Guarded on `defined?(ActiveJob::Base)` → standalone wurk (no Rails) unaffected.

## Tests
New `cron_test`: a cron loop targeting an ActiveJob class enqueues the `Sidekiq::ActiveJob::Wrapper` payload (asserts `class` + `wrapped`). Full coverage suite green locally (line+branch ≥ 90%).

Ships as **1.0.1** (version + CHANGELOG bumped).

## How to test in prod
After 1.0.1 is out, schedule an ActiveJob via `config.periodic`:
```ruby
Sidekiq.configure_server do |c|
  c.periodic { |mgr| mgr.register("0 6 * * *", "KeywordFetchJob") }
end
```
On the next tick the dashboard shows a `Sidekiq::ActiveJob::Wrapper` job (not a bare `KeywordFetchJob`), and the job runs through full ActiveJob execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)