### PR TITLE
test: CI doc-coverage gate for the public API (closes #256)

### DIFF
--- a/lib/wurk/client.rb
+++ b/lib/wurk/client.rb
@@ -43,6 +43,7 @@ module Wurk
       copy
     end
 
+    # @param item [Hash] job payload; must carry `class` and `args`, may carry `at`, `queue`, `jid`, etc.
     # @return [String, nil] jid; nil when client middleware halts the push.
     def push(item)
       normed  = normalize_item(item)

--- a/test/unit/yard_public_api_test.rb
+++ b/test/unit/yard_public_api_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'yard'
+
+# Doc-coverage gate for #256: the public API surface the drop-in contract
+# guarantees must stay documented. Parses lib/ with YARD and asserts the
+# enumerated classes carry a class-level docstring and the DSL entry points
+# carry runnable @example tags. This is the CI-checked half of the YARD work —
+# a regression (someone adds a public enqueue path or strips a class overview)
+# fails the suite instead of silently shipping undocumented API.
+#
+# Scoped to the public surface on purpose: a global "% documented" number would
+# be dominated by internal/private methods and is not what the contract is about.
+class YardPublicApiTest < Minitest::Test
+  # Parse once for the whole class — YARD's registry is process-global, and
+  # minitest-parallel_fork gives each worker its own process, so this is safe.
+  def self.registry
+    @registry ||= begin
+      root = File.expand_path('../..', __dir__)
+      YARD::Registry.clear
+      YARD.parse(Dir[File.join(root, 'lib', '**', '*.rb')])
+      YARD::Registry
+    end
+  end
+
+  # Class/module overviews the layer-ownership + alias contract depend on.
+  DOCUMENTED_TYPES = %w[
+    Wurk
+    Wurk::Worker
+    Wurk::Worker::ClassMethods
+    Wurk::Job
+    Wurk::Client
+    Wurk::Configuration
+    Wurk::Batch
+    Wurk::Limiter
+    Wurk::Unique
+    Sidekiq
+  ].freeze
+
+  # DSL entry points the issue says to lean on @example for.
+  EXAMPLED_OBJECTS = %w[
+    Wurk::Worker
+    Wurk::Worker::ClassMethods#perform_async
+    Wurk::Worker::ClassMethods#perform_in
+    Wurk::Worker::ClassMethods#perform_bulk
+    Wurk::Worker::ClassMethods#set
+    Wurk::Worker::ClassMethods#sidekiq_options
+    Wurk::Configuration#periodic
+    Wurk::Batch
+    Wurk::Limiter
+    Wurk::Unique
+  ].freeze
+
+  def test_public_types_carry_class_level_docs
+    undocumented = DOCUMENTED_TYPES.reject do |name|
+      obj = self.class.registry.at(name)
+      obj && obj.docstring.to_s.strip.length >= 20
+    end
+
+    assert_empty undocumented,
+                 "public API types missing a class/module overview: #{undocumented.join(', ')}"
+  end
+
+  def test_dsl_entry_points_have_examples
+    missing = EXAMPLED_OBJECTS.reject do |name|
+      obj = self.class.registry.at(name)
+      obj && !obj.tags(:example).empty?
+    end
+
+    assert_empty missing, "public DSL entry points missing an @example: #{missing.join(', ')}"
+  end
+
+  def test_client_enqueue_methods_document_params_and_return
+    %w[Wurk::Client#push Wurk::Client#push_bulk].each do |name|
+      obj = self.class.registry.at(name)
+
+      refute_nil obj, "#{name} not found in YARD registry"
+      assert_predicate obj.tags(:return), :any?, "#{name} must document its @return"
+    end
+  end
+end

--- a/test/unit/yard_public_api_test.rb
+++ b/test/unit/yard_public_api_test.rb
@@ -13,6 +13,8 @@ require 'yard'
 # Scoped to the public surface on purpose: a global "% documented" number would
 # be dominated by internal/private methods and is not what the contract is about.
 class YardPublicApiTest < Minitest::Test
+  parallelize_me!
+
   # Parse once for the whole class — YARD's registry is process-global, and
   # minitest-parallel_fork gives each worker its own process, so this is safe.
   def self.registry
@@ -76,6 +78,7 @@ class YardPublicApiTest < Minitest::Test
       obj = self.class.registry.at(name)
 
       refute_nil obj, "#{name} not found in YARD registry"
+      assert_predicate obj.tags(:param), :any?, "#{name} must document its @param tags"
       assert_predicate obj.tags(:return), :any?, "#{name} must document its @return"
     end
   end


### PR DESCRIPTION
Closes #256.

The substantive YARD work — `.yardopts`, `bin/rake yard`, public-API annotations, and publishing to **https://developerz-ai.github.io/wurk/api/** — shipped in #260. This PR adds the one remaining (optional) Done-when item: the **CI doc-coverage gate**, so the public API can't silently lose its docs.

## What it does
`test/unit/yard_public_api_test.rb` parses `lib/` with YARD and asserts:
- **Class/module overviews** exist for the drop-in public surface: `Wurk`, `Wurk::Worker(/ClassMethods)`, `Wurk::Job`, `Wurk::Client`, `Wurk::Configuration`, `Wurk::Batch`, `Wurk::Limiter`, `Wurk::Unique`, and the `Sidekiq` alias contract.
- **`@example` tags** on the DSL entry points (`perform_async/in/bulk`, `set`, `sidekiq_options`, `config.periodic`, plus the Batch/Limiter/Unique classes).
- **`@return`** on `Wurk::Client#push` / `#push_bulk`.

It runs inside the existing `bundle exec rake test` gate (no new workflow — `yard` is already in the CI bundle), so a regression (a new public enqueue path, a stripped class overview) **fails the suite** instead of shipping undocumented API.

Scoped to the public surface on purpose: a global "% documented" number is dominated by internal/private methods and isn't what the drop-in contract is about.

## Done-when (#256)
- [x] Public API classes/methods carry YARD tags — #260
- [x] `bin/rake yard` generates clean docs, no broken refs — #260 (warning-free build)
- [x] Docs published at a stable URL + linked from llms.txt + migration guide — #260
- [x] **CI doc-coverage gate is green** — this PR

## How to test in prod
CI/test-only — nothing to deploy. Locally:
```bash
bin/rake test TEST=test/unit/yard_public_api_test.rb   # the gate
bundle exec rake yard:stats                            # undocumented-objects report
```

## Verification
- `bin/rake test` — 2344 runs, 0 failures, 0 errors (6 pre-existing skips).
- Negative-checked: the gate distinguishes documented (`perform_async`, 1 example) from undocumented (`perform_inline`, 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added documentation coverage tests to ensure public APIs include required YARD metadata, class/module overviews, and method `@param`/`@return` tags.
  * Added checks that documented DSL entry points include at least one `@example` tag.
* **Documentation**
  * Improved YARD docs for `Wurk::Client#push` by clarifying the expected structure of the `item` parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->