### PR TITLE
docs: migration guide + YARD API docs + llms.txt (closes #254, #255, #256)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,11 +1,16 @@
 name: pages
 
-# Publishes the static marketing/docs site in docs/site/ to GitHub Pages.
+# Publishes the static marketing/docs site in docs/site/ to GitHub Pages,
+# generating the YARD API docs into docs/site/api/ at build time so they ship
+# alongside the landing page (and llms.txt links resolve).
 on:
   push:
     branches: [main]
     paths:
       - "docs/site/**"
+      - "lib/**"
+      - ".yardopts"
+      - "README.md"
       - ".github/workflows/pages.yml"
   workflow_dispatch:
 
@@ -31,6 +36,13 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
+      - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      # Generate the YARD API docs into docs/site/api/ (per .yardopts) so the
+      # upload step ships them with the static site.
+      - run: bundle exec rake yard
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,6 +11,9 @@ on:
       - "lib/**"
       - ".yardopts"
       - "README.md"
+      - "Rakefile"
+      - "Gemfile"
+      - "Gemfile.lock"
       - ".github/workflows/pages.yml"
   workflow_dispatch:
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ pkg/
 tmp/
 log/
 coverage/
+docs/site/api/
 .idea/
 .vscode/
 .DS_Store

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,14 @@
+--output-dir docs/site/api
+--markup markdown
+--readme README.md
+--title "Wurk API Documentation"
+--no-private
+--protected
+--embed-mixins
+lib/**/*.rb
+-
+docs/migrate-from-sidekiq.md
+docs/dashboard.md
+docs/deployment.md
+docs/active-job.md
+LICENSE

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ group :development, :test do
   gem "benchmark-ips"
   gem "memory_profiler"
   gem "pry"
+  gem "yard", require: false
 end
 
 group :test do

--- a/Rakefile
+++ b/Rakefile
@@ -68,6 +68,22 @@ namespace :test do
   end
 end
 
+# YARD API docs. Generates into docs/site/api (gitignored) so the pages
+# workflow can publish them alongside the static landing page. The whole config
+# lives in .yardopts; this task just shells out so `bin/rake yard` works without
+# requiring yard/rake/yardoctask at load time (yard is a dev-only dep).
+desc "Generate YARD API docs into docs/site/api (config in .yardopts)"
+task :yard do
+  sh "yard", "doc"
+end
+
+namespace :yard do
+  desc "Report public-API doc coverage (undocumented objects)"
+  task :stats do
+    sh "yard", "stats", "--list-undoc"
+  end
+end
+
 desc "Run all benchmarks (enqueue, fetch+execute, bulk enqueue, swarm boot, memory)"
 task :bench do
   Dir.glob(File.join(GEM_ROOT, "bench", "*.rb")).sort.each do |script|

--- a/docs/migrate-from-sidekiq.md
+++ b/docs/migrate-from-sidekiq.md
@@ -6,14 +6,18 @@ the common case the migration is a one-line `Gemfile` change — your existing j
 batches, limiters, cron entries, and live Redis data keep working untouched, and the
 Pro/Enterprise features ship in the same free gem with no license check.
 
-This guide covers what stays the same, what to watch for, and a one-page cutover.
+This guide covers what stays the same, the two knobs that surprise people
+(parallelism vs concurrency), how to run a dedicated worker, the third-party gem
+mappings, and a one-page cutover.
 
 - **Authoritative API surface:** [`docs/target/sidekiq-free.md`](target/sidekiq-free.md) ·
   [`sidekiq-pro.md`](target/sidekiq-pro.md) · [`sidekiq-ent.md`](target/sidekiq-ent.md)
 - **Why this is legal:** [`docs/clean-room.md`](clean-room.md)
 
 > Verified against Wurk's Sidekiq-compat layer (`lib/wurk/compat.rb`), which mirrors
-> Sidekiq **8.1.x**. Requires **Ruby ≥ 3.2** and **Redis ≥ 7.0**.
+> Sidekiq **8.1.x**. Requires **Ruby ≥ 3.2** and **Redis ≥ 7.0**. On JRuby /
+> TruffleRuby / Windows, Wurk falls back to threads-only mode (no fork),
+> behaviorally equivalent to stock Sidekiq.
 
 ---
 
@@ -53,6 +57,11 @@ bin/rails g wurk:install          # writes config/initializers/wurk.rb
 processes can run against the same Redis during cutover, each picking up the other's
 enqueued jobs. Roll back by reverting the `Gemfile` line; no data migration either way.
 
+> ⚠️ **The one thing to size before you ship:** Wurk forks one worker process *per CPU
+> core* by default, each running its own thread pool — so a single Sidekiq process
+> becomes N processes on the same box. Read [§2](#2-concurrency-vs-parallelism-read-this)
+> before the first production deploy; it's the only behavioral surprise in the swap.
+
 ---
 
 ## 1. Configuration: `Sidekiq.configure_server` ↔ `Wurk.configure_server`
@@ -74,7 +83,7 @@ Config options verified identical (`lib/wurk/configuration.rb`):
 
 | Option | Notes |
 |---|---|
-| `concurrency` | threads per worker (default `5`) |
+| `concurrency` | threads per worker process (default `5`) |
 | `queues` | ordered/weighted queue list |
 | `redis = { url:, … }` | defaults to `ENV["REDIS_URL"]` → `redis://localhost:6379/0` |
 | `logger`, `logger =` | standard `Logger` |
@@ -90,21 +99,140 @@ Config options verified identical (`lib/wurk/configuration.rb`):
 > child opens a fresh pool), so you only need a fork hook for *your own* non-fork-safe
 > libraries (sockets, threads). It does not fire in single-process (non-swarm) mode.
 
-### Config file
+---
 
-The standalone runner is `bundle exec wurk` (the gem ships a `wurk` executable — there
-is **no `sidekiq` binary**, so update any `bundle exec sidekiq` invocations, Procfile
-lines, and systemd units to `wurk`). It takes the familiar flags (`-c` concurrency,
-`-q` queue, `-r` require, `-t` timeout, `-e` environment, `-C` config), reads a YAML
-config with `-C path`, and auto-discovers `config/wurk.yml` then `config/sidekiq.yml`
-(`.erb` supported). The YAML structure matches Sidekiq's `sidekiq.yml`.
+## 2. Concurrency vs parallelism (read this)
 
-For running the worker under systemd or capistrano-sidekiq — including an example
-unit file and the deploy signal dance — see [`docs/deployment.md`](deployment.md).
+This is the **single biggest difference** from Sidekiq, and the #1 source of
+migration surprises. Sidekiq runs one process with a thread pool. Wurk runs **a swarm
+of forked processes, each with its own thread pool**, for real CPU parallelism on
+MRI (the GIL means threads alone can't parallelize Ruby CPU work).
+
+Two independent knobs:
+
+| Knob | What it controls | How to set it | Default |
+|---|---|---|---|
+| **Parallelism** | Number of forked **worker processes** (real OS processes, true CPU parallelism) | `WURK_COUNT` (or the `SIDEKIQ_COUNT` alias) env var | **CPU core count** (`Etc.nprocessors`) |
+| **Concurrency** | **Threads per process** (Sidekiq-style; great for IO-bound, GIL-bound for CPU) | `config.concurrency`, CLI `-c`, YAML `:concurrency`, or `RAILS_MAX_THREADS` | `5` |
+
+> There is **no `WURK_CONCURRENCY` env var.** Threads-per-process is `config.concurrency`
+> / `-c` / `RAILS_MAX_THREADS` (the same env knob Sidekiq honors). `WURK_COUNT` is the
+> *new* knob — it has no Sidekiq equivalent because Sidekiq never forks.
+
+### Total in-flight jobs = `WURK_COUNT × concurrency`
+
+A whole-number `WURK_COUNT` is an absolute process count; a fractional value is a CPU
+multiplier (`WURK_COUNT=0.5` → half the cores, rounded). The result is floored at 1.
+
+```text
+16-core box, defaults:   16 processes × 5 threads  = 80 jobs in flight at once
+                                                     + 16 separate DB connection pools
+```
+
+**That last line is the foot-gun.** Each forked process opens its own DB pool, its
+own Redis pool, and carries its own memory footprint. A Sidekiq box that comfortably
+ran `concurrency: 25` in one process can exhaust your Postgres `max_connections` or
+your RAM the moment it becomes 16 processes × 25 threads = 400 connections.
+
+### Worked example: mapping a Sidekiq `concurrency: 10` app
+
+Your Sidekiq process ran 10 threads = 10 jobs in flight, 10 DB connections.
+
+```ruby
+# config/initializers/wurk.rb
+Wurk.configure_server do |config|
+  config.concurrency = 5        # threads per process
+end
+```
+
+```bash
+# Pick the process count to land near your old in-flight number:
+WURK_COUNT=2  bundle exec wurk   # 2 × 5  = 10 jobs in flight (matches Sidekiq, now on 2 cores)
+WURK_COUNT=1  bundle exec wurk   # 1 × 10 if you also set concurrency: 10 — single-process, Sidekiq-like
+WURK_COUNT=4  bundle exec wurk   # 4 × 5  = 20 in flight — 2× the throughput, 4× the CPU parallelism
+```
+
+**Size your database pool for the per-process thread count, then check the total.**
+Each process needs `pool >= concurrency` in `database.yml`:
+
+```yaml
+# config/database.yml
+production:
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5).to_i %>   # per-process; must cover concurrency
+```
+
+Then verify the whole box fits: **`WURK_COUNT × pool ≤ your DB's spare connections`**.
+On the 16-core default that's 16 × 5 = 80 connections from one host — size
+`max_connections` (or PgBouncer) accordingly, or cap `WURK_COUNT`.
+
+> **Rule of thumb:** start with `WURK_COUNT` = cores you want to dedicate to jobs and
+> `concurrency` = 5 for IO-bound work. Raise `concurrency` for IO-heavy jobs (HTTP,
+> Redis, slow SQL); raise `WURK_COUNT` for CPU-heavy jobs. Always re-check the DB-pool
+> and memory math after either change.
 
 ---
 
-## 2. Redis key layout: identical, no namespace
+## 3. Running a worker process
+
+### Dedicated worker: `bundle exec wurk`
+
+The standalone runner is `bundle exec wurk`. The gem ships a `wurk` executable (and
+`wurkswarm`) — there is **no `sidekiq` binary**, so update any `bundle exec sidekiq`
+invocations, Procfile lines, and systemd/Capistrano units to `wurk`. It takes the
+familiar flags (`-c` concurrency, `-q` queue, `-r` require, `-t` timeout, `-e`
+environment, `-C` config), reads a YAML config with `-C path`, and auto-discovers
+`config/wurk.yml` then `config/sidekiq.yml` (`.erb` supported). The YAML structure
+matches Sidekiq's `sidekiq.yml`.
+
+```bash
+bundle exec wurk -C config/wurk.yml -e production
+```
+
+The standalone runner does **not** load the Rails engine (the dashboard) — that's by
+design, so a worker host stays lean. It does fully boot your Rails app (`-r`/the
+environment) so your jobs and models are available.
+
+> ✅ **ActiveJob works standalone.** If your app uses
+> `config.active_job.queue_adapter = :wurk` (or `:sidekiq`), the standalone CLI now
+> defines the adapter *before* the Rails environment loads, so a dedicated `wurk`
+> process boots cleanly. (Earlier builds raised `uninitialized constant WurkAdapter`
+> in standalone mode — fixed in [#253](https://github.com/developerz-ai/wurk/issues/253).)
+
+For an example systemd unit and the Capistrano / deploy signal dance (replacing
+`capistrano-sidekiq`), see [`docs/deployment.md`](deployment.md). A `Procfile`
+worker line is simply:
+
+```procfile
+worker: bundle exec wurk -e production
+```
+
+### Clustered Puma + the embedded swarm (important)
+
+When you mount the engine, the railtie **auto-starts an embedded swarm inside every
+non-console Rails process** (unless `WURK_DISABLED=1`, Rails console, or the Rails
+test env). Under **clustered Puma** (`workers > 0`) that means **every Puma worker
+forks its own Wurk swarm** — N Puma workers × `WURK_COUNT` children = a lot of
+duplicate worker processes you didn't intend, all fetching the same queues.
+
+**The fix: run workers in a dedicated process and disable the embedded swarm on the
+web role.**
+
+```bash
+# Web dyno / Puma role — serve HTTP only, no jobs:
+WURK_DISABLED=1 bundle exec puma -C config/puma.rb
+
+# Worker dyno / role — run the jobs:
+bundle exec wurk -e production
+```
+
+This mirrors the standard Sidekiq topology (Puma for web, a separate `sidekiq`
+process for jobs) — you just set `WURK_DISABLED=1` on web so the engine mount keeps
+serving the dashboard without also forking workers. Leave the embedded swarm on only
+if you intentionally want web processes to also run jobs (single-dyno / hobby setups).
+
+---
+
+## 4. Redis key layout: identical, no namespace
 
 Wurk reads and writes the **exact same keys** as Sidekiq OSS (`lib/wurk/keys.rb`),
 with **no global namespace/prefix** (matching Sidekiq OSS). Job payloads are **JSON**
@@ -132,7 +260,7 @@ the Sidekiq web UI / `redis-cli` introspection you already use keeps working.
 
 ---
 
-## 3. `sidekiq_options` mapping
+## 5. `sidekiq_options` mapping
 
 Define jobs exactly as before — `include Sidekiq::Job` (or `Sidekiq::Worker`) and
 `sidekiq_options`. Enqueue with `perform_async` / `perform_in` / `perform_at` /
@@ -149,7 +277,7 @@ Define jobs exactly as before — `include Sidekiq::Job` (or `Sidekiq::Worker`) 
 | `tags:` | ✅ | array of strings; surfaced in the dashboard + logs |
 | `batch` | ✅ (Pro, free) | not a `sidekiq_options` key — `bid` is stamped automatically inside `Sidekiq::Batch#jobs { … }`; access via `#bid` / `#batch` |
 | `pool:` | ✅ | selects the client Redis pool; stripped from the stored payload |
-| `lock:` | ⚠️ not native | Wurk's native uniqueness uses `unique_for:` / `unique_until:` (below). The `sidekiq-unique-jobs` gem and its `lock:` option run against Wurk in the ecosystem CI suite if you prefer that gem |
+| `lock:` | ⚠️ not native | Wurk's native uniqueness uses `unique_for:` / `unique_until:` (see [§6](#6-third-party-gem-mappings)). The `sidekiq-unique-jobs` gem and its `lock:` option also run against Wurk in the ecosystem CI suite |
 
 Custom retry hooks are unchanged: `sidekiq_retry_in { |count, ex, msg| … }` and
 `sidekiq_retries_exhausted { |msg, ex| … }`. The retry backoff formula matches
@@ -159,7 +287,8 @@ Sidekiq: `count**4 + 15 + rand(10 * (count + 1))` seconds.
 
 - **Unique jobs:** enable with `Sidekiq::Enterprise.unique!`, then
   `sidekiq_options unique_for: 10.minutes, unique_until: :success` (or `:start`).
-  *(This is Enterprise's API — not the `sidekiq-unique-jobs` gem's `lock:` DSL.)*
+  *(This is Enterprise's API — not the `sidekiq-unique-jobs` gem's `lock:` DSL; see
+  [§6](#6-third-party-gem-mappings) for the gem mapping.)*
 - **Encryption:** `Sidekiq::Enterprise::Crypto.enable(active_version: 1) { |v| key }`,
   then `sidekiq_options encrypt: true` (the last arg is encrypted).
 - **Batches:** `Sidekiq::Batch.new` with `on(:success/:complete/:death)`, nesting,
@@ -168,7 +297,78 @@ Sidekiq: `count**4 + 15 + rand(10 * (count + 1))` seconds.
 
 ---
 
-## 4. Known incompatibilities — what *not* to expect
+## 6. Third-party gem mappings
+
+Wurk ships native replacements for the most common add-on gems, so you can **drop the
+gem** and use the built-in feature — or keep the gem, since its upstream test suite is
+run against Wurk in the [`ecosystem` CI job](../.github/workflows/ecosystem.yml). The
+native path is recommended (fewer dependencies, first-class dashboard support).
+
+### `sidekiq-cron` → native periodic jobs
+
+Wurk has Enterprise-grade periodic jobs built in. Register them in a `config.periodic`
+block at boot. By design there is **no `Sidekiq::Cron::Job` shim** ([#204](https://github.com/developerz-ai/wurk/issues/204));
+real Sidekiq never defined that constant, and faking it would break the drop-in
+contract.
+
+```ruby
+# sidekiq-cron (old):                       # Wurk (native):
+# config/schedule.yml + Sidekiq::Cron::Job   Wurk.configure_server do |config|
+#                                              config.periodic do |mgr|
+#                                                mgr.register("*/5 * * * *", ReportJob)
+#                                                mgr.register("0 0 * * *", NightlyJob, tz: "UTC")
+#                                              end
+#                                            end
+```
+
+`mgr.register(cron, JobClass, **opts)` takes a standard 5-field cron string and the
+worker class; `tz:` sets the timezone. Periodic state lives in the `periodic` / `loops:<lid>`
+Redis keys and is visible in the dashboard.
+
+### `sidekiq-unique-jobs` → native `unique_for:` / `unique_until:`
+
+Activate Enterprise uniqueness once, then declare it per worker:
+
+```ruby
+# config/initializers/wurk.rb
+Sidekiq::Enterprise.unique!   # required to activate the unique middleware
+
+class ChargeJob
+  include Sidekiq::Job
+  sidekiq_options unique_for: 600,            # seconds (or 10.minutes); the lock TTL
+                  unique_until: :success      # :success (default) | :start
+end
+```
+
+Mapping from `sidekiq-unique-jobs`:
+
+| `sidekiq-unique-jobs` | Wurk native |
+|---|---|
+| `lock: :until_executed` | `unique_until: :success` (lock held through retries, released on success) |
+| `lock: :until_executing` / `:while_executing` | `unique_until: :start` (server middleware releases the lock when the job starts) |
+| `lock_ttl` / `lock_timeout` | `unique_for: <int seconds>` (also accepts an `ActiveSupport::Duration`) |
+| `lock_args_method` / custom uniqueness args | define `self.sidekiq_unique_context(job)` on the worker, returning any JSON-serializable value |
+
+> ⚠️ Unique jobs and encryption are **mutually exclusive on the same worker** — each
+> encryption produces different ciphertext, which defeats the uniqueness digest.
+
+### Quick reference — other ecosystem gems
+
+These run their own upstream suites against Wurk in CI; most work unchanged because
+they only touch the Sidekiq API surface and Redis keys Wurk already mirrors.
+
+| Gem | Status on Wurk | Notes |
+|---|---|---|
+| `sidekiq-scheduler` | ✅ works unchanged | uses the standard schedule ZSET |
+| `sidekiq-status` | ✅ works unchanged | rides the standard job lifecycle + middleware |
+| `sidekiq-failures` | ✅ works unchanged | reads the standard `retry`/`dead` sets |
+| `sidekiq-throttled` | ✅ works unchanged | client/server middleware contract is identical |
+| `sidekiq-cron` | ⚠️ prefer native | works in CI, but native `config.periodic` is recommended (no `Sidekiq::Cron::Job` constant) |
+| `sidekiq-unique-jobs` | ⚠️ prefer native | works in CI, but native `unique_for:` is recommended |
+
+---
+
+## 7. Known incompatibilities — what *not* to expect
 
 Wurk aims for 100% drop-in. A couple of Sidekiq Pro-isms simply no-op or alias
 (items 1–2 — there to reassure, not to fix); the rest are genuine differences worth
@@ -186,9 +386,9 @@ issue** — that feedback is part of the v1.0.0 acceptance gate for this guide.
    the wurk dashboard.
 3. **`config.workers` / `config.shutdown_timeout` are not Configuration setters.**
    Use `config.concurrency` for threads-per-process and `config[:timeout]` for the
-   shutdown grace; process/fork count is governed by the swarm topology
-   (`config.topology = Wurk::Topology.flat(count:, queues:, concurrency:)`), not a
-   `workers=` accessor.
+   shutdown grace; process/fork count is governed by `WURK_COUNT` and the swarm
+   topology (`config.topology = Wurk::Topology.flat(count:, queues:, concurrency:)`),
+   not a `workers=` accessor. See [§2](#2-concurrency-vs-parallelism-read-this).
 4. **Unique jobs + encryption are mutually exclusive on the same worker** — each
    encryption produces different ciphertext, which defeats the uniqueness digest.
 5. **No Redis namespacing** in the free gem (same as Sidekiq OSS). One logical
@@ -202,28 +402,32 @@ issue** — that feedback is part of the v1.0.0 acceptance gate for this guide.
    itself as OSS, even though the Pro/Ent features are present. Don't gate behavior on
    these predicates.
 
-Third-party gems (`sidekiq-cron`, `sidekiq-unique-jobs`, `sidekiq-scheduler`,
-`sidekiq-status`, `sidekiq-failures`, `sidekiq-throttled`) are exercised against Wurk
-by running their own upstream test suites in the [`ecosystem` CI job](../.github/workflows/ecosystem.yml).
-
 ---
 
-## 5. Cutover checklist
+## 8. Cutover checklist
 
 1. **Swap the gem** — replace `sidekiq` (+ `sidekiq-pro` / `sidekiq-ent`) with `wurk`
    in the `Gemfile`; `bundle install`.
-2. **Keep your config as-is** — Pro toggles like `config.super_fetch!` /
+2. **Size parallelism × concurrency** — decide `WURK_COUNT` (processes) and
+   `concurrency` (threads), then check your DB pool and memory against
+   `WURK_COUNT × concurrency`. See [§2](#2-concurrency-vs-parallelism-read-this). This
+   is the only step that needs real thought.
+3. **Keep your config as-is** — Pro toggles like `config.super_fetch!` /
    `config.reliable_scheduler!` are accepted no-ops (already the default), so there's
    nothing to strip out.
-3. **Re-point the dashboard route** — `mount Wurk::Engine => "/wurk"` (gate it behind
+4. **Re-point the dashboard route** — `mount Wurk::Engine => "/wurk"` (gate it behind
    your app auth — see [`docs/dashboard.md`](dashboard.md)).
-4. **Boot a worker** — `bundle exec wurk` (standalone) or your existing Rails process
-   (the engine auto-starts the swarm unless `WURK_DISABLED=1`). Deploying under
-   systemd/capistrano? See [`docs/deployment.md`](deployment.md).
-5. **Verify on the same Redis** — enqueue a test job, watch it run, and confirm the
+5. **Split web from workers** — run a dedicated `bundle exec wurk` process and set
+   `WURK_DISABLED=1` on the web role so clustered Puma doesn't fork duplicate swarms.
+   See [§3](#3-running-a-worker-process). Deploying under systemd/Capistrano? See
+   [`docs/deployment.md`](deployment.md).
+6. **Map any add-on gems** — swap `sidekiq-cron` → `config.periodic` and
+   `sidekiq-unique-jobs` → `unique_for:` if you want the native path. See
+   [§6](#6-third-party-gem-mappings).
+7. **Verify on the same Redis** — enqueue a test job, watch it run, and confirm the
    dashboard + your existing `redis-cli` checks look normal. Because the schema is
    shared, you can roll one process at a time.
-6. **Roll back anytime** — revert the `Gemfile` line. No schema changes were made.
+8. **Roll back anytime** — revert the `Gemfile` line. No schema changes were made.
 
 ---
 

--- a/docs/migrate-from-sidekiq.md
+++ b/docs/migrate-from-sidekiq.md
@@ -12,6 +12,7 @@ mappings, and a one-page cutover.
 
 - **Authoritative API surface:** [`docs/target/sidekiq-free.md`](target/sidekiq-free.md) ·
   [`sidekiq-pro.md`](target/sidekiq-pro.md) · [`sidekiq-ent.md`](target/sidekiq-ent.md)
+- **Generated API reference (YARD):** <https://developerz-ai.github.io/wurk/api/>
 - **Why this is legal:** [`docs/clean-room.md`](clean-room.md)
 
 > Verified against Wurk's Sidekiq-compat layer (`lib/wurk/compat.rb`), which mirrors

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -435,6 +435,8 @@ mount Wurk::Engine =&gt; <span class="add">"/wurk"</span></pre>
         <a href="https://github.com/developerz-ai/wurk">GitHub</a> ·
         <a href="https://rubygems.org/gems/wurk">RubyGems</a> ·
         <a href="https://github.com/developerz-ai/wurk/wiki">Docs</a> ·
+        <a href="api/">API</a> ·
+        <a href="llms.txt">llms.txt</a> ·
         <a href="https://wurk.demo.developerz.ai/wurk">Live demo</a>
       </p>
       <p>Wurk is a clean-room reimplementation of the Sidekiq <b>API</b> — MIT licensed. Sidekiq is a trademark of Contributed Systems LLC; Wurk is not affiliated with or endorsed by it.</p>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -420,8 +420,11 @@ mount Wurk::Engine =&gt; <span class="add">"/wurk"</span></pre>
 <span class="del">- gem "sidekiq-ent", source: "https://enterprise.contribsys.com/"</span>
 <span class="add">+ gem "wurk"</span></pre>
         </div>
-        <p style="color:var(--muted);margin-top:14px"><code>bundle install &amp;&amp; restart</code>. That's it — see the
-          <a href="https://github.com/developerz-ai/wurk/wiki/Migrating-from-Sidekiq">migration guide</a>.</p>
+        <p style="color:var(--muted);margin-top:14px"><code>bundle install &amp;&amp; restart</code>. One thing to size first:
+          Wurk forks one worker process per CPU core, so total in-flight jobs =
+          <code>WURK_COUNT × concurrency</code> — check your DB pool before the first deploy. The
+          <a href="https://github.com/developerz-ai/wurk/blob/main/docs/migrate-from-sidekiq.md">migration guide</a>
+          walks through parallelism, clustered Puma, and the gem mappings (cron, unique-jobs).</p>
       </section>
     </div>
   </main>

--- a/docs/site/llms.txt
+++ b/docs/site/llms.txt
@@ -1,0 +1,44 @@
+# Wurk
+
+> Wurk is a 100% API-compatible, free, faster drop-in replacement for Sidekiq, Sidekiq Pro, and Sidekiq Enterprise. It uses the same Redis key schema, the same job JSON, and the same Ruby DSL, so an existing Sidekiq app migrates with a one-line Gemfile change. Pro and Enterprise features (batches, rate limiters, unique jobs, periodic/cron, encryption) ship in the same gem with no license check. It is faster than Sidekiq via a fork-based swarm that gives real multi-core parallelism. Requires Ruby >= 3.2 and Redis >= 7.0; on JRuby/TruffleRuby/Windows it falls back to threads-only mode, behaviorally equivalent to stock Sidekiq.
+
+## Three pillars
+
+- **Drop-in.** Same Redis key schema, job JSON, and Ruby DSL. Every public `Wurk::*` class is also exposed under its `Sidekiq::*` name (`Sidekiq::Job`, `Sidekiq::Worker`, `Sidekiq::Batch`, `Sidekiq::Limiter`, `Sidekiq.configure_server`, `Sidekiq::Client`, `Sidekiq::Pro::Web`, `Sidekiq::Enterprise`). Existing jobs, initializers, `sidekiq_options`, and live Redis data keep working. `Sidekiq.pro?` / `Sidekiq.ent?` return `false` (Wurk advertises as free OSS) — never gate behavior on them.
+- **Free.** Pro + Enterprise feature parity in one gem. No tiers, no flags, no license check.
+- **Faster.** Every release is benchmarked against stock Sidekiq on enqueue, fetch+execute, bulk enqueue, swarm boot, and memory.
+
+## Concurrency vs parallelism (the #1 migration gotcha)
+
+Sidekiq runs one process with a thread pool. Wurk runs a swarm of forked processes, each with its own thread pool, for real CPU parallelism on MRI. Two independent knobs:
+
+- **Parallelism** = number of forked worker processes. Set with the `WURK_COUNT` env var (alias `SIDEKIQ_COUNT`). Defaults to the CPU core count. There is **no Sidekiq equivalent** — Sidekiq never forks.
+- **Concurrency** = threads per process. Set with `config.concurrency`, the CLI `-c` flag, YAML `:concurrency`, or the `RAILS_MAX_THREADS` env var. Defaults to 5. There is **no `WURK_CONCURRENCY` env var.**
+- **Total in-flight jobs = `WURK_COUNT × concurrency`.** Each forked process opens its own DB pool and Redis pool, so on a 16-core box the default is 16 processes — size your database `max_connections` and memory before the first deploy.
+
+## Running it
+
+- **Rails engine (default).** Mount `Wurk::Engine => "/wurk"` for the dashboard. The railtie auto-starts an embedded swarm in every non-console Rails process unless `WURK_DISABLED=1`.
+- **Clustered Puma gotcha.** Under clustered Puma (`workers > 0`) every Puma worker would fork its own swarm. Run a dedicated worker process and set `WURK_DISABLED=1` on the web role so it serves HTTP (and the dashboard) without forking workers.
+- **Standalone worker.** `bundle exec wurk -C config/wurk.yml -e production`. There is no `sidekiq` binary; the gem ships `wurk` / `wurkswarm`. The standalone runner does not load the dashboard engine but does boot your app, and defines the ActiveJob `:wurk` / `:sidekiq` adapters before the environment loads.
+
+## Third-party gem mappings
+
+- `sidekiq-cron` → native `config.periodic { |mgr| mgr.register("*/5 * * * *", MyJob) }`. There is no `Sidekiq::Cron::Job` shim by design.
+- `sidekiq-unique-jobs` → native uniqueness: call `Sidekiq::Enterprise.unique!` once, then `sidekiq_options unique_for: 600, unique_until: :success` (`:start` releases the lock at perform start). Customize the dedup key with `self.sidekiq_unique_context(job)`.
+- `sidekiq-scheduler`, `sidekiq-status`, `sidekiq-failures`, `sidekiq-throttled` work unchanged; their upstream suites run against Wurk in CI.
+
+## Docs
+
+- [Migration guide (Sidekiq → Wurk)](https://github.com/developerz-ai/wurk/blob/main/docs/migrate-from-sidekiq.md): the comprehensive cutover — parallelism, clustered Puma, dedicated worker, gem mappings, known incompatibilities, cutover checklist.
+- [Generated API reference (YARD)](https://developerz-ai.github.io/wurk/api/): params, return types, and examples for the public classes (`Wurk::Worker`, `Wurk::Client`, `Wurk::Configuration`, `Wurk::Batch`, `Wurk::Limiter`, `Wurk::Unique`, the `Sidekiq::*` aliases).
+- [README](https://github.com/developerz-ai/wurk/blob/main/README.md): overview, install, dashboard.
+- [Deployment](https://github.com/developerz-ai/wurk/blob/main/docs/deployment.md): systemd unit, Capistrano, Heroku/Procfile, signal handling.
+- [Active Job adapter](https://github.com/developerz-ai/wurk/blob/main/docs/active-job.md): `queue_adapter = :wurk`.
+- [Securing the dashboard](https://github.com/developerz-ai/wurk/blob/main/docs/dashboard.md): auth recipes for the mounted engine.
+
+## Authoritative API specs
+
+- [Sidekiq OSS surface](https://github.com/developerz-ai/wurk/blob/main/docs/target/sidekiq-free.md): the exact free API Wurk matches.
+- [Sidekiq Pro surface](https://github.com/developerz-ai/wurk/blob/main/docs/target/sidekiq-pro.md): batches and reliability.
+- [Sidekiq Enterprise surface](https://github.com/developerz-ai/wurk/blob/main/docs/target/sidekiq-ent.md): rate limiters, unique jobs, periodic, encryption.

--- a/lib/wurk.rb
+++ b/lib/wurk.rb
@@ -72,6 +72,18 @@ require_relative 'wurk/deploy'
 
 require 'json'
 
+# Wurk — a 100% API-compatible, free, faster drop-in for Sidekiq + Sidekiq Pro
+# + Sidekiq Enterprise. Same Redis key schema, same job JSON, same Ruby DSL;
+# real parallelism via a fork-based swarm. Every public class is also exposed
+# under its `Sidekiq::*` name (see {Sidekiq}).
+#
+# Start here:
+#   * {Wurk::Worker} / `Sidekiq::Job` — define and enqueue jobs.
+#   * {Wurk::Configuration} — `Wurk.configure_server { |config| ... }`; note
+#     `WURK_COUNT` (forked processes) × `concurrency` (threads) = total in-flight.
+#   * {Wurk::Batch}, {Wurk::Limiter}, {Wurk::Unique} — Pro/Enterprise features, free.
+#
+# @see https://github.com/developerz-ai/wurk/blob/main/docs/migrate-from-sidekiq.md Migration guide
 module Wurk
   class Error < StandardError; end
 

--- a/lib/wurk/batch.rb
+++ b/lib/wurk/batch.rb
@@ -9,6 +9,15 @@ module Wurk
   # Sidekiq Pro Batches. Group jobs, attach success/complete/death callbacks,
   # track progress. Spec: docs/target/sidekiq-pro.md §2.
   #
+  # @example Define a batch with a success callback
+  #   batch = Sidekiq::Batch.new
+  #   batch.description = "Nightly import"
+  #   batch.on(:success, ImportCallback, "user_id" => user.id)
+  #   batch.jobs do
+  #     rows.each { |r| ImportRowJob.perform_async(r.id) }
+  #   end
+  #   batch.bid   # => the batch id, persisted in Redis
+  #
   # Lifecycle:
   #   1. `Batch.new` allocates a fresh BID; the batch is `mutable?` until the
   #      first `#jobs` block flushes — that flush HSETs the core hash, ZADDs

--- a/lib/wurk/capsule.rb
+++ b/lib/wurk/capsule.rb
@@ -38,7 +38,7 @@ module Wurk
     #   %w[high default low]        → mode :strict,   weights all 0
     #   %w[high,3 default,2 low,1]  → mode :weighted, weights {q=>w}
     #   %w[a,1 b,1 c,1]             → mode :random,   weights all 1
-    # @queues is expanded by weight so a uniform shuffle gives weighted
+    # `@queues` is expanded by weight so a uniform shuffle gives weighted
     # fairness (e.g. ["high","high","high","default","default","low"]).
     def queues=(val)
       parsed = Array(val).map { |entry| parse_queue_entry(entry) }

--- a/lib/wurk/client.rb
+++ b/lib/wurk/client.rb
@@ -7,7 +7,14 @@ require_relative 'lua'
 module Wurk
   # Enqueue interface. Pipelined LPUSH / ZADD writes against the canonical
   # Sidekiq Redis schema — never change keys, JSON shape, or score format here:
-  # wire-compat is sacred.
+  # wire-compat is sacred. Most apps enqueue through the {Wurk::Worker} DSL
+  # (`MyJob.perform_async`), which routes here; reach for Client directly only to
+  # push a raw job hash or to drive the bulk/scheduled path explicitly.
+  #
+  # @example Push a raw job hash
+  #   Wurk::Client.new.push("class" => "MyJob", "args" => [1, 2], "queue" => "default")
+  # @example Bulk enqueue in one round-trip
+  #   Wurk::Client.new.push_bulk("class" => "MyJob", "args" => [[1], [2], [3]])
   #
   # Spec: docs/target/sidekiq-free.md §7.
   class Client

--- a/lib/wurk/compat.rb
+++ b/lib/wurk/compat.rb
@@ -5,6 +5,25 @@
 #
 # Spec: docs/target/sidekiq-{free,pro,ent}.md.
 
+# The `Sidekiq::*` compatibility namespace. Every public Wurk class is exposed
+# here under its Sidekiq name so an existing Sidekiq/Pro/Enterprise app runs on
+# Wurk after a one-line gem swap. `Sidekiq::Job` / `Sidekiq::Worker` are
+# {Wurk::Job} / {Wurk::Worker}; `Sidekiq.configure_server` is
+# {Wurk.configure_server}; `Sidekiq::Batch`, `Sidekiq::Limiter`,
+# `Sidekiq::Client`, `Sidekiq::Pro::Web`, `Sidekiq::Enterprise` all resolve to
+# their Wurk implementations. This alias surface is the drop-in contract and is
+# never broken.
+#
+# @example The same code targets Sidekiq or Wurk unchanged
+#   class MyJob
+#     include Sidekiq::Job
+#     def perform(id); end
+#   end
+#   Sidekiq.configure_server { |c| c.concurrency = 10 }
+#
+# @note `Sidekiq.pro?` and `Sidekiq.ent?` return `false` — Wurk ships the Pro/Ent
+#   features for free but advertises as OSS. Don't gate behavior on them.
+# @see https://github.com/developerz-ai/wurk/blob/main/docs/migrate-from-sidekiq.md Migration guide
 module Sidekiq
   # Version stamps mirror Sidekiq's OSS release Wurk targets for compat.
   # Third-party gems version-gate on these; raise the MAJOR only when the

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -112,9 +112,11 @@ module Wurk
 
     # --- Default capsule shortcuts ---------------------------------------
 
-    # @return [Integer] threads per worker process (default 5). The *process*
-    #   count is separate — see {#default_child_count} / `WURK_COUNT`. Total
-    #   in-flight jobs = `WURK_COUNT × concurrency`.
+    # @return [Integer] threads per worker process for the default capsule
+    #   (default 5). The *process* count is separate — set via `WURK_COUNT`
+    #   (defaults to the CPU count). With a single capsule, total in-flight
+    #   jobs = `WURK_COUNT × concurrency`; with multiple capsules see
+    #   {#total_concurrency} for the cluster aggregate.
     def concurrency = default_capsule.concurrency
 
     # @param val [Integer] threads per worker process

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -112,8 +112,12 @@ module Wurk
 
     # --- Default capsule shortcuts ---------------------------------------
 
+    # @return [Integer] threads per worker process (default 5). The *process*
+    #   count is separate — see {#default_child_count} / `WURK_COUNT`. Total
+    #   in-flight jobs = `WURK_COUNT × concurrency`.
     def concurrency = default_capsule.concurrency
 
+    # @param val [Integer] threads per worker process
     def concurrency=(val)
       default_capsule.concurrency = val
     end
@@ -251,7 +255,18 @@ module Wurk
 
     # Yields a Wurk::Cron::Manager so the host app can register periodic
     # jobs at boot. Manager state is shared per-process so multiple
-    # `config.periodic` blocks accumulate (matches Sidekiq Ent §2.1).
+    # `config.periodic` blocks accumulate (matches Sidekiq Ent §2.1). This is
+    # the native replacement for the `sidekiq-cron` gem.
+    #
+    # @example Register cron jobs at boot
+    #   Wurk.configure_server do |config|
+    #     config.periodic do |mgr|
+    #       mgr.register("*/5 * * * *", ReportJob)
+    #       mgr.register("0 0 * * *", NightlyJob, tz: "UTC")
+    #     end
+    #   end
+    # @yieldparam mgr [Wurk::Cron::Manager] call `mgr.register(cron, JobClass, **opts)`
+    # @return [Wurk::Cron::Manager]
     #
     # Spec: docs/target/sidekiq-ent.md §2.
     def periodic

--- a/lib/wurk/fetcher/reliable.rb
+++ b/lib/wurk/fetcher/reliable.rb
@@ -96,7 +96,7 @@ module Wurk
 
       # Prefixed queue keys (`queue:<name>`) in fetch order. Strict mode
       # preserves declaration order. Random/weighted shuffle each call —
-      # @queues is pre-expanded by weight in Capsule#queues=, so uniform
+      # `@queues` is pre-expanded by weight in Capsule#queues=, so uniform
       # shuffle yields weighted fairness; .uniq trims duplicates. Paused
       # queues are filtered after shuffle so the membership test runs on
       # the smallest possible set.

--- a/lib/wurk/launcher.rb
+++ b/lib/wurk/launcher.rb
@@ -241,10 +241,10 @@ module Wurk
     end
 
     # Heartbeat thread loop. `safe_thread` already wraps exceptions. Loops on
-    # @stopped — NOT @done — so a *quieted* process keeps beating and publishes
+    # `@stopped` — NOT `@done` — so a *quieted* process keeps beating and publishes
     # `quiet=true` instead of vanishing from the live set (#236). Only `#stop`
-    # flips @stopped; its `Thread#wakeup` breaks the sleep so the loop re-checks
-    # @stopped and exits without waiting out the interval.
+    # flips `@stopped`; its `Thread#wakeup` breaks the sleep so the loop re-checks
+    # `@stopped` and exits without waiting out the interval.
     def start_heartbeat
       until @stopped
         heartbeat

--- a/lib/wurk/limiter.rb
+++ b/lib/wurk/limiter.rb
@@ -11,6 +11,16 @@ module Wurk
   # clock skew across hosts doesn't matter inside one Redis. Spec:
   # docs/target/sidekiq-ent.md §1.
   #
+  # @example Throttle to 50 concurrent uses, waiting up to the default timeout
+  #   STRIPE = Sidekiq::Limiter.concurrent("stripe", 50)
+  #
+  #   class ChargeJob
+  #     include Sidekiq::Job
+  #     def perform(id)
+  #       STRIPE.within_limit { Stripe::Charge.create(...) }
+  #     end
+  #   end
+  #
   # Layout (one file per type under `lib/wurk/limiter/`):
   #   * `Limiter::Base` owns the metadata write (lmtr:{name}) + the global
   #     `lmtr-list` registration so the Web UI can list every limiter, and

--- a/lib/wurk/limiter/leaky.rb
+++ b/lib/wurk/limiter/leaky.rb
@@ -5,7 +5,7 @@ require_relative 'base'
 module Wurk
   module Limiter
     # Leaky bucket: drain rate = bucket_size / drain ops/sec. Stored as a
-    # HASH of {level, last} — Lua compares level vs bucket_size after
+    # HASH of `{level, last}` — Lua compares level vs bucket_size after
     # leaking elapsed * drain_per_sec.
     class Leaky < Base
       WAIT_SLEEP = 0.05

--- a/lib/wurk/unique.rb
+++ b/lib/wurk/unique.rb
@@ -25,6 +25,22 @@ module Wurk
   # holding the owning JID. Scheduled jobs extend the TTL by the delay so
   # the lock covers the entire wait+execution window (§3.4).
   #
+  # This is the native replacement for the `sidekiq-unique-jobs` gem; see the
+  # migration guide for the `lock:` → `unique_until:` translation table.
+  #
+  # @example Enable globally, then declare per worker
+  #   Sidekiq::Enterprise.unique!   # activate the middleware once, at boot
+  #
+  #   class ChargeJob
+  #     include Sidekiq::Job
+  #     sidekiq_options unique_for: 10.minutes, unique_until: :success
+  #
+  #     # optional: customize the dedup key
+  #     def self.sidekiq_unique_context(job)
+  #       job["args"].first   # dedup on the first arg only
+  #     end
+  #   end
+  #
   # Spec: docs/target/sidekiq-ent.md §3.
   module Unique
     KEY_PREFIX = 'unique:'

--- a/lib/wurk/worker.rb
+++ b/lib/wurk/worker.rb
@@ -3,9 +3,27 @@
 require_relative 'worker/setter'
 
 module Wurk
-  # The user-facing DSL: `include Wurk::Worker` (aliased to Sidekiq::Worker).
-  # Owns `sidekiq_options`, `perform_async`, `perform_in`, `perform_at`,
-  # `set`, `sidekiq_retry_in`, etc.
+  # The user-facing job DSL. `include Wurk::Worker` — or its modern alias
+  # `Sidekiq::Job` / `Sidekiq::Worker` — onto a class to make it a background
+  # job. The class gains `sidekiq_options`, the `perform_*` enqueue methods,
+  # `set`, and the retry-hook DSL; each instance gains `jid`, `logger`,
+  # `interrupted?`, and the batch helpers.
+  #
+  # @example A minimal job
+  #   class HardJob
+  #     include Sidekiq::Job
+  #     sidekiq_options queue: "critical", retry: 5
+  #
+  #     def perform(user_id, opts = {})
+  #       # ... your work ...
+  #     end
+  #   end
+  #
+  #   HardJob.perform_async(42, "fast" => true)   # enqueue now
+  #   HardJob.perform_in(5.minutes, 42)           # enqueue later
+  #
+  # @see Wurk::Worker::ClassMethods the enqueue + options DSL added to the class
+  # @see https://github.com/developerz-ai/wurk/blob/main/docs/migrate-from-sidekiq.md Migration guide
   #
   # Spec: docs/target/sidekiq-free.md §6 (Sidekiq::Job).
   module Worker
@@ -65,7 +83,17 @@ module Wurk
       batch.valid?
     end
 
+    # Class-level DSL mixed into every job class by {Wurk::Worker}. These are
+    # the public enqueue and configuration entry points.
     module ClassMethods # rubocop:disable Metrics/ModuleLength
+      # Set per-class job options (merged over any inherited options).
+      #
+      # @example
+      #   sidekiq_options queue: "mailers", retry: 3, unique_for: 10.minutes
+      # @param opts [Hash] any of `queue:`, `retry:`, `dead:`, `backtrace:`,
+      #   `expires_in:`, `tags:`, `pool:`, `unique_for:`, … (see the migration
+      #   guide's sidekiq_options table for the full set)
+      # @return [Hash] the merged, string-keyed options hash
       def sidekiq_options(opts = {})
         merged = get_sidekiq_options.merge(opts.transform_keys(&:to_s))
         @sidekiq_options_hash = merged
@@ -92,24 +120,57 @@ module Wurk
         self.sidekiq_retries_exhausted_block = block
       end
 
+      # Enqueue the job to run as soon as a worker is free. Arguments are
+      # forwarded to `#perform` and must be JSON-serializable
+      # (string/number/bool/nil/array/hash).
+      #
+      # @example
+      #   EmailJob.perform_async(user.id, "welcome")
+      # @return [String, nil] the job id (jid), or nil if a client middleware
+      #   halted the push
       def perform_async(*)
         Wurk::Worker::Setter.new(self, {}).perform_async(*)
       end
 
+      # Run `#perform` synchronously in the current thread (no Redis). Useful in
+      # tests and for inline execution.
+      #
+      # @return [Object] the return value of `#perform`
       def perform_inline(*)
         new.perform(*)
       end
       alias perform_sync perform_inline
 
+      # Schedule the job for later. `perform_at` is an alias taking an absolute
+      # time; `perform_in` takes a relative interval.
+      #
+      # @example
+      #   ReminderJob.perform_in(1.hour, lead.id)
+      #   ReminderJob.perform_at(Time.now + 3600, lead.id)
+      # @param interval [Numeric, Time] seconds-from-now, or an absolute Time
+      # @return [String, nil] the job id (jid)
       def perform_in(interval, *)
         Wurk::Worker::Setter.new(self, {}).perform_in(interval, *)
       end
       alias perform_at perform_in
 
+      # Enqueue many jobs in one round-trip via the Lua bulk path.
+      #
+      # @example
+      #   ImportJob.perform_bulk([[1], [2], [3]])
+      # @param items [Array<Array>] one args array per job
+      # @return [Array<String>] the job ids, in order
       def perform_bulk(items, **)
         Wurk::Worker::Setter.new(self, {}).perform_bulk(items, **)
       end
 
+      # Return a per-call option carrier so a single enqueue can override
+      # class-level options (queue, scheduling, pool, …).
+      #
+      # @example
+      #   ReportJob.set(queue: "low").perform_async(account.id)
+      # @param opts [Hash] per-call overrides
+      # @return [Wurk::Worker::Setter]
       def set(opts)
         Wurk::Worker::Setter.new(self, opts)
       end

--- a/test/unit/llms_txt_test.rb
+++ b/test/unit/llms_txt_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Guards docs/site/llms.txt (the AI-agent map published at /wurk/llms.txt).
+# Keeps it from silently drifting: it must follow the llms.txt format and every
+# in-repo doc it links to must still exist. External (github.io / blob) links
+# aren't fetched here — the repo-relative ones are the ones a rename can break.
+class LlmsTxtTest < Minitest::Test
+  ROOT = File.expand_path('../..', __dir__)
+  LLMS = File.join(ROOT, 'docs', 'site', 'llms.txt')
+
+  def setup
+    @text = File.read(LLMS)
+  end
+
+  def test_exists_and_follows_format
+    assert File.file?(LLMS), 'docs/site/llms.txt must exist (published at /wurk/llms.txt)'
+    assert_match(/\A# Wurk\n/, @text, 'must open with an H1 title')
+    assert_match(/^> Wurk is a /, @text, 'must have a blockquote summary after the title')
+    assert_match(/^## Docs$/, @text, 'must have a sectioned link list')
+  end
+
+  def test_states_the_core_migration_facts
+    # The facts agents rely on — keep them present and correct.
+    assert_includes @text, 'WURK_COUNT', 'must document the parallelism knob'
+    assert_includes @text, 'no `WURK_CONCURRENCY` env var', 'must correct the WURK_CONCURRENCY misconception'
+    assert_includes @text, 'WURK_DISABLED=1', 'must document the clustered-Puma fix'
+  end
+
+  def test_links_to_the_migration_guide_and_api_docs
+    assert_includes @text, 'docs/migrate-from-sidekiq.md', 'must link the migration guide (#254)'
+    assert_includes @text, 'developerz-ai.github.io/wurk/api/', 'must link the YARD API docs (#256)'
+  end
+
+  def test_repo_relative_doc_links_resolve
+    # Every github.com/.../blob/main/<path> link must point at a real file.
+    paths = @text.scan(%r{blob/main/([\w./-]+)}).flatten.uniq
+
+    refute_empty paths, 'expected at least one in-repo doc link'
+    missing = paths.reject { |rel| File.file?(File.join(ROOT, rel)) }
+
+    assert_empty missing, "llms.txt links to missing repo files: #{missing.join(', ')}"
+  end
+end


### PR DESCRIPTION
Completes the **Migration & AI-agent docs** milestone (#5) — closes #254, #255, #256.

A coherent docs push so a human (and an AI agent) can take a production Sidekiq / Pro / Enterprise app to Wurk with no surprises. The three deliverables cross-link each other.

## #254 — Comprehensive migration guide
Rewrote [`docs/migrate-from-sidekiq.md`](https://github.com/developerz-ai/wurk/blob/main/docs/migrate-from-sidekiq.md) to close the gaps surfaced by the real migration in #253:
- **§2 Concurrency vs parallelism** — `WURK_COUNT` (forked processes) × `concurrency` (threads) = total in-flight, with a worked example mapping a Sidekiq `concurrency: 10` app and the DB-pool / memory foot-gun. **Documents that there is no `WURK_CONCURRENCY` env var** (threads = `config.concurrency` / `-c` / `RAILS_MAX_THREADS`) — the issue assumed one; the code doesn't have it.
- **§3 Running a worker** — dedicated `bundle exec wurk` (ActiveJob adapter now works standalone post-#253) + the **clustered-Puma embedded-swarm foot-gun** and the `WURK_DISABLED=1`-on-web fix.
- **§6 Third-party gem mappings** — `sidekiq-cron` → `config.periodic`, `sidekiq-unique-jobs` → `unique_for:`/`unique_until:` with the exact lock-translation table, plus an ecosystem quick-reference.
- Reflowed cutover checklist; surfaced the parallelism callout on the docs-site landing page.

## #256 — YARD API docs
- `yard` dev dep, `.yardopts` (lib-only), `bin/rake yard` + `rake yard:stats`, output to `docs/site/api/` (gitignored).
- Class overviews + `@example`/`@param`/`@return` on the public entry points: Worker DSL, Client, Configuration, Batch, Limiter, Unique, the `Sidekiq::*` alias contract, top-level `Wurk`.
- Pages workflow now generates + publishes the API docs at **developerz-ai.github.io/wurk/api/**. Build is **warning-free** (fixed 4 existing comments YARD misparsed as tags).

## #255 — llms.txt for AI agents
- [`docs/site/llms.txt`](https://github.com/developerz-ai/wurk/blob/main/docs/site/llms.txt) → published at **/wurk/llms.txt**. llms.txt format (H1, blockquote, sectioned link lists); every claim links to a canonical source.
- Kept current by `test/unit/llms_txt_test.rb` (asserts format + core facts + that every in-repo doc it links to still exists).

## How to test in prod
These are docs — nothing to deploy to your job fleet. To verify the published artifacts after merge:

```bash
# Migration guide + API reference + AI-agent map all resolve:
curl -sI https://developerz-ai.github.io/wurk/llms.txt | head -1     # 200
curl -sI https://developerz-ai.github.io/wurk/api/ | head -1         # 200
open  https://developerz-ai.github.io/wurk/api/                      # YARD index

# Generate the API docs locally (no network):
bundle exec rake yard && open docs/site/api/index.html
bundle exec rake yard:stats        # public-API doc coverage report
```

The one operational takeaway from the guide, worth pinning for any real migrant: **total in-flight jobs = `WURK_COUNT × concurrency`**, and each forked process opens its own DB pool — size `max_connections` before the first deploy.

## Verification
- `bin/rake test` — 2341 runs, 0 failures, 0 errors.
- `bundle exec yard doc` — clean, no warnings.
- New `llms_txt_test.rb` green; touched files lint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added auto-generated API documentation accessible via `/api/`
  * Added `llms.txt` for AI agent discovery
* **Documentation**
  * Expanded the “Migrating from Sidekiq” guide with clearer sizing guidance and clustered Puma cautions
  * Improved and extended YARD documentation and in-library examples
  * Updated the website to link to the API and enhanced migration instructions
* **Tests**
  * Added automated checks to validate `llms.txt` formatting and documentation links
* **Build & Deployment**
  * Enhanced GitHub Pages publishing to generate and publish API docs automatically
<!-- end of auto-generated comment: release notes by coderabbit.ai -->