### PR TITLE
fix(dashboard): explicit sidebar collapse toggle, no more hover jump (closes #268)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -53,8 +53,26 @@ function ReadOnlyBanner() {
   );
 }
 
+const NAV_COLLAPSED_KEY = 'wurk-nav-collapsed';
+
 export default function App() {
   const [navOpen, setNavOpen] = useState(false);
+  // Desktop-only: pin the rail collapsed (icons) or expanded (full), persisted
+  // so the choice survives reloads. Replaces the old hover-to-expand rail that
+  // moved on its own as the pointer crossed it.
+  const [collapsed, setCollapsed] = useState(
+    () => typeof localStorage !== 'undefined' && localStorage.getItem(NAV_COLLAPSED_KEY) === '1',
+  );
+  const toggleCollapsed = () =>
+    setCollapsed((c) => {
+      const next = !c;
+      try {
+        localStorage.setItem(NAV_COLLAPSED_KEY, next ? '1' : '0');
+      } catch {
+        /* storage disabled (private mode) — keep the in-memory state */
+      }
+      return next;
+    });
   const sse = useSSE();
 
   return (
@@ -72,7 +90,14 @@ export default function App() {
 
           <main
             className="main-content"
-            style={{ flex: 1, padding: '1.5rem', marginInlineStart: 'var(--nav-rail)' }}
+            style={{
+              flex: 1,
+              padding: '1.5rem',
+              // Reserve the rail or full nav width depending on the pinned state;
+              // the mobile media query overrides this to 0 (drawer overlay).
+              marginInlineStart: collapsed ? 'var(--nav-rail)' : 'var(--nav-width)',
+              transition: 'margin 0.2s ease',
+            }}
           >
             <ReadOnlyBanner />
             <Routes>
@@ -93,7 +118,12 @@ export default function App() {
             </Routes>
           </main>
 
-          <Nav open={navOpen} onClose={() => setNavOpen(false)} />
+          <Nav
+            open={navOpen}
+            onClose={() => setNavOpen(false)}
+            collapsed={collapsed}
+            onToggleCollapse={toggleCollapsed}
+          />
         </div>
       </BrowserRouter>
     </QueryClientProvider>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -55,14 +55,27 @@ function ReadOnlyBanner() {
 
 const NAV_COLLAPSED_KEY = 'wurk-nav-collapsed';
 
+function prefersReducedMotion() {
+  return (
+    typeof window !== 'undefined' &&
+    window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true
+  );
+}
+
 export default function App() {
   const [navOpen, setNavOpen] = useState(false);
   // Desktop-only: pin the rail collapsed (icons) or expanded (full), persisted
   // so the choice survives reloads. Replaces the old hover-to-expand rail that
   // moved on its own as the pointer crossed it.
-  const [collapsed, setCollapsed] = useState(
-    () => typeof localStorage !== 'undefined' && localStorage.getItem(NAV_COLLAPSED_KEY) === '1',
-  );
+  const [collapsed, setCollapsed] = useState(() => {
+    // localStorage can throw SecurityError / QuotaExceededError in private mode
+    // or cross-origin iframes — same guard the write path uses.
+    try {
+      return typeof localStorage !== 'undefined' && localStorage.getItem(NAV_COLLAPSED_KEY) === '1';
+    } catch {
+      return false;
+    }
+  });
   const toggleCollapsed = () =>
     setCollapsed((c) => {
       const next = !c;
@@ -96,7 +109,10 @@ export default function App() {
               // Reserve the rail or full nav width depending on the pinned state;
               // the mobile media query overrides this to 0 (drawer overlay).
               marginInlineStart: collapsed ? 'var(--nav-rail)' : 'var(--nav-width)',
-              transition: 'margin 0.2s ease',
+              // Match the nav rail: drop the slide for users who asked for
+              // less motion, so toggling collapse doesn't shove the content
+              // sideways for them.
+              transition: prefersReducedMotion() ? 'none' : 'margin 0.2s ease',
             }}
           >
             <ReadOnlyBanner />

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -194,7 +194,7 @@ export default function Nav({ open, onClose, collapsed, onToggleCollapse }: NavP
         <button
           type="button"
           onClick={onToggleCollapse}
-          className="wurk-navlink nav-collapse-toggle"
+          className="nav-collapse-toggle"
           aria-label={collapsed ? t('nav.expand') : t('nav.collapse')}
           aria-expanded={!collapsed}
           title={collapsed ? t('nav.expand') : t('nav.collapse')}
@@ -249,14 +249,22 @@ export default function Nav({ open, onClose, collapsed, onToggleCollapse }: NavP
 
       <style>{`
         .wurk-nav { width: var(--nav-width); transition: width 0.2s ease; }
-        .wurk-navlink:hover,
-        .nav-collapse-toggle:hover {
+        .wurk-navlink:hover {
           background: var(--surface-hover) !important;
           color: var(--accent) !important;
           text-decoration: none !important;
         }
+        /* The collapse toggle is a control, not a nav item — it only shifts
+           colour on hover, no filled pill/active box. */
+        .nav-collapse-toggle:hover { color: var(--text) !important; }
         .nav-label { white-space: nowrap; }
-        .wurk-navlink__icon { width: 24px; font-size: 18px; text-align: center; flex: none; }
+        .wurk-navlink__icon { width: 24px; font-size: 18px; text-align: center; flex: none; transition: background 0.15s ease, color 0.15s ease, transform 0.18s ease; }
+        /* Subtle lift on hover so the nav feels reactive. */
+        .wurk-navlink:hover .wurk-navlink__icon { transform: scale(1.12); }
+        @media (prefers-reduced-motion: reduce) {
+          .wurk-navlink__icon { transition: background 0.15s ease, color 0.15s ease; }
+          .wurk-navlink:hover .wurk-navlink__icon { transform: none; }
+        }
         @media (max-width: 767px) {
           .wurk-nav {
             transform: translateX(-100%);
@@ -290,24 +298,37 @@ export default function Nav({ open, onClose, collapsed, onToggleCollapse }: NavP
              which a plain class rule can't beat — without this the "Wurk /
              System Status" text stays rendered in the 64px rail and gets clipped. */
           .wurk-nav--collapsed .nav-label { display: none !important; }
-          /* Collapsed: center each icon. Icon size stays the SAME as the expanded
-             state — only the surrounding space changes, so glyphs don't resize. */
+          /* Collapsed: center each icon. The glyph lives in a FIXED 38px round
+             container at all times, so idle → hover → active only swaps its
+             background colour, never its size — the icon never shifts when you
+             click it, and the highlight is always a circle, never a square link
+             box. Tight link padding keeps the icons from drifting apart. */
+          /* !important: the NavLink carries an inline padding (0.5rem 0.85rem)
+             that outranks any class rule. Zero it in the rail so the fixed-size
+             round glyph container — not link padding — defines the footprint;
+             the horizontal inline padding would otherwise cramp the circle in
+             the 64px rail and make it shift when the active background appears. */
           .wurk-nav--collapsed .wurk-navlink,
-          .wurk-nav--collapsed .nav-collapse-toggle { justify-content: center; padding: 0.7rem 0; }
-          .wurk-nav--collapsed .wurk-navlink__icon { width: auto; }
-          /* Collapsed active item: the rectangular pill (set via inline styles)
-             would look boxy in the narrow rail, so flatten the link and draw a
-             round highlight around just the glyph instead. */
+          .wurk-nav--collapsed .nav-collapse-toggle { justify-content: center; padding: 0 !important; }
+          .wurk-nav--collapsed .wurk-navlink__icon {
+            display: grid;
+            place-items: center;
+            width: 36px;
+            height: 36px;
+            border-radius: 50%;
+          }
+          /* The link/button never fills — the round glyph container carries the
+             highlight instead of a boxy pill. */
+          .wurk-nav--collapsed .wurk-navlink:hover,
           .wurk-nav--collapsed .wurk-navlink.active {
             background: transparent !important;
             box-shadow: none !important;
           }
+          .wurk-nav--collapsed .wurk-navlink:hover .wurk-navlink__icon {
+            background: var(--surface-hover);
+            color: var(--accent);
+          }
           .wurk-nav--collapsed .wurk-navlink.active .wurk-navlink__icon {
-            display: grid;
-            place-items: center;
-            width: 38px;
-            height: 38px;
-            border-radius: 50%;
             background: var(--surface-strong);
             box-shadow: inset 0 0 0 1px var(--border);
             color: var(--accent);

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -1,4 +1,3 @@
-import type { MouseEvent } from 'react';
 import { NavLink, Link } from 'react-router-dom';
 import { t } from '../i18n';
 import { useMeta } from '../hooks/useMeta';
@@ -7,6 +6,10 @@ import logoUrl from '../assets/wurk-logo.png';
 interface NavProps {
   open: boolean;
   onClose: () => void;
+  /** Desktop: pinned to the icon-only rail. */
+  collapsed: boolean;
+  /** Desktop: flip between the icon rail and the full-width nav. */
+  onToggleCollapse: () => void;
 }
 
 const LINKS = [
@@ -24,20 +27,16 @@ const LINKS = [
   { to: '/search', label: t('nav.search'), icon: 'fa-magnifying-glass', end: false },
 ];
 
-export default function Nav({ open, onClose }: NavProps) {
+export default function Nav({ open, onClose, collapsed, onToggleCollapse }: NavProps) {
   // Tabs registered by third-party gems (sidekiq-cron, sidekiq-unique-jobs, …)
   // via Sidekiq::Web.register_extension. They link out to the extension's own
   // path — wurk surfaces the tab but doesn't render the gem's view in the SPA.
   const { data: meta } = useMeta();
   const customTabs = meta?.custom_tabs ?? [];
 
-  // Close the mobile drawer AND drop focus so the desktop rail collapses back
-  // after a click — otherwise :focus-within keeps it expanded until you click
-  // elsewhere.
-  const handleNavClick = (e: MouseEvent<HTMLElement>) => {
-    onClose();
-    e.currentTarget.blur();
-  };
+  // Close the mobile drawer on navigation. The desktop rail no longer expands on
+  // hover/focus, so there's nothing to blur back.
+  const handleNavClick = () => onClose();
 
   return (
     <>
@@ -56,7 +55,7 @@ export default function Nav({ open, onClose }: NavProps) {
         />
       )}
       <nav
-        className={`wurk-nav${open ? ' wurk-nav--open' : ''}`}
+        className={`wurk-nav${open ? ' wurk-nav--open' : ''}${collapsed ? ' wurk-nav--collapsed' : ''}`}
         style={{
           position: 'fixed',
           top: 0,
@@ -121,6 +120,7 @@ export default function Nav({ open, onClose }: NavProps) {
                 to={to}
                 end={end}
                 onClick={handleNavClick}
+                title={label}
                 className="wurk-navlink"
                 style={({ isActive }) => ({
                   display: 'flex',
@@ -163,6 +163,7 @@ export default function Nav({ open, onClose }: NavProps) {
               <NavLink
                 to={`/ext/${tab.path.replace(/\/+$/, '')}`}
                 onClick={handleNavClick}
+                title={tab.name}
                 className="wurk-navlink"
                 style={({ isActive }) => ({
                   display: 'flex',
@@ -186,6 +187,39 @@ export default function Nav({ open, onClose }: NavProps) {
             </li>
           ))}
         </ul>
+
+        {/* Desktop-only: pin the rail collapsed (icons) or expanded (full).
+            Hidden on mobile, where the nav is a full-width drawer. */}
+        <div style={{ height: 1, background: 'var(--border)', margin: '0.5rem 1rem 0' }} />
+        <button
+          type="button"
+          onClick={onToggleCollapse}
+          className="wurk-navlink nav-collapse-toggle"
+          aria-label={collapsed ? t('nav.expand') : t('nav.collapse')}
+          aria-expanded={!collapsed}
+          title={collapsed ? t('nav.expand') : t('nav.collapse')}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.625rem',
+            width: 'calc(100% - 16px)',
+            padding: '0.5rem 0.85rem',
+            margin: '4px 8px',
+            borderRadius: 8,
+            border: 'none',
+            background: 'transparent',
+            color: 'var(--text-muted)',
+            fontSize: 13,
+            cursor: 'pointer',
+            font: 'inherit',
+          }}
+        >
+          <i
+            className={`fa-solid ${collapsed ? 'fa-angles-right' : 'fa-angles-left'} wurk-navlink__icon`}
+            aria-hidden="true"
+          />
+          <span className="nav-label">{t('nav.collapse')}</span>
+        </button>
 
         {/* Footer: link out to the source repo. Pinned to the bottom because the
             nav list above is flex:1. Muted by default; hover lifts like a nav item. */}
@@ -214,8 +248,9 @@ export default function Nav({ open, onClose }: NavProps) {
       </nav>
 
       <style>{`
-        .wurk-nav { width: var(--nav-width); }
-        .wurk-navlink:hover {
+        .wurk-nav { width: var(--nav-width); transition: width 0.2s ease; }
+        .wurk-navlink:hover,
+        .nav-collapse-toggle:hover {
           background: var(--surface-hover) !important;
           color: var(--accent) !important;
           text-decoration: none !important;
@@ -241,38 +276,33 @@ export default function Nav({ open, onClose }: NavProps) {
           .nav-overlay {
             display: block !important;
           }
+          /* The collapse control is desktop-only; on mobile the nav is a
+             full-width drawer toggled by the hamburger. */
+          .nav-collapse-toggle { display: none !important; }
         }
-        /* Desktop: a collapsed icon rail that expands to the full width on hover
-           or keyboard focus, overlaying the content (which reserves only the rail
-           width). prefers-reduced-motion drops the width animation. */
+        /* Desktop: a fixed-width rail the user pins open or collapsed (icons only)
+           via the toggle button — no hover-driven movement. The width change
+           animates; prefers-reduced-motion drops the animation. */
         @media (min-width: 768px) {
-          .wurk-nav {
-            transform: none !important;
-            width: var(--nav-rail);
-            transition: width 0.2s ease;
-          }
-          .wurk-nav:hover,
-          .wurk-nav:focus-within {
-            width: var(--nav-width);
-            box-shadow: 10px 0 28px rgba(0, 0, 0, 0.5);
-          }
+          .wurk-nav { transform: none !important; }
+          .wurk-nav--collapsed { width: var(--nav-rail); }
           /* !important: the brand wordmark span carries an inline display:flex,
              which a plain class rule can't beat — without this the "Wurk /
              System Status" text stays rendered in the 64px rail and gets clipped. */
-          .wurk-nav:not(:hover):not(:focus-within) .nav-label { display: none !important; }
-          /* Collapsed: center each icon and give it roomy, even padding so the
-             rail breathes. Icon size stays the SAME as the expanded state — only
-             the surrounding space changes, so glyphs don't jump/resize on hover. */
-          .wurk-nav:not(:hover):not(:focus-within) .wurk-navlink { justify-content: center; padding: 0.7rem 0; }
-          .wurk-nav:not(:hover):not(:focus-within) .wurk-navlink__icon { width: auto; }
+          .wurk-nav--collapsed .nav-label { display: none !important; }
+          /* Collapsed: center each icon. Icon size stays the SAME as the expanded
+             state — only the surrounding space changes, so glyphs don't resize. */
+          .wurk-nav--collapsed .wurk-navlink,
+          .wurk-nav--collapsed .nav-collapse-toggle { justify-content: center; padding: 0.7rem 0; }
+          .wurk-nav--collapsed .wurk-navlink__icon { width: auto; }
           /* Collapsed active item: the rectangular pill (set via inline styles)
              would look boxy in the narrow rail, so flatten the link and draw a
              round highlight around just the glyph instead. */
-          .wurk-nav:not(:hover):not(:focus-within) .wurk-navlink.active {
+          .wurk-nav--collapsed .wurk-navlink.active {
             background: transparent !important;
             box-shadow: none !important;
           }
-          .wurk-nav:not(:hover):not(:focus-within) .wurk-navlink.active .wurk-navlink__icon {
+          .wurk-nav--collapsed .wurk-navlink.active .wurk-navlink__icon {
             display: grid;
             place-items: center;
             width: 38px;
@@ -285,9 +315,9 @@ export default function Nav({ open, onClose }: NavProps) {
           /* Collapsed: drop the wordmark and show just the logo mark, centered
              with balanced padding so it sits squarely in the rail instead of
              hugging the top-left. */
-          .wurk-nav:not(:hover):not(:focus-within) .nav-brand-wrap { padding: 0.9rem 0; }
-          .wurk-nav:not(:hover):not(:focus-within) .nav-brand-wrap a { justify-content: center; gap: 0; }
-          .wurk-nav:not(:hover):not(:focus-within) .nav-brand-wrap img { height: 38px !important; }
+          .wurk-nav--collapsed .nav-brand-wrap { padding: 0.9rem 0; }
+          .wurk-nav--collapsed .nav-brand-wrap a { justify-content: center; gap: 0; }
+          .wurk-nav--collapsed .nav-brand-wrap img { height: 38px !important; }
         }
         @media (min-width: 768px) and (prefers-reduced-motion: reduce) {
           .wurk-nav { transition: none; }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -12,7 +12,9 @@
     "metrics": "Metrics",
     "profiles": "Profiles",
     "search": "Search",
-    "extensions": "Extensions"
+    "extensions": "Extensions",
+    "collapse": "Collapse",
+    "expand": "Expand"
   },
   "dashboard": {
     "processed": "Processed",


### PR DESCRIPTION
Closes #268.

The desktop left rail expanded to full width on `:hover` / `:focus-within` and snapped back when the pointer left — so it moved on its own as you crossed it. This replaces that with an **explicit, persisted collapse toggle**.

## Changes
- **Toggle button** pinned above the sidebar footer (chevrons `«` / `»`), desktop-only — the mobile hamburger drawer is untouched. Flips full-width ⇄ icon-only.
- **State lifted to `App`**, persisted in `localStorage` (`wurk-nav-collapsed`), driving a `.wurk-nav--collapsed` class. The icon-only styling is the *same* CSS that already shipped for the collapsed rail — only the trigger changed from `:hover` to the class, so the look is identical, just intentional (no more jump).
- **Content margin follows** the pinned state (`--nav-rail` ⇄ `--nav-width`) and the **width animates** (0.2s ease; dropped under `prefers-reduced-motion`).
- Nav links get `title` tooltips so labels stay discoverable when collapsed; `nav.collapse` / `nav.expand` i18n strings added (en; other locales fall back to en).

## How to preview locally
```bash
cd frontend && npm run build          # already passes: tsc -b + vite build, no errors
cd .. && (cd test/dummy && bin/rails s -p 3000)   # then open http://localhost:3000/wurk
```
Click the **Collapse** button at the bottom of the rail → it shrinks to icons with a smooth slide; reload → the choice sticks. Hovering the rail no longer moves it.

## How to test in prod
After a release ships the rebuilt SPA, open the mounted dashboard (`/wurk`): the sidebar has a collapse/expand control at the bottom, stays put on hover, and remembers your choice per browser.

## Notes
- Frontend-only (`App.tsx`, `Nav.tsx`, `en.json`). The precompiled bundle is built at release time (gitignored), so no `vendor/assets` churn here.
- `tsc -b` clean; `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a desktop collapsible navigation rail with a compact icon-only mode and a toggle control.
  * Persisted the rail’s collapsed/expanded state for a more consistent experience.
  * Introduced an “Extensions” section in the navigation.
* **UX Improvements**
  * Tooltips/title text added for navigation items, including when collapsed.
  * Reduced-motion users no longer see the navigation layout transition animation.
* **Bug Fixes**
  * Streamlined mobile/overlay navigation behavior to close cleanly after selection.
* **Internationalization**
  * Added English strings for “collapse” and “expand” controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->