### PR TITLE
fix(ci): de-noise bench gate with best-of-N to stop push_bulk false-positives (#250)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -73,13 +73,31 @@ jobs:
       # Keep the comparator from this PR available after we check out the base.
       - name: stage comparator
         run: cp bin/bench-compare /tmp/bench-compare
+      # Best-of-N: run the suite BENCH_RUNS times per side and concatenate; the
+      # comparator keeps the fastest run per benchmark, which damps the
+      # cross-process noise that false-positives low-throughput benches (#250).
       - name: bench head
-        run: bundle exec rake bench | tee /tmp/bench-head.txt
+        env:
+          BENCH_RUNS: 3
+        run: |
+          : > /tmp/bench-head.txt
+          for i in $(seq 1 "$BENCH_RUNS"); do
+            echo "::group::bench head run $i"
+            bundle exec rake bench | tee -a /tmp/bench-head.txt
+            echo "::endgroup::"
+          done
       - name: bench base
+        env:
+          BENCH_RUNS: 3
         run: |
           git checkout --quiet ${{ github.event.pull_request.base.sha }}
           bundle install --quiet
-          bundle exec rake bench | tee /tmp/bench-base.txt
+          : > /tmp/bench-base.txt
+          for i in $(seq 1 "$BENCH_RUNS"); do
+            echo "::group::bench base run $i"
+            bundle exec rake bench | tee -a /tmp/bench-base.txt
+            echo "::endgroup::"
+          done
       - name: compare, comment, gate
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to Wurk are recorded here. Format: [Keep a Changelog](https:
 
 ## [Unreleased]
 
-## [1.0.2] - 2026-06-13
+### Changed
+- **CI — bench gate de-noised (best-of-N)** — the PR `compare` job intermittently flagged the low-throughput `push_bulk(1000)` bench (~250 i/s) as a regression on pure runner noise: at that iteration count a single noisy base-vs-head pair could clear even the noise-aware ± band (e.g. #249 saw a spurious -18.2% over a ±13.3% band; the re-run passed). The job now runs the bench suite three times per side and `bin/bench-compare` keeps the fastest run per benchmark, so the cross-process tail (GC, runner CPU contention) is damped. Best-of-N is applied symmetrically to base and head, so a real regression — slower on every run — still fails the gate. (#250)
 
 ### Added
 - **Dashboard — per-request read-only** — `/api/meta` now reports a per-request `read_only` flag derived from the registered authorization hook, so a viewer-role user (a hook that permits `GET` but denies mutations) sees the SPA hide destructive actions instead of showing buttons that then 403. The probe asks the hook about `POST` on a canonical mutating route (`/api/retries`) so a path-sensitive hook resolves it the same way the Authorization middleware resolves the real mutation. With no hook registered the flag still reflects global read-only mode. (#244)

--- a/bin/bench-compare
+++ b/bin/bench-compare
@@ -8,6 +8,13 @@
 # Parses the benchmark/ips report lines ("<label>  5.70k (± 6.9%) i/s ...")
 # from each file and prints a Markdown table of the per-benchmark change.
 #
+# Each side's file may concatenate SEVERAL `rake bench` runs (best-of-N): when a
+# label appears more than once we keep the fastest run. The least-contended run
+# is the truest measure of throughput, so taking the max per label damps the
+# cross-process tail (GC, runner CPU contention) that makes low-throughput
+# benches like `push_bulk(1000)` false-positive (#250). It can't hide a real
+# regression — best-of-N is applied symmetrically to base and head.
+#
 # A slowdown is only *flagged as a regression* when it clears the combined
 # noise of both runs — benchmark/ips reports a relative error (the "± X%") per
 # result, and CI runners are noisy — plus a signal margin. Concretely it fails
@@ -21,6 +28,13 @@ MARKER = '<!-- bench-compare -->'
 SCALE = { '' => 1, 'k' => 1_000, 'M' => 1_000_000, 'G' => 1_000_000_000 }.freeze
 IPS_LINE = %r{^\s*(\S.*?)\s+([\d.,]+)\s*([kMG]?)\s*\(±\s*([\d.,]+)%\)\s*i/s}i
 
+# Best-of-N: keep the fastest run for this label across repeated bench runs.
+def keep_fastest(results, label, value, err)
+  return if results[label] && results[label][0] >= value
+
+  results[label] = [value, err] # [ips, ± error %]
+end
+
 def parse(path)
   results = {}
   File.foreach(path) do |line|
@@ -28,7 +42,7 @@ def parse(path)
     next unless m
 
     value = m[2].delete(',').to_f * SCALE[m[3]]
-    results[m[1].strip] = [value, m[4].delete(',').to_f] # [ips, ± error %]
+    keep_fastest(results, m[1].strip, value, m[4].delete(',').to_f)
   end
   results
 end

--- a/test/unit/bench_compare_test.rb
+++ b/test/unit/bench_compare_test.rb
@@ -23,8 +23,11 @@ class BenchCompareTest < Wurk::Test::UnitCase
     path
   end
 
+  # Pin BENCH_REGRESSION_PCT to the script's documented default so the gate's
+  # threshold is decoupled from whatever the parent test process (or CI) has
+  # in its environment — otherwise these assertions drift on env coupling.
   def compare(base, head)
-    out = `#{SCRIPT} #{base} #{head} 2>&1`
+    out = IO.popen({ 'BENCH_REGRESSION_PCT' => '5' }, [SCRIPT, base, head], err: %i[child out], &:read)
     [out, $CHILD_STATUS.exitstatus]
   end
 

--- a/test/unit/bench_compare_test.rb
+++ b/test/unit/bench_compare_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'English'
+require 'tmpdir'
+
+# Drives bin/bench-compare against synthetic `rake bench` output so the bench
+# gate's noise handling — and the best-of-N de-noising added for #250 — is
+# covered without running the (slow, noisy) real benchmarks.
+class BenchCompareTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  SCRIPT = File.expand_path('../../bin/bench-compare', __dir__)
+
+  # benchmark/ips report line, as bin/bench-compare parses it.
+  def ips_line(label, ips, err)
+    format('%<label>s   %<ips>.1f (± %<err>.1f%%) i/s -    1.00k in   5.000s', label: label, ips: ips, err: err)
+  end
+
+  def write_runs(label, *runs)
+    path = File.join(@dir, "#{label.gsub(/\W+/, '_')}_#{object_id}_#{runs.hash.abs}.txt")
+    File.write(path, runs.map { |ips, err| ips_line(label, ips, err) }.join("\n") << "\n")
+    path
+  end
+
+  def compare(base, head)
+    out = `#{SCRIPT} #{base} #{head} 2>&1`
+    [out, $CHILD_STATUS.exitstatus]
+  end
+
+  def setup
+    super
+    @dir = Dir.mktmpdir('bench-compare')
+    @label = 'wurk push_bulk(1000)'
+  end
+
+  def teardown
+    FileUtils.remove_entry(@dir) if @dir && File.directory?(@dir)
+  ensure
+    super
+  end
+
+  # The #250 false-positive: a single noisy head sample clears the noise band.
+  def test_single_noisy_sample_trips_the_gate
+    base = write_runs(@label, [251.0, 4.15])
+    head = write_runs(@label, [206.0, 4.15])
+
+    out, code = compare(base, head)
+
+    assert_equal 1, code, 'a -18% drop over a ±13.3% band must flag'
+    assert_includes out, '🔴 regressed'
+  end
+
+  # Best-of-N rescue: same noisy run plus two clean runs => fastest wins, passes.
+  def test_best_of_n_keeps_the_fastest_run_and_clears_noise
+    base = write_runs(@label, [251.0, 4.15], [254.0, 4.15], [249.0, 4.15])
+    head = write_runs(@label, [206.0, 4.15], [250.0, 4.15], [248.0, 4.15])
+
+    out, code = compare(base, head)
+
+    assert_equal 0, code, 'fastest head run (250) vs fastest base (254) is within noise'
+    assert_includes out, '| 254 | 250 |', 'table must report the best-of-N ips, not the noisy sample'
+    refute_includes out, '🔴 regressed'
+  end
+
+  # Best-of-N must not mask a real regression present across every run.
+  def test_real_regression_survives_best_of_n
+    base = write_runs(@label, [251.0, 4.15], [254.0, 4.15])
+    head = write_runs(@label, [176.0, 4.15], [178.0, 4.15])
+
+    out, code = compare(base, head)
+
+    assert_equal 1, code, 'a ~30% drop on every run must still flag'
+    assert_includes out, '🔴 regressed'
+  end
+
+  # A baseline benchmark missing on head still fails the gate (anti-hiding).
+  def test_missing_benchmark_on_head_fails
+    base = write_runs(@label, [251.0, 4.15])
+    head = write_runs('wurk enqueue', [5700.0, 6.9])
+
+    out, code = compare(base, head)
+
+    assert_equal 1, code
+    assert_includes out, 'Missing on head'
+  end
+end


### PR DESCRIPTION
## Why

The PR `compare` job in [.github/workflows/bench.yml](.github/workflows/bench.yml) intermittently flags the low-throughput **`push_bulk(1000)`** bench (~250 i/s) as a regression on pure runner noise. At that iteration count a single noisy base-vs-head pair can clear even the noise-aware ± band:

| benchmark | base | head | Δ | run |
|---|---:|---:|---:|---|
| `wurk push_bulk(1000)` | 251 i/s | 206 i/s | **-18.2%** (cleared ±13.3% noise band) → 🔴 | [#249 run 27529509179](https://github.com/developerz-ai/wurk/actions/runs/27529509179) — re-run passed |

#249 only touched the Rails boot/require path — nothing in the Lua bulk-enqueue hot path — so this is variance, not a real regression. Closes #250.

## What

**Best-of-N.** The `compare` job now runs the bench suite **three times per side** (`BENCH_RUNS=3`) and `bin/bench-compare` keeps the **fastest run per benchmark**. The least-contended run is the truest measure of throughput, so taking the max per label damps the cross-process tail (GC, runner CPU contention) that makes low-throughput benches false-positive.

- It **can't mask a real regression**: best-of-N is applied symmetrically to base and head, so code that's slower on *every* run still fails the gate.
- Speedups are still always reported, never gated. The noise-aware ± band + `BENCH_REGRESSION_PCT` logic is unchanged.

### Changes
- [bin/bench-compare](bin/bench-compare) — `keep_fastest` parse keeps the max-ips entry per label; concatenated multi-run files are supported.
- [.github/workflows/bench.yml](.github/workflows/bench.yml) — `BENCH_RUNS=3` loop per side with grouped logs.
- [test/unit/bench_compare_test.rb](test/unit/bench_compare_test.rb) — drives the **real** script over synthetic `rake bench` output.

## Tests

`test/unit/bench_compare_test.rb` (4 cases, shells out to the real `bin/bench-compare`):
- the #250 single noisy sample **trips** the gate (reproduces the bug),
- best-of-N over the same noisy run + two clean runs **clears** it and reports the best-of-N ips,
- a genuine ~30% regression on every run **still fails**,
- a benchmark missing on head **still fails** (anti-hiding).

Full suite green locally: `2335 runs, 4691 assertions, 0 failures, 0 errors, 6 skips`.

## How to test in prod

This is a CI-only change (no library/runtime code touched). To exercise it:

```bash
# Reproduce the gate locally against any two `rake bench` outputs:
bundle exec rake bench | tee /tmp/base.txt
bundle exec rake bench | tee -a /tmp/base.txt   # append a 2nd/3rd run for best-of-N
bundle exec rake bench | tee /tmp/head.txt
bin/bench-compare /tmp/base.txt /tmp/head.txt; echo "exit=$?"   # 0 = pass, 1 = regression
```

On a PR, the bench bot comment now reflects the fastest of three runs per side; watch that `push_bulk(1000)` stops false-flagging across re-runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI “bench gate” comparisons by running benchmarks multiple times per side and using the best (fastest) result to reduce false regression flags from runner noise.

* **Tests**
  * Added unit tests covering best-of-N selection behavior, ensuring real regressions still fail the gate and missing benchmarks correctly produce a failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->