### PR TITLE
fix(packaging): declare base64 + logger runtime deps so wurk loads without Rails (#237)

### DIFF
--- a/test/unit/packaging_test.rb
+++ b/test/unit/packaging_test.rb
@@ -5,17 +5,19 @@ require_relative '../test_helper'
 # Guards the gemspec against the "works under Rails, explodes standalone" trap.
 #
 # wurk requires a few libraries that Ruby has moved OUT of the default gems
-# (base64 in 3.4, logger in 4.0). A Rails app pulls them in transitively, so a
+# (base64 in 3.4, logger in 3.5). A Rails app pulls them in transitively, so a
 # missing runtime dep is invisible in-suite and only blows up for a non-Rails
 # consumer at `require "wurk"`. This test pins those deps so a future cleanup
 # can't silently drop them again (#237).
 class PackagingTest < Wurk::Test::UnitCase
+  parallelize_me!
+
   GEMSPEC = Gem::Specification.load(File.expand_path('../../wurk.gemspec', __dir__))
 
   # require '<name>' in lib/ → the gem that ships it once it leaves stdlib.
   EXTRACTED_STDLIB = {
     'base64' => 'base64', # left default gems in Ruby 3.4
-    'logger' => 'logger'  # leaves default gems in Ruby 4.0
+    'logger' => 'logger'  # bundled gem in Ruby 3.5 (deprecation warnings in 3.4)
   }.freeze
 
   def runtime_dep_names

--- a/test/unit/packaging_test.rb
+++ b/test/unit/packaging_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Guards the gemspec against the "works under Rails, explodes standalone" trap.
+#
+# wurk requires a few libraries that Ruby has moved OUT of the default gems
+# (base64 in 3.4, logger in 4.0). A Rails app pulls them in transitively, so a
+# missing runtime dep is invisible in-suite and only blows up for a non-Rails
+# consumer at `require "wurk"`. This test pins those deps so a future cleanup
+# can't silently drop them again (#237).
+class PackagingTest < Wurk::Test::UnitCase
+  GEMSPEC = Gem::Specification.load(File.expand_path('../../wurk.gemspec', __dir__))
+
+  # require '<name>' in lib/ → the gem that ships it once it leaves stdlib.
+  EXTRACTED_STDLIB = {
+    'base64' => 'base64', # left default gems in Ruby 3.4
+    'logger' => 'logger'  # leaves default gems in Ruby 4.0
+  }.freeze
+
+  def runtime_dep_names
+    GEMSPEC.runtime_dependencies.map(&:name)
+  end
+
+  def test_extracted_stdlib_requires_are_declared_runtime_deps
+    libdir = File.expand_path('../../lib', __dir__)
+    required = Dir[File.join(libdir, '**', '*.rb')].flat_map do |f|
+      File.readlines(f).filter_map { |l| l[/^\s*require\s+['"]([a-z0-9_]+)['"]/, 1] }
+    end.uniq
+
+    EXTRACTED_STDLIB.each do |lib, gem_name|
+      next unless required.include?(lib)
+
+      assert_includes runtime_dep_names, gem_name,
+                      "lib/ requires '#{lib}' but #{gem_name} is not a gemspec runtime " \
+                      "dependency — `require \"wurk\"` will LoadError on a Ruby version " \
+                      "where #{lib} has left the default gems (non-Rails apps, #237)."
+    end
+  end
+
+  # The whole point is the gem loads with ONLY its declared deps present, not
+  # whatever Rails happens to drag in. Assert the two known-risky ones are there.
+  def test_base64_and_logger_are_runtime_dependencies
+    assert_includes runtime_dep_names, 'base64'
+    assert_includes runtime_dep_names, 'logger'
+  end
+end

--- a/wurk.gemspec
+++ b/wurk.gemspec
@@ -46,7 +46,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "connection_pool", ">= 2.4", "< 4"
   spec.add_dependency "rack", ">= 2.2", "< 4"
   spec.add_dependency "concurrent-ruby", "~> 1.2"
-  # Bundled-gem extractions: base64 left default gems in Ruby 3.4, logger in 4.0.
+  # Bundled-gem extractions: base64 left default gems in Ruby 3.4, logger became
+  # a bundled gem in Ruby 3.5 (with deprecation warnings starting in Ruby 3.4).
   # A Rails app pulls them in transitively, but a standalone (non-Rails) consumer
   # has neither — without these, `require "wurk"` raises LoadError on Ruby 3.4+.
   spec.add_dependency "base64", ">= 0.1", "< 1"

--- a/wurk.gemspec
+++ b/wurk.gemspec
@@ -46,4 +46,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "connection_pool", ">= 2.4", "< 4"
   spec.add_dependency "rack", ">= 2.2", "< 4"
   spec.add_dependency "concurrent-ruby", "~> 1.2"
+  # Bundled-gem extractions: base64 left default gems in Ruby 3.4, logger in 4.0.
+  # A Rails app pulls them in transitively, but a standalone (non-Rails) consumer
+  # has neither — without these, `require "wurk"` raises LoadError on Ruby 3.4+.
+  spec.add_dependency "base64", ">= 0.1", "< 1"
+  spec.add_dependency "logger", ">= 1.5", "< 2"
 end


### PR DESCRIPTION
Closes #237.

## What

`require "wurk"` raised `LoadError: cannot load such file -- base64` on **Ruby 3.4+**
in any **non-Rails** app — the gem was unusable standalone, breaking the documented
"Running without Rails" flow in [docs/running.md](docs/running.md).

Root cause: the code requires `base64` ([job_record.rb](lib/wurk/job_record.rb), [encryption.rb](lib/wurk/encryption.rb))
and `logger` ([configuration.rb](lib/wurk/configuration.rb), [logger.rb](lib/wurk/logger.rb)),
but neither was a declared runtime dep. Ruby extracted `base64` from default gems in
**3.4** and `logger` in **4.0**. A Rails app pulls both in transitively (so legaldiligence
CI stayed green and this was never caught); a standalone consumer has neither.

## Change
- `wurk.gemspec`: add `base64` (`>= 0.1, < 1`) and `logger` (`>= 1.5, < 2`) as runtime
  deps. Bounded ranges → warning-free `gem build`.
- `test/unit/packaging_test.rb`: regression guard — fails if a future cleanup drops a
  gemspec dep for an extracted-stdlib `require` still present in `lib/`.

## Verification (Ruby 3.4.9)
A minimal non-Rails app (`gem "wurk"` only, no Rails) following docs/running.md:
```
require "wurk" OK -> Wurk 1.0.1
worker booted: processes=1
enqueued jid=86adc9c0bb44b33d141e48fb
EmailJob: start
[MyApp] welcome delivered to user 42
EmailJob elapsed=0.002: done
worker drained + exited on TERM
```
Full suite green except one **pre-existing, unrelated** local failure
(`StaticAssetsTest` — stale vendored manifest `1.0.0.rc1` vs VERSION `1.0.1`; CI
rebuilds the SPA via `vite build`, so it passes there). This PR touches no assets.

## Release
Targets **1.0.2**, alongside the #236 heartbeat/quiet fix. No version bump here — the
bump + release happens once #236 also lands.

## How to test in prod
Nothing to deploy. To confirm the standalone fix on a Ruby 3.4+ box:
```bash
mkdir /tmp/norails && cd /tmp/norails
printf 'source "https://rubygems.org"\ngem "wurk"\n' > Gemfile
bundle install
ruby -e 'require "wurk"; puts "loaded wurk #{Wurk::VERSION}"'   # was: base64 LoadError
```
(Rails apps like legaldiligence are unaffected either way — Rails supplies base64/logger.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests to verify that extracted stdlib requires (e.g., base64, logger) are declared as runtime dependencies.

* **Chores**
  * Explicitly declared base64 and logger as runtime dependencies to prevent LoadError on Ruby versions where those stdlib gems may be unbundled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->