### PR TITLE
docs: generate llms-full.txt for single-fetch agent reading (closes #255)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,11 +7,12 @@ on:
   push:
     branches: [main]
     paths:
-      - "docs/site/**"
+      - "docs/**"
       - "lib/**"
       - ".yardopts"
       - "README.md"
       - "Rakefile"
+      - "tasks/llms_full.rb"
       - "Gemfile"
       - "Gemfile.lock"
       - ".github/workflows/pages.yml"
@@ -43,9 +44,9 @@ jobs:
         with:
           ruby-version: "3.4"
           bundler-cache: true
-      # Generate the YARD API docs into docs/site/api/ (per .yardopts) so the
-      # upload step ships them with the static site.
-      - run: bundle exec rake yard
+      # Generate the YARD API docs into docs/site/api/ (per .yardopts) and the
+      # single-fetch llms-full.txt, so the upload step ships both with the site.
+      - run: bundle exec rake yard docs:llms_full
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ tmp/
 log/
 coverage/
 docs/site/api/
+docs/site/llms-full.txt
 .idea/
 .vscode/
 .DS_Store

--- a/Rakefile
+++ b/Rakefile
@@ -84,6 +84,15 @@ namespace :yard do
   end
 end
 
+namespace :docs do
+  desc "Generate docs/site/llms-full.txt (single-fetch full docs for AI agents)"
+  task :llms_full do
+    require_relative "tasks/llms_full"
+    out = WurkDocs::LlmsFull.write(GEM_ROOT)
+    puts "wrote #{out}"
+  end
+end
+
 desc "Run all benchmarks (enqueue, fetch+execute, bulk enqueue, swarm boot, memory)"
 task :bench do
   Dir.glob(File.join(GEM_ROOT, "bench", "*.rb")).sort.each do |script|

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -437,6 +437,7 @@ mount Wurk::Engine =&gt; <span class="add">"/wurk"</span></pre>
         <a href="https://github.com/developerz-ai/wurk/wiki">Docs</a> ·
         <a href="api/">API</a> ·
         <a href="llms.txt">llms.txt</a> ·
+        <a href="llms-full.txt">llms-full.txt</a> ·
         <a href="https://wurk.demo.developerz.ai/wurk">Live demo</a>
       </p>
       <p>Wurk is a clean-room reimplementation of the Sidekiq <b>API</b> — MIT licensed. Sidekiq is a trademark of Contributed Systems LLC; Wurk is not affiliated with or endorsed by it.</p>

--- a/docs/site/llms.txt
+++ b/docs/site/llms.txt
@@ -2,6 +2,8 @@
 
 > Wurk is a 100% API-compatible, free, faster drop-in replacement for Sidekiq, Sidekiq Pro, and Sidekiq Enterprise. It uses the same Redis key schema, the same job JSON, and the same Ruby DSL, so an existing Sidekiq app migrates with a one-line Gemfile change. Pro and Enterprise features (batches, rate limiters, unique jobs, periodic/cron, encryption) ship in the same gem with no license check. It is faster than Sidekiq via a fork-based swarm that gives real multi-core parallelism. Requires Ruby >= 3.2 and Redis >= 7.0; on JRuby/TruffleRuby/Windows it falls back to threads-only mode, behaviorally equivalent to stock Sidekiq.
 
+> Prefer everything in one fetch? See [llms-full.txt](https://developerz-ai.github.io/wurk/llms-full.txt) — this map plus the full text of every guide below, inlined.
+
 ## Three pillars
 
 - **Drop-in.** Same Redis key schema, job JSON, and Ruby DSL. Every public `Wurk::*` class is also exposed under its `Sidekiq::*` name (`Sidekiq::Job`, `Sidekiq::Worker`, `Sidekiq::Batch`, `Sidekiq::Limiter`, `Sidekiq.configure_server`, `Sidekiq::Client`, `Sidekiq::Pro::Web`, `Sidekiq::Enterprise`). Existing jobs, initializers, `sidekiq_options`, and live Redis data keep working. `Sidekiq.pro?` / `Sidekiq.ent?` return `false` (Wurk advertises as free OSS) — never gate behavior on them.

--- a/tasks/llms_full.rb
+++ b/tasks/llms_full.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Builds docs/site/llms-full.txt — the single-fetch, full-content companion to
+# llms.txt for AI agents that would rather inline everything than follow links.
+# Generated (never hand-edited) from the canonical guides so it cannot drift:
+# the llms.txt map up top, then each user-facing guide inlined verbatim.
+#
+# `rake docs:llms_full` writes the file; the pages workflow regenerates it on
+# every publish; llms_full_test.rb exercises this builder so a removed/renamed
+# source doc fails CI instead of silently dropping out of the dump.
+module WurkDocs
+  module LlmsFull
+    # The concise map (already published at /wurk/llms.txt). Inlined first so a
+    # full-text reader still gets the H1 + summary + sectioned overview.
+    MAP = 'docs/site/llms.txt'
+
+    # User-facing guides worth inlining whole. The big target/sidekiq-*.md parity
+    # specs (1k+ lines each) are intentionally left as links in the map — too
+    # large to inline, and not the migration-path narrative an agent needs first.
+    DOCS = %w[
+      docs/migrate-from-sidekiq.md
+      docs/running.md
+      docs/deployment.md
+      docs/active-job.md
+      docs/dashboard.md
+      docs/metrics-history.md
+    ].freeze
+
+    def self.build(root)
+      sections = [File.read(File.join(root, MAP)).rstrip]
+      intro = 'The complete text of each guide linked above, inlined for single-fetch reading.'
+      sections << "---\n\n# Full documents\n\n#{intro}"
+      DOCS.each do |rel|
+        body = File.read(File.join(root, rel)).rstrip
+        sections << "---\n\n<!-- source: #{rel} -->\n\n#{body}"
+      end
+      "#{sections.join("\n\n")}\n"
+    end
+
+    def self.write(root)
+      out = File.join(root, 'docs/site/llms-full.txt')
+      File.write(out, build(root))
+      out
+    end
+  end
+end

--- a/test/unit/llms_full_test.rb
+++ b/test/unit/llms_full_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require_relative '../../tasks/llms_full'
+
+# Exercises the llms-full.txt generator (#255 optional deliverable). The file
+# itself is build-time generated (gitignored, written by `rake docs:llms_full`
+# in the pages workflow), so this tests the builder: a renamed/removed source
+# doc, or a dropped map section, fails CI instead of silently shrinking the dump.
+class LlmsFullTest < Minitest::Test
+  ROOT = File.expand_path('../..', __dir__)
+
+  def setup
+    @text = WurkDocs::LlmsFull.build(ROOT)
+  end
+
+  def test_starts_with_the_map_h1_and_summary
+    assert_match(/\A# Wurk\n/, @text, 'llms-full must lead with the H1 (llms.txt map first)')
+    assert_match(/^> Wurk is a /, @text, 'must carry the blockquote summary')
+    assert_includes @text, '# Full documents', 'must separate the inlined full guides'
+  end
+
+  def test_every_source_doc_exists_and_is_inlined
+    WurkDocs::LlmsFull::DOCS.each do |rel|
+      assert_path_exists File.join(ROOT, rel), "generator references a missing doc: #{rel}"
+      assert_includes @text, "<!-- source: #{rel} -->", "#{rel} not inlined in llms-full"
+    end
+  end
+
+  def test_inlines_real_guide_content
+    # Anchor on distinctive strings so an empty/placeholder doc is caught.
+    assert_includes @text, 'Concurrency vs parallelism', 'migration-guide body missing'
+    assert_includes @text, 'queue_adapter = :wurk', 'active-job guide body missing'
+  end
+
+  def test_map_source_is_present
+    assert_path_exists File.join(ROOT, WurkDocs::LlmsFull::MAP)
+  end
+end

--- a/test/unit/llms_full_test.rb
+++ b/test/unit/llms_full_test.rb
@@ -8,6 +8,8 @@ require_relative '../../tasks/llms_full'
 # in the pages workflow), so this tests the builder: a renamed/removed source
 # doc, or a dropped map section, fails CI instead of silently shrinking the dump.
 class LlmsFullTest < Minitest::Test
+  parallelize_me!
+
   ROOT = File.expand_path('../..', __dir__)
 
   def setup


### PR DESCRIPTION
Closes #255.

`llms.txt` (the concise map) shipped in #260. This adds the issue's **optional `llms-full.txt`** — the same map *plus the full text of every user-facing guide inlined*, for agents that prefer one fetch over following links. Published at **https://developerz-ai.github.io/wurk/llms-full.txt**.

## Generated, not hand-maintained
Per the issue's "stays current — ideally generated or CI-checked":
- **`tasks/llms_full.rb`** builds it from `docs/site/llms.txt` + the canonical guides (migration, running, deployment, active-job, dashboard, metrics-history). The 1k-line `target/sidekiq-*.md` parity specs stay linked in the map, not inlined.
- **`rake docs:llms_full`** writes `docs/site/llms-full.txt` (gitignored build artifact). The **pages workflow** regenerates it on every publish alongside the YARD docs, and now triggers on `docs/**` + `tasks/llms_full.rb` so any guide edit republishes.
- **`test/unit/llms_full_test.rb`** exercises the builder — a renamed/removed source doc or a dropped map section fails CI instead of silently shrinking the dump.
- Linked from `llms.txt` and the site footer.

## Done-when (#255)
- [x] `llms.txt` (and `llms-full.txt`) served under `developerz-ai.github.io/wurk/` — #260 + this
- [x] llms.txt format (H1, blockquote, sectioned lists) — llms-full leads with the map's H1
- [x] Plain English, token-frugal, claims link to canonical sources
- [x] Wired into the build so it stays current (generated + CI-checked) — this PR
- [x] Links the migration guide + YARD docs — #260

## How to test in prod
Docs-only — nothing to deploy. Locally:
```bash
bundle exec rake docs:llms_full && head -20 docs/site/llms-full.txt
bin/rake test TEST=test/unit/llms_full_test.rb
```
After merge + Pages redeploy: `curl -sI https://developerz-ai.github.io/wurk/llms-full.txt | head -1` → 200.

## Verification
- `bin/rake test` — 2348 runs, 0 failures, 0 errors (6 pre-existing skips).
- Generated output: 1175 lines, H1 first, 6 guides inlined; lint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `llms-full.txt`: a single inlined documentation file that combines the existing docs map with the full contents of all referenced guides.
* **Documentation**
  * Updated the documentation site to link to the new comprehensive resource.
  * Improved docs publishing so the generated `llms-full.txt` is produced and deployed to GitHub Pages.
* **Tests**
  * Added automated tests to verify generation correctness and that all referenced guide content is included.
* **Chores**
  * Ignored the generated `docs/site/llms-full.txt` output file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->