### PR TITLE
fix(rails): auto-load engine under Rails + skip swarm boot during builds (#246, #247)

### DIFF
--- a/lib/wurk.rb
+++ b/lib/wurk.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 # Standalone entry point. Loading "wurk" must work without Rails.
-# The engine and railtie live under "wurk/rails" and are only loaded
-# when the host app opts in.
+# The engine and railtie live under "wurk/rails"; they're auto-loaded at the
+# end of this file when Rails is present (drop-in parity, #246), and stay
+# unloaded otherwise so a no-Rails boot pulls in zero Rails code.
 
 require_relative 'wurk/version'
 require_relative 'wurk/keys'
@@ -280,3 +281,14 @@ require_relative 'wurk/api/fast'
 # fully defined first. compat.rb only redefines names, it does not gate
 # behavior, so trailing the load order is safe.
 require_relative 'wurk/compat'
+
+# Drop-in parity (#246): stock Sidekiq auto-loads its Rails integration when
+# Rails is present (`lib/sidekiq.rb`: `require "sidekiq/rails" if
+# defined?(Rails::Engine)`). Without the equivalent here, a host that follows
+# the README/migration guide with a plain `gem "wurk"` (no `require:`) boots
+# with the engine/railtie unloaded, so the `:wurk` / `:sidekiq` ActiveJob
+# adapter constant is never defined and `config.active_job.queue_adapter =
+# :wurk` raises NameError during the railtie phase. Loading the engine here
+# (idempotent with an explicit `require "wurk/rails"`) closes that gap while
+# keeping standalone, no-Rails boot fully Rails-free.
+require_relative 'wurk/rails' if defined?(Rails::Engine)

--- a/lib/wurk.rb
+++ b/lib/wurk.rb
@@ -291,4 +291,14 @@ require_relative 'wurk/compat'
 # :wurk` raises NameError during the railtie phase. Loading the engine here
 # (idempotent with an explicit `require "wurk/rails"`) closes that gap while
 # keeping standalone, no-Rails boot fully Rails-free.
-require_relative 'wurk/rails' if defined?(Rails::Engine)
+#
+# Also gate on ActionDispatch::Routing::RouteSet: the engine's class body calls
+# `isolate_namespace Wurk`, which under railties >= 8.1 eager-reads
+# `ActionDispatch::Routing::RouteSet` to set the engine's @route_set_class.
+# Ecosystem test helpers (sidekiq-cron, …) load `rails/engine/railties` for the
+# railtie API alone — Rails::Engine is defined but ActionDispatch isn't — so a
+# bare `defined?(Rails::Engine)` check would crash with `uninitialized constant
+# Rails::Engine::Configuration::ActionDispatch` mid-`require "sidekiq"`. In a
+# real Rails host both are loaded by `rails/all` before Bundler.require, so the
+# stricter gate is invisible there.
+require_relative 'wurk/rails' if defined?(Rails::Engine) && defined?(::ActionDispatch::Routing::RouteSet)

--- a/lib/wurk/railtie.rb
+++ b/lib/wurk/railtie.rb
@@ -36,7 +36,25 @@ module Wurk
     # and the swarm boot. Console mode is detected reliably here — the console
     # command file defines ::Rails::Console before initializers run.
     def self.skip_boot?
-      ENV['WURK_DISABLED'] == '1' || defined?(::Rails::Console) || ::Rails.env.test?
+      ENV['WURK_DISABLED'] == '1' ||
+        building? ||
+        defined?(::Rails::Console) ||
+        ::Rails.env.test?
+    end
+
+    # A build/precompile step must never fork the swarm (#247). The default
+    # Rails Dockerfile runs `SECRET_KEY_BASE_DUMMY=1 ./bin/rails
+    # assets:precompile`; that loads `:environment` → fires after_initialize,
+    # but there's no Redis during `docker build`, so a fork would hang/fail the
+    # build. Same for other env-loading rake tasks (db:prepare, db:migrate).
+    # The real server path is unaffected: `rails server` / `puma` boot through
+    # Rails::Command, not Rake, and don't set the dummy secret.
+    def self.building?
+      return true if ENV.key?('SECRET_KEY_BASE_DUMMY')
+
+      defined?(::Rake) && ::Rake.application.top_level_tasks.any?
+    rescue StandardError
+      false
     end
   end
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -12,6 +12,11 @@ require "action_dispatch/railtie"
 
 Bundler.require(*Rails.groups)
 
+# Explicit require keeps the dummy order-independent under the shared test
+# loader (a prior unit test may `require "wurk"` before Rails is loaded, which
+# would make wurk.rb's auto-load guard a no-op). The plain-`require "wurk"`
+# drop-in path from #246 is proven order-faithfully in
+# test/unit/rails_autoload_test.rb (fresh subprocess, Rails present).
 require "wurk/rails"
 
 module Dummy

--- a/test/engine/railtie_test.rb
+++ b/test/engine/railtie_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../engine_test_helper'
+require 'rake' # `::Rake` for the application doubles below
 
 # The railtie owns two boot decisions, both gated by Railtie.skip_boot?:
 #   * entering server mode before config/initializers load (#191), and
@@ -21,5 +22,73 @@ class RailtieTest < Wurk::Test::EngineCase
     assert_predicate Wurk::Railtie, :skip_boot?
   ensure
     original.nil? ? ENV.delete('WURK_DISABLED') : (ENV['WURK_DISABLED'] = original)
+  end
+
+  # #247 build-context guard. skip_boot? short-circuits on Rails.env.test? in
+  # this suite, so the new logic is asserted through `building?` directly.
+
+  # The default Rails Dockerfile precompiles assets under SECRET_KEY_BASE_DUMMY;
+  # that fires after_initialize during `docker build` where there's no Redis,
+  # so forking the swarm hangs/fails the build.
+  def test_building_is_true_under_dummy_secret_key_base
+    with_env('SECRET_KEY_BASE_DUMMY' => '1') do
+      assert_predicate Wurk::Railtie, :building?, 'asset precompile (SECRET_KEY_BASE_DUMMY) must skip the swarm boot'
+    end
+  end
+
+  # Any env-loading rake task (assets:precompile, db:prepare, ...) is a one-off,
+  # not the server, and must not fork. `rails server` boots via Rails::Command,
+  # not Rake, so the real server path keeps booting.
+  def test_building_is_true_during_a_rake_task
+    with_env('SECRET_KEY_BASE_DUMMY' => nil) do
+      with_rake_application(fake_rake(['assets:precompile'])) do
+        assert_predicate Wurk::Railtie, :building?, 'a running rake task must skip the swarm boot'
+      end
+    end
+  end
+
+  def test_building_is_false_without_dummy_secret_or_rake_task
+    with_env('SECRET_KEY_BASE_DUMMY' => nil) do
+      with_rake_application(fake_rake([])) do
+        refute_predicate Wurk::Railtie, :building?, 'a plain server boot must not be treated as a build step'
+      end
+    end
+  end
+
+  # Rake internals must never propagate out of the boot decision.
+  def test_building_swallows_rake_errors
+    raising = Object.new
+    def raising.top_level_tasks = raise('boom')
+
+    with_env('SECRET_KEY_BASE_DUMMY' => nil) do
+      with_rake_application(raising) do
+        refute_predicate Wurk::Railtie, :building?
+      end
+    end
+  end
+
+  private
+
+  def fake_rake(tasks)
+    Struct.new(:top_level_tasks).new(tasks)
+  end
+
+  # Swap Rake's application for a double (save/restore). Avoids a minitest/mock
+  # dependency, which isn't loadable under the Ruby 3.4 bundled-gems guard.
+  def with_rake_application(app)
+    original = ::Rake.application
+    ::Rake.application = app
+    yield
+  ensure
+    ::Rake.application = original if original
+  end
+
+  def with_env(pairs)
+    originals = pairs.transform_values { |_| :__unset__ }
+    pairs.each_key { |k| originals[k] = ENV.fetch(k, :__unset__) }
+    pairs.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
+    yield
+  ensure
+    originals.each { |k, v| v == :__unset__ ? ENV.delete(k) : ENV[k] = v }
   end
 end

--- a/test/unit/rails_autoload_test.rb
+++ b/test/unit/rails_autoload_test.rb
@@ -41,6 +41,30 @@ class RailsAutoloadTest < Wurk::Test::UnitCase
     assert ok, 'standalone `require "wurk"` (no Rails) must not load the engine/railtie'
   end
 
+  # Mirrors how sidekiq-cron's test_helper loads things (rails/engine/railties
+  # for the railtie API, NO action_dispatch, then `require "sidekiq"`). The
+  # auto-load must skip the engine here — `isolate_namespace Wurk` would crash
+  # the require chain looking up ActionDispatch::Routing::RouteSet (#249 CI).
+  def test_require_wurk_with_partial_rails_skips_engine
+    # Mirrors sidekiq-cron's test/test_helper.rb load order (active_job pulls
+    # active_support in so rails/railtie can resolve `delegate_missing_to`, then
+    # rails/engine/railties defines Rails::Engine — but action_dispatch is never
+    # loaded). The auto-load must skip the engine here: `isolate_namespace Wurk`
+    # would crash the require chain looking up ActionDispatch::Routing::RouteSet
+    # (#249 CI).
+    ok = run_ruby(<<~RUBY)
+      require "active_job"
+      require "rails/railtie"
+      require "rails/engine/railties"
+      exit 1 if !defined?(::Rails::Engine)
+      exit 1 if  defined?(::ActionDispatch::Routing::RouteSet)
+      require "wurk"
+      exit(defined?(Wurk::Engine) ? 1 : 0)
+    RUBY
+
+    assert ok, 'partial Rails (rails/engine/railties without action_dispatch) must not crash `require "wurk"` (#249)'
+  end
+
   private
 
   def run_ruby(code)

--- a/test/unit/rails_autoload_test.rb
+++ b/test/unit/rails_autoload_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# #246: `gem "wurk"` (the default `require "wurk"`, no explicit `require:`) must
+# auto-load the Rails engine when Rails is present, so the `:wurk` / `:sidekiq`
+# ActiveJob adapter constant exists by the time ActiveJob resolves it during the
+# railtie phase. Stock Sidekiq does this via
+# `require "sidekiq/rails" if defined?(Rails::Engine)` in lib/sidekiq.rb.
+#
+# Cold-start subprocesses keep `defined?(Rails)` from leaking into the rest of
+# the parallel suite — the same reason SidekiqEntrypointTest subprocess-tests
+# `require "sidekiq/rails"`.
+class RailsAutoloadTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  LIB = File.expand_path('../../lib', __dir__)
+
+  def test_require_wurk_under_rails_defines_active_job_adapter
+    ok = run_ruby(<<~RUBY)
+      require "rails"
+      require "rails/engine"
+      require "active_job"
+      require "wurk"
+      adapter = defined?(ActiveJob::QueueAdapters::WurkAdapter)
+      engine  = defined?(Wurk::Engine)
+      exit(adapter && engine ? 0 : 1)
+    RUBY
+
+    assert ok, '`require "wurk"` with Rails present must auto-load the engine and define the :wurk AJ adapter (#246)'
+  end
+
+  def test_require_wurk_standalone_stays_rails_free
+    ok = run_ruby(<<~RUBY)
+      require "wurk"
+      # No Rails required: the engine/railtie must NOT load — standalone boot
+      # stays Rails-free.
+      exit(defined?(Wurk::Engine) || defined?(Wurk::Railtie) ? 1 : 0)
+    RUBY
+
+    assert ok, 'standalone `require "wurk"` (no Rails) must not load the engine/railtie'
+  end
+
+  private
+
+  def run_ruby(code)
+    system(RbConfig.ruby, '-I', LIB, '-e', code, out: File::NULL, err: File::NULL)
+  end
+end


### PR DESCRIPTION
Two embedded-Rails **drop-in gaps** that broke a real consumer migration (`developerz-ai/legaldiligencemedellin.com` PR #32, which had to hand-roll both workarounds in-app). Fixing them upstream so a plain `gem "wurk"` is actually drop-in and the app can drop its workarounds on the next routine bump.

## #246 — `gem "wurk"` doesn't auto-load the Rails engine
A host following the README/migration guide (`gem "wurk"`, no `require:`) only loads the **standalone** entry point, so the engine/railtie never load and `ActiveJob::QueueAdapters::WurkAdapter` is undefined. ActiveJob resolves `:wurk` during the railtie phase → `config.active_job.queue_adapter = :wurk` raises `NameError` at boot.

**Fix:** mirror stock Sidekiq (`require "sidekiq/rails" if defined?(Rails::Engine)`) — auto-load `wurk/rails` from the tail of `lib/wurk.rb` when Rails is present. Idempotent with an explicit `require "wurk/rails"`; standalone/no-Rails boot stays fully Rails-free.

## #247 — swarm forks during asset precompile / builds
`Railtie.skip_boot?` didn't cover the build context. The default Rails Dockerfile runs `SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile`, which fires `after_initialize` → forked the swarm and connected to Redis during `docker build` (no Redis there → hang/fail).

**Fix:** add `Railtie.building?` — skip boot when `SECRET_KEY_BASE_DUMMY` is set **or** any rake task is running (`assets:precompile`, `db:prepare`, …). The real server path is unaffected: `rails server` / `puma` boot via `Rails::Command`, not Rake, and don't set the dummy secret. Rake errors are swallowed (never propagate out of the boot decision).

## Tests
- `test/unit/rails_autoload_test.rb` — fresh-subprocess cold loads: `require "wurk"` with Rails present defines the `:wurk` adapter + engine; without Rails it loads neither. (Subprocess keeps `defined?(Rails)` from leaking into the parallel suite, same pattern as `SidekiqEntrypointTest`.)
- `test/engine/railtie_test.rb` — `building?` is true under the dummy secret and a running rake task, false for a plain boot, and swallows Rake errors.

## Verification
- `bin/rake test` — **2330 runs, 0 failures, 0 errors** (full suite, NCPU=4).
- `bundle exec rubocop` — clean.
- Built in an isolated git worktree off `main`.

## How to test in prod
After this ships in a wurk release and an app bumps to it:

1. **Drop-in adapter (#246):** use a plain `gem "wurk"` (no `require:`), set `config.active_job.queue_adapter = :wurk`, boot:
   ```bash
   bin/rails runner 'puts ActiveJob::Base.queue_adapter.class'
   # => ActiveJob::QueueAdapters::WurkAdapter   (no NameError)
   ```
2. **Build-safe precompile (#247):** with no Redis reachable, the standard build step must finish without forking/hanging:
   ```bash
   SECRET_KEY_BASE_DUMMY=1 RAILS_ENV=production bin/rails assets:precompile
   # => exits 0, no swarm boot, no Redis connection attempt
   ```
3. Real boot still starts workers: `rails server` / `puma` boots the swarm as before (no dummy secret, not a rake task).

Once merged + released, `legaldiligencemedellin.com` can drop its `require: "wurk/rails"` and the build-step `WURK_DISABLED=1` workarounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Rails auto-integration: when Rails is present, Wurk now loads the required Rails components automatically, including the ActiveJob adapter.

* **Improvements**
  * Railtie now avoids booting during build/precompile scenarios (including dummy/test-style boot contexts) to prevent unintended initialization.

* **Tests**
  * Added coverage to verify standalone vs Rails-required behavior, and to ensure the build-context boot detection works as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->