### PR TITLE
fix(config): accept Sidekiq's nested-array weighted-queue YAML (#241)

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -126,11 +126,21 @@ queue/concurrency topology). Per-environment overlays work like Sidekiq's:
 # config/wurk.yml
 :concurrency: 10
 :queues:
+  - critical            # plain list = strict priority (first wins)
   - default
-  - [critical, 2]      # weighted
 
 :production:
   :concurrency: 25
+```
+
+For weighted fetch, give every queue a weight (Sidekiq's nested-array form). Mixing
+weighted and unweighted entries puts the unweighted ones at weight 0, so weight them
+all:
+
+```yaml
+:queues:
+  - [critical, 2]
+  - [default, 1]
 ```
 
 ```bash

--- a/lib/wurk/capsule.rb
+++ b/lib/wurk/capsule.rb
@@ -153,13 +153,23 @@ module Wurk
       fetcher
     end
 
+    # Accepts both the CLI/string form (`"name"` / `"name,weight"`) and the
+    # nested-array form Sidekiq's YAML produces for weighted queues
+    # (`:queues: - [critical, 2]` parses to `["critical", 2]`). Without the Array
+    # branch a real sidekiq.yml crashes at boot with `Integer(): " 2]"` (#241).
     def parse_queue_entry(entry)
-      qname, weight_str = entry.to_s.split(',', 2)
-      qname = qname.to_s.strip
-      raise ArgumentError, "queue name cannot be empty: `#{entry}`" if qname.empty?
-      return [qname, 0] if weight_str.nil?
+      return parse_pair_queue_entry(entry[0], entry[1], entry) if entry.is_a?(::Array)
 
-      weight = Integer(weight_str)
+      qname, weight_str = entry.to_s.split(',', 2)
+      parse_pair_queue_entry(qname, weight_str, entry)
+    end
+
+    def parse_pair_queue_entry(name, weight, entry)
+      qname = name.to_s.strip
+      raise ArgumentError, "queue name cannot be empty: `#{entry}`" if qname.empty?
+      return [qname, 0] if weight.nil?
+
+      weight = Integer(weight)
       raise ArgumentError, "queue weight must be > 0: `#{entry}`" if weight <= 0
 
       [qname, weight]

--- a/lib/wurk/capsule.rb
+++ b/lib/wurk/capsule.rb
@@ -158,7 +158,11 @@ module Wurk
     # (`:queues: - [critical, 2]` parses to `["critical", 2]`). Without the Array
     # branch a real sidekiq.yml crashes at boot with `Integer(): " 2]"` (#241).
     def parse_queue_entry(entry)
-      return parse_pair_queue_entry(entry[0], entry[1], entry) if entry.is_a?(::Array)
+      if entry.is_a?(::Array)
+        raise ArgumentError, "queue entry must be `[name]` or `[name, weight]`: `#{entry}`" if entry.size > 2
+
+        return parse_pair_queue_entry(entry[0], entry[1], entry)
+      end
 
       qname, weight_str = entry.to_s.split(',', 2)
       parse_pair_queue_entry(qname, weight_str, entry)

--- a/test/unit/capsule_test.rb
+++ b/test/unit/capsule_test.rb
@@ -205,6 +205,35 @@ class CapsuleTest < Wurk::Test::UnitCase
     assert_raises(ArgumentError) { @capsule.queues = ['high,foo'] }
   end
 
+  # #241: Sidekiq's weighted-queue YAML (`:queues: - [high, 3]`) parses to nested
+  # arrays, which used to crash `parse_queue_entry` with `Integer(): " 3]"`.
+  def test_queues_setter_accepts_nested_array_weight_pairs
+    @capsule.queues = [['high', 3], ['default', 2], ['low', 1]]
+
+    assert_equal :weighted, @capsule.mode
+    assert_equal({ 'high' => 3, 'default' => 2, 'low' => 1 }, @capsule.weights)
+    assert_equal %w[high high high default default low], @capsule.queues
+  end
+
+  # A bare array entry (no weight) is a plain/strict queue, same as a plain string.
+  def test_queues_setter_accepts_nested_array_without_weight
+    @capsule.queues = [['high'], ['low']]
+
+    assert_equal :strict, @capsule.mode
+    assert_equal({ 'high' => 0, 'low' => 0 }, @capsule.weights)
+  end
+
+  # Mixed string + array entries (as a hand-written YAML might combine them).
+  def test_queues_setter_accepts_mixed_string_and_array_entries
+    @capsule.queues = ['high,3', ['default', 2], 'low,1']
+
+    assert_equal({ 'high' => 3, 'default' => 2, 'low' => 1 }, @capsule.weights)
+  end
+
+  def test_queues_setter_raises_on_non_integer_array_weight
+    assert_raises(ArgumentError) { @capsule.queues = [%w[high foo]] }
+  end
+
   def test_queues_setter_raises_on_blank_queue_name
     assert_raises(ArgumentError) { @capsule.queues = [''] }
     assert_raises(ArgumentError) { @capsule.queues = ['  '] }

--- a/test/unit/capsule_test.rb
+++ b/test/unit/capsule_test.rb
@@ -234,6 +234,12 @@ class CapsuleTest < Wurk::Test::UnitCase
     assert_raises(ArgumentError) { @capsule.queues = [%w[high foo]] }
   end
 
+  # A nested array with a stray third element is a config mistake, not a
+  # [name, weight] pair — reject it instead of silently truncating to entry[0..1].
+  def test_queues_setter_raises_on_oversized_array_entry
+    assert_raises(ArgumentError) { @capsule.queues = [['high', 2, 'x']] }
+  end
+
   def test_queues_setter_raises_on_blank_queue_name
     assert_raises(ArgumentError) { @capsule.queues = [''] }
     assert_raises(ArgumentError) { @capsule.queues = ['  '] }

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -52,6 +52,7 @@ class CLITest < Wurk::Test::UnitCase
 
     yielded = false
     @cli.config.configure_server { yielded = true }
+
     assert yielded, 'configure_server must fire once server mode is entered'
   end
 
@@ -169,6 +170,24 @@ class CLITest < Wurk::Test::UnitCase
 
       assert_equal 7, @cli.config[:concurrency]
       assert_includes @cli.config.default_capsule.weights.keys, 'critical'
+    end
+  end
+
+  # #241: a real sidekiq.yml writes weighted queues as nested arrays
+  # (`- [critical, 2]`). YAML parses those to `["critical", 2]`, which used to
+  # crash the CLI at boot with `invalid value for Integer(): " 2]"`.
+  def test_loads_yaml_with_sidekiq_weighted_queue_arrays
+    Tempfile.create(['wurk', '.yml']) do |f|
+      f.write(<<~YAML)
+        :concurrency: 5
+        :queues:
+          - [critical, 2]
+          - [default, 1]
+      YAML
+      f.flush
+      with_require_set { @cli.parse(['-C', f.path]) }
+
+      assert_equal({ 'critical' => 2, 'default' => 1 }, @cli.config.default_capsule.weights)
     end
   end
 


### PR DESCRIPTION
Closes #241.

## Bug
Booting with the standard Sidekiq weighted-queue YAML crashed at startup:
```
wurk: invalid value for Integer(): " 2]"   ← capsule.rb parse_queue_entry
```
A real `sidekiq.yml` writes weighted queues as **nested arrays**:
```yaml
:queues:
  - [critical, 2]
  - [default, 1]
```
YAML parses each entry to `["critical", 2]`, but `parse_queue_entry` only handled
the string form (`"name"` / `"name,weight"`). The array stringified to
`'["critical", 2]'`, split to `['["critical"', ' 2]']`, and `Integer(" 2]")` raised.
Drop-in violation — an existing weighted `sidekiq.yml` couldn't boot on Wurk.

## Fix
`parse_queue_entry` now accepts the `[name, weight]` (and bare `[name]`) array form
in addition to the string form, via a shared `parse_pair_queue_entry`.

## Tests
- `capsule_test`: nested-array weighted pairs, bare-array (no weight), mixed
  string+array entries, and a non-integer array weight raising.
- `cli_test`: loads a YAML with `- [critical, 2]` end-to-end (the exact #241 repro)
  without crashing.
- Behavioral: booted `wurk -C` against the previously-crashing config — now starts
  with `queues=['critical', 'default']`.

Full suite green except the pre-existing, unrelated `StaticAssetsTest` stale-manifest
failure (CI rebuilds the SPA).

## Docs
Fixes the `docs/running.md` config example (it showed this crashing syntax) and adds
a note about the weight-0 gotcha when mixing weighted and unweighted entries.

## Found by
Following `docs/running.md` end-to-end. `docs/active-job.md` was also followed in full
and is accurate — no issues.

## How to test in prod
Point a worker at a `sidekiq.yml`/`wurk.yml` with weighted queues:
```yaml
:queues:
  - [critical, 2]
  - [default, 1]
```
`bundle exec wurk -C config/wurk.yml` now boots (previously exited 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed boot-time crashes when using Sidekiq-style weighted queue arrays in configuration files. Queue entries formatted as `[queue_name, weight]` now parse correctly without errors.

* **Documentation**
  * Updated configuration examples to clarify weighted and unweighted queue list formats and their interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->