### PR TITLE
docs: Active Job adapter, standalone (no-Rails) runs, and starting the worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Plus Wurk extras: a worker topology DSL, a Kubernetes liveness/readiness listene
 
 - **[Website](https://developerz-ai.github.io/wurk/)** · **[Wiki / full docs](https://github.com/developerz-ai/wurk/wiki)** — the pitch, install, and the complete guide.
 - **[Getting started & architecture](https://github.com/developerz-ai/wurk/blob/main/docs/idea/01-overview.md)** — how the swarm, manager, fetcher, and processor fit together.
+- **[Starting the worker](https://github.com/developerz-ai/wurk/blob/main/docs/running.md)** — Rails auto-start, the `wurk`/`wurkswarm` runners, and running standalone without Rails.
+- **[Active Job adapter](https://github.com/developerz-ai/wurk/blob/main/docs/active-job.md)** — run `ActiveJob`/`deliver_later` on Wurk with `queue_adapter = :wurk`.
 - **[Migrating from Sidekiq](#migrating-from-sidekiq)** — the one-line swap and what to expect.
 - **API reference (parity specs):** [Sidekiq OSS](https://github.com/developerz-ai/wurk/blob/main/docs/target/sidekiq-free.md) · [Pro](https://github.com/developerz-ai/wurk/blob/main/docs/target/sidekiq-pro.md) · [Enterprise](https://github.com/developerz-ai/wurk/blob/main/docs/target/sidekiq-ent.md) — the authoritative surface Wurk matches exactly.
 - **[Securing the dashboard](https://github.com/developerz-ai/wurk/blob/main/docs/dashboard.md)** · **[Metrics history](https://github.com/developerz-ai/wurk/blob/main/docs/metrics-history.md)**

--- a/docs/active-job.md
+++ b/docs/active-job.md
@@ -1,0 +1,74 @@
+# Active Job adapter
+
+Wurk ships an Active Job queue adapter, so Rails apps that enqueue through
+`ActiveJob::Base` (mailers, `deliver_later`, Turbo broadcasts, your own
+`ApplicationJob` subclasses) run on Wurk without touching a single job class.
+
+> Authoritative surface: [`docs/target/sidekiq-free.md`](target/sidekiq-free.md) §28.
+> Adapter source: [`lib/active_job/queue_adapters/wurk_adapter.rb`](../lib/active_job/queue_adapters/wurk_adapter.rb).
+
+---
+
+## Enabling it
+
+```ruby
+# config/application.rb (or config/environments/*.rb)
+config.active_job.queue_adapter = :wurk
+```
+
+Rails resolves `:wurk` to `ActiveJob::QueueAdapters::WurkAdapter` by convention.
+The engine loads the adapter eagerly at boot, so the constant exists before your
+config line runs — no extra `require`.
+
+Per-job overrides work the same as any adapter:
+
+```ruby
+class HardJob < ApplicationJob
+  self.queue_adapter = :wurk
+  queue_as :critical
+end
+```
+
+---
+
+## Migrating apps already on `:sidekiq`
+
+You don't have to change `queue_adapter = :sidekiq` to flip the switch. When the
+real `sidekiq` gem is **not** in your bundle, Wurk resolves `:sidekiq` to a
+Wurk-backed adapter as well — same enqueue path, same payload — so a one-line
+gem swap keeps a `config.active_job.queue_adapter = :sidekiq` app working
+untouched (pillar 1). If the genuine `sidekiq` gem *is* still bundled (a mixed
+mid-migration setup), Wurk leaves its adapter alone and never clobbers it.
+
+So: leave `:sidekiq` as-is for a zero-edit cutover, or switch to `:wurk` once
+Sidekiq is fully removed. Both run on Wurk.
+
+---
+
+## Wire compatibility
+
+Active Job jobs are wrapped in `Sidekiq::ActiveJob::Wrapper` before they hit
+Redis — the canonical `class` string Sidekiq itself writes. That means:
+
+- Jobs enqueued by stock Sidekiq before the swap deserialize and run on Wurk.
+- A mixed pool of Sidekiq and Wurk workers can drain the same Active Job queue.
+- The legacy `ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper` constant and
+  the old `Wurk::ActiveJob::Wrapper` name both resolve to the same wrapper, so
+  payloads written by any Rails version load on the gem swap.
+
+The wrapper's `provider_job_id` is set to the Wurk `jid`, so
+`job.provider_job_id` works exactly as it does under Sidekiq.
+
+## Behavior worth knowing
+
+| Behavior | Detail |
+|---|---|
+| **Transaction-safe enqueue** | `enqueue_after_transaction_commit?` is `true`. A job enqueued inside a DB transaction is pushed only after that transaction commits, so you never dispatch a job whose row hasn't landed. Matches Sidekiq. |
+| **Bulk enqueue** | `enqueue_all` (Rails 7.1+ `perform_all_later`) groups jobs by class and queue and pushes each group in one `push_bulk` pipeline. |
+| **`sidekiq_options` on AJ classes** | Native Active Job classes gain `sidekiq_options` (retry count, queue, etc.) via `Wurk::Job::Options`, so existing `sidekiq_options retry: 5`-style config on an AJ class keeps working. |
+| **Quiet on shutdown** | The adapter's `stopping?` flips `true` on the `:quiet` lifecycle event, so Active Job's own shutdown checks behave as under Sidekiq. |
+
+## Requirements
+
+`activejob >= 7.0`. If Active Job isn't in the bundle the adapter is simply
+unavailable — same as Sidekiq, no error at boot.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -7,6 +7,7 @@ change is the binary name (`sidekiq` → `wurk`) — the signals, flags, and con
 file are identical.
 
 > Authoritative signal reference: [`docs/target/sidekiq-free.md`](target/sidekiq-free.md) §21 (CLI).
+> Just getting a worker running (incl. standalone, no Rails)? See [`docs/running.md`](running.md).
 > Migrating an existing app? Start with [`docs/migrate-from-sidekiq.md`](migrate-from-sidekiq.md).
 
 ---

--- a/docs/running.md
+++ b/docs/running.md
@@ -1,0 +1,151 @@
+# Starting the Wurk process
+
+How to boot a Wurk worker — inside Rails (where it usually starts itself) and
+standalone, with no Rails engine at all.
+
+> Production init systems (systemd, capistrano, Heroku) and the full signal
+> table live in [`docs/deployment.md`](deployment.md). This doc is about getting
+> a worker running.
+
+---
+
+## Inside Rails: it auto-starts
+
+In a Rails app you usually start **nothing**. The mountable engine's railtie
+boots the swarm during `after_initialize`, so a normal `rails server` (or a
+worker dyno that just boots the app) already has workers forking and fetching.
+
+Set `WURK_DISABLED=1` on any process that should *not* fork workers — typically
+your web process if you'd rather run the workers in their own unit:
+
+```bash
+WURK_DISABLED=1 bundle exec rails server   # web only, no workers
+```
+
+The auto-fork is also skipped automatically in the Rails console and the Rails
+test environment, so those never spawn a swarm.
+
+If you'd rather run the worker as its own process even under Rails, disable the
+auto-fork as above and use one of the standalone runners below pointed at your
+app directory.
+
+---
+
+## The two runners
+
+| Binary | What it does | Sidekiq equivalent |
+|---|---|---|
+| `bundle exec wurk` | One process, a thread pool | `sidekiq` |
+| `bundle exec wurkswarm` | Forks N worker children from one preloaded parent — fork-based real parallelism | `sidekiqswarm` |
+
+`sidekiqswarm` ships as an alias for `wurkswarm`, so an existing Enterprise
+invocation drops in unchanged. There is **no `sidekiq` binary** — point any
+`bundle exec sidekiq` command at `wurk`.
+
+```bash
+bundle exec wurk        -e production            # single process
+bundle exec wurkswarm   -e production            # forked swarm (real parallelism)
+```
+
+`wurkswarm` is the only way to get fork-based parallelism **without** Rails —
+the auto-boot path is Rails-only.
+
+### Common flags
+
+Identical to Sidekiq:
+
+| Flag | Meaning |
+|---|---|
+| `-c INT` | Processor threads (concurrency). Defaults to `RAILS_MAX_THREADS` or 10. |
+| `-q queue[,weight]` | Queue to process, optionally weighted. Repeatable. Defaults to `default`. |
+| `-r PATH` | App to load — a Rails app **directory**, or a single `.rb` file (see below). |
+| `-t NUM` | Shutdown timeout in seconds (default 25). |
+| `-e ENV` | Application environment. |
+| `-g TAG` | Process tag shown in the procline / dashboard. |
+| `-C PATH` | Path to a YAML config file. |
+| `-v` | Verbose logging. |
+
+With no `-C`, Wurk auto-discovers `config/wurk.yml`, then `config/sidekiq.yml`
+(`.erb` variants too), relative to the required path.
+
+---
+
+## Running without Rails
+
+Wurk's standalone runners never load the engine, so they work in any Ruby app —
+a Sinatra service, a plain Rack app, a CLI daemon, whatever. You point `-r` at a
+single Ruby file that loads your code and defines your jobs.
+
+**1. A boot file that requires your app and defines jobs:**
+
+```ruby
+# app.rb
+require "wurk"
+
+Wurk.configure_server do |config|
+  config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/0") }
+end
+
+require_relative "lib/my_app"   # your own code / job classes
+
+class EmailJob
+  include Sidekiq::Worker       # or `include Wurk::Job` — same thing
+  def perform(user_id)
+    MyApp.deliver_welcome(user_id)
+  end
+end
+```
+
+**2. Start a worker against it:**
+
+```bash
+bundle exec wurk      -r ./app.rb -q default -c 5      # single process
+bundle exec wurkswarm -r ./app.rb -q default           # forked swarm
+```
+
+When `-r` is a **file**, Wurk just `require`s it. When `-r` is a **directory**
+it's treated as a Rails app root and `config/environment.rb` is loaded instead —
+that's the only Rails-aware branch, and it's the host app's call, not the gem's.
+
+**3. Enqueue from anywhere** (web process, console, cron) — just load `wurk`,
+point it at the same Redis, and call the job:
+
+```ruby
+require "wurk"
+Wurk.configure_client { |c| c.redis = { url: ENV.fetch("REDIS_URL") } }
+
+EmailJob.perform_async(42)        # or EmailJob.perform_in(5.minutes, 42)
+```
+
+### Config file instead of flags
+
+Anything you can pass as a flag can live in a YAML file (handy for the swarm's
+queue/concurrency topology). Per-environment overlays work like Sidekiq's:
+
+```yaml
+# config/wurk.yml
+:concurrency: 10
+:queues:
+  - default
+  - [critical, 2]      # weighted
+
+:production:
+  :concurrency: 25
+```
+
+```bash
+bundle exec wurk -C config/wurk.yml -e production
+```
+
+ERB is evaluated, so `<%= ENV["..."] %>` works inside the file.
+
+---
+
+## Stopping it
+
+Send `TERM` (or `INT`) for a graceful drain — fetching stops, in-flight jobs
+finish up to the shutdown timeout (`-t`, default 25s), then the process exits. A
+`SIGKILL` is always safe: reliable fetch keeps in-flight jobs on a per-process
+private list in Redis and reclaims them on the next boot. The full signal table
+(quiet, rolling restart, thread dump, log reopen) is in
+[`docs/deployment.md`](deployment.md#signals).


### PR DESCRIPTION
## What

Documents three reader-facing gaps that weren't covered anywhere in `docs/`:

1. **Active Job adapter** — [`docs/active-job.md`](docs/active-job.md)
   - Enabling it (`config.active_job.queue_adapter = :wurk`) + per-job overrides.
   - The migration nuance: a `queue_adapter = :sidekiq` app keeps working when the real `sidekiq` gem is absent (Wurk resolves `:sidekiq` too), but Wurk leaves a genuine Sidekiq install untouched in a mixed bundle.
   - Wire-compat via `Sidekiq::ActiveJob::Wrapper` (mixed pools, pre-swap payloads, `provider_job_id`).
   - Behavior table: transaction-safe enqueue, bulk `enqueue_all`, `sidekiq_options` on AJ classes, `stopping?` on quiet.

2. **Starting the worker** — [`docs/running.md`](docs/running.md)
   - Rails auto-start via the railtie + `WURK_DISABLED=1` opt-out.
   - The `wurk` / `wurkswarm` runners (`sidekiqswarm` alias, no `sidekiq` binary), full flag table, `config/wurk.yml` auto-discovery.

3. **Running without Rails** (part of `docs/running.md`)
   - End-to-end standalone walkthrough: a `-r ./app.rb` boot file, starting single/swarm workers, enqueuing from another process, and the file-vs-directory `-r` branch (only a directory loads `config/environment.rb`).

Cross-linked from the README "Documentation" section and `docs/deployment.md`.

## Why

All three were undocumented for end users. The Active Job adapter only appeared in the parity spec (`docs/target/sidekiq-ent.md`); standalone/no-Rails usage was mentioned in passing in `deployment.md` but never walked through. Everything here is sourced from the actual code (`lib/active_job/queue_adapters/wurk_adapter.rb`, `lib/wurk/cli.rb`, `exe/wurk`, `exe/wurkswarm`), not assumptions.

## Scope

Docs only — no code, no behavior change.

## How to test in prod

Nothing to deploy. To sanity-check the standalone path described in `docs/running.md`:

```bash
# point at any Redis and a one-file app, no Rails
cat > /tmp/app.rb <<'RUBY'
require "wurk"
Wurk.configure_server { |c| c.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/0") } }
class PingJob; include Sidekiq::Worker; def perform(n); puts "pong #{n}"; end; end
RUBY

bundle exec wurk -r /tmp/app.rb -q default -c 2 &
ruby -r wurk -e 'Wurk.configure_client { |c| c.redis = { url: ENV.fetch("REDIS_URL","redis://localhost:6379/0") } }; PingJob.perform_async(1)'
# expect "pong 1" in the worker log; TERM to drain
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for running Wurk workers in both Rails applications and standalone Ruby environments, including runner options and configuration
  * New documentation for configuring Wurk as a Rails Active Job queue adapter, including migration guidance from other adapters
  * Updated README with references to new documentation resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->