### PR TITLE
feat(dashboard): per-request read_only in /api/meta for viewer-role auth hooks (#243)

### DIFF
--- a/app/controllers/wurk/api_controller.rb
+++ b/app/controllers/wurk/api_controller.rb
@@ -44,7 +44,7 @@ module Wurk
     def meta
       config = ::Wurk::Web.config
       render json: {
-        read_only: config.read_only?,
+        read_only: config.read_only? || !mutations_authorized?(config),
         read_only_message: config.read_only_message,
         custom_tabs: config.custom_tabs
       }
@@ -293,6 +293,19 @@ module Wurk
     end
 
     private
+
+    # Per-request read-only signal for the SPA. When a registered authorization
+    # hook would reject a *mutating* request for this user (e.g. a viewer role
+    # that may GET but not retry/kill), report `read_only` so the SPA hides the
+    # destructive actions — the Authorization middleware already 403s the
+    # mutation itself, this just stops the buttons from showing. With no hook
+    # registered, `authorized?` is always true, so this is a no-op and the flag
+    # keeps reflecting the global read-only mode. Probes with POST as a
+    # representative mutating method (SAFE_METHODS are GET/HEAD/OPTIONS); a
+    # path-independent role hook resolves the same regardless of path.
+    def mutations_authorized?(config)
+      config.authorized?(request.env, 'POST', request.path_info)
+    end
 
     # Resolves a single entry by "<score>|<jid>" key and applies a whitelisted
     # action. 400 on an unknown action, 404 when the key matches nothing (e.g.

--- a/app/controllers/wurk/api_controller.rb
+++ b/app/controllers/wurk/api_controller.rb
@@ -294,17 +294,25 @@ module Wurk
 
     private
 
+    # Engine-relative path probed as a representative mutation. Must be a real
+    # mutating route (POST /api/retries — bulk retry/delete/kill) so that a
+    # path-sensitive hook resolves it the same way the Authorization middleware
+    # will resolve the actual mutation. Probing `request.path_info` (which here
+    # is the GET /api/meta path) would let such a hook allow the probe while
+    # still 403ing real mutations, reviving the "button shows, then 403s" gap.
+    MUTATION_PROBE_PATH = '/api/retries'
+
     # Per-request read-only signal for the SPA. When a registered authorization
     # hook would reject a *mutating* request for this user (e.g. a viewer role
     # that may GET but not retry/kill), report `read_only` so the SPA hides the
     # destructive actions — the Authorization middleware already 403s the
     # mutation itself, this just stops the buttons from showing. With no hook
     # registered, `authorized?` is always true, so this is a no-op and the flag
-    # keeps reflecting the global read-only mode. Probes with POST as a
-    # representative mutating method (SAFE_METHODS are GET/HEAD/OPTIONS); a
-    # path-independent role hook resolves the same regardless of path.
+    # keeps reflecting the global read-only mode. Probes POST on a canonical
+    # mutating path (SAFE_METHODS are GET/HEAD/OPTIONS) so a path-sensitive hook
+    # answers for a real mutation, not the GET /api/meta request carrying it.
     def mutations_authorized?(config)
-      config.authorized?(request.env, 'POST', request.path_info)
+      config.authorized?(request.env, 'POST', MUTATION_PROBE_PATH)
     end
 
     # Resolves a single entry by "<score>|<jid>" key and applies a whitelisted

--- a/test/engine/web_authorization_test.rb
+++ b/test/engine/web_authorization_test.rb
@@ -128,6 +128,21 @@ class WebAuthorizationTest < Wurk::Test::EngineCase
     assert_equal false, JSON.parse(last_response.body)['read_only']
   end
 
+  # A path-sensitive hook (permits the current /api/meta path but denies real
+  # mutating routes) must still report read_only=true. The probe has to ask
+  # about a canonical mutating path, not the GET request's own /api/meta path —
+  # otherwise the SPA shows actions that the Authorization middleware then 403s.
+  def test_meta_reports_read_only_for_a_path_sensitive_authorization
+    Wurk::Web.configure do |c|
+      c.authorization { |_, _, path| path == '/api/meta' }
+    end
+
+    get '/wurk/api/meta'
+
+    assert_equal 200, last_response.status
+    assert_equal true, JSON.parse(last_response.body)['read_only']
+  end
+
   def test_meta_includes_read_only_message_when_set
     Wurk::Web.configure do |c|
       c.read_only = true

--- a/test/engine/web_authorization_test.rb
+++ b/test/engine/web_authorization_test.rb
@@ -105,6 +105,29 @@ class WebAuthorizationTest < Wurk::Test::EngineCase
     assert_equal true, JSON.parse(last_response.body)['read_only']
   end
 
+  # Per-request read-only: a viewer role (authorization hook permits GET but
+  # denies mutations) must surface read_only=true so the SPA hides destructive
+  # actions — even with the global read-only mode off.
+  def test_meta_reports_read_only_for_a_view_only_authorization
+    Wurk::Web.configure { |c| c.authorization { |_, method, _| method == 'GET' } }
+
+    get '/wurk/api/meta'
+
+    assert_equal 200, last_response.status
+    assert_equal true, JSON.parse(last_response.body)['read_only']
+  end
+
+  # An authorization hook that permits mutations (e.g. an admin role) keeps
+  # read_only false so the SPA shows the actions.
+  def test_meta_reports_read_write_for_a_mutating_authorization
+    Wurk::Web.configure { |c| c.authorization { |_, _, _| true } }
+
+    get '/wurk/api/meta'
+
+    assert_equal 200, last_response.status
+    assert_equal false, JSON.parse(last_response.body)['read_only']
+  end
+
   def test_meta_includes_read_only_message_when_set
     Wurk::Web.configure do |c|
       c.read_only = true


### PR DESCRIPTION
Closes #243.

## What
Makes the dashboard's read-only signal **per-request**, so a role-based authorization
hook (admin = full, viewer = read-only) gives viewers a clean read-only UI instead of
buttons that 403 on click.

`/api/meta`'s `read_only` is now `true` when **either**:
- the global flag is on (`WURK_WEB_READ_ONLY` / `config.read_only = true`), **or**
- the per-request authorization hook would reject a mutating request for this user
  (probed with `POST`).

The SPA already hides destructive actions when `meta.read_only` is true, so no
frontend change is needed.

## Why
The authorization hook can grant read-only access (allow GET, deny mutations), and the
Authorization middleware already 403s those mutations server-side — but `/api/meta`
reported `read_only: false`, so the SPA still rendered retry/kill/delete/pause buttons.
Found while wiring a Zitadel role hook (`legald-admin` → full, `legald-user` → read-only).

## Safety
- **No hook registered → no change.** `authorized?` returns true with no hook, so
  `read_only` keeps reflecting the global mode (default false).
- Server-side enforcement is untouched; this only aligns the SPA's affordances with
  what the hook already enforces.

## Tests
`web_authorization_test`: a GET-only hook → `meta.read_only == true`; a permit-all
hook → `false`. Full suite green except the pre-existing, unrelated `StaticAssetsTest`
stale-manifest failure (CI rebuilds the SPA).

## Release
Target **1.0.2**.

## How to test in prod
With a role-based hook installed:
```ruby
Wurk::Web.configure do |c|
  c.authorization { |_, method, _| admin?(env) || %w[GET HEAD OPTIONS].include?(method) }
end
```
A viewer (non-admin) now sees the dashboard in read-only mode (no destructive buttons,
read-only banner); an admin sees full controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The API now properly evaluates user permissions for write operations and sets read-only mode accordingly. Users without write authorization will see the interface in read-only mode.

* **Tests**
  * Added comprehensive tests for authorization-driven read-only behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->