### PR TITLE
bench: real fetch+execute driver replacing the TODO stub (closes #259)

### DIFF
--- a/bench/fetch_execute.rb
+++ b/bench/fetch_execute.rb
@@ -1,17 +1,66 @@
 # frozen_string_literal: true
 
+require "benchmark/ips"
+require "logger"
 require "wurk"
 
-# End-to-end: enqueue, BLMOVE to private list, pop, run middleware chain,
-# invoke perform, ACK. Single child, single thread, no real work in perform.
+# End-to-end fetch+execute — one of the four "Faster" pillar critical paths
+# (CLAUDE.md). Each iteration enqueues one job, then drives the REAL reliable
+# fetcher (atomic LMOVE: public `queue:default` -> per-process private list)
+# and the REAL Processor#process_one: parse JSON, walk the server-middleware
+# chain, invoke `perform`, then ACK (LREM from the private list).
 #
-# STUB — tracked in #259. fetch+execute is one of the four "Faster" pillar
-# critical paths (CLAUDE.md), so this gap is flagged loudly: while the stub
-# stands the bench gate cannot verify perf claims on the end-to-end path.
-# Emitting a benchmark/ips line for `1 + 1` false-positived the noise-aware
-# gate (~14% cross-run jitter on a ~50M i/s baseline > ±5.7% band), so the
-# stub is a no-op + STDERR warning instead.
+# Closed loop (push one, drain one) holds the queue at a steady depth so the
+# fetcher always takes the non-blocking LMOVE branch and never stalls the
+# benchmark on an empty 2s BLMOVE. The measured cost is the fetch + perform +
+# ack Redis round-trips plus the dispatch onion — the path the gate protects.
+# Real Redis round-trips keep throughput in the low thousands i/s, so cross-run
+# jitter sits inside the noise band (unlike the old `1 + 1` stub, #258/#259).
+#
+# Runs on a dedicated Redis logical DB (default 15, like the test layer's
+# fixed-DB slot — DB 0 is never touched) so a stray worker draining `queue:*`
+# on the default DB can't steal our jobs and starve the fetcher into BLMOVE.
+#
+# Gate: >5% regression vs main blocks merge.
 
-warn "[wurk bench] MISSING: fetch+execute driver (TODO, tracked in #259) — " \
-     "critical-path gate cannot verify regressions until this lands"
-puts "fetch_execute bench: TODO (see #259)"
+def bench_redis_url
+  base = ENV["REDIS_URL"] || "redis://localhost:6379/0"
+  db = ENV.fetch("WURK_BENCH_DB", "15")
+  base.match?(%r{/\d+\z}) ? base.sub(%r{/\d+\z}, "/#{db}") : "#{base}/#{db}"
+end
+
+class BenchJob
+  include Wurk::Job
+
+  def perform(*); end
+end
+
+config = Wurk::Configuration.new
+config.logger = Logger.new(IO::NULL)
+config.redis = { url: bench_redis_url }
+config.queues = %w[default]
+capsule = config.default_capsule
+capsule.prepare!
+
+# Isolated scratch DB: a clean slate at both ends keeps the closed loop the
+# only consumer of queue:default, so every LMOVE finds the job we just pushed.
+capsule.redis { |c| c.call("FLUSHDB") }
+capsule.redis { |c| Wurk::Lua::Loader.script_load_all(c) }
+
+client    = Wurk::Client.new(pool: capsule.redis_pool)
+processor = Wurk::Processor.new(capsule)
+job       = { "class" => "BenchJob", "args" => [], "queue" => "default" }
+
+# Seed a small backlog so the first LMOVE of every tick always finds a job.
+3.times { client.push(job.dup) }
+
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+
+  x.report("wurk fetch+execute") do
+    client.push(job.dup)
+    processor.process_one
+  end
+end
+
+capsule.redis { |c| c.call("FLUSHDB") }


### PR DESCRIPTION
Closes #259.

`bench/fetch_execute.rb` was a no-op stub (`puts "fetch_execute bench: TODO"`, #258) because a synthetic `1 + 1` ips line false-positived the noise-aware gate. This replaces it with a **real end-to-end fetch+execute driver** — one of the four "Faster" pillar critical paths the gate must protect (CLAUDE.md).

## What it measures
Each iteration enqueues one job, then drives the **real** machinery:
- `Wurk::Fetcher::Reliable` — atomic LMOVE from `queue:default` → per-process private list,
- `Wurk::Processor#process_one` (its documented "drive the loop step-by-step" entry point) — JSON parse → server-middleware chain → `perform` → ACK (LREM from the private list).

Closed loop (push one, drain one) holds the queue at a steady depth so the fetcher stays on the non-blocking LMOVE branch and never stalls the benchmark on an empty 2s BLMOVE.

## Why isolated Redis (done-when bullet 3)
The driver both **enqueues and consumes** `queue:default`, so any other consumer on the same DB steals its jobs and starves the fetcher into the BLMOVE fallback (I hit exactly this locally — a stray worker dragged it to ~0.6 i/s). It now runs on a dedicated logical DB (default **15**, like the test layer's fixed-DB slot; DB 0 is never touched), `FLUSHDB`-clean at both ends. Override with `WURK_BENCH_DB`.

## Output + gate
Emits a `benchmark/ips` line `wurk fetch+execute` (~1.5k i/s — Redis-bound, so cross-run jitter sits inside the gate's noise band). `bin/bench-compare` picks it up with no changes, so the existing CI gate compares head vs base and **blocks >5% regressions exactly as it does for `enqueue`/`bulk_enqueue`**. On this PR it shows as "new on head" (base still has the stub); once merged it's gated on both sides.

Sibling stubs tracked as follow-ups (done-when bullet 5): **#265** (swarm_boot), **#266** (memory).

## How to test in prod
Bench-only — nothing ships to a job fleet. Locally:
```bash
ruby -Ilib bench/fetch_execute.rb          # ~1.5k i/s "wurk fetch+execute"
bundle exec rake bench                      # full suite; fetch_execute no longer "TODO"
WURK_BENCH_DB=14 ruby -Ilib bench/fetch_execute.rb   # pick a different scratch DB
```

## Verification
- `rake bench` runs the whole suite clean; `fetch_execute` emits a real ips line (was `TODO`).
- `bin/bench-compare` parses the label; self-compare 🟢, base(stub)-vs-head → "new on head" (not gated).
- Matches bench/ house style (double quotes, like `enqueue.rb`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented a functional end-to-end performance benchmark for job queue operations. The new benchmark script replaces a previous placeholder and measures throughput for job enqueueing and processing. It includes proper environment setup and cleanup to provide accurate performance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->