### PR TITLE
design: obsidian dashboard redesign + landing tier-card glow

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -122,15 +122,15 @@
     /* Cursor-tracking spotlight: a soft brightness glow follows the pointer
        across each card (JS sets --mx/--my). Brightness only, no chroma — keeps
        the monochrome palette. A faint ring brightens to read as "alive". */
-    .pillar, .feature { position: relative; overflow: hidden; isolation: isolate; }
+    .pillar { position: relative; overflow: hidden; isolation: isolate; }
     .pillar > *, .feature > * { position: relative; z-index: 1; }
-    .pillar::before, .feature::before {
+    .pillar::before {
       content: ""; position: absolute; inset: 0; z-index: 0; border-radius: inherit;
       background: radial-gradient(280px circle at var(--mx, 50%) var(--my, -30%),
         rgba(255,255,255,0.11), rgba(255,255,255,0.04) 38%, transparent 62%);
       opacity: 0; transition: opacity .3s ease; pointer-events: none;
     }
-    .pillar::after, .feature::after {
+    .pillar::after {
       content: ""; position: absolute; inset: 0; z-index: 0; border-radius: inherit;
       padding: 1px; pointer-events: none; opacity: 0; transition: opacity .3s ease;
       background: radial-gradient(360px circle at var(--mx, 50%) var(--my, -30%),
@@ -139,8 +139,74 @@
       -webkit-mask-composite: xor; mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
       mask-composite: exclude;
     }
-    .pillar:hover::before, .feature:hover::before,
-    .pillar:hover::after, .feature:hover::after { opacity: 1; }
+    .pillar:hover::before, .pillar:hover::after { opacity: 1; }
+
+    /* ── Per-tier BorderGlow on the feature (tier) cards ──
+       Ported from the React Bits <BorderGlow/> to vanilla CSS/JS. A colored 1px
+       border and an outer bloom track the cursor and brighten as it nears an
+       edge; the hue is the Sidekiq tier each feature replaces — OSS green, Pro
+       blue, Enterprise purple — so each card shows which paid tier Wurk frees.
+       The three hues are GitHub-dark accents, so they sit on the existing
+       palette (OSS green == --success). JS sets --edge-proximity (0–100) and
+       --cursor-angle; both stay 0/45deg without JS, so the cards degrade to the
+       plain bordered panels. */
+    :root { --tier-oss: 63 185 80; --tier-pro: 88 166 255; --tier-ent: 188 140 255; }
+    .feature {
+      isolation: isolate; overflow: visible;
+      --edge-proximity: 0; --cursor-angle: 45deg;
+      --edge-sensitivity: 26; --color-sensitivity: 46;
+      --glow: var(--tier-oss);
+    }
+    .feature--oss { --glow: var(--tier-oss); }
+    .feature--pro { --glow: var(--tier-pro); }
+    .feature--ent { --glow: var(--tier-ent); }
+
+    /* Soft inner colour wash that follows the pointer (under the text). */
+    .feature::before {
+      content: ""; position: absolute; inset: 0; z-index: 0; border-radius: inherit;
+      pointer-events: none; opacity: 0; transition: opacity .35s ease;
+      background: radial-gradient(360px circle at var(--mx, 50%) var(--my, -30%),
+        rgb(var(--glow) / 0.16), rgb(var(--glow) / 0.05) 40%, transparent 64%);
+    }
+    .feature:hover::before { opacity: 1; }
+
+    /* Colored 1px border, masked to a cone around the cursor, opacity driven by
+       edge proximity — the BorderGlow signature. */
+    .feature::after {
+      content: ""; position: absolute; inset: 0; z-index: 0; border-radius: inherit;
+      padding: 1px; pointer-events: none;
+      background: conic-gradient(from var(--cursor-angle) at center,
+        rgb(var(--glow) / 0.95), rgb(var(--glow) / 0) 24%,
+        rgb(var(--glow) / 0) 76%, rgb(var(--glow) / 0.95));
+      -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+      -webkit-mask-composite: xor; mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+      mask-composite: exclude;
+      opacity: calc((var(--edge-proximity) - var(--color-sensitivity)) / (100 - var(--color-sensitivity)));
+      transition: opacity .12s linear;
+    }
+
+    /* Outer + inner bloom in the tier colour (BorderGlow's edge-light layer). */
+    .feature > .edge-light {
+      position: absolute; inset: -18px; z-index: 0; border-radius: 22px;
+      pointer-events: none; mix-blend-mode: plus-lighter;
+      opacity: calc((var(--edge-proximity) - var(--edge-sensitivity)) / (100 - var(--edge-sensitivity)));
+      transition: opacity .12s linear;
+      -webkit-mask: conic-gradient(from var(--cursor-angle) at center,
+        #000 3%, transparent 12%, transparent 88%, #000 97%);
+      mask: conic-gradient(from var(--cursor-angle) at center,
+        #000 3%, transparent 12%, transparent 88%, #000 97%);
+    }
+    .feature > .edge-light::before {
+      content: ""; position: absolute; inset: 18px; border-radius: inherit;
+      box-shadow:
+        inset 0 0 0 1px rgb(var(--glow) / 1),
+        inset 0 0 6px 0 rgb(var(--glow) / 0.40),
+        inset 0 0 16px 0 rgb(var(--glow) / 0.26),
+        0 0 6px 0 rgb(var(--glow) / 0.45),
+        0 0 16px 0 rgb(var(--glow) / 0.30),
+        0 0 30px 2px rgb(var(--glow) / 0.15);
+    }
+    .feature:not(:hover) > .edge-light { opacity: 0; transition: opacity .6s ease; }
     .feature__ic { display: inline-flex; align-items: center; justify-content: center;
       width: 44px; height: 44px; border-radius: 11px; margin-bottom: 14px;
       background: var(--panel-2); border: 1px solid var(--line-strong); color: var(--fg); font-size: 18px; }
@@ -253,37 +319,43 @@ gem <span class="add">"wurk"</span></pre>
           No license keys, no per-seat math, no feature flags. Just <code>bundle install</code>.
         </p>
         <div class="features-grid">
-          <div class="feature">
+          <div class="feature feature--oss">
+            <span class="edge-light" aria-hidden="true"></span>
             <span class="feature__ic"><i class="fa-solid fa-bolt" aria-hidden="true"></i></span>
             <h3>Real parallelism, not just threads</h3>
             <p>Fork-based workers use every core — no GIL bottleneck. Reliable BLMOVE fetch, PID supervision, zero-downtime rolling restarts, and graceful drain are built in.</p>
             <span class="feature__tier"><i class="fa-solid fa-check free" aria-hidden="true"></i> Sidekiq OSS + Pro</span>
           </div>
-          <div class="feature">
+          <div class="feature feature--pro">
+            <span class="edge-light" aria-hidden="true"></span>
             <span class="feature__ic"><i class="fa-solid fa-table-cells-large" aria-hidden="true"></i></span>
             <h3>Batches that fan out &amp; call back</h3>
             <p>Track thousands of jobs as one unit. Fire success / complete / death callbacks, nest batches arbitrarily deep, and watch live progress roll in.</p>
             <span class="feature__tier"><s>Sidekiq Pro</s> · <span class="free">free</span></span>
           </div>
-          <div class="feature">
+          <div class="feature feature--ent">
+            <span class="edge-light" aria-hidden="true"></span>
             <span class="feature__ic"><i class="fa-solid fa-gauge" aria-hidden="true"></i></span>
             <h3>Rate limiting that holds the line</h3>
             <p>Concurrent, bucket, window, leaky, and points limiters protect fragile downstreams — throttle a third-party API or a hot database without ever dropping work.</p>
             <span class="feature__tier"><s>Sidekiq Enterprise</s> · <span class="free">free</span></span>
           </div>
-          <div class="feature">
+          <div class="feature feature--ent">
+            <span class="edge-light" aria-hidden="true"></span>
             <span class="feature__ic"><i class="fa-solid fa-stopwatch" aria-hidden="true"></i></span>
             <h3>Cron that fires exactly once</h3>
             <p>Leader-elected periodic jobs mean every schedule tick runs once across your whole fleet — no duplicate sends, no missed ticks, no extra moving parts.</p>
             <span class="feature__tier"><s>Sidekiq Enterprise</s> · <span class="free">free</span></span>
           </div>
-          <div class="feature">
+          <div class="feature feature--ent">
+            <span class="edge-light" aria-hidden="true"></span>
             <span class="feature__ic"><i class="fa-solid fa-shield-halved" aria-hidden="true"></i></span>
             <h3>Encrypted arguments, rotated keys</h3>
             <p>AES-256-GCM encryption for sensitive job arguments with zero-downtime key rotation. PII and secrets never sit in Redis as plaintext.</p>
             <span class="feature__tier"><s>Sidekiq Enterprise</s> · <span class="free">free</span></span>
           </div>
-          <div class="feature">
+          <div class="feature feature--oss">
+            <span class="edge-light" aria-hidden="true"></span>
             <span class="feature__ic"><i class="fa-solid fa-gauge-high" aria-hidden="true"></i></span>
             <h3>A dashboard you'll keep open</h3>
             <p>A precompiled React SPA ships inside the gem — consumers never touch Node. Live queues, retries, busy workers, batches, limiters, cron, and metrics, with click-through job detail.</p>
@@ -412,17 +484,40 @@ mount Wurk::Engine =&gt; <span class="add">"/wurk"</span></pre>
       });
     })();
 
-    // Cursor-tracking spotlight: update --mx/--my to the pointer position so the
-    // radial glow + glowing border in ::before/::after follow the mouse.
+    // Cursor-tracking glow. For every card --mx/--my follow the pointer (the
+    // monochrome pillar spotlight). Feature/tier cards additionally get the
+    // BorderGlow inputs: --edge-proximity (0–100, 100 == on an edge) and
+    // --cursor-angle (deg from centre, 0 == up), which drive the per-tier
+    // colored border + bloom. Math mirrors the React Bits <BorderGlow/>.
     (function () {
       if (window.matchMedia && window.matchMedia('(pointer: coarse)').matches) return;
       var cards = document.querySelectorAll('.pillar, .feature');
       cards.forEach(function (card) {
+        var isFeature = card.classList.contains('feature');
         card.addEventListener('pointermove', function (e) {
           var r = card.getBoundingClientRect();
-          card.style.setProperty('--mx', (e.clientX - r.left) + 'px');
-          card.style.setProperty('--my', (e.clientY - r.top) + 'px');
+          var x = e.clientX - r.left, y = e.clientY - r.top;
+          card.style.setProperty('--mx', x + 'px');
+          card.style.setProperty('--my', y + 'px');
+          if (!isFeature) return;
+          var cx = r.width / 2, cy = r.height / 2;
+          var dx = x - cx, dy = y - cy;
+          var kx = dx === 0 ? Infinity : cx / Math.abs(dx);
+          var ky = dy === 0 ? Infinity : cy / Math.abs(dy);
+          var edge = Math.min(Math.max(1 / Math.min(kx, ky), 0), 1);
+          var angle = 0;
+          if (dx !== 0 || dy !== 0) {
+            angle = Math.atan2(dy, dx) * 180 / Math.PI + 90;
+            if (angle < 0) angle += 360;
+          }
+          card.style.setProperty('--edge-proximity', (edge * 100).toFixed(2));
+          card.style.setProperty('--cursor-angle', angle.toFixed(2) + 'deg');
         });
+        if (isFeature) {
+          card.addEventListener('pointerleave', function () {
+            card.style.setProperty('--edge-proximity', '0');
+          });
+        }
       });
     })();
   </script>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "wurk-dashboard",
       "version": "0.0.1",
       "dependencies": {
+        "@fontsource/geist-sans": "^5.2.5",
+        "@fontsource/jetbrains-mono": "^5.2.8",
         "@fortawesome/fontawesome-free": "^7.2.0",
         "@tanstack/react-query": "^5.100.0",
         "react": "^19.2.0",
@@ -319,6 +321,24 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fontsource/geist-sans": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@fontsource/geist-sans/-/geist-sans-5.2.5.tgz",
+      "integrity": "sha512-anllOHyJbElRs9fV15TeDRqAeb1IKm4bSknPl6ZMoyPTx1BBy7logudcUwpNjmQLkzn4Q0JGQLRCUKJYoyST6A==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@fortawesome/fontawesome-free": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,8 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@fontsource/geist-sans": "^5.2.5",
+    "@fontsource/jetbrains-mono": "^5.2.8",
     "@fortawesome/fontawesome-free": "^7.2.0",
     "@tanstack/react-query": "^5.100.0",
     "react": "^19.2.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -72,7 +72,7 @@ export default function App() {
 
           <main
             className="main-content"
-            style={{ flex: 1, padding: '1.5rem', marginInlineStart: 'var(--nav-width)' }}
+            style={{ flex: 1, padding: '1.5rem', marginInlineStart: 'var(--nav-rail)' }}
           >
             <ReadOnlyBanner />
             <Routes>

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -1,3 +1,4 @@
+import type { MouseEvent } from 'react';
 import { NavLink, Link } from 'react-router-dom';
 import { t } from '../i18n';
 import { useMeta } from '../hooks/useMeta';
@@ -30,12 +31,20 @@ export default function Nav({ open, onClose }: NavProps) {
   const { data: meta } = useMeta();
   const customTabs = meta?.custom_tabs ?? [];
 
+  // Close the mobile drawer AND drop focus so the desktop rail collapses back
+  // after a click — otherwise :focus-within keeps it expanded until you click
+  // elsewhere.
+  const handleNavClick = (e: MouseEvent<HTMLElement>) => {
+    onClose();
+    e.currentTarget.blur();
+  };
+
   return (
     <>
       {/* Overlay for mobile */}
       {open && (
         <div
-          onClick={onClose}
+          onClick={handleNavClick}
           style={{
             position: 'fixed',
             inset: 0,
@@ -53,38 +62,53 @@ export default function Nav({ open, onClose }: NavProps) {
           top: 0,
           insetInlineStart: 0,
           bottom: 0,
-          width: 'var(--nav-width)',
           background: 'var(--surface)',
           borderInlineEnd: '1px solid var(--border)',
           display: 'flex',
           flexDirection: 'column',
           zIndex: 100,
           overflowY: 'auto',
-          transition: 'transform 0.25s ease',
+          overflowX: 'hidden',
         }}
       >
-        <div style={{ padding: '1.25rem 1rem 0.75rem' }}>
+        <div className="nav-brand-wrap" style={{ padding: '1.25rem 1rem 0.75rem' }}>
           <Link
             to="/"
-            onClick={onClose}
+            onClick={handleNavClick}
             aria-label="Wurk — dashboard home"
             style={{
-              fontSize: 20,
-              fontWeight: 800,
-              letterSpacing: '-0.03em',
               color: 'var(--text)',
               textDecoration: 'none',
               display: 'flex',
               alignItems: 'center',
-              gap: '0.55rem',
+              gap: '0.6rem',
             }}
           >
             <img
               src={logoUrl}
               alt="Wurk"
-              style={{ height: 48, width: 'auto', display: 'block', filter: 'drop-shadow(0 2px 6px rgba(0,0,0,0.45))' }}
+              style={{ height: 36, width: 'auto', display: 'block', flex: 'none', filter: 'drop-shadow(0 2px 6px rgba(0,0,0,0.45))' }}
             />
-            Wurk
+            <span className="nav-label" style={{ display: 'flex', flexDirection: 'column', lineHeight: 1.15 }}>
+              <span style={{ fontSize: 18, fontWeight: 700, letterSpacing: '-0.02em', color: 'var(--text-bright)' }}>Wurk</span>
+              <span
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 9,
+                  fontWeight: 500,
+                  letterSpacing: '0.1em',
+                  textTransform: 'uppercase',
+                  color: 'var(--text-muted)',
+                  marginTop: 2,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 5,
+                }}
+              >
+                <span className="live-dot" style={{ width: 6, height: 6 }} />
+                System Status: Active
+              </span>
+            </span>
           </Link>
         </div>
 
@@ -96,7 +120,7 @@ export default function Nav({ open, onClose }: NavProps) {
               <NavLink
                 to={to}
                 end={end}
-                onClick={onClose}
+                onClick={handleNavClick}
                 className="wurk-navlink"
                 style={({ isActive }) => ({
                   display: 'flex',
@@ -116,8 +140,8 @@ export default function Nav({ open, onClose }: NavProps) {
                   transition: 'background 0.15s, color 0.15s, box-shadow 0.15s',
                 })}
               >
-                <i className={`fa-solid ${icon}`} style={{ fontSize: 14, width: 20, textAlign: 'center' }} />
-                <span>{label}</span>
+                <i className={`fa-solid ${icon} wurk-navlink__icon`} aria-hidden="true" />
+                <span className="nav-label">{label}</span>
               </NavLink>
             </li>
           ))}
@@ -125,7 +149,7 @@ export default function Nav({ open, onClose }: NavProps) {
           {customTabs.length > 0 && (
             <li aria-hidden="true" style={{ padding: '0.5rem 0.95rem 0.2rem', marginTop: '0.4rem' }}>
               <div style={{ height: 1, background: 'var(--border)', marginBottom: '0.45rem' }} />
-              <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'var(--text-muted)' }}>
+              <span className="nav-label" style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'var(--text-muted)' }}>
                 {t('nav.extensions')}
               </span>
             </li>
@@ -138,7 +162,7 @@ export default function Nav({ open, onClose }: NavProps) {
                   route param round-trips to the same tab. */}
               <NavLink
                 to={`/ext/${tab.path.replace(/\/+$/, '')}`}
-                onClick={onClose}
+                onClick={handleNavClick}
                 className="wurk-navlink"
                 style={({ isActive }) => ({
                   display: 'flex',
@@ -156,8 +180,8 @@ export default function Nav({ open, onClose }: NavProps) {
                   transition: 'background 0.15s, color 0.15s, box-shadow 0.15s',
                 })}
               >
-                <i className="fa-solid fa-puzzle-piece" style={{ fontSize: 14, width: 20, textAlign: 'center' }} />
-                <span>{tab.name}</span>
+                <i className="fa-solid fa-puzzle-piece wurk-navlink__icon" aria-hidden="true" />
+                <span className="nav-label">{tab.name}</span>
               </NavLink>
             </li>
           ))}
@@ -184,20 +208,24 @@ export default function Nav({ open, onClose }: NavProps) {
             transition: 'background 0.15s, color 0.15s',
           }}
         >
-          <i className="fa-brands fa-github" style={{ fontSize: 16, width: 20, textAlign: 'center' }} />
-          <span>GitHub</span>
+          <i className="fa-brands fa-github" style={{ fontSize: 16, width: 20, textAlign: 'center', flex: 'none' }} />
+          <span className="nav-label">GitHub</span>
         </a>
       </nav>
 
       <style>{`
+        .wurk-nav { width: var(--nav-width); }
         .wurk-navlink:hover {
           background: var(--surface-hover) !important;
           color: var(--accent) !important;
           text-decoration: none !important;
         }
+        .nav-label { white-space: nowrap; }
+        .wurk-navlink__icon { width: 24px; font-size: 18px; text-align: center; flex: none; }
         @media (max-width: 767px) {
           .wurk-nav {
             transform: translateX(-100%);
+            transition: transform 0.25s ease;
           }
           .wurk-nav--open {
             transform: translateX(0);
@@ -214,10 +242,55 @@ export default function Nav({ open, onClose }: NavProps) {
             display: block !important;
           }
         }
+        /* Desktop: a collapsed icon rail that expands to the full width on hover
+           or keyboard focus, overlaying the content (which reserves only the rail
+           width). prefers-reduced-motion drops the width animation. */
         @media (min-width: 768px) {
           .wurk-nav {
             transform: none !important;
+            width: var(--nav-rail);
+            transition: width 0.2s ease;
           }
+          .wurk-nav:hover,
+          .wurk-nav:focus-within {
+            width: var(--nav-width);
+            box-shadow: 10px 0 28px rgba(0, 0, 0, 0.5);
+          }
+          /* !important: the brand wordmark span carries an inline display:flex,
+             which a plain class rule can't beat — without this the "Wurk /
+             System Status" text stays rendered in the 64px rail and gets clipped. */
+          .wurk-nav:not(:hover):not(:focus-within) .nav-label { display: none !important; }
+          /* Collapsed: center each icon and give it roomy, even padding so the
+             rail breathes. Icon size stays the SAME as the expanded state — only
+             the surrounding space changes, so glyphs don't jump/resize on hover. */
+          .wurk-nav:not(:hover):not(:focus-within) .wurk-navlink { justify-content: center; padding: 0.7rem 0; }
+          .wurk-nav:not(:hover):not(:focus-within) .wurk-navlink__icon { width: auto; }
+          /* Collapsed active item: the rectangular pill (set via inline styles)
+             would look boxy in the narrow rail, so flatten the link and draw a
+             round highlight around just the glyph instead. */
+          .wurk-nav:not(:hover):not(:focus-within) .wurk-navlink.active {
+            background: transparent !important;
+            box-shadow: none !important;
+          }
+          .wurk-nav:not(:hover):not(:focus-within) .wurk-navlink.active .wurk-navlink__icon {
+            display: grid;
+            place-items: center;
+            width: 38px;
+            height: 38px;
+            border-radius: 50%;
+            background: var(--surface-strong);
+            box-shadow: inset 0 0 0 1px var(--border);
+            color: var(--accent);
+          }
+          /* Collapsed: drop the wordmark and show just the logo mark, centered
+             with balanced padding so it sits squarely in the rail instead of
+             hugging the top-left. */
+          .wurk-nav:not(:hover):not(:focus-within) .nav-brand-wrap { padding: 0.9rem 0; }
+          .wurk-nav:not(:hover):not(:focus-within) .nav-brand-wrap a { justify-content: center; gap: 0; }
+          .wurk-nav:not(:hover):not(:focus-within) .nav-brand-wrap img { height: 38px !important; }
+        }
+        @media (min-width: 768px) and (prefers-reduced-motion: reduce) {
+          .wurk-nav { transition: none; }
         }
       `}</style>
     </>

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -29,7 +29,20 @@
     "strapline": "وُرك، وُرك. جاهز للعمل. زوغ زوغ.",
     "tagline": "بديل متوافق 100% مع Sidekiq + Sidekiq Pro + Sidekiq Enterprise. مجاني للأبد. أسرع.",
     "install": "التثبيت",
-    "docs": "التوثيق"
+    "docs": "التوثيق",
+    "active": "نشط",
+    "vs_last_hour": "مقارنة بآخر ساعة",
+    "stable_threshold": "ضمن العتبة",
+    "above_threshold": "فوق العتبة",
+    "system_idle": "النظام خامل",
+    "processing": "قيد المعالجة",
+    "performance_insight": "رؤية الأداء",
+    "perf_subtitle": "المهام المُعالَجة مقابل الفاشلة على مدى {range}",
+    "no_history": "لا توجد بيانات بعد — يمتلئ الرسم البياني مع تشغيل المهام.",
+    "range_1h_desc": "آخر ساعة",
+    "range_24h_desc": "آخر 24 ساعة",
+    "range_7d_desc": "آخر 7 أيام",
+    "range_30d_desc": "آخر 30 يومًا"
   },
   "table": {
     "class": "الفئة",

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -26,7 +26,7 @@
     "latency": "زمن الاستجابة",
     "live": "مباشر",
     "paused": "متوقّف مؤقتًا",
-    "strapline": "وُرك، وُرك. 🪓 جاهز للعمل. زوغ زوغ.",
+    "strapline": "وُرك، وُرك. جاهز للعمل. زوغ زوغ.",
     "tagline": "بديل متوافق 100% مع Sidekiq + Sidekiq Pro + Sidekiq Enterprise. مجاني للأبد. أسرع.",
     "install": "التثبيت",
     "docs": "التوثيق"

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -27,7 +27,7 @@
     "latency": "Latency",
     "live": "Live",
     "paused": "Paused",
-    "strapline": "Wurk, wurk. 🪓 Ready to work. Zug zug.",
+    "strapline": "Wurk, wurk. Ready to work. Zug zug.",
     "tagline": "A 100% drop-in replacement for Sidekiq + Sidekiq Pro + Sidekiq Enterprise. Free forever. Faster.",
     "install": "Install",
     "docs": "Documentation"

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -30,7 +30,20 @@
     "strapline": "Wurk, wurk. Ready to work. Zug zug.",
     "tagline": "A 100% drop-in replacement for Sidekiq + Sidekiq Pro + Sidekiq Enterprise. Free forever. Faster.",
     "install": "Install",
-    "docs": "Documentation"
+    "docs": "Documentation",
+    "active": "Active",
+    "vs_last_hour": "vs last hour",
+    "stable_threshold": "Stable threshold",
+    "above_threshold": "Above threshold",
+    "system_idle": "System idle",
+    "processing": "Processing",
+    "performance_insight": "Performance Insight",
+    "perf_subtitle": "Jobs Processed vs Failed over {range}",
+    "no_history": "No history yet — the chart fills in as jobs run.",
+    "range_1h_desc": "the last hour",
+    "range_24h_desc": "the last 24 hours",
+    "range_7d_desc": "the last 7 days",
+    "range_30d_desc": "the last 30 days"
   },
   "table": {
     "class": "Class",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+// Obsidian design system fonts, self-hosted in the bundle (no CDN / Node at
+// runtime). Geist for UI text + metrics, JetBrains Mono for labels/metadata.
+import '@fontsource/geist-sans/400.css';
+import '@fontsource/geist-sans/500.css';
+import '@fontsource/geist-sans/600.css';
+import '@fontsource/geist-sans/700.css';
+import '@fontsource/jetbrains-mono/500.css';
 import './styles.css';
 import App from './App';
 import { dir, locale, t } from './i18n';

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -61,12 +61,13 @@ function hourlyDeltaPct(series: HistoryPoint[], key: 'processed' | 'failed'): nu
 
 // Range buttons → rollup bucket + retention window, matching the Metrics page.
 // "1h" reuses the 1m/24h rollup and slices client-side; the rest map 1:1 to a
-// stored window. `desc` feeds the panel subtitle.
+// stored window. `desc_key` is an i18n path (resolved via t()) so the panel
+// subtitle localizes alongside the rest of the dashboard copy.
 const RANGES = [
-  { key: '1h', bucket: '1m', window: '24h', slice: 60, desc: 'the last hour' },
-  { key: '24h', bucket: '1m', window: '24h', desc: 'the last 24 hours' },
-  { key: '7d', bucket: '5m', window: '7d', desc: 'the last 7 days' },
-  { key: '30d', bucket: '1h', window: '30d', desc: 'the last 30 days' },
+  { key: '1h', bucket: '1m', window: '24h', slice: 60, desc_key: 'dashboard.range_1h_desc' },
+  { key: '24h', bucket: '1m', window: '24h', desc_key: 'dashboard.range_24h_desc' },
+  { key: '7d', bucket: '5m', window: '7d', desc_key: 'dashboard.range_7d_desc' },
+  { key: '30d', bucket: '1h', window: '30d', desc_key: 'dashboard.range_30d_desc' },
 ] as const;
 
 const fmtBucket = (at: number, bucket: string) => {
@@ -78,7 +79,7 @@ const fmtBucket = (at: number, bucket: string) => {
 };
 
 function DeltaSub({ pct, goodWhenUp }: { pct: number | null; goodWhenUp: boolean }) {
-  if (pct === null) return <span className="obs-metric__sub">vs last hour</span>;
+  if (pct === null) return <span className="obs-metric__sub">{t('dashboard.vs_last_hour')}</span>;
   const up = pct >= 0;
   const good = up === goodWhenUp;
   return (
@@ -86,7 +87,7 @@ function DeltaSub({ pct, goodWhenUp }: { pct: number | null; goodWhenUp: boolean
       <span className={good ? 'up' : 'down'}>
         {up ? '▲' : '▼'} {up ? '+' : ''}{pct}%
       </span>{' '}
-      vs last hour
+      {t('dashboard.vs_last_hour')}
     </span>
   );
 }
@@ -116,9 +117,12 @@ export default function Dashboard({ sse }: DashboardProps) {
   });
 
   const stats: StatsData | null = sse.stats ?? fetched ?? null;
-  let series = (history?.series ?? []).map((p) => ({ ...p, label: fmtBucket(p.at, range.bucket) }));
+  // Delta math needs the prior-hour buckets, so keep the full history for
+  // hourlyDeltaPct() and slice only for chart rendering. Slicing first would
+  // drop the comparison window on the 1h tab and force the 100% fallback.
+  const fullSeries = (history?.series ?? []).map((p) => ({ ...p, label: fmtBucket(p.at, range.bucket) }));
   const sliceN = 'slice' in range ? range.slice : undefined;
-  if (sliceN) series = series.slice(-sliceN);
+  const series = sliceN ? fullSeries.slice(-sliceN) : fullSeries;
   const hasHistory = series.some((p) => p.processed > 0 || p.failed > 0);
 
   if (isLoading && !stats) {
@@ -143,7 +147,7 @@ export default function Dashboard({ sse }: DashboardProps) {
       value: stats.processed,
       icon: 'fa-circle-check',
       to: '/metrics',
-      sub: <DeltaSub pct={hourlyDeltaPct(series, 'processed')} goodWhenUp />,
+      sub: <DeltaSub pct={hourlyDeltaPct(fullSeries, 'processed')} goodWhenUp />,
     },
     {
       key: 'failed',
@@ -151,7 +155,7 @@ export default function Dashboard({ sse }: DashboardProps) {
       value: stats.failed,
       icon: 'fa-triangle-exclamation',
       to: '/retries',
-      sub: <DeltaSub pct={hourlyDeltaPct(series, 'failed')} goodWhenUp={false} />,
+      sub: <DeltaSub pct={hourlyDeltaPct(fullSeries, 'failed')} goodWhenUp={false} />,
     },
     {
       key: 'expired',
@@ -159,7 +163,7 @@ export default function Dashboard({ sse }: DashboardProps) {
       value: stats.expired,
       icon: 'fa-ban',
       to: '/dead',
-      sub: <span className="obs-metric__sub">{stats.expired === 0 ? 'Stable threshold' : 'Above threshold'}</span>,
+      sub: <span className="obs-metric__sub">{stats.expired === 0 ? t('dashboard.stable_threshold') : t('dashboard.above_threshold')}</span>,
     },
     {
       key: 'busy',
@@ -167,7 +171,7 @@ export default function Dashboard({ sse }: DashboardProps) {
       value: stats.busy,
       icon: 'fa-spinner',
       to: '/busy',
-      sub: <span className="obs-metric__sub">{stats.busy === 0 ? 'System idle' : 'Processing'}</span>,
+      sub: <span className="obs-metric__sub">{stats.busy === 0 ? t('dashboard.system_idle') : t('dashboard.processing')}</span>,
     },
   ];
 
@@ -199,8 +203,8 @@ export default function Dashboard({ sse }: DashboardProps) {
       <div className="obs-card obs-panel">
         <div className="obs-panel__head">
           <div>
-            <h2 className="obs-panel__title">Performance Insight</h2>
-            <p className="obs-panel__sub">Jobs Processed vs Failed over {range.desc}</p>
+            <h2 className="obs-panel__title">{t('dashboard.performance_insight')}</h2>
+            <p className="obs-panel__sub">{t('dashboard.perf_subtitle', { range: t(range.desc_key) })}</p>
           </div>
           <div className="obs-panel__controls">
             <div className="obs-seg" role="tablist" aria-label="Time range">
@@ -286,7 +290,7 @@ export default function Dashboard({ sse }: DashboardProps) {
             </ResponsiveContainer>
           ) : (
             <div className="empty-state" style={{ height: 320, display: 'grid', placeItems: 'center' }}>
-              No history yet — the chart fills in as jobs run.
+              {t('dashboard.no_history')}
             </div>
           )}
         </div>
@@ -334,7 +338,7 @@ export default function Dashboard({ sse }: DashboardProps) {
                     {q.paused ? (
                       <span className="obs-chip obs-chip--paused">{t('dashboard.paused')}</span>
                     ) : (
-                      <span className="obs-chip obs-chip--active">Active</span>
+                      <span className="obs-chip obs-chip--active">{t('dashboard.active')}</span>
                     )}
                   </td>
                 </tr>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,10 +1,18 @@
 import { useQuery } from '@tanstack/react-query';
-import { useEffect } from 'react';
-import { StatCard } from '../components/StatCard';
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
 import { AnimatedNumber } from '../components/AnimatedNumber';
 import { t } from '../i18n';
 import type { StatsSnapshot } from '../hooks/useSSE';
-import { relativeTime, formatDuration } from '../utils';
+import { formatDuration } from '../utils';
 
 interface StatsData {
   processed: number;
@@ -20,11 +28,73 @@ interface StatsData {
   queues: Array<{ name: string; size: number; latency: number; paused: boolean }>;
 }
 
+interface HistoryPoint {
+  at: number;
+  processed: number;
+  failed: number;
+}
+
+interface HistoryResponse {
+  bucket: string;
+  window: number;
+  series: HistoryPoint[];
+}
+
 interface DashboardProps {
   sse: { stats: StatsSnapshot | null; connected: boolean };
 }
 
+// Throughput change over the trailing hour vs the hour before it, derived from
+// the same buckets the chart plots — no extra request, no fabricated number.
+function hourlyDeltaPct(series: HistoryPoint[], key: 'processed' | 'failed'): number | null {
+  if (series.length < 2) return null;
+  const now = series[series.length - 1].at;
+  let cur = 0;
+  let prev = 0;
+  for (const p of series) {
+    if (p.at > now - 3600) cur += p[key];
+    else if (p.at > now - 7200) prev += p[key];
+  }
+  if (prev === 0) return cur === 0 ? null : 100;
+  return Math.round(((cur - prev) / prev) * 100);
+}
+
+// Range buttons → rollup bucket + retention window, matching the Metrics page.
+// "1h" reuses the 1m/24h rollup and slices client-side; the rest map 1:1 to a
+// stored window. `desc` feeds the panel subtitle.
+const RANGES = [
+  { key: '1h', bucket: '1m', window: '24h', slice: 60, desc: 'the last hour' },
+  { key: '24h', bucket: '1m', window: '24h', desc: 'the last 24 hours' },
+  { key: '7d', bucket: '5m', window: '7d', desc: 'the last 7 days' },
+  { key: '30d', bucket: '1h', window: '30d', desc: 'the last 30 days' },
+] as const;
+
+const fmtBucket = (at: number, bucket: string) => {
+  const d = new Date(at * 1000);
+  const hh = String(d.getHours()).padStart(2, '0');
+  return bucket === '1h'
+    ? `${d.getMonth() + 1}/${d.getDate()} ${hh}:00`
+    : `${hh}:${String(d.getMinutes()).padStart(2, '0')}`;
+};
+
+function DeltaSub({ pct, goodWhenUp }: { pct: number | null; goodWhenUp: boolean }) {
+  if (pct === null) return <span className="obs-metric__sub">vs last hour</span>;
+  const up = pct >= 0;
+  const good = up === goodWhenUp;
+  return (
+    <span className="obs-metric__sub">
+      <span className={good ? 'up' : 'down'}>
+        {up ? '▲' : '▼'} {up ? '+' : ''}{pct}%
+      </span>{' '}
+      vs last hour
+    </span>
+  );
+}
+
 export default function Dashboard({ sse }: DashboardProps) {
+  const [rangeIdx, setRangeIdx] = useState(0); // default 1h
+  const range = RANGES[rangeIdx];
+
   useEffect(() => {
     document.title = `${t('nav.dashboard')} — Wurk`;
   }, []);
@@ -36,7 +106,20 @@ export default function Dashboard({ sse }: DashboardProps) {
     refetchInterval: sse.connected ? false : 5000,
   });
 
+  // Throughput for the Performance Insight chart over the selected range (same
+  // source as Metrics).
+  const { data: history, isPending: historyPending } = useQuery<HistoryResponse>({
+    queryKey: ['history', range.bucket, range.window],
+    queryFn: () =>
+      fetch(`/wurk/api/history/${range.bucket}?window=${range.window}`).then((r) => r.json() as Promise<HistoryResponse>),
+    refetchInterval: 30000,
+  });
+
   const stats: StatsData | null = sse.stats ?? fetched ?? null;
+  let series = (history?.series ?? []).map((p) => ({ ...p, label: fmtBucket(p.at, range.bucket) }));
+  const sliceN = 'slice' in range ? range.slice : undefined;
+  if (sliceN) series = series.slice(-sliceN);
+  const hasHistory = series.some((p) => p.processed > 0 || p.failed > 0);
 
   if (isLoading && !stats) {
     return (
@@ -46,75 +129,192 @@ export default function Dashboard({ sse }: DashboardProps) {
       </div>
     );
   }
-
   if (isError && !stats) {
     return <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>;
   }
-
   if (!stats) {
     return <div className="empty-state">{t('common.empty')}</div>;
   }
 
-  const cards = [
-    { key: 'processed', label: t('dashboard.processed'), value: stats.processed, color: 'var(--success)' },
-    { key: 'failed', label: t('dashboard.failed'), value: stats.failed, color: 'var(--danger)' },
-    { key: 'expired', label: t('dashboard.expired'), value: stats.expired, color: 'var(--text-muted)' },
-    { key: 'busy', label: t('dashboard.busy'), value: stats.busy, color: 'var(--warning)' },
-    { key: 'enqueued', label: t('dashboard.enqueued'), value: stats.enqueued },
-    { key: 'retries', label: t('dashboard.retries'), value: stats.retries, color: 'var(--warning)' },
-    { key: 'scheduled', label: t('dashboard.scheduled'), value: stats.scheduled },
-    { key: 'dead', label: t('dashboard.dead'), value: stats.dead, color: 'var(--danger)' },
-    { key: 'processes', label: t('dashboard.processes'), value: stats.processes },
-    { key: 'latency', label: t('dashboard.latency'), value: formatDuration(stats.latency) },
+  const metrics = [
+    {
+      key: 'processed',
+      label: t('dashboard.processed'),
+      value: stats.processed,
+      icon: 'fa-circle-check',
+      to: '/metrics',
+      sub: <DeltaSub pct={hourlyDeltaPct(series, 'processed')} goodWhenUp />,
+    },
+    {
+      key: 'failed',
+      label: t('dashboard.failed'),
+      value: stats.failed,
+      icon: 'fa-triangle-exclamation',
+      to: '/retries',
+      sub: <DeltaSub pct={hourlyDeltaPct(series, 'failed')} goodWhenUp={false} />,
+    },
+    {
+      key: 'expired',
+      label: t('dashboard.expired'),
+      value: stats.expired,
+      icon: 'fa-ban',
+      to: '/dead',
+      sub: <span className="obs-metric__sub">{stats.expired === 0 ? 'Stable threshold' : 'Above threshold'}</span>,
+    },
+    {
+      key: 'busy',
+      label: t('dashboard.busy'),
+      value: stats.busy,
+      icon: 'fa-spinner',
+      to: '/busy',
+      sub: <span className="obs-metric__sub">{stats.busy === 0 ? 'System idle' : 'Processing'}</span>,
+    },
+  ];
+
+  const secondary = [
+    { key: 'enqueued', label: t('dashboard.enqueued'), value: stats.enqueued, to: '/queues' },
+    { key: 'retries', label: t('dashboard.retries'), value: stats.retries, to: '/retries' },
+    { key: 'scheduled', label: t('dashboard.scheduled'), value: stats.scheduled, to: '/scheduled' },
+    { key: 'dead', label: t('dashboard.dead'), value: stats.dead, to: '/dead' },
   ];
 
   return (
-    <div>
-      <div className="dash-hero">
-        <div className="dash-hero__body">
-          <h1 className="dash-hero__title">Wurk ⚡</h1>
-          <p className="dash-hero__strapline">{t('dashboard.strapline')}</p>
-          <p className="dash-hero__tagline">{t('dashboard.tagline')}</p>
-          <div className="dash-hero__actions">
-            <a className="btn btn-accent" href="https://developerz-ai.github.io/wurk/" target="_blank" rel="noreferrer">
-              <i className="fa-solid fa-download" /> {t('dashboard.install')}
-            </a>
-            <a className="btn" href="https://github.com/developerz-ai/wurk/wiki" target="_blank" rel="noreferrer">
-              <i className="fa-solid fa-book" /> {t('dashboard.docs')}
-            </a>
-          </div>
-        </div>
-        <div className="dash-hero__status">
-          {sse.connected && (
-            <span className="dash-hero__live">
-              <span className="live-dot" />
-              {t('dashboard.live')}
+    <div className="obs">
+      <div className="obs-metrics">
+        {metrics.map((m) => (
+          <Link key={m.key} className="obs-card obs-metric obs-card--link" to={m.to}>
+            <div className="obs-metric__head">
+              <span className="obs-mono">{m.label}</span>
+              <i className={`fa-solid ${m.icon} obs-metric__icon`} aria-hidden="true" />
+            </div>
+            <span className="obs-metric__value">
+              <AnimatedNumber value={m.value} />
             </span>
-          )}
-          {sse.stats?.at && (
-            <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>{relativeTime(sse.stats.at)}</span>
-          )}
-        </div>
-      </div>
-
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))',
-          gap: '0.75rem',
-          marginBottom: '2rem',
-        }}
-      >
-        {cards.map((c) => (
-          <StatCard key={c.key} label={c.label} value={c.value} color={c.color} />
+            {m.sub}
+            <i className="fa-solid fa-arrow-right obs-card__go" aria-hidden="true" />
+          </Link>
         ))}
       </div>
 
-      <h2 className="section-title" style={{ marginBottom: '0.75rem' }}>{t('table.queues')}</h2>
-      {stats.queues.length === 0 ? (
-        <div className="empty-state">{t('common.empty')}</div>
-      ) : (
-        <div className="table-wrapper">
+      <div className="obs-card obs-panel">
+        <div className="obs-panel__head">
+          <div>
+            <h2 className="obs-panel__title">Performance Insight</h2>
+            <p className="obs-panel__sub">Jobs Processed vs Failed over {range.desc}</p>
+          </div>
+          <div className="obs-panel__controls">
+            <div className="obs-seg" role="tablist" aria-label="Time range">
+              {RANGES.map((r, i) => (
+                <button
+                  key={r.key}
+                  role="tab"
+                  aria-selected={i === rangeIdx}
+                  className={i === rangeIdx ? 'is-active' : ''}
+                  onClick={() => setRangeIdx(i)}
+                >
+                  {r.key}
+                </button>
+              ))}
+            </div>
+            <div className="obs-legend">
+              <span><i className="dot dot--processed" /> {t('dashboard.processed')}</span>
+              <span><i className="dot dot--failed" /> {t('dashboard.failed')}</span>
+            </div>
+          </div>
+        </div>
+        <div className="obs-chartbox">
+          {historyPending ? (
+            <div style={{ height: 320, display: 'grid', placeItems: 'center' }}>
+              <span className="spinner" role="status" aria-label={t('common.loading')} />
+            </div>
+          ) : hasHistory ? (
+            <ResponsiveContainer width="100%" height={320}>
+              <AreaChart data={series} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+                <defs>
+                  <linearGradient id="obsProcessed" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="#fafafa" stopOpacity={0.22} />
+                    <stop offset="95%" stopColor="#fafafa" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="rgba(255,255,255,0.06)" />
+                <XAxis
+                  dataKey="label"
+                  tick={{ fill: '#71717a', fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }}
+                  axisLine={false}
+                  tickLine={false}
+                  minTickGap={64}
+                  interval="preserveStartEnd"
+                />
+                <Tooltip
+                  contentStyle={{
+                    background: '#161618',
+                    border: '1px solid #272729',
+                    borderRadius: 6,
+                    fontSize: 12,
+                    fontFamily: 'JetBrains Mono, monospace',
+                  }}
+                  labelStyle={{ color: '#a1a1aa' }}
+                  cursor={{ stroke: 'rgba(255,255,255,0.25)', strokeWidth: 1 }}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="processed"
+                  name={t('dashboard.processed')}
+                  stroke="#fafafa"
+                  strokeWidth={2}
+                  fill="url(#obsProcessed)"
+                  dot={false}
+                  activeDot={{ r: 4, fill: '#fafafa', stroke: '#09090b', strokeWidth: 2 }}
+                  animationDuration={1100}
+                  animationEasing="ease-out"
+                />
+                <Area
+                  type="monotone"
+                  dataKey="failed"
+                  name={t('dashboard.failed')}
+                  stroke="#a1a1aa"
+                  strokeWidth={1.5}
+                  strokeDasharray="5 4"
+                  fill="transparent"
+                  dot={false}
+                  activeDot={{ r: 3, fill: '#a1a1aa', stroke: '#09090b', strokeWidth: 2 }}
+                  animationDuration={1100}
+                  animationBegin={250}
+                  animationEasing="ease-out"
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          ) : (
+            <div className="empty-state" style={{ height: 320, display: 'grid', placeItems: 'center' }}>
+              No history yet — the chart fills in as jobs run.
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="obs-stats">
+        {secondary.map((s) => (
+          <Link key={s.key} className="obs-card obs-stat obs-card--link" to={s.to}>
+            <span className="obs-mono">{s.label}</span>
+            <span className="obs-stat__value">
+              <AnimatedNumber value={s.value} />
+            </span>
+            <i className="fa-solid fa-arrow-right obs-card__go" aria-hidden="true" />
+          </Link>
+        ))}
+      </div>
+
+      <div className="obs-card obs-table">
+        <div className="obs-table__head">
+          <h2 className="obs-table__title">{t('table.queues')}</h2>
+          <Link className="obs-table__link" to="/queues">
+            View All <i className="fa-solid fa-arrow-right" aria-hidden="true" />
+          </Link>
+        </div>
+        {stats.queues.length === 0 ? (
+          <div className="empty-state">{t('common.empty')}</div>
+        ) : (
+          <div className="obs-tablescroll">
           <table>
             <thead>
               <tr>
@@ -127,22 +327,37 @@ export default function Dashboard({ sse }: DashboardProps) {
             <tbody>
               {stats.queues.map((q) => (
                 <tr key={q.name}>
-                  <td style={{ fontWeight: 500 }}>{q.name}</td>
+                  <td style={{ fontWeight: 500, color: 'var(--obs-text)' }}>{q.name}</td>
                   <td><AnimatedNumber value={q.size} /></td>
                   <td title={`${q.latency.toFixed(3)}s`}>{formatDuration(q.latency)}</td>
                   <td>
                     {q.paused ? (
-                      <span className="badge badge-warning">{t('dashboard.paused')}</span>
+                      <span className="obs-chip obs-chip--paused">{t('dashboard.paused')}</span>
                     ) : (
-                      <span className="badge badge-success">Active</span>
+                      <span className="obs-chip obs-chip--active">Active</span>
                     )}
                   </td>
                 </tr>
               ))}
             </tbody>
           </table>
+          </div>
+        )}
+      </div>
+
+      <div className="obs-card obs-cta">
+        <span className="obs-cta__icon"><i className="fa-solid fa-bolt" aria-hidden="true" /></span>
+        <h2 className="obs-cta__title">{t('dashboard.strapline')}</h2>
+        <p className="obs-cta__text">{t('dashboard.tagline')}</p>
+        <div className="obs-cta__actions">
+          <a className="obs-btn obs-btn--primary" href="https://developerz-ai.github.io/wurk/" target="_blank" rel="noreferrer">
+            <i className="fa-solid fa-download" aria-hidden="true" /> {t('dashboard.install')}
+          </a>
+          <a className="obs-btn obs-btn--ghost" href="https://github.com/developerz-ai/wurk/wiki" target="_blank" rel="noreferrer">
+            <i className="fa-solid fa-book" aria-hidden="true" /> {t('dashboard.docs')}
+          </a>
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/Metrics.test.tsx
+++ b/frontend/src/pages/Metrics.test.tsx
@@ -1,22 +1,24 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Metrics from './Metrics';
 
-// Stub Recharts so the per-queue chart logic (one <Line> per queue, pivoted
-// rows) is observable without a real layout — ResponsiveContainer renders
-// nothing under jsdom otherwise. Each Line exposes its dataKey as text.
+// Stub Recharts so chart logic (one series per queue/field, pivoted rows) is
+// observable without a real layout — ResponsiveContainer renders nothing under
+// jsdom otherwise. Line/Area expose their dataKey via distinct testids so the
+// per-queue line charts and the throughput area chart can be told apart.
 vi.mock('recharts', () => {
   const Pass = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>;
   return {
     ResponsiveContainer: Pass,
-    LineChart: ({ children }: { children?: React.ReactNode }) => (
-      <div data-testid="linechart">{children}</div>
-    ),
+    LineChart: ({ children }: { children?: React.ReactNode }) => <div data-testid="linechart">{children}</div>,
     Line: ({ dataKey }: { dataKey: string }) => <span data-testid="line">{dataKey}</span>,
-    BarChart: Pass,
-    Bar: () => null,
+    AreaChart: ({ children }: { children?: React.ReactNode }) => <div data-testid="areachart">{children}</div>,
+    Area: ({ dataKey }: { dataKey: string }) => <span data-testid="area">{dataKey}</span>,
+    BarChart: ({ children }: { children?: React.ReactNode }) => <div data-testid="barchart">{children}</div>,
+    Bar: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    Cell: () => null,
     XAxis: () => null,
     YAxis: () => null,
     CartesianGrid: () => null,
@@ -34,111 +36,134 @@ function renderMetrics() {
   );
 }
 
-// Route the component's three fetches by URL; the queue-history payload is the
-// one under test, the others return empty so the page renders. `queueOk: false`
-// drives the queue-history error path.
-function mockFetch(queueHistory: unknown, queueOk = true, snapshots: unknown[] = []) {
+// Route the component's fetches by URL. Defaults render an empty-but-valid page;
+// each test overrides the payload it cares about.
+function mockFetch(opts: {
+  queueHistory?: unknown;
+  snapshots?: unknown[];
+  topJobs?: unknown[];
+  series?: unknown[];
+  stats?: unknown;
+} = {}) {
+  const { queueHistory = { bucket: '1m', window: 86400, queues: [] }, snapshots = [], topJobs = [], series = [], stats = {} } = opts;
   return vi.fn((url: string) => {
     let body: unknown = {};
-    let ok = true;
     // /history/snapshots must be matched before the /history/ rollup route.
     if (url.includes('/history/snapshots')) body = { snapshots };
-    else if (url.includes('/queue-history/')) {
-      body = queueHistory;
-      ok = queueOk;
-    } else if (url.includes('/history/')) body = { bucket: '1m', window: 86400, series: [] };
-    else if (url.includes('/metrics')) body = { minutes: 60, top_jobs: [] };
-    return Promise.resolve({ ok, status: ok ? 200 : 400, json: () => Promise.resolve(body) } as Response);
+    else if (url.includes('/queue-history/')) body = queueHistory;
+    else if (url.includes('/history/')) body = { bucket: '1m', window: 86400, series };
+    else if (url.includes('/metrics')) body = { minutes: 60, top_jobs: topJobs };
+    else if (url.includes('/stats')) body = stats;
+    return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body) } as Response);
   });
 }
 
-describe('QueueGaugeCharts', () => {
+describe('Metrics page', () => {
   beforeEach(() => {
-    vi.stubGlobal('fetch', mockFetch({ bucket: '1m', window: 86400, queues: [] }));
+    vi.stubGlobal('fetch', mockFetch({ stats: { processed: 100, failed: 5, latency: 1.2, processes: 4 } }));
   });
   afterEach(() => {
     cleanup();
     vi.unstubAllGlobals();
   });
 
-  it('always renders the section heading', async () => {
+  it('renders the four metric cards', async () => {
     renderMetrics();
-    expect(await screen.findByText('Queue Size & Latency')).toBeDefined();
+    expect(await screen.findByText('Total Processed')).toBeDefined();
+    expect(screen.getByText('Failed Jobs')).toBeDefined();
+    expect(screen.getByText('Avg Latency')).toBeDefined();
+    expect(screen.getByText('Active Workers')).toBeDefined();
   });
 
-  it('shows the empty state when no queue history exists', async () => {
+  it('renders the throughput, queue depth, and top-job sections', async () => {
     renderMetrics();
-    await waitFor(() =>
-      expect(screen.getByText(/No queue history yet/i)).toBeDefined()
-    );
-    expect(screen.queryByText('Depth (jobs)')).toBeNull();
+    expect(await screen.findByText('Throughput & Failures')).toBeDefined();
+    expect(screen.getByText('Queue Depth')).toBeDefined();
+    expect(screen.getByText('Top Job Types (Volume)')).toBeDefined();
   });
 
-  it('renders a size and a latency chart with one line per queue', async () => {
-    const at = 1_781_000_000;
-    vi.stubGlobal(
-      'fetch',
-      mockFetch({
-        bucket: '1m',
-        window: 86400,
-        queues: [
-          { name: 'default', points: [{ at, size: 5, latency: 1.2 }] },
-          { name: 'critical', points: [{ at, size: 0, latency: 0 }] },
-        ],
-      })
-    );
-
+  it('lists top job types with their share of total volume', async () => {
+    vi.stubGlobal('fetch', mockFetch({
+      stats: { processed: 100, failed: 5, latency: 1.2, processes: 4 },
+      topJobs: [
+        { klass: 'App::FooJob', processed: 80, failed: 20, runtime_ms: 0 },
+        { klass: 'BarJob', processed: 50, failed: 0, runtime_ms: 0 },
+      ],
+    }));
     renderMetrics();
-
-    // Both gauge charts render (size + latency).
-    await waitFor(() => expect(screen.getByText('Depth (jobs)')).toBeDefined());
-    expect(screen.getByText('Latency (seconds)')).toBeDefined();
-
-    // One <Line> per queue in each of the two charts → each queue name twice.
-    const lines = screen.getAllByTestId('line').map((n) => n.textContent);
-    expect(lines.filter((k) => k === 'default')).toHaveLength(2);
-    expect(lines.filter((k) => k === 'critical')).toHaveLength(2);
-
-    // Empty state is gone once there's data.
-    expect(screen.queryByText(/No queue history yet/i)).toBeNull();
+    // foo = 100, bar = 50, total = 150 → 67% / 33%.
+    expect(await screen.findByText('FooJob')).toBeDefined();
+    expect(screen.getByText('67%')).toBeDefined();
+    expect(screen.getByText('33%')).toBeDefined();
   });
 
-  it('shows an error state (not the empty state) when the API fails', async () => {
-    vi.stubGlobal('fetch', mockFetch({ error: 'bucket must be one of …' }, false));
-
+  it('shows the throughput empty state when there is no history', async () => {
     renderMetrics();
+    await waitFor(() => expect(screen.getByText(/No history yet/i)).toBeDefined());
+  });
 
-    await waitFor(() => expect(screen.getByText('Error loading data')).toBeDefined());
-    expect(screen.queryByText(/No queue history yet/i)).toBeNull();
-    expect(screen.queryByText('Depth (jobs)')).toBeNull();
+  it('switches the time range when a segment is clicked', async () => {
+    renderMetrics();
+    const btn = await screen.findByRole('tab', { name: '24h' });
+    fireEvent.click(btn);
+    await waitFor(() => expect(btn.getAttribute('aria-selected')).toBe('true'));
   });
 });
 
-describe('HistoricalSnapshots', () => {
+describe('Metrics — queue latency history', () => {
   afterEach(() => {
     cleanup();
     vi.unstubAllGlobals();
   });
 
-  it('shows the empty state when the history:metrics stream is empty', async () => {
-    vi.stubGlobal('fetch', mockFetch({ bucket: '1m', window: 86400, queues: [] }, true, []));
+  it('renders one latency line per queue when data exists', async () => {
+    const at = 1_781_000_000;
+    vi.stubGlobal('fetch', mockFetch({
+      stats: { processed: 1, failed: 0, latency: 0, processes: 1 },
+      queueHistory: {
+        bucket: '1m', window: 86400,
+        queues: [
+          { name: 'default', points: [{ at, size: 5, latency: 1.2 }] },
+          { name: 'critical', points: [{ at, size: 2, latency: 0.4 }] },
+        ],
+      },
+    }));
     renderMetrics();
+    expect(await screen.findByText('Queue Latency (seconds)')).toBeDefined();
+    const lines = screen.getAllByTestId('line').map((n) => n.textContent);
+    expect(lines).toContain('default');
+    expect(lines).toContain('critical');
+  });
 
-    expect(await screen.findByText('Historical Snapshots')).toBeDefined();
-    await waitFor(() => expect(screen.getByText(/No snapshots yet/i)).toBeDefined());
+  it('hides the latency section when there is no queue latency', async () => {
+    vi.stubGlobal('fetch', mockFetch({ stats: { processed: 1, failed: 0, latency: 0, processes: 1 } }));
+    renderMetrics();
+    await screen.findByText('Throughput & Failures');
+    expect(screen.queryByText('Queue Latency (seconds)')).toBeNull();
+  });
+});
+
+describe('Metrics — historical snapshots', () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('is hidden when the history:metrics stream is empty', async () => {
+    vi.stubGlobal('fetch', mockFetch({ stats: { processed: 1, failed: 0, latency: 0, processes: 1 } }));
+    renderMetrics();
+    await screen.findByText('Throughput & Failures');
+    expect(screen.queryByText('Historical Snapshots')).toBeNull();
   });
 
   it('charts the backlog gauge fields and hides the cumulative counters', async () => {
     const snapshots = [{ at: 1_781_000_000, processed: 100, failures: 2, enqueued: 5, dead: 1 }];
-    vi.stubGlobal('fetch', mockFetch({ bucket: '1m', window: 86400, queues: [] }, true, snapshots));
+    vi.stubGlobal('fetch', mockFetch({ stats: { processed: 1, failed: 0, latency: 0, processes: 1 }, snapshots }));
     renderMetrics();
-
-    const lines = (await screen.findAllByTestId('line')).map((n) => n.textContent);
-
-    // backlog gauges charted…
+    expect(await screen.findByText('Historical Snapshots')).toBeDefined();
+    const lines = screen.getAllByTestId('line').map((n) => n.textContent);
     expect(lines).toContain('enqueued');
     expect(lines).toContain('dead');
-    // …cumulative counters are not (HistoryCharts shows throughput instead).
     expect(lines).not.toContain('processed');
     expect(lines).not.toContain('failures');
   });

--- a/frontend/src/pages/Metrics.test.tsx
+++ b/frontend/src/pages/Metrics.test.tsx
@@ -13,7 +13,11 @@ vi.mock('recharts', () => {
   return {
     ResponsiveContainer: Pass,
     LineChart: ({ children }: { children?: React.ReactNode }) => <div data-testid="linechart">{children}</div>,
-    Line: ({ dataKey }: { dataKey: string }) => <span data-testid="line">{dataKey}</span>,
+    // Show `name` when it's set (per-queue charts, where the synthetic
+    // `queue_<i>` dataKey carries no human-readable info) and fall back to
+    // `dataKey` for the Historical Snapshots panel, which uses field names
+    // directly as the series key.
+    Line: ({ dataKey, name }: { dataKey: string; name?: string }) => <span data-testid="line">{name ?? dataKey}</span>,
     AreaChart: ({ children }: { children?: React.ReactNode }) => <div data-testid="areachart">{children}</div>,
     Area: ({ dataKey }: { dataKey: string }) => <span data-testid="area">{dataKey}</span>,
     BarChart: ({ children }: { children?: React.ReactNode }) => <div data-testid="barchart">{children}</div>,

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -79,11 +79,13 @@ const JOB_DOTS = ['#fafafa', '#d4d4d8', '#a1a1aa', '#71717a', '#52525b', '#3f3f4
 
 // Range buttons → rollup bucket + retention window. "1h" reuses the 1m/24h
 // rollup and slices client-side; the rest map 1:1 to a stored window.
+// `minutes` is the corresponding /api/metrics window so Top Job Types tracks
+// the toolbar instead of being permanently pinned to the last hour.
 const RANGES = [
-  { key: '1h', bucket: '1m', window: '24h', slice: 60 },
-  { key: '24h', bucket: '1m', window: '24h' },
-  { key: '7d', bucket: '5m', window: '7d' },
-  { key: '30d', bucket: '1h', window: '30d' },
+  { key: '1h', bucket: '1m', window: '24h', slice: 60, minutes: 60 },
+  { key: '24h', bucket: '1m', window: '24h', minutes: 24 * 60 },
+  { key: '7d', bucket: '5m', window: '7d', minutes: 7 * 24 * 60 },
+  { key: '30d', bucket: '1h', window: '30d', minutes: 30 * 24 * 60 },
 ] as const;
 
 const fmtBucket = (at: number, bucket: string) => {
@@ -118,10 +120,16 @@ function Delta({ pct, goodWhenUp }: { pct: number | null; goodWhenUp: boolean })
   );
 }
 
+// Even downsample that anchors both endpoints — Math.floor with step =
+// arr.length/n never lands on the last index, so the highlighted peak could
+// silently drop the newest bucket. Math.round across (n-1) intervals keeps
+// the latest sample.
 const sample = <T,>(arr: T[], n: number): T[] => {
+  if (n <= 0) return [];
   if (arr.length <= n) return arr;
-  const step = arr.length / n;
-  return Array.from({ length: n }, (_, i) => arr[Math.floor(i * step)]);
+  if (n === 1) return [arr[arr.length - 1]];
+  const step = (arr.length - 1) / (n - 1);
+  return Array.from({ length: n }, (_, i) => arr[Math.round(i * step)]);
 };
 
 const tooltipStyle = {
@@ -167,8 +175,8 @@ export default function Metrics() {
   });
 
   const { data: metrics, isPending: metricsPending } = useQuery<MetricsResponse>({
-    queryKey: ['metrics', 60],
-    queryFn: () => fetch('/wurk/api/metrics?minutes=60').then((r) => r.json() as Promise<MetricsResponse>),
+    queryKey: ['metrics', range.minutes],
+    queryFn: () => fetch(`/wurk/api/metrics?minutes=${range.minutes}`).then((r) => r.json() as Promise<MetricsResponse>),
     refetchInterval: 30000,
   });
 
@@ -182,9 +190,11 @@ export default function Metrics() {
     refetchInterval: 30000,
   });
 
-  let series = (history?.series ?? []).map((p) => ({ ...p, label: fmtBucket(p.at, range.bucket) }));
+  // Keep the full history for deltaPct() — slicing first would drop the
+  // previous-hour comparison window and force the 100% fallback on the 1h tab.
+  const fullSeries = (history?.series ?? []).map((p) => ({ ...p, label: fmtBucket(p.at, range.bucket) }));
   const sliceN = 'slice' in range ? range.slice : undefined;
-  if (sliceN) series = series.slice(-sliceN);
+  const series = sliceN ? fullSeries.slice(-sliceN) : fullSeries;
   const hasThroughput = series.some((p) => p.processed > 0 || p.failed > 0);
 
   // Queue depth = total jobs enqueued across all queues per bucket, downsampled
@@ -200,11 +210,14 @@ export default function Metrics() {
   );
   const maxDepth = Math.max(0, ...depthRows.map((r) => r.depth));
 
-  const jobs = (metrics?.top_jobs ?? [])
+  // % Total compares each top job against the full returned volume — the
+  // jobs.slice(0, 6) trims the displayed rows only; computing the total off
+  // the slice would let three jobs at 30/30/30 each report 33%.
+  const allJobs = (metrics?.top_jobs ?? [])
     .map((j) => ({ klass: j.klass, count: j.processed + j.failed }))
-    .sort((a, b) => b.count - a.count)
-    .slice(0, 6);
-  const jobsTotal = jobs.reduce((s, j) => s + j.count, 0);
+    .sort((a, b) => b.count - a.count);
+  const jobsTotal = allJobs.reduce((s, j) => s + j.count, 0);
+  const jobs = allJobs.slice(0, 6);
 
   return (
     <div className="obs">
@@ -233,7 +246,7 @@ export default function Metrics() {
           </div>
           <span className="obs-metric__value">
             {(stats?.processed ?? 0).toLocaleString()}
-            <Delta pct={deltaPct(series, 'processed')} goodWhenUp />
+            <Delta pct={deltaPct(fullSeries, 'processed')} goodWhenUp />
           </span>
           <span className="obs-metric__sub">across all queues</span>
         </div>
@@ -244,7 +257,7 @@ export default function Metrics() {
           </div>
           <span className="obs-metric__value">
             {(stats?.failed ?? 0).toLocaleString()}
-            <Delta pct={deltaPct(series, 'failed')} goodWhenUp={false} />
+            <Delta pct={deltaPct(fullSeries, 'failed')} goodWhenUp={false} />
           </span>
           <span className="obs-metric__sub">total failures</span>
         </div>
@@ -394,10 +407,15 @@ function QueueLatencyHistory({ range }: { range: (typeof RANGES)[number] }) {
   });
 
   const queues = data?.queues ?? [];
+  // Recharts 3.x interprets dots in `dataKey` as nested-object accessors, so
+  // a Sidekiq-compatible queue name like `emails.critical` would silently
+  // fail to render. Pivot through synthetic `queue_<i>` keys and pass the
+  // real queue name via Recharts' `name` prop (legend + tooltip label).
+  const queueKeys = queues.map((q, i) => ({ key: `queue_${i}`, name: q.name }));
   const ats = queues[0]?.points.map((p) => p.at) ?? [];
   const rows = ats.map((at, i) => {
     const row: Record<string, number | string> = { label: fmtBucket(at, range.bucket) };
-    queues.forEach((q) => { row[q.name] = q.points[i]?.latency ?? 0; });
+    queues.forEach((q, qi) => { row[queueKeys[qi].key] = q.points[i]?.latency ?? 0; });
     return row;
   });
   const hasData = queues.some((q) => q.points.some((p) => p.latency > 0));
@@ -416,8 +434,8 @@ function QueueLatencyHistory({ range }: { range: (typeof RANGES)[number] }) {
             <YAxis tick={{ fill: '#71717a', fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }} axisLine={false} tickLine={false} width={40} />
             <Tooltip contentStyle={tooltipStyle} labelStyle={{ color: '#a1a1aa' }} />
             <Legend wrapperStyle={{ fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }} />
-            {queues.map((q, i) => (
-              <Line key={q.name} type="monotone" dataKey={q.name} stroke={queueColor(i)} strokeWidth={2} dot={false} />
+            {queueKeys.map((q, i) => (
+              <Line key={q.key} type="monotone" dataKey={q.key} name={q.name} stroke={queueColor(i)} strokeWidth={2} dot={false} />
             ))}
           </LineChart>
         </ResponsiveContainer>

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -1,8 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import {
+  AreaChart,
+  Area,
   BarChart,
   Bar,
+  Cell,
   LineChart,
   Line,
   XAxis,
@@ -13,12 +16,10 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { t } from '../i18n';
-import { PageHeader } from '../components/PageHeader';
-import { truncate } from '../utils';
+import { formatDuration, truncate } from '../utils';
 
 // Matches Wurk::Api::Serializers.metric_row — processed (successes), failed,
-// and total runtime ms across both. Avg latency is derived client-side; there
-// is no per-job percentile histogram, so no p99 here.
+// and total runtime ms across both.
 interface TopJob {
   klass: string;
   processed: number;
@@ -44,9 +45,6 @@ interface HistoryResponse {
   series: HistoryPoint[];
 }
 
-// Matches Wurk::Api::Serializers.queue_history_series — one entry per queue,
-// each with a size/latency gauge sampled into the same time buckets as the
-// throughput chart (see Metrics::QueueRollup).
 interface QueueGaugePoint {
   at: number;
   size: number;
@@ -64,120 +62,378 @@ interface QueueHistoryResponse {
   queues: QueueSeries[];
 }
 
-// Distinct line colors per queue; the first reuses the accent so a
-// single-queue cluster matches the throughput chart's palette.
-const QUEUE_COLORS = [
-  'var(--accent)',
-  '#e0b341',
-  '#46b3a8',
-  '#d4737e',
-  '#8a7fd1',
-  '#5fa8d3',
-  '#c08457',
-  '#7bb274',
-] as const;
+interface StatsData {
+  processed: number;
+  failed: number;
+  latency: number;
+  processes: number;
+}
 
+const QUEUE_COLORS = [
+  'var(--accent)', '#e0b341', '#46b3a8', '#d4737e', '#8a7fd1', '#5fa8d3', '#c08457', '#7bb274',
+] as const;
 const queueColor = (i: number) => QUEUE_COLORS[i % QUEUE_COLORS.length];
 
-// Hourly buckets span days, so show a date; sub-hour buckets show the clock.
-function bucketLabel(at: number, bucket: string): string {
+// Greyscale dots for the Top Job Types table (luminance, not hue).
+const JOB_DOTS = ['#fafafa', '#d4d4d8', '#a1a1aa', '#71717a', '#52525b', '#3f3f46'];
+
+// Range buttons → rollup bucket + retention window. "1h" reuses the 1m/24h
+// rollup and slices client-side; the rest map 1:1 to a stored window.
+const RANGES = [
+  { key: '1h', bucket: '1m', window: '24h', slice: 60 },
+  { key: '24h', bucket: '1m', window: '24h' },
+  { key: '7d', bucket: '5m', window: '7d' },
+  { key: '30d', bucket: '1h', window: '30d' },
+] as const;
+
+const fmtBucket = (at: number, bucket: string) => {
   const d = new Date(at * 1000);
   const hh = String(d.getHours()).padStart(2, '0');
   return bucket === '1h'
     ? `${d.getMonth() + 1}/${d.getDate()} ${hh}:00`
     : `${hh}:${String(d.getMinutes()).padStart(2, '0')}`;
-}
-
-const MINUTE_OPTIONS = [15, 30, 60, 120, 480] as const;
-
-// Each maps to a rollup bucket + its retention window (see Metrics::Rollup).
-const HISTORY_RANGES = [
-  { label: '24h · 1m', bucket: '1m', window: '24h' },
-  { label: '7d · 5m', bucket: '5m', window: '7d' },
-  { label: '30d · 1h', bucket: '1h', window: '30d' },
-] as const;
-
-const tooltipStyle = {
-  background: 'var(--surface)',
-  border: '1px solid var(--border)',
-  color: 'var(--text)',
-  borderRadius: 6,
-  fontSize: 12,
 };
 
-function HistoryCharts() {
-  const [range, setRange] = useState(0);
-  const { bucket, window } = HISTORY_RANGES[range];
+function deltaPct(series: HistoryPoint[], key: 'processed' | 'failed'): number | null {
+  if (series.length < 2) return null;
+  const now = series[series.length - 1].at;
+  let cur = 0;
+  let prev = 0;
+  for (const p of series) {
+    if (p.at > now - 3600) cur += p[key];
+    else if (p.at > now - 7200) prev += p[key];
+  }
+  if (prev === 0) return cur === 0 ? null : 100;
+  return Math.round(((cur - prev) / prev) * 100);
+}
 
-  const { data, isLoading, isError } = useQuery<HistoryResponse>({
-    queryKey: ['history', bucket, window],
-    queryFn: () =>
-      fetch(`/wurk/api/history/${bucket}?window=${window}`).then(
-        (r) => r.json() as Promise<HistoryResponse>
-      ),
-    refetchInterval: 30000,
-  });
-
-  // Hourly buckets span days, so show a date; sub-hour buckets show the clock.
-  const fmt = (at: number) => {
-    const d = new Date(at * 1000);
-    return bucket === '1h'
-      ? `${d.getMonth() + 1}/${d.getDate()} ${String(d.getHours()).padStart(2, '0')}:00`
-      : `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
-  };
-  const series = (data?.series ?? []).map((p) => ({ ...p, label: fmt(p.at) }));
-  const hasData = series.some((p) => p.processed > 0 || p.failed > 0);
-
+function Delta({ pct, goodWhenUp }: { pct: number | null; goodWhenUp: boolean }) {
+  if (pct === null) return null;
+  const up = pct >= 0;
+  const good = up === goodWhenUp;
   return (
-    <div className="card" style={{ marginBottom: '1.5rem' }}>
-      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '1rem' }}>
-        <div className="section-title">Throughput &amp; Failures</div>
-        <select
-          className="select"
-          style={{ marginInlineStart: 'auto' }}
-          value={range}
-          onChange={(e) => setRange(Number(e.target.value))}
-        >
-          {HISTORY_RANGES.map((r, i) => (
-            <option key={r.label} value={i}>{r.label}</option>
-          ))}
-        </select>
-      </div>
+    <span style={{ fontSize: 12, marginInlineStart: 8, color: good ? 'var(--success)' : 'var(--danger)' }}>
+      {up ? '↑' : '↓'}{Math.abs(pct)}%
+    </span>
+  );
+}
 
-      {isLoading && <div className="empty-state"><span className="spinner" /></div>}
-      {isError && <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>}
-      {data && !hasData && <div className="empty-state">No history yet — charts fill in as jobs run.</div>}
+const sample = <T,>(arr: T[], n: number): T[] => {
+  if (arr.length <= n) return arr;
+  const step = arr.length / n;
+  return Array.from({ length: n }, (_, i) => arr[Math.floor(i * step)]);
+};
 
-      {data && hasData && (
-        <ResponsiveContainer width="100%" height={260}>
-          <LineChart data={series} margin={{ top: 4, right: 16, left: 0, bottom: 4 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
-            <XAxis dataKey="label" tick={{ fill: 'var(--text-muted)', fontSize: 11 }} minTickGap={48} />
-            <YAxis tick={{ fill: 'var(--text-muted)', fontSize: 11 }} allowDecimals={false} />
-            <Tooltip contentStyle={tooltipStyle} />
-            <Line type="monotone" dataKey="processed" stroke="var(--accent)" strokeWidth={2} dot={false} name="Processed" />
-            <Line type="monotone" dataKey="failed" stroke="var(--danger)" strokeWidth={2} dot={false} name="Failed" />
-          </LineChart>
-        </ResponsiveContainer>
-      )}
+const tooltipStyle = {
+  background: '#161618',
+  border: '1px solid #272729',
+  color: '#e4e4e7',
+  borderRadius: 6,
+  fontSize: 12,
+  fontFamily: 'JetBrains Mono, monospace',
+};
+
+// Centered spinner sized to a chart/table box. Shown while a query is pending —
+// i.e. the initial load and every range-filter change, where the query key flips
+// and there's no cached data yet — so the panel doesn't flash an empty state for
+// a beat before the data lands.
+function ChartLoader({ height }: { height: number }) {
+  return (
+    <div style={{ height, display: 'grid', placeItems: 'center' }}>
+      <span className="spinner" role="status" aria-label={t('common.loading')} />
     </div>
   );
 }
 
-// Ent §5.3 Historical snapshots from the capped `history:metrics` stream. One
-// point per periodic snapshot; a line per numeric field. The two cumulative
-// counters (processed/failures) are charted by HistoryCharts already, so this
-// "backlog over time" view hides them — but any other numeric field (incl. a
-// migrated Ent install's own fields) renders generically.
+export default function Metrics() {
+  const [rangeIdx, setRangeIdx] = useState(2); // default 7d, matching the mock
+  const range = RANGES[rangeIdx];
+
+  useEffect(() => {
+    document.title = `${t('nav.metrics')} — Wurk`;
+  }, []);
+
+  const { data: stats } = useQuery<StatsData>({
+    queryKey: ['stats'],
+    queryFn: () => fetch('/wurk/api/stats').then((r) => r.json() as Promise<StatsData>),
+    refetchInterval: 5000,
+  });
+
+  const { data: history, isPending: historyPending } = useQuery<HistoryResponse>({
+    queryKey: ['history', range.bucket, range.window],
+    queryFn: () =>
+      fetch(`/wurk/api/history/${range.bucket}?window=${range.window}`).then((r) => r.json() as Promise<HistoryResponse>),
+    refetchInterval: 30000,
+  });
+
+  const { data: metrics, isPending: metricsPending } = useQuery<MetricsResponse>({
+    queryKey: ['metrics', 60],
+    queryFn: () => fetch('/wurk/api/metrics?minutes=60').then((r) => r.json() as Promise<MetricsResponse>),
+    refetchInterval: 30000,
+  });
+
+  const { data: queueHistory, isPending: queuePending } = useQuery<QueueHistoryResponse>({
+    queryKey: ['queue-history', range.bucket, range.window],
+    queryFn: async () => {
+      const r = await fetch(`/wurk/api/queue-history/${range.bucket}?window=${range.window}`);
+      if (!r.ok) throw new Error(`queue-history failed (${r.status})`);
+      return r.json() as Promise<QueueHistoryResponse>;
+    },
+    refetchInterval: 30000,
+  });
+
+  let series = (history?.series ?? []).map((p) => ({ ...p, label: fmtBucket(p.at, range.bucket) }));
+  const sliceN = 'slice' in range ? range.slice : undefined;
+  if (sliceN) series = series.slice(-sliceN);
+  const hasThroughput = series.some((p) => p.processed > 0 || p.failed > 0);
+
+  // Queue depth = total jobs enqueued across all queues per bucket, downsampled
+  // to a readable number of bars; the busiest bar is highlighted (design spec).
+  const queues = queueHistory?.queues ?? [];
+  const ats = queues[0]?.points.map((p) => p.at) ?? [];
+  const depthRows = sample(
+    ats.map((at, i) => ({
+      label: fmtBucket(at, range.bucket),
+      depth: queues.reduce((s, q) => s + (q.points[i]?.size ?? 0), 0),
+    })),
+    16,
+  );
+  const maxDepth = Math.max(0, ...depthRows.map((r) => r.depth));
+
+  const jobs = (metrics?.top_jobs ?? [])
+    .map((j) => ({ klass: j.klass, count: j.processed + j.failed }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 6);
+  const jobsTotal = jobs.reduce((s, j) => s + j.count, 0);
+
+  return (
+    <div className="obs">
+      <div className="obs-toolbar">
+        <span className="obs-toolbar__label"><i className="fa-regular fa-calendar" aria-hidden="true" /> Time Range:</span>
+        <div className="obs-seg" role="tablist" aria-label="Time range">
+          {RANGES.map((r, i) => (
+            <button
+              key={r.key}
+              role="tab"
+              aria-selected={i === rangeIdx}
+              className={i === rangeIdx ? 'is-active' : ''}
+              onClick={() => setRangeIdx(i)}
+            >
+              {r.key}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="obs-metrics">
+        <div className="obs-card obs-metric">
+          <div className="obs-metric__head">
+            <span className="obs-mono">Total Processed</span>
+            <i className="fa-solid fa-circle-check obs-metric__icon" aria-hidden="true" />
+          </div>
+          <span className="obs-metric__value">
+            {(stats?.processed ?? 0).toLocaleString()}
+            <Delta pct={deltaPct(series, 'processed')} goodWhenUp />
+          </span>
+          <span className="obs-metric__sub">across all queues</span>
+        </div>
+        <div className="obs-card obs-metric">
+          <div className="obs-metric__head">
+            <span className="obs-mono">Failed Jobs</span>
+            <i className="fa-solid fa-triangle-exclamation obs-metric__icon" aria-hidden="true" />
+          </div>
+          <span className="obs-metric__value">
+            {(stats?.failed ?? 0).toLocaleString()}
+            <Delta pct={deltaPct(series, 'failed')} goodWhenUp={false} />
+          </span>
+          <span className="obs-metric__sub">total failures</span>
+        </div>
+        <div className="obs-card obs-metric">
+          <div className="obs-metric__head">
+            <span className="obs-mono">Avg Latency</span>
+            <i className="fa-solid fa-stopwatch obs-metric__icon" aria-hidden="true" />
+          </div>
+          <span className="obs-metric__value">{stats ? formatDuration(stats.latency) : '—'}</span>
+          <span className="obs-metric__sub">head-of-line</span>
+        </div>
+        <div className="obs-card obs-metric">
+          <div className="obs-metric__head">
+            <span className="obs-mono">Active Workers</span>
+            <i className="fa-solid fa-gears obs-metric__icon" aria-hidden="true" />
+          </div>
+          <span className="obs-metric__value">{(stats?.processes ?? 0).toLocaleString()}</span>
+          <span className="obs-metric__sub">{(stats?.processes ?? 0) > 0 ? 'Stable' : 'No workers'}</span>
+        </div>
+      </div>
+
+      <div className="obs-card obs-panel">
+        <div className="obs-panel__head">
+          <div>
+            <h2 className="obs-panel__title">Throughput &amp; Failures</h2>
+            <p className="obs-panel__sub">Jobs processed per bucket over the last {range.key}</p>
+          </div>
+          <div className="obs-legend">
+            <span><i className="dot dot--processed" /> Processed</span>
+            <span><i className="dot dot--failed" /> Failed</span>
+          </div>
+        </div>
+        <div className="obs-chartbox">
+          {historyPending ? (
+            <ChartLoader height={300} />
+          ) : hasThroughput ? (
+            <ResponsiveContainer width="100%" height={300}>
+              <AreaChart data={series} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+                <defs>
+                  <linearGradient id="mProcessed" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="#fafafa" stopOpacity={0.22} />
+                    <stop offset="95%" stopColor="#fafafa" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="rgba(255,255,255,0.06)" />
+                <XAxis dataKey="label" tick={{ fill: '#71717a', fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }} axisLine={false} tickLine={false} minTickGap={56} interval="preserveStartEnd" />
+                <YAxis tick={{ fill: '#71717a', fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }} axisLine={false} tickLine={false} width={36} allowDecimals={false} />
+                <Tooltip contentStyle={tooltipStyle} labelStyle={{ color: '#a1a1aa' }} cursor={{ stroke: 'rgba(255,255,255,0.25)', strokeWidth: 1 }} />
+                <Area type="monotone" dataKey="processed" name="Processed" stroke="#fafafa" strokeWidth={2} fill="url(#mProcessed)" dot={false} activeDot={{ r: 4, fill: '#fafafa', stroke: '#09090b', strokeWidth: 2 }} animationDuration={1100} animationEasing="ease-out" />
+                <Area type="monotone" dataKey="failed" name="Failed" stroke="#a1a1aa" strokeWidth={1.5} strokeDasharray="5 4" fill="transparent" dot={false} animationDuration={1100} animationBegin={250} animationEasing="ease-out" />
+              </AreaChart>
+            </ResponsiveContainer>
+          ) : (
+            <div className="empty-state" style={{ height: 300, display: 'grid', placeItems: 'center' }}>
+              No history yet — the chart fills in as jobs run.
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="obs-grid2">
+        <div className="obs-card obs-panel">
+          <div className="obs-panel__head">
+            <h2 className="obs-panel__title" style={{ fontSize: 18 }}>Queue Depth</h2>
+            <span className="obs-mono">{maxDepth > 0 ? `peak ${maxDepth.toLocaleString()}` : ''}</span>
+          </div>
+          <div className="obs-chartbox">
+            {queuePending ? (
+              <ChartLoader height={240} />
+            ) : depthRows.length > 0 ? (
+              <ResponsiveContainer width="100%" height={240}>
+                <BarChart data={depthRows} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="rgba(255,255,255,0.06)" />
+                  <XAxis dataKey="label" tick={{ fill: '#71717a', fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }} axisLine={false} tickLine={false} minTickGap={40} interval="preserveStartEnd" />
+                  <YAxis tick={{ fill: '#71717a', fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }} axisLine={false} tickLine={false} width={36} allowDecimals={false} />
+                  <Tooltip contentStyle={tooltipStyle} labelStyle={{ color: '#a1a1aa' }} cursor={{ fill: 'rgba(255,255,255,0.04)' }} />
+                  <Bar dataKey="depth" name="Depth" radius={[3, 3, 0, 0]} animationDuration={900} animationEasing="ease-out">
+                    {depthRows.map((r, i) => (
+                      <Cell key={i} fill={r.depth === maxDepth && maxDepth > 0 ? '#fafafa' : '#3f3f46'} />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            ) : (
+              <div className="empty-state" style={{ height: 240, display: 'grid', placeItems: 'center' }}>
+                No queue history yet.
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="obs-card obs-table">
+          <div className="obs-table__head">
+            <h2 className="obs-table__title" style={{ fontSize: 18 }}>Top Job Types (Volume)</h2>
+          </div>
+          {metricsPending ? (
+            <ChartLoader height={240} />
+          ) : jobs.length === 0 ? (
+            <div className="obs-empty">{t('common.empty')}</div>
+          ) : (
+            <div className="obs-tablescroll">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Job Class</th>
+                    <th style={{ textAlign: 'end' }}>Count</th>
+                    <th style={{ textAlign: 'end' }}>% Total</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {jobs.map((j, i) => (
+                    <tr key={j.klass}>
+                      <td style={{ color: 'var(--obs-text)' }} title={j.klass}>
+                        <span className="obs-jobdot" style={{ background: JOB_DOTS[i % JOB_DOTS.length] }} />
+                        {truncate(j.klass.split('::').pop() ?? j.klass, 36)}
+                      </td>
+                      <td style={{ textAlign: 'end', fontVariantNumeric: 'tabular-nums' }}>{j.count.toLocaleString()}</td>
+                      <td className="obs-pct" style={{ textAlign: 'end' }}>
+                        {jobsTotal > 0 ? Math.round((j.count / jobsTotal) * 100) : 0}%
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <QueueLatencyHistory range={range} />
+      <HistoricalSnapshots />
+    </div>
+  );
+}
+
+// Per-queue head-of-line latency over the selected window (Ent Historical tab,
+// §5.2) — kept below the mock layout so the feature isn't lost.
+function QueueLatencyHistory({ range }: { range: (typeof RANGES)[number] }) {
+  const { data } = useQuery<QueueHistoryResponse>({
+    queryKey: ['queue-history-lat', range.bucket, range.window],
+    queryFn: async () => {
+      const r = await fetch(`/wurk/api/queue-history/${range.bucket}?window=${range.window}`);
+      if (!r.ok) throw new Error(`queue-history failed (${r.status})`);
+      return r.json() as Promise<QueueHistoryResponse>;
+    },
+    refetchInterval: 30000,
+  });
+
+  const queues = data?.queues ?? [];
+  const ats = queues[0]?.points.map((p) => p.at) ?? [];
+  const rows = ats.map((at, i) => {
+    const row: Record<string, number | string> = { label: fmtBucket(at, range.bucket) };
+    queues.forEach((q) => { row[q.name] = q.points[i]?.latency ?? 0; });
+    return row;
+  });
+  const hasData = queues.some((q) => q.points.some((p) => p.latency > 0));
+  if (!hasData) return null;
+
+  return (
+    <div className="obs-card obs-panel">
+      <div className="obs-panel__head">
+        <h2 className="obs-panel__title" style={{ fontSize: 18 }}>Queue Latency (seconds)</h2>
+      </div>
+      <div className="obs-chartbox">
+        <ResponsiveContainer width="100%" height={240}>
+          <LineChart data={rows} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="rgba(255,255,255,0.06)" />
+            <XAxis dataKey="label" tick={{ fill: '#71717a', fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }} axisLine={false} tickLine={false} minTickGap={48} interval="preserveStartEnd" />
+            <YAxis tick={{ fill: '#71717a', fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }} axisLine={false} tickLine={false} width={40} />
+            <Tooltip contentStyle={tooltipStyle} labelStyle={{ color: '#a1a1aa' }} />
+            <Legend wrapperStyle={{ fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }} />
+            {queues.map((q, i) => (
+              <Line key={q.name} type="monotone" dataKey={q.name} stroke={queueColor(i)} strokeWidth={2} dot={false} />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
 interface Snapshot {
   at: number;
   [field: string]: number;
 }
-
 const CUMULATIVE_FIELDS = new Set(['processed', 'failures']);
 
 function HistoricalSnapshots() {
-  const { data, isLoading, isError } = useQuery<{ snapshots: Snapshot[] }>({
+  const { data } = useQuery<{ snapshots: Snapshot[] }>({
     queryKey: ['history-snapshots'],
     queryFn: async () => {
       const r = await fetch('/wurk/api/history/snapshots?limit=1000');
@@ -199,262 +455,27 @@ function HistoricalSnapshots() {
     const d = new Date(s.at * 1000);
     return { ...s, label: `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}` };
   });
-  const hasData = snapshots.length > 0 && fields.length > 0;
+  if (snapshots.length === 0 || fields.length === 0) return null;
 
   return (
-    <div className="card" style={{ marginBottom: '1.5rem' }}>
-      <div className="section-title" style={{ marginBottom: '1rem' }}>Historical Snapshots</div>
-
-      {isLoading && <div className="empty-state"><span className="spinner" /></div>}
-      {isError && <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>}
-      {data && !hasData && (
-        <div className="empty-state">No snapshots yet — enable <code>config.retain_history</code> to record history.</div>
-      )}
-
-      {data && hasData && (
-        <ResponsiveContainer width="100%" height={260}>
-          <LineChart data={rows} margin={{ top: 4, right: 16, left: 0, bottom: 4 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
-            <XAxis dataKey="label" tick={{ fill: 'var(--text-muted)', fontSize: 11 }} minTickGap={48} />
-            <YAxis tick={{ fill: 'var(--text-muted)', fontSize: 11 }} allowDecimals={false} />
-            <Tooltip contentStyle={tooltipStyle} />
-            <Legend wrapperStyle={{ fontSize: 12 }} />
+    <div className="obs-card obs-panel">
+      <div className="obs-panel__head">
+        <h2 className="obs-panel__title" style={{ fontSize: 18 }}>Historical Snapshots</h2>
+      </div>
+      <div className="obs-chartbox">
+        <ResponsiveContainer width="100%" height={240}>
+          <LineChart data={rows} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="rgba(255,255,255,0.06)" />
+            <XAxis dataKey="label" tick={{ fill: '#71717a', fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }} axisLine={false} tickLine={false} minTickGap={48} interval="preserveStartEnd" />
+            <YAxis tick={{ fill: '#71717a', fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }} axisLine={false} tickLine={false} width={40} allowDecimals={false} />
+            <Tooltip contentStyle={tooltipStyle} labelStyle={{ color: '#a1a1aa' }} />
+            <Legend wrapperStyle={{ fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }} />
             {fields.map((f, i) => (
               <Line key={f} type="monotone" dataKey={f} stroke={queueColor(i)} strokeWidth={2} dot={false} />
             ))}
           </LineChart>
         </ResponsiveContainer>
-      )}
-    </div>
-  );
-}
-
-// Per-queue size + head-of-line latency gauges over the selected window
-// (Sidekiq Ent Historical tab, §5.2). One line per queue in each of the two
-// charts; the range selector mirrors the throughput chart's buckets.
-function QueueGaugeCharts() {
-  const [range, setRange] = useState(0);
-  const { bucket, window } = HISTORY_RANGES[range];
-
-  const { data, isLoading, isError } = useQuery<QueueHistoryResponse>({
-    queryKey: ['queue-history', bucket, window],
-    // Throw on a non-OK response so react-query's `isError` fires instead of an
-    // error payload (which has no `queues`) falling through to the empty state.
-    queryFn: async () => {
-      const r = await fetch(`/wurk/api/queue-history/${bucket}?window=${window}`);
-      if (!r.ok) {
-        const err = (await r.json().catch(() => null)) as { error?: string } | null;
-        throw new Error(err?.error ?? `queue-history request failed (${r.status})`);
-      }
-      return r.json() as Promise<QueueHistoryResponse>;
-    },
-    refetchInterval: 30000,
-  });
-
-  const queues = data?.queues ?? [];
-  // Every queue shares the same gap-filled bucket timestamps, so pivot to wide
-  // rows keyed by timestamp with one column per queue for Recharts.
-  const ats = queues[0]?.points.map((p) => p.at) ?? [];
-  const rowsFor = (field: 'size' | 'latency') =>
-    ats.map((at, i) => {
-      const row: Record<string, number | string> = { label: bucketLabel(at, bucket) };
-      queues.forEach((q) => {
-        row[q.name] = q.points[i]?.[field] ?? 0;
-      });
-      return row;
-    });
-  const hasData = queues.some((q) => q.points.some((p) => p.size > 0 || p.latency > 0));
-
-  const chart = (rows: ReturnType<typeof rowsFor>, decimals: boolean) => (
-    <ResponsiveContainer width="100%" height={240}>
-      <LineChart data={rows} margin={{ top: 4, right: 16, left: 0, bottom: 4 }}>
-        <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
-        <XAxis dataKey="label" tick={{ fill: 'var(--text-muted)', fontSize: 11 }} minTickGap={48} />
-        <YAxis tick={{ fill: 'var(--text-muted)', fontSize: 11 }} allowDecimals={decimals} />
-        <Tooltip contentStyle={tooltipStyle} />
-        <Legend wrapperStyle={{ fontSize: 12 }} />
-        {queues.map((q, i) => (
-          <Line
-            key={q.name}
-            type="monotone"
-            dataKey={q.name}
-            stroke={queueColor(i)}
-            strokeWidth={2}
-            dot={false}
-          />
-        ))}
-      </LineChart>
-    </ResponsiveContainer>
-  );
-
-  return (
-    <div className="card" style={{ marginBottom: '1.5rem' }}>
-      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '1rem' }}>
-        <div className="section-title">Queue Size &amp; Latency</div>
-        <select
-          className="select"
-          style={{ marginInlineStart: 'auto' }}
-          value={range}
-          onChange={(e) => setRange(Number(e.target.value))}
-          aria-label="Queue history range"
-        >
-          {HISTORY_RANGES.map((r, i) => (
-            <option key={r.label} value={i}>{r.label}</option>
-          ))}
-        </select>
       </div>
-
-      {isLoading && <div className="empty-state"><span className="spinner" /></div>}
-      {isError && <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>}
-      {data && !hasData && <div className="empty-state">No queue history yet — charts fill in as queues build up.</div>}
-
-      {data && hasData && (
-        <>
-          <div className="section-subtitle" style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 4 }}>
-            Depth (jobs)
-          </div>
-          {chart(rowsFor('size'), false)}
-          <div className="section-subtitle" style={{ fontSize: 12, color: 'var(--text-muted)', margin: '1rem 0 4px' }}>
-            Latency (seconds)
-          </div>
-          {chart(rowsFor('latency'), true)}
-        </>
-      )}
-    </div>
-  );
-}
-
-export default function Metrics() {
-  const [minutes, setMinutes] = useState(60);
-
-  useEffect(() => {
-    document.title = `${t('nav.metrics')} — Wurk`;
-  }, []);
-
-  const { data, isLoading, isError } = useQuery<MetricsResponse>({
-    queryKey: ['metrics', minutes],
-    queryFn: () =>
-      fetch(`/wurk/api/metrics?minutes=${minutes}`).then(
-        (r) => r.json() as Promise<MetricsResponse>
-      ),
-    refetchInterval: 30000,
-  });
-
-  const chartData = (data?.top_jobs ?? []).slice(0, 10).map((j) => ({
-    name: j.klass.split('::').pop() ?? j.klass,
-    fullName: j.klass,
-    total: j.processed + j.failed,
-    failed: j.failed,
-  }));
-
-  return (
-    <div>
-      <PageHeader icon="fa-chart-line" title={t('nav.metrics')} summary={t('summaries.metrics')}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-          <span style={{ fontSize: 13, color: 'var(--text-muted)' }}>Last</span>
-          <select
-            className="select"
-            value={minutes}
-            onChange={(e) => setMinutes(Number(e.target.value))}
-          >
-            {MINUTE_OPTIONS.map((m) => (
-              <option key={m} value={m}>
-                {m >= 60 ? `${m / 60}h` : `${m}m`}
-              </option>
-            ))}
-          </select>
-        </div>
-      </PageHeader>
-
-      <HistoryCharts />
-
-      <HistoricalSnapshots />
-
-      <QueueGaugeCharts />
-
-      {isLoading && (
-        <div className="empty-state"><span className="spinner" /></div>
-      )}
-
-      {isError && (
-        <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>
-      )}
-
-      {data && data.top_jobs.length === 0 && (
-        <div className="empty-state">{t('common.empty')}</div>
-      )}
-
-      {data && data.top_jobs.length > 0 && (
-        <>
-          <div className="card" style={{ marginBottom: '1.5rem' }}>
-            <div className="section-title" style={{ marginBottom: '1rem' }}>Top Jobs by Count</div>
-            <ResponsiveContainer width="100%" height={280}>
-              <BarChart data={chartData} margin={{ top: 4, right: 16, left: 0, bottom: 40 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
-                <XAxis
-                  dataKey="name"
-                  tick={{ fill: 'var(--text-muted)', fontSize: 11 }}
-                  angle={-35}
-                  textAnchor="end"
-                  interval={0}
-                />
-                <YAxis tick={{ fill: 'var(--text-muted)', fontSize: 11 }} />
-                <Tooltip
-                  contentStyle={{
-                    background: 'var(--surface)',
-                    border: '1px solid var(--border)',
-                    color: 'var(--text)',
-                    borderRadius: 6,
-                    fontSize: 12,
-                  }}
-                  labelFormatter={(_: unknown, payload: readonly unknown[]) => {
-                    const item = payload?.[0] as { payload?: { fullName?: string } } | undefined;
-                    return item?.payload?.fullName ?? '';
-                  }}
-                />
-                <Bar dataKey="total" fill="var(--accent)" radius={[3, 3, 0, 0]} name="Total" />
-                <Bar dataKey="failed" fill="var(--danger)" radius={[3, 3, 0, 0]} name="Failed" />
-              </BarChart>
-            </ResponsiveContainer>
-          </div>
-
-          <div className="table-wrapper">
-            <table>
-              <thead>
-                <tr>
-                  <th>{t('table.class')}</th>
-                  <th>{t('table.total')}</th>
-                  <th>Failed</th>
-                  <th>Error Rate</th>
-                  <th>Avg {t('common.ms')}</th>
-                </tr>
-              </thead>
-              <tbody>
-                {data.top_jobs.map((job) => {
-                  const total = job.processed + job.failed;
-                  const errorRate = total > 0 ? (job.failed / total) * 100 : 0;
-                  const avgMs = total > 0 ? job.runtime_ms / total : 0;
-                  return (
-                    <tr key={job.klass}>
-                      <td title={job.klass} style={{ fontWeight: 500 }}>
-                        {truncate(job.klass, 50)}
-                      </td>
-                      <td style={{ fontVariantNumeric: 'tabular-nums' }}>{total.toLocaleString()}</td>
-                      <td style={{ color: job.failed > 0 ? 'var(--danger)' : undefined, fontVariantNumeric: 'tabular-nums' }}>
-                        {job.failed.toLocaleString()}
-                      </td>
-                      <td style={{ color: errorRate > 5 ? 'var(--danger)' : errorRate > 1 ? 'var(--warning)' : 'var(--success)' }}>
-                        {errorRate.toFixed(1)}%
-                      </td>
-                      <td style={{ fontVariantNumeric: 'tabular-nums' }}>{avgMs.toFixed(1)}</td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        </>
-      )}
     </div>
   );
 }

--- a/frontend/src/pages/Profiles.tsx
+++ b/frontend/src/pages/Profiles.tsx
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { t } from '../i18n';
-import { PageHeader } from '../components/PageHeader';
 
 // One row from GET /wurk/api/profiles (Wurk::Api::Serializers.profile_record).
 interface Profile {
@@ -39,58 +38,64 @@ export default function Profiles() {
     refetchInterval: 5000,
   });
 
-  if (isLoading) return <div className="empty-state"><span className="spinner" /></div>;
+  if (isLoading) return <div className="obs"><div className="empty-state"><span className="spinner" /></div></div>;
   // Guard against a non-array body slipping past isError — render the error
   // state rather than crashing on .length / .map.
   if (isError || !Array.isArray(data)) {
-    return <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>;
+    return <div className="obs"><div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div></div>;
   }
 
   return (
-    <div>
-      <PageHeader icon="fa-fire" title={t('nav.profiles')} summary={t('summaries.profiles')}>
-        <span className="badge badge-muted">{data.length.toLocaleString()}</span>
-      </PageHeader>
+    <div className="obs">
+      <div className="obs-pagehead">
+        <div>
+          <h1>{t('nav.profiles')}</h1>
+          <p className="obs-panel__sub">{t('summaries.profiles')}</p>
+        </div>
+        <span className="obs-chip obs-chip--active">{data.length.toLocaleString()}</span>
+      </div>
 
       {data.length === 0 ? (
-        <div className="empty-state">{t('common.empty')}</div>
+        <div className="obs-card obs-empty">{t('common.empty')}</div>
       ) : (
-        <div className="table-wrapper">
-          <table>
-            <thead>
-              <tr>
-                <th>Type</th>
-                <th>JID</th>
-                <th>Started</th>
-                <th>Elapsed</th>
-                <th>Size</th>
-                <th />
-              </tr>
-            </thead>
-            <tbody>
-              {data.map((p) => (
-                <tr key={p.key}>
-                  <td>{p.type}</td>
-                  <td><code>{p.jid}</code></td>
-                  <td>{fmtWhen(p.started_at)}</td>
-                  <td>{p.elapsed.toLocaleString()} ms</td>
-                  <td>{fmtBytes(p.size)}</td>
-                  <td style={{ textAlign: 'end' }}>
-                    {/* Full reload (not client-route): the backend POSTs the blob
-                        to the Firefox profiler then 302s out to profiler.firefox.com. */}
-                    <a
-                      className="btn btn-sm"
-                      href={`/wurk/profiles/${encodeURIComponent(p.key)}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      <i className="fa-solid fa-up-right-from-square" /> Open profile
-                    </a>
-                  </td>
+        <div className="obs-card obs-table">
+          <div className="obs-tablescroll">
+            <table>
+              <thead>
+                <tr>
+                  <th>Type</th>
+                  <th>JID</th>
+                  <th>Started</th>
+                  <th>Elapsed</th>
+                  <th>Size</th>
+                  <th />
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {data.map((p) => (
+                  <tr key={p.key}>
+                    <td style={{ fontWeight: 500, color: 'var(--obs-text)' }}>{p.type}</td>
+                    <td><span className="obs-mono-cell">{p.jid}</span></td>
+                    <td>{fmtWhen(p.started_at)}</td>
+                    <td>{p.elapsed.toLocaleString()} ms</td>
+                    <td>{fmtBytes(p.size)}</td>
+                    <td style={{ textAlign: 'end' }}>
+                      {/* Full reload (not client-route): the backend POSTs the blob
+                          to the Firefox profiler then 302s out to profiler.firefox.com. */}
+                      <a
+                        className="obs-btn obs-btn--ghost obs-btn--sm"
+                        href={`/wurk/profiles/${encodeURIComponent(p.key)}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <i className="fa-solid fa-up-right-from-square" aria-hidden="true" /> Open
+                      </a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/pages/Profiles.tsx
+++ b/frontend/src/pages/Profiles.tsx
@@ -28,7 +28,7 @@ export default function Profiles() {
     document.title = `${t('nav.profiles')} — Wurk`;
   }, []);
 
-  const { data, isLoading, isError } = useQuery<Profile[]>({
+  const { data, isLoading } = useQuery<Profile[]>({
     queryKey: ['profiles'],
     queryFn: async () => {
       const r = await fetch('/wurk/api/profiles');
@@ -39,9 +39,11 @@ export default function Profiles() {
   });
 
   if (isLoading) return <div className="obs"><div className="empty-state"><span className="spinner" /></div></div>;
-  // Guard against a non-array body slipping past isError — render the error
-  // state rather than crashing on .length / .map.
-  if (isError || !Array.isArray(data)) {
+  // Only gate on shape, not isError — with refetchInterval polling, a transient
+  // background refetch failure flips isError true while the last good payload
+  // is still cached. Showing the error state then would blank the page on
+  // every blip; falling through keeps stale data visible until the next poll.
+  if (!Array.isArray(data)) {
     return <div className="obs"><div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div></div>;
   }
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -17,48 +17,59 @@
    page markup changes. Override lives in an unlayered `:root` (wins over
    daisyUI's layered theme rules regardless of source order). */
 :root {
-  --color-base-100: #0d1117;   /* page background */
-  --color-base-200: #161b22;   /* card / surface  */
-  --color-base-300: #21262d;   /* raised surface, inputs */
-  --color-base-content: #e6edf3;
-  --color-primary: #ffffff;
-  --color-primary-content: #0d1117;
-  --color-secondary: #ffffff;
-  --color-accent: #ffffff;
-  --color-accent-content: #0d1117;
-  --color-error: #e5534b;
-  --color-error-content: #ffffff;
-  --color-warning: #d29922;
-  --color-warning-content: #0d1117;
+  /* Obsidian Engineering System — zinc palette (canonical). Monochromatic,
+     engineered/HUD: near-black canvas, tonal surfaces, 1px solid borders (no
+     shadows), luminance over hue. Geist + JetBrains Mono. The whole SPA is
+     driven by these vars, so this re-skins every page. */
+  --color-base-100: #09090b;   /* page background (canvas) */
+  --color-base-200: #161618;   /* card / surface  */
+  --color-base-300: #1f1f22;   /* raised surface, inputs */
+  --color-base-content: #e4e4e7;
+  --color-primary: #fafafa;
+  --color-primary-content: #09090b;
+  --color-secondary: #fafafa;
+  --color-accent: #fafafa;
+  --color-accent-content: #09090b;
+  --color-error: #f0786f;
+  --color-error-content: #09090b;
+  --color-warning: #d8b34a;
+  --color-warning-content: #09090b;
   --color-success: #3fb950;
-  --color-success-content: #0d1117;
+  --color-success-content: #09090b;
 
   --bg: var(--color-base-100);
   --text: var(--color-base-content);
-  --text-muted: #8b949e;
+  --text-muted: #a1a1aa;
+  --text-bright: #fafafa;
 
   /* Monochrome accent: no chroma. Interactive emphasis comes from brightness,
      a subtle white fill, and hover underlines — colour is reserved for the logo
      and status (red/amber/green). */
-  --accent: #ffffff;
-  --accent-hover: #f0f3f6;
-  --accent-soft: oklch(1 0 0 / 0.1);
+  --accent: #fafafa;
+  --accent-hover: #ffffff;
+  --accent-soft: oklch(1 0 0 / 0.06);
   --accent-ring: oklch(1 0 0 / 0.22);
   --danger: var(--color-error);
   --warning: var(--color-warning);
   --success: var(--color-success);
 
-  /* Flat surfaces: opaque fills, a hairline edge, a faint shadow for the
-     barest separation from the background. Elevation is border-led, not blur. */
+  /* Flat surfaces: opaque fills, a 1px solid edge, no shadow. Elevation is
+     border + tone, never blur (Obsidian: no muddiness in dark mode). */
   --surface: var(--color-base-200);
   --surface-strong: var(--color-base-300);
-  --surface-hover: #1c232c;
-  --border: oklch(1 0 0 / 0.08);
-  --border-strong: #30363d;
-  --shadow: 0 1px 2px oklch(0 0 0 / 0.4);
+  --surface-hover: #1f1f22;
+  --border: #272729;
+  --border-strong: #3a3a3d;
+  --shadow: none;
   --radius: 8px;
+  --radius-sm: 4px;
 
-  --nav-width: 248px;
+  /* Obsidian typography */
+  --font-sans: 'Geist', system-ui, -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  --nav-width: 248px;   /* expanded (hover / mobile drawer) */
+  --nav-rail: 64px;     /* collapsed icon rail (desktop default) */
 }
 
 * {
@@ -71,7 +82,7 @@ body {
   min-height: 100vh;
   background: var(--bg);
   color: var(--text);
-  font-family: system-ui, -apple-system, sans-serif;
+  font-family: var(--font-sans);
   font-size: 14px;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
@@ -117,10 +128,11 @@ th, td {
 
 th {
   color: var(--text-muted);
-  font-weight: 600;
+  font-family: var(--font-mono);
+  font-weight: 500;
   font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   /* Sticky header floats over scrolling rows, so it gets an opaque fill. */
   background: var(--surface-strong);
   position: sticky;
@@ -132,12 +144,9 @@ tbody tr {
   transition: background 0.12s;
 }
 
-tbody tr:nth-child(even) td {
-  background: color-mix(in oklch, var(--color-base-300) 30%, transparent);
-}
-
+/* Obsidian tables: row borders only, no zebra striping. */
 tbody tr:hover td {
-  background: var(--accent-soft);
+  background: var(--surface-hover);
 }
 
 tbody tr:last-child td {
@@ -233,12 +242,13 @@ tbody tr:last-child td {
 /* ── Badges ───────────────────────────────────────────────────────────────*/
 .badge {
   display: inline-block;
-  padding: 2px 9px;
+  padding: 3px 10px;
   border-radius: 999px;
-  font-size: 11px;
-  font-weight: 600;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 500;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.07em;
   border: 1px solid transparent;
 }
 
@@ -303,9 +313,13 @@ tbody tr:last-child td {
 }
 
 .btn {
-  padding: 0.42rem 0.95rem;
-  font-size: 13px;
+  padding: 0.5rem 0.9rem;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
   font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-radius: var(--radius-sm);
 }
 
 .btn:hover {
@@ -873,11 +887,11 @@ tbody tr:last-child td {
   flex: none;
   width: 44px;
   height: 44px;
-  border-radius: 11px;
+  border-radius: var(--radius);
   display: grid;
   place-items: center;
   background: var(--surface-strong);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--border);
   color: var(--accent);
   font-size: 18px;
   transition: transform 0.18s ease, border-color 0.18s ease;
@@ -891,9 +905,9 @@ tbody tr:last-child td {
 .page-header__text { min-width: 0; }
 
 .page-header__title {
-  font-size: 22px;
-  font-weight: 800;
-  letter-spacing: -0.02em;
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
   line-height: 1.1;
 }
 
@@ -1031,3 +1045,184 @@ tbody tr:last-child td {
 }
 .ext-view input[type='submit']:hover,
 .ext-view button:hover { border-color: var(--accent); }
+
+/* ════════════════════════════════════════════════════════════════════════
+   Obsidian Engineering System — scoped to the dashboard (page-by-page rollout).
+   Monochromatic, engineered/HUD aesthetic: Geist + JetBrains Mono, tonal
+   surfaces, 1px borders (no shadows), luminance over hue. Reconciled to the
+   spec's zinc palette, which matches the dashboard mockup most closely.
+   ════════════════════════════════════════════════════════════════════════ */
+.obs {
+  --obs-bg: #09090b;
+  --obs-surface: #161618;
+  --obs-surface-2: #1e1e21;
+  --obs-border: #272729;
+  --obs-border-hover: #3a3a3d;
+  --obs-text: #fafafa;
+  --obs-text-2: #e4e4e7;
+  --obs-muted: #a1a1aa;
+  --obs-faint: #3f3f46;
+  --obs-success: #3fb950;
+  --obs-danger: #f0786f;
+  --obs-radius: 8px;
+  --obs-radius-sm: 4px;
+  --font-sans: 'Geist', system-ui, -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
+  font-family: var(--font-sans);
+  color: var(--obs-text-2);
+}
+.obs .obs-mono {
+  font-family: var(--font-mono); font-size: 11px; font-weight: 500;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--obs-muted);
+}
+.obs-card {
+  background: var(--obs-surface); border: 1px solid var(--obs-border);
+  border-radius: var(--obs-radius); transition: border-color 0.15s ease;
+}
+.obs-card:hover { border-color: var(--obs-border-hover); }
+
+/* ── Metric cards (Processed / Failed / Expired / Busy) ── */
+.obs-metrics, .obs-stats {
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 12px;
+}
+@media (max-width: 900px) { .obs-metrics, .obs-stats { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 520px) { .obs-metrics, .obs-stats { grid-template-columns: 1fr; } }
+.obs-metric { padding: 18px 18px 16px; display: flex; flex-direction: column; gap: 12px; }
+.obs-metric__head { display: flex; align-items: center; justify-content: space-between; }
+.obs-metric__icon { color: var(--obs-muted); font-size: 13px; }
+.obs-metric__value {
+  font-size: 40px; font-weight: 600; line-height: 1; letter-spacing: -0.02em;
+  color: var(--obs-text); font-variant-numeric: tabular-nums;
+}
+.obs-metric__sub { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.02em; color: var(--obs-muted); }
+.obs-metric__sub .up { color: var(--obs-success); }
+.obs-metric__sub .down { color: var(--obs-danger); }
+
+/* ── Performance Insight panel ── */
+.obs-panel { padding: 22px 22px 14px; margin-bottom: 12px; }
+.obs-panel__head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
+.obs-panel__title { font-size: 20px; font-weight: 600; letter-spacing: -0.01em; color: var(--obs-text); margin: 0; }
+.obs-panel__sub { font-size: 13px; color: var(--obs-muted); margin: 4px 0 0; }
+.obs-panel__controls { display: flex; flex-direction: column; align-items: flex-end; gap: 12px; flex-shrink: 0; }
+.obs-legend { display: flex; gap: 18px; flex-shrink: 0; }
+.obs-legend span {
+  font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--obs-muted); display: inline-flex; align-items: center; gap: 7px;
+}
+.obs-legend .dot { width: 9px; height: 9px; border-radius: 2px; display: inline-block; }
+.obs-legend .dot--processed { background: #fafafa; }
+.obs-legend .dot--failed { border: 1px solid var(--obs-muted); }
+.obs-chartbox { margin-top: 16px; }
+
+/* ── Secondary stat cards ── */
+.obs-stat { padding: 16px 18px; display: flex; flex-direction: column; gap: 10px; }
+.obs-stat__value { font-size: 26px; font-weight: 600; line-height: 1; color: var(--obs-text); font-variant-numeric: tabular-nums; }
+
+/* ── Queues table ── */
+.obs-table { overflow: hidden; margin-bottom: 12px; }
+.obs-table__head { display: flex; align-items: center; justify-content: space-between; padding: 18px 20px 14px; }
+.obs-table__title { font-size: 18px; font-weight: 600; color: var(--obs-text); margin: 0; }
+.obs-table__link { font-size: 13px; color: var(--obs-muted); display: inline-flex; align-items: center; gap: 6px; }
+.obs-table__link:hover { color: var(--obs-text); text-decoration: none; }
+.obs-table table { width: 100%; border-collapse: collapse; background: transparent; border: none; border-radius: 0; }
+.obs-table thead th {
+  font-family: var(--font-mono); font-size: 11px; font-weight: 500; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--obs-muted); text-align: left; padding: 10px 20px; border-bottom: 1px solid var(--obs-border); background: transparent;
+}
+.obs-table tbody td { padding: 16px 20px; border-bottom: 1px solid var(--obs-border); color: var(--obs-text-2); font-size: 14px; vertical-align: middle; }
+.obs-table tbody tr:last-child td { border-bottom: none; }
+.obs-table tbody tr:hover td { background: var(--obs-surface-2); }
+.obs-table th:last-child, .obs-table td:last-child { text-align: right; }
+.obs-chip {
+  display: inline-block; font-family: var(--font-mono); font-size: 10.5px; font-weight: 500; letter-spacing: 0.08em;
+  text-transform: uppercase; color: var(--obs-muted); border: 1px solid var(--obs-border); border-radius: 999px;
+  padding: 4px 11px; background: var(--obs-surface-2);
+}
+.obs-chip--active { color: var(--obs-text-2); }
+.obs-chip--paused { color: #d8b34a; border-color: #4a3f1e; }
+
+/* ── Footer CTA ── */
+.obs-cta {
+  padding: 56px 24px 60px; text-align: center; margin-bottom: 8px;
+  background: radial-gradient(130% 120% at 50% 0%, #1b1b1f 0%, var(--obs-surface) 55%);
+}
+.obs-cta__icon {
+  width: 56px; height: 56px; border-radius: 12px; display: inline-flex; align-items: center; justify-content: center;
+  background: var(--obs-surface-2); border: 1px solid var(--obs-border); color: var(--obs-text); font-size: 22px; margin-bottom: 22px;
+}
+.obs-cta__title { font-size: 26px; font-weight: 600; letter-spacing: -0.01em; margin: 0 0 10px; color: var(--obs-text); }
+.obs-cta__text { color: var(--obs-muted); max-width: 540px; margin: 0 auto 26px; font-size: 15px; line-height: 1.6; }
+.obs-cta__actions { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+.obs-btn {
+  display: inline-flex; align-items: center; gap: 8px; padding: 11px 18px; border-radius: var(--obs-radius-sm);
+  font-family: var(--font-mono); font-size: 12px; font-weight: 500; letter-spacing: 0.04em; text-transform: uppercase;
+  border: 1px solid var(--obs-border); transition: border-color 0.15s ease, background 0.15s ease, filter 0.15s ease; cursor: pointer;
+}
+.obs-btn--primary { background: #fafafa; color: #09090b; border-color: #fafafa; }
+.obs-btn--primary:hover { filter: brightness(0.92); text-decoration: none; }
+.obs-btn--ghost { background: transparent; color: var(--obs-text-2); }
+.obs-btn--ghost:hover { border-color: var(--obs-muted); background: var(--obs-surface-2); text-decoration: none; }
+
+@media (prefers-reduced-motion: reduce) {
+  .obs-card { transition: none; }
+}
+
+/* ── Clickable tiles (dashboard shortcuts to tabs) ── */
+.obs-card--link { position: relative; cursor: pointer; color: inherit; text-decoration: none; }
+.obs-card--link:hover { text-decoration: none; border-color: var(--obs-border-hover); background: var(--obs-surface-2); }
+.obs-card--link:focus-visible { outline: 2px solid var(--obs-muted); outline-offset: 2px; }
+.obs-card__go {
+  position: absolute; right: 16px; bottom: 16px; font-size: 11px; color: var(--obs-muted);
+  opacity: 0; transform: translateX(-4px); transition: opacity 0.15s ease, transform 0.15s ease;
+}
+.obs-card--link:hover .obs-card__go { opacity: 1; transform: translateX(0); }
+
+/* ── Horizontal scroll for wide tables on small screens ── */
+.obs-tablescroll { overflow-x: auto; }
+
+/* ── Mobile polish ── */
+@media (max-width: 560px) {
+  .obs-panel { padding: 18px 16px 12px; }
+  .obs-panel__head { flex-direction: column; gap: 10px; }
+  .obs-legend { gap: 14px; }
+  .obs-metric__value { font-size: 34px; }
+  .obs-cta { padding: 44px 18px 48px; }
+  .obs-table thead th, .obs-table tbody td { padding-left: 16px; padding-right: 16px; }
+}
+
+/* ── Page header (for inner pages like Profiles) ── */
+.obs-pagehead { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 18px; }
+.obs-pagehead h1 { font-size: 24px; font-weight: 600; letter-spacing: -0.01em; margin: 0; color: var(--obs-text); }
+.obs-pagehead .obs-panel__sub { margin-top: 4px; }
+.obs-mono-cell { font-family: var(--font-mono); font-size: 12.5px; color: var(--obs-text-2); }
+.obs-empty { padding: 48px 24px; text-align: center; color: var(--obs-muted); }
+.obs-btn--sm { padding: 7px 12px; font-size: 11px; }
+
+/* ── Metrics page: toolbar, segmented range control, 2-col grid ── */
+.obs-toolbar {
+  display: flex; align-items: center; justify-content: space-between; gap: 16px;
+  margin-bottom: 18px; padding-bottom: 18px; border-bottom: 1px solid var(--obs-border);
+}
+.obs-toolbar__label {
+  font-family: var(--font-mono); font-size: 12px; letter-spacing: 0.04em; color: var(--obs-muted);
+  display: inline-flex; align-items: center; gap: 9px;
+}
+.obs-seg {
+  display: inline-flex; background: var(--obs-surface); border: 1px solid var(--obs-border);
+  border-radius: var(--obs-radius-sm); padding: 3px; gap: 2px;
+}
+.obs-seg button {
+  font-family: var(--font-mono); font-size: 12px; padding: 6px 16px; border: none; background: transparent;
+  color: var(--obs-muted); border-radius: 3px; cursor: pointer; transition: background 0.12s ease, color 0.12s ease;
+}
+.obs-seg button:hover { color: var(--obs-text-2); }
+.obs-seg button.is-active { background: var(--obs-surface-2); color: var(--obs-text); }
+.obs-grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 12px; }
+@media (max-width: 820px) { .obs-grid2 { grid-template-columns: 1fr; } }
+.obs-panel__menu {
+  background: none; border: none; color: var(--obs-muted); cursor: pointer; font-size: 16px;
+  padding: 2px 8px; border-radius: 4px; line-height: 1;
+}
+.obs-panel__menu:hover { color: var(--obs-text); background: var(--obs-surface-2); }
+.obs-jobdot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-inline-end: 10px; flex: none; vertical-align: middle; }
+.obs-pct { color: var(--obs-muted); font-variant-numeric: tabular-nums; }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -66,7 +66,7 @@
 
   /* Obsidian typography */
   --font-sans: 'Geist', system-ui, -apple-system, sans-serif;
-  --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-mono: 'JetBrains Mono', ui-monospace, 'SFMono-Regular', 'Menlo', monospace;
 
   --nav-width: 248px;   /* expanded (hover / mobile drawer) */
   --nav-rail: 64px;     /* collapsed icon rail (desktop default) */
@@ -1067,7 +1067,8 @@ tbody tr:last-child td {
   --obs-radius: 8px;
   --obs-radius-sm: 4px;
   --font-sans: 'Geist', system-ui, -apple-system, sans-serif;
-  --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
+  --font-mono: 'JetBrains Mono', ui-monospace, 'SFMono-Regular', monospace;
+
   font-family: var(--font-sans);
   color: var(--obs-text-2);
 }

--- a/test/dummy/seed_demo_profiles.rb
+++ b/test/dummy/seed_demo_profiles.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Seed a handful of demo job profiles so the Profiles page has content to show.
 # Uses the real Wurk::Profiler.store path (same wire schema the worker writes).
 require 'securerandom'

--- a/test/dummy/seed_demo_profiles.rb
+++ b/test/dummy/seed_demo_profiles.rb
@@ -1,0 +1,32 @@
+# Seed a handful of demo job profiles so the Profiles page has content to show.
+# Uses the real Wurk::Profiler.store path (same wire schema the worker writes).
+require 'securerandom'
+require 'json'
+
+samples = [
+  ['Demo::ReportJob',       15_200, 4],
+  ['Demo::FastJob',            120, 11],
+  ['Demo::RateLimitedJob',     890, 23],
+  ['Demo::BatchChildJob',    3_400, 47],
+  ['ThrottledApiJob',          540, 95],
+  ['Demo::SlowReportJob',    7_600, 140],
+  ['MailerJob',                250, 320],
+]
+
+now = Time.now.to_i
+samples.each do |type, ms, mins_ago|
+  frames = Array.new((ms / 40) + 8) { |n| { name: "#{type}#run##{n}", line: n + 1 } }
+  gecko = {
+    meta: { interval: 1, startTime: 0, product: type },
+    threads: [{ name: 'main', funcTable: frames, samples: { length: frames.size } }],
+  }.to_json
+  Wurk::Profiler.store(
+    jid: SecureRandom.hex(12),
+    type: type,
+    gecko_json: gecko,
+    started_at: now - (mins_ago * 60),
+    elapsed_ms: ms,
+  )
+end
+
+puts "seeded #{samples.size} demo profiles"


### PR DESCRIPTION
Applies the **obsidian design system** ([[obsidian-design-system]]) to the dashboard SPA, and folds in the landing-site tier-card polish from `design/landing-overhaul` so the design pass ships as one unit.

## Dashboard SPA
- **Fonts:** self-hosted Geist (UI) + JetBrains Mono (labels/metadata) via `@fontsource` — no CDN or Node at runtime, bundled into the gem.
- **Collapsible left rail** that expands on hover/focus; main content reserves the rail width (`--nav-rail`).
- **Nav fixes**
  - Constant icon size across collapsed/expanded — no shrink-on-hover; spacing comes from padding, not glyph scaling.
  - Collapsed rail now shows just the centered logo mark. The brand wordmark span carried an inline `display:flex` that a plain class rule couldn't override, so the hide rule uses `!important` — previously the "Wurk / System Status" text leaked into the 64px rail and got clipped.
  - Active item draws a round highlight around the glyph when collapsed; reverts to the pill when expanded.
- **Performance Insight** gains a `1h / 24h / 7d / 30d` range filter (defaults to **1h**), with a range-aware subtitle + x-axis labels and a loading spinner while the range query is pending.
- **Metrics** panels (throughput, queue depth, top job types) get loading spinners so switching the range filter no longer flashes an empty state.
- `test/dummy/seed_demo_profiles.rb` seeds demo profiles so the Profiles page has content in local preview.

## Landing site
- Per-tier `BorderGlow` on the landing tier cards (`docs/site/index.html`), cherry-picked from `design/landing-overhaul`.

## Verification
- `npm run build` (runs `tsc -b`) — clean.
- `npx vitest run` — 25/25 pass.
- Changes are frontend SPA + static `docs/site/index.html` only; no Ruby `lib/` touched, so the parity/ecosystem suites are unaffected.
- Manually previewed at `:3000/wurk` — collapsed/expanded rail, active-circle, range filters, and spinners all verified live.

## How to test in prod
This is dashboard UI + landing-page only — no worker, Redis, or wire-format changes. After deploy:

1. Open the mounted dashboard (e.g. `https://your-app/wurk`).
2. Hover the left rail — icons hold their size, labels + "Wurk / System Status" wordmark slide in; collapsed shows only the centered logo and a round highlight on the active item.
3. On the **Dashboard**, the Performance Insight chart defaults to **1h**; click `24h / 7d / 30d` — the subtitle and chart update, with a spinner during load.
4. On **Metrics**, switch the time range — panels show a spinner instead of a blank flash.
5. Landing site (`docs/site/index.html` / Pages): tier cards show the per-tier border glow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cursor-driven spotlight and tiered glow effects to homepage “pillar” and “feature” cards
  * Dashboard now shows performance insights using historical trend charts
  * Metrics and queue latency views were refreshed with new time-range-driven “obs” styling
* **Design & Style**
  * Rolled out a new Obsidian/zinc dark theme across dashboard, metrics, and profiles
  * Improved navigation behavior (mobile drawer closing + better desktop collapsed-rail interactions)
  * Added self-hosted Geist Sans and JetBrains Mono fonts
* **Bug Fixes**
  * Removed emojis from dashboard and Arabic straplines
* **Tests**
  * Updated Metrics page tests to match the new charts and data states
<!-- end of auto-generated comment: release notes by coderabbit.ai -->