### PR TITLE
fix(dashboard): Quiet/Stop on a swarm worker no longer kills its heartbeat (#236)

### DIFF
--- a/lib/wurk/launcher.rb
+++ b/lib/wurk/launcher.rb
@@ -48,7 +48,12 @@ module Wurk
     def initialize(config, embedded: false)
       @config = config
       @embedded = embedded
+      # Two separate flags, deliberately. @done = "quieted" (stop fetching, stay
+      # alive, report quiet=true). @stopped = "shutting down" (terminate the
+      # heartbeat loop). Quiet must NOT stop the heartbeat — otherwise a quieted
+      # process never publishes quiet=true and expires out of the live set (#236).
       @done = false
+      @stopped = false
       @managers = config.capsules.values.map { |cap| Manager.new(cap) }
       @poller = build_poller
       @cron_poller = build_cron_poller
@@ -127,6 +132,7 @@ module Wurk
       # CAS-release the cluster lock now (planned shutdown) so a follower can
       # take over immediately instead of waiting out the TTL.
       @leader&.stop
+      stop_heartbeat
       clear_heartbeat
       fire_event(:exit, reverse: true)
     end
@@ -217,11 +223,30 @@ module Wurk
       @health_server&.stop
     end
 
-    # Heartbeat thread loop. `safe_thread` already wraps exceptions; we
-    # exit the loop the moment `stop` flips @done so the thread doesn't
-    # outlive the shutdown.
+    # Terminate the heartbeat loop and wait for it to exit before clear_heartbeat
+    # removes us from the `processes` SET — otherwise a final in-flight beat could
+    # SADD us back right after the SREM. Wakes the thread out of its BEAT_PAUSE
+    # sleep so shutdown isn't delayed up to a full interval.
+    def stop_heartbeat
+      @stopped = true
+      thread = @heartbeat_thread
+      return unless thread
+
+      begin
+        thread.wakeup
+      rescue ThreadError
+        nil
+      end
+      thread.join(BEAT_PAUSE)
+    end
+
+    # Heartbeat thread loop. `safe_thread` already wraps exceptions. Loops on
+    # @stopped — NOT @done — so a *quieted* process keeps beating and publishes
+    # `quiet=true` instead of vanishing from the live set (#236). Only `#stop`
+    # flips @stopped; its `Thread#wakeup` breaks the sleep so the loop re-checks
+    # @stopped and exits without waiting out the interval.
     def start_heartbeat
-      until @done
+      until @stopped
         heartbeat
         sleep BEAT_PAUSE
       end

--- a/test/integration/swarm_cli_test.rb
+++ b/test/integration/swarm_cli_test.rb
@@ -73,6 +73,35 @@ class SwarmCliTest < Wurk::Test::UnitCase
     end
   end
 
+  # Regression #236 (real fork): the dashboard "Quiet" button does
+  # `Sidekiq::ProcessSet#quiet!`, which LPUSHes `TSTP` to `<identity>-signals`.
+  # A swarm child must apply that quiet WITHOUT killing its heartbeat — it has to
+  # keep beating, publish `quiet=true`, and stay in the live `processes` SET.
+  # Before the fix the heartbeat loop ran `until @done` and quiet flipped @done,
+  # so the child stopped beating, never reported quiet, and expired off the
+  # dashboard's Busy page.
+  def test_dashboard_quiet_keeps_child_beating_and_reports_quiet
+    parent_pid = fork_swarm_cli
+
+    begin
+      child_id = wait_for_child_identity
+
+      refute_nil child_id, "swarm child never registered within #{POLL_TIMEOUT}s"
+      assert_equal 'false', @observer.call('HGET', child_id, 'quiet'),
+                   'precondition: a fresh child is not quieted'
+
+      # Exactly what the dashboard does.
+      @observer.call('LPUSH', "#{child_id}-signals", 'TSTP')
+
+      assert_equal 'true', wait_for_quiet_flag(child_id),
+                   'quieted swarm child never published quiet=true — heartbeat died on quiet (#236)'
+      assert_equal 1, @observer.call('SISMEMBER', Wurk::Keys::PROCESSES, child_id),
+                   'a quieted child must stay in the live process set, not vanish (#236)'
+    ensure
+      stop(parent_pid)
+    end
+  end
+
   # config.on(:startup) hooks must fire in each swarm worker child before its
   # managers spin up (Sidekiq lifecycle contract).
   def test_run_swarm_fires_startup_in_child
@@ -233,6 +262,41 @@ class SwarmCliTest < Wurk::Test::UnitCase
       sleep POLL_INTERVAL
     end
     nil
+  end
+
+  # Poll the child's published `quiet` field until it reads "true" (or timeout),
+  # returning whatever it last read so the caller asserts on the value.
+  def wait_for_quiet_flag(identity)
+    deadline = monotonic_now + POLL_TIMEOUT
+    loop do
+      val = @observer.call('HGET', identity, 'quiet')
+      return val if val == 'true' || monotonic_now >= deadline
+
+      sleep POLL_INTERVAL
+    end
+  end
+
+  # Poll the live `processes` SET for *this* test's child, identified by the
+  # unique queue it fetches (parallel test methods share one Redis DB, so match
+  # on queue rather than assuming a single registrant).
+  def wait_for_child_identity
+    deadline = monotonic_now + POLL_TIMEOUT
+    while monotonic_now < deadline
+      id = child_identity
+      return id if id
+
+      sleep POLL_INTERVAL
+    end
+    nil
+  end
+
+  def child_identity
+    @observer.call('SMEMBERS', Wurk::Keys::PROCESSES).find do |id|
+      info = @observer.call('HGET', id, 'info')
+      info && Array(Wurk.load_json(info)['queues']).include?(@queue_name)
+    rescue ::JSON::ParserError
+      false
+    end
   end
 
   def stop(pid)

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -320,6 +320,52 @@ class LauncherTest < Wurk::Test::UnitCase
     assert_equal %i[second first], order
   end
 
+  # Regression #236: quiet must NOT stop the heartbeat. A quieted process keeps
+  # beating so it publishes `quiet=true` and stays in the live `processes` SET —
+  # before the fix, quiet flipped the same @done the heartbeat loop ran `until`,
+  # so the process never reported quiet and expired out of the dashboard.
+  def test_quieted_process_publishes_quiet_true_and_stays_listed
+    launcher = build_isolated_launcher
+    silence_managers(launcher)
+    id = launcher_identity(launcher)
+    track(id)
+
+    launcher.send(:beat) # register; writes quiet=false
+    launcher.quiet
+    launcher.send(:beat) # the post-quiet beat must publish the quieted state
+
+    assert_equal 'true', published(id, 'quiet'), 'a quieted process must publish quiet=true (#236)'
+    assert_equal 1, listed?(id), 'a quieted process must stay in the live set (#236)'
+  end
+
+  # Regression #236: the heartbeat survives quiet, so #stop is now what tears the
+  # thread down — via stop_heartbeat (flip @stopped + wake the sleeping loop).
+  def test_stop_terminates_the_heartbeat_thread
+    @config[:timeout] = 0
+    launcher = build_isolated_launcher
+    launcher.managers.each do |m|
+      m.define_singleton_method(:start) { nil }
+      m.define_singleton_method(:quiet) { nil }
+      m.define_singleton_method(:stop) { |_d| nil }
+    end
+    silence_beat(launcher)
+    launcher.poller = launcher.cron_poller = launcher.metrics_rollup = launcher.queue_rollup = launcher.history = nil
+    launcher.instance_variable_set(:@leader, nil)
+    reaper = launcher.instance_variable_get(:@reaper)
+    reaper.define_singleton_method(:start) { nil }
+    reaper.define_singleton_method(:stop) { nil }
+    track(launcher_identity(launcher))
+
+    launcher.run(async_beat: true)
+    thread = launcher.heartbeat_thread
+
+    assert_predicate thread, :alive?, 'heartbeat thread should be running after boot'
+
+    launcher.stop
+
+    refute_predicate thread, :alive?, 'stop must terminate the heartbeat thread (#236)'
+  end
+
   # --- stop ------------------------------------------------------------
 
   def test_stop_invokes_quiet_then_manager_stop_with_deadline
@@ -755,6 +801,14 @@ class LauncherTest < Wurk::Test::UnitCase
 
   def launcher_identity(launcher)
     launcher.identity
+  end
+
+  def published(identity, field)
+    @pool.with { |c| c.call('HGET', identity, field) }
+  end
+
+  def listed?(identity)
+    @pool.with { |c| c.call('SISMEMBER', Wurk::Keys::PROCESSES, identity) }
   end
 
   def track(key)


### PR DESCRIPTION
Closes #236.

## Symptom

Clicking **Quiet** (or **Stop**) on a worker in the dashboard **Busy** page made it
**silently vanish** instead of showing as quieted: the worker stopped reporting
`quiet=true` and then expired out of the live `processes` SET. Repros on every
`wurkswarm` worker (and the deployed demo). Found while dogfooding `test/dummy`.

## Root cause

`Launcher#@done` was **overloaded**:
- the heartbeat loop ran `until @done`, and
- `#quiet` set that **same** `@done = true`.

So quieting a process **terminated its heartbeat thread**. The HSET that publishes
`quiet=true` only lands on the *next* beat — which never happened — and with the
heartbeat dead the identity's TTL lapsed, dropping it off the dashboard. The Quiet
button reaches this through `Sidekiq::ProcessSet#quiet!` → `LPUSH TSTP` to
`<identity>-signals`, drained by the child's own heartbeat, so it hit every worker.

## Fix

Split the two concerns:
- `@done` stays the **quieted** flag — stop fetching, keep `stopping?` true, publish `quiet=true`.
- a new `@stopped` flag (set **only** by `#stop`) is what the heartbeat loop runs `until`.

A quieted process now keeps beating and stays visible as quiet. `#stop` gains
`stop_heartbeat`: flip `@stopped`, `Thread#wakeup` the loop out of its sleep, and
`join` it **before** `clear_heartbeat` removes us from the SET (so a final in-flight
beat can't re-`SADD` right after the `SREM`).

## Tests
- **unit** (`launcher_test.rb`): a quieted launcher publishes `quiet=true` and stays
  listed; `#stop` still terminates the heartbeat thread.
- **integration** (`swarm_cli_test.rb`, real fork + real Redis): a dashboard-style
  quiet (`LPUSH TSTP`) on a swarm child keeps it beating, publishes `quiet=true`, and
  leaves it in the live set. **Confirmed RED before the fix** (heartbeat died, quiet
  never published).

Full suite green except the pre-existing, unrelated `StaticAssetsTest` stale-manifest
local failure (CI rebuilds the SPA via `vite build`). No assets touched.

## Release
Targets **1.0.2**, alongside the #237 base64/logger fix (PR #238).

## How to test in prod
On a `wurkswarm` deploy, open the dashboard **Busy** page and click **Quiet** on a
worker. Expected after this fix: the row flips to **quiet** and **stays listed**
(in-flight finishes, no new fetches) instead of disappearing. **Stop** still drains
and removes the worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition during launcher shutdown that could cause heartbeat activity to persist after cleanup begins, ensuring consistent and reliable shutdown timing.

* **Tests**
  * Added regression tests verifying that quiet operations maintain process visibility and heartbeat, while stop operations fully terminate heartbeat activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->