### PR TITLE
docs: fix WURK_COUNT runner inaccuracy + surface API-docs link (closes #261)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Plus Wurk extras: a worker topology DSL, a Kubernetes liveness/readiness listene
 ## Documentation
 
 - **[Website](https://developerz-ai.github.io/wurk/)** · **[Wiki / full docs](https://github.com/developerz-ai/wurk/wiki)** — the pitch, install, and the complete guide.
+- **[API reference (YARD)](https://developerz-ai.github.io/wurk/api/)** — generated docs for the public classes (`Wurk::Worker`, `Wurk::Client`, `Wurk::Configuration`, `Wurk::Batch`, `Wurk::Limiter`, `Wurk::Unique`, and the `Sidekiq::*` aliases). Machine-readable map for AI agents: **[llms.txt](https://developerz-ai.github.io/wurk/llms.txt)**.
 - **[Getting started & architecture](https://github.com/developerz-ai/wurk/blob/main/docs/idea/01-overview.md)** — how the swarm, manager, fetcher, and processor fit together.
 - **[Starting the worker](https://github.com/developerz-ai/wurk/blob/main/docs/running.md)** — Rails auto-start, the `wurk`/`wurkswarm` runners, and running standalone without Rails.
 - **[Active Job adapter](https://github.com/developerz-ai/wurk/blob/main/docs/active-job.md)** — run `ActiveJob`/`deliver_later` on Wurk with `queue_adapter = :wurk`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -119,8 +119,11 @@ integration mode drops in the same way — replace the generated unit's `ExecSta
 ## Heroku / Procfile
 
 ```procfile
-worker: bundle exec wurk -e production
+worker: bundle exec wurkswarm -e production
 ```
 
-Heroku sends `SIGTERM` on dyno cycle, which triggers Wurk's graceful drain — set the
-shutdown timeout (`-t`) below Heroku's 30s kill window so jobs finish cleanly.
+Use `wurkswarm` for fork-based parallelism inside the dyno (set `WURK_COUNT` to the
+dyno's core count), or `bundle exec wurk` for a single process if you'd rather scale
+out by adding worker dynos. Heroku sends `SIGTERM` on dyno cycle, which triggers
+Wurk's graceful drain — set the shutdown timeout (`-t`) below Heroku's 30s kill window
+so jobs finish cleanly.

--- a/docs/migrate-from-sidekiq.md
+++ b/docs/migrate-from-sidekiq.md
@@ -120,6 +120,12 @@ Two independent knobs:
 > / `-c` / `RAILS_MAX_THREADS` (the same env knob Sidekiq honors). `WURK_COUNT` is the
 > *new* knob — it has no Sidekiq equivalent because Sidekiq never forks.
 
+> ⚠️ **`WURK_COUNT` only applies to the forking runners** — the Rails engine's
+> auto-boot swarm and the standalone `bundle exec wurkswarm` (alias `sidekiqswarm`).
+> Plain `bundle exec wurk` is a **single process** (one thread pool, like `sidekiq`);
+> it ignores `WURK_COUNT`. Use `wurkswarm` when you want multi-process parallelism
+> outside Rails. See [§3](#3-running-a-worker-process).
+
 ### Total in-flight jobs = `WURK_COUNT × concurrency`
 
 A whole-number `WURK_COUNT` is an absolute process count; a fractional value is a CPU
@@ -147,11 +153,16 @@ end
 ```
 
 ```bash
-# Pick the process count to land near your old in-flight number:
-WURK_COUNT=2  bundle exec wurk   # 2 × 5  = 10 jobs in flight (matches Sidekiq, now on 2 cores)
-WURK_COUNT=1  bundle exec wurk   # 1 × 10 if you also set concurrency: 10 — single-process, Sidekiq-like
-WURK_COUNT=4  bundle exec wurk   # 4 × 5  = 20 in flight — 2× the throughput, 4× the CPU parallelism
+# Pick the process count to land near your old in-flight number. WURK_COUNT
+# drives the forking runner (wurkswarm), or the Rails engine's auto-boot swarm:
+WURK_COUNT=2  bundle exec wurkswarm   # 2 × 5  = 10 jobs in flight (matches Sidekiq, now on 2 cores)
+WURK_COUNT=4  bundle exec wurkswarm   # 4 × 5  = 20 in flight — 2× the throughput, 4× the CPU parallelism
+
+bundle exec wurk -c 10                # or stay single-process (no fork) with 10 threads, Sidekiq-like
 ```
+
+In a Rails app you don't run either binary — the engine auto-boots the swarm and
+reads `WURK_COUNT` itself; set the env var on the worker role.
 
 **Size your database pool for the per-process thread count, then check the total.**
 Each process needs `pool >= concurrency` in `database.yml`:
@@ -175,27 +186,37 @@ On the 16-core default that's 16 × 5 = 80 connections from one host — size
 
 ## 3. Running a worker process
 
-### Dedicated worker: `bundle exec wurk`
+### Dedicated worker: `wurk` vs `wurkswarm`
 
-The standalone runner is `bundle exec wurk`. The gem ships a `wurk` executable (and
-`wurkswarm`) — there is **no `sidekiq` binary**, so update any `bundle exec sidekiq`
-invocations, Procfile lines, and systemd/Capistrano units to `wurk`. It takes the
-familiar flags (`-c` concurrency, `-q` queue, `-r` require, `-t` timeout, `-e`
-environment, `-C` config), reads a YAML config with `-C path`, and auto-discovers
-`config/wurk.yml` then `config/sidekiq.yml` (`.erb` supported). The YAML structure
-matches Sidekiq's `sidekiq.yml`.
+The gem ships two standalone runners (and an alias) — there is **no `sidekiq`
+binary**, so update any `bundle exec sidekiq` invocation, Procfile line, and
+systemd/Capistrano unit:
+
+| Binary | What it does | Sidekiq equivalent |
+|---|---|---|
+| `bundle exec wurk` | One process, one thread pool | `sidekiq` |
+| `bundle exec wurkswarm` | Forks `WURK_COUNT` worker children from one preloaded parent — fork-based real parallelism | `sidekiqswarm` |
+
+`sidekiqswarm` is shipped as an alias for `wurkswarm`, so an existing Enterprise
+invocation drops in unchanged. **Use `wurkswarm` for a multi-process worker host**
+(it's the only way to get fork-based parallelism without Rails); use `wurk` for a
+single-process worker. Both take the familiar flags (`-c` concurrency, `-q` queue,
+`-r` require, `-t` timeout, `-e` environment, `-C` config), read a YAML config with
+`-C path`, and auto-discover `config/wurk.yml` then `config/sidekiq.yml` (`.erb`
+supported). The YAML structure matches Sidekiq's `sidekiq.yml`.
 
 ```bash
-bundle exec wurk -C config/wurk.yml -e production
+bundle exec wurkswarm -C config/wurk.yml -e production   # forked swarm (real parallelism)
+bundle exec wurk      -C config/wurk.yml -e production    # single process
 ```
 
-The standalone runner does **not** load the Rails engine (the dashboard) — that's by
-design, so a worker host stays lean. It does fully boot your Rails app (`-r`/the
-environment) so your jobs and models are available.
+Neither runner loads the Rails engine (the dashboard) — by design, so a worker host
+stays lean. They do fully boot your Rails app (`-r`/the environment) so your jobs and
+models are available.
 
 > ✅ **ActiveJob works standalone.** If your app uses
 > `config.active_job.queue_adapter = :wurk` (or `:sidekiq`), the standalone CLI now
-> defines the adapter *before* the Rails environment loads, so a dedicated `wurk`
+> defines the adapter *before* the Rails environment loads, so a dedicated worker
 > process boots cleanly. (Earlier builds raised `uninitialized constant WurkAdapter`
 > in standalone mode — fixed in [#253](https://github.com/developerz-ai/wurk/issues/253).)
 
@@ -204,7 +225,7 @@ For an example systemd unit and the Capistrano / deploy signal dance (replacing
 worker line is simply:
 
 ```procfile
-worker: bundle exec wurk -e production
+worker: bundle exec wurkswarm -e production
 ```
 
 ### Clustered Puma + the embedded swarm (important)
@@ -222,8 +243,8 @@ web role.**
 # Web dyno / Puma role — serve HTTP only, no jobs:
 WURK_DISABLED=1 bundle exec puma -C config/puma.rb
 
-# Worker dyno / role — run the jobs:
-bundle exec wurk -e production
+# Worker dyno / role — run the jobs (wurkswarm for multi-process parallelism):
+bundle exec wurkswarm -e production
 ```
 
 This mirrors the standard Sidekiq topology (Puma for web, a separate `sidekiq`
@@ -418,7 +439,7 @@ issue** — that feedback is part of the v1.0.0 acceptance gate for this guide.
    nothing to strip out.
 4. **Re-point the dashboard route** — `mount Wurk::Engine => "/wurk"` (gate it behind
    your app auth — see [`docs/dashboard.md`](dashboard.md)).
-5. **Split web from workers** — run a dedicated `bundle exec wurk` process and set
+5. **Split web from workers** — run a dedicated `bundle exec wurkswarm` process and set
    `WURK_DISABLED=1` on the web role so clustered Puma doesn't fork duplicate swarms.
    See [§3](#3-running-a-worker-process). Deploying under systemd/Capistrano? See
    [`docs/deployment.md`](deployment.md).

--- a/docs/running.md
+++ b/docs/running.md
@@ -56,7 +56,7 @@ Identical to Sidekiq:
 
 | Flag | Meaning |
 |---|---|
-| `-c INT` | Processor threads (concurrency). Defaults to `RAILS_MAX_THREADS` or 10. |
+| `-c INT` | Processor threads (concurrency). Defaults to `RAILS_MAX_THREADS`, else `5`. |
 | `-q queue[,weight]` | Queue to process, optionally weighted. Repeatable. Defaults to `default`. |
 | `-r PATH` | App to load — a Rails app **directory**, or a single `.rb` file (see below). |
 | `-t NUM` | Shutdown timeout in seconds (default 25). |

--- a/docs/site/llms.txt
+++ b/docs/site/llms.txt
@@ -20,7 +20,7 @@ Sidekiq runs one process with a thread pool. Wurk runs a swarm of forked process
 
 - **Rails engine (default).** Mount `Wurk::Engine => "/wurk"` for the dashboard. The railtie auto-starts an embedded swarm in every non-console Rails process unless `WURK_DISABLED=1`.
 - **Clustered Puma gotcha.** Under clustered Puma (`workers > 0`) every Puma worker would fork its own swarm. Run a dedicated worker process and set `WURK_DISABLED=1` on the web role so it serves HTTP (and the dashboard) without forking workers.
-- **Standalone worker.** `bundle exec wurk -C config/wurk.yml -e production`. There is no `sidekiq` binary; the gem ships `wurk` / `wurkswarm`. The standalone runner does not load the dashboard engine but does boot your app, and defines the ActiveJob `:wurk` / `:sidekiq` adapters before the environment loads.
+- **Standalone worker.** There is no `sidekiq` binary; the gem ships `wurk` (single process, like `sidekiq`) and `wurkswarm` (alias `sidekiqswarm`; forks `WURK_COUNT` children for real parallelism — the only way to get multi-process parallelism without Rails). `WURK_COUNT` only affects `wurkswarm` and the Rails engine swarm, not plain `wurk`. Neither runner loads the dashboard engine but both boot your app and define the ActiveJob `:wurk` / `:sidekiq` adapters before the environment loads. Example: `bundle exec wurkswarm -C config/wurk.yml -e production`.
 
 ## Third-party gem mappings
 

--- a/wurk.gemspec
+++ b/wurk.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.2.0"
 
   spec.metadata["source_code_uri"]   = spec.homepage
-  spec.metadata["documentation_uri"] = "#{spec.homepage}/tree/main/docs"
+  spec.metadata["documentation_uri"] = "https://developerz-ai.github.io/wurk/api/"
   spec.metadata["changelog_uri"]     = "#{spec.homepage}/blob/main/CHANGELOG.md"
   spec.metadata["bug_tracker_uri"]   = "#{spec.homepage}/issues"
   spec.metadata["rubygems_mfa_required"] = "true"


### PR DESCRIPTION
Closes #261. Follow-up to the docs milestone (#260) — fixes a correctness bug that shipped in the migration guide and surfaces the generated API-docs URL everywhere.

## Correctness: `WURK_COUNT` runner
Auditing the other `docs/` guides against the code caught an error in the just-merged migration guide + llms.txt. `WURK_COUNT` only drives the **forking** runners:
- the Rails engine's auto-boot swarm, and
- standalone `bundle exec wurkswarm` (alias `sidekiqswarm`) → `Wurk::CLI#run_swarm`.

Plain `bundle exec wurk` is a **single process** (`Wurk::CLI#run`, no fork) and ignores `WURK_COUNT`. The guide's §2 worked example and §3 used `WURK_COUNT=N bundle exec wurk`, which silently does nothing.

- **migrate-from-sidekiq.md** §2: worked example now uses `wurkswarm` + a callout that `WURK_COUNT` applies only to the forking runners; §3 replaces the single `wurk` section with a `wurk` vs `wurkswarm` table; Procfile / worker-dyno / cutover step now use `wurkswarm`.
- **llms.txt**: clarifies the `wurk`/`wurkswarm` split.
- **running.md**: `-c` default fixed to `RAILS_MAX_THREADS` else `5` (was “10”; the config default is 5 — no literal-10 default exists in the CLI).
- **deployment.md**: Heroku Procfile harmonized (offers `wurkswarm`).

active-job / metrics-history / dashboard / clean-room were spot-checked against the code — accurate, no change needed.

## Expose the API docs link
The generated YARD API docs publish at **https://developerz-ai.github.io/wurk/api/**. Surfaced everywhere it's needed:
- **README** Documentation section — new API-reference + llms.txt bullet.
- **gem `documentation_uri`** → the API site (was `/tree/main/docs`), so the RubyGems “Documentation” link lands there.
- migration guide + llms.txt already link it (from #260); the docs-site footer already exposes `api/` + `llms.txt`.

## How to test in prod
Docs/metadata only — nothing to deploy to your job fleet. After merge:
```bash
curl -sI https://developerz-ai.github.io/wurk/api/ | head -1     # 200 once Pages redeploys
gem spec wurk metadata | grep documentation_uri                  # → the api URL after the next release
```
Operator takeaway from the fix: for a multi-process standalone worker use **`bundle exec wurkswarm`** (or set `WURK_COUNT` on the Rails worker role) — plain `wurk` is single-process.

## Verification
- `bin/rake test TEST=test/unit/llms_txt_test.rb` — green.
- gemspec loads; `documentation_uri` resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added API reference documentation and machine-readable docs link for AI agents.
  * Updated Heroku deployment guidance with recommended runner configurations and parallelism options.
  * Clarified distinction between single-process and multi-process worker execution modes with updated examples.
  * Updated default concurrency documentation.
  * Updated documentation URL to point to hosted API reference site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->