### PR TITLE
ci: gate PRs on the dashboard Vitest suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,3 +153,28 @@ jobs:
           name: coverage
           path: coverage/coverage.xml
           if-no-files-found: warn
+
+  # The matrix `test` and `coverage` jobs only *build* the SPA (tsc + vite) via
+  # `rake frontend:build`; hand-written frontend types can typecheck clean yet
+  # null-render at runtime (#272), so the build alone is not a regression gate.
+  # This dedicated Node-only job runs the dashboard's Vitest suite on every PR
+  # (no Ruby/Redis needed; the suite is fast). Closes #273.
+  frontend:
+    name: frontend (vitest)
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+      - name: install dashboard deps
+        run: npm ci
+        working-directory: frontend
+      - name: vitest
+        run: npm run test
+        working-directory: frontend


### PR DESCRIPTION
## What

Add a dedicated `frontend (vitest)` CI job so the dashboard's existing Vitest suite gates PRs. Closes #273.

## Why

`frontend/package.json` defines `test: vitest run` with 4 committed suites (25 tests), but no workflow runs them — CI only *builds* the SPA via `rake frontend:build` (tsc + vite). `tsc` can typecheck clean while the app null-renders at runtime (exactly how #272's `/dead` white-screen shipped), so the build step is not a regression gate. Frontend regressions currently merge unblocked.

## Changes

- `.github/workflows/test.yml`: new `frontend (vitest)` job, sibling to `test` / `parity` / `coverage`. Node-only (no Ruby/Redis): `blacksmith-4vcpu-ubuntu-2404`, `timeout-minutes: 10`, pinned `actions/setup-node@v6` (node 24, npm cache on `frontend/package-lock.json`), `npm ci` + `npm run test` in `frontend/`. Inherits the workflow-level `concurrency` group and `contents: read` permissions.

## Notes / decisions

- **Runs unconditionally (no `frontend/**` path filter).** A path-filtered *required* check hangs "Expected — waiting for status" on backend-only PRs and blocks merge forever (a known GitHub trap). The job is ~2s and the existing `test` job already runs the full node/vite toolchain on every PR, so an always-on run is consistent and negligible. Deliberate deviation from the issue's "gated on frontend/**" wording.
- **No new tests in this PR.** The `/dead` null-`error_class` regression test is red on current `main` (it only goes green once #272's `truncate` guard + serializer normalize land), so adding it here would block the gate. It rides with #272 as one atomic red->green change. The #273 acceptance criterion "the /dead null case is covered by a test that runs in CI" closes jointly: this PR builds the gate, #272 delivers the test the gate runs.

## Verification

- Frontend suite locally on this branch: `cd frontend && npm ci && npm run test` -> 4 files / 25 tests pass (~2.3s, node 24).
- Workflow YAML is not gated by the repo's Ruby suite, so verified manually: `actionlint .github/workflows/test.yml` reports only the pre-existing `blacksmith-4vcpu-ubuntu-2404` unknown-label warning (identical on the existing `test`/`parity`/`coverage` jobs — actionlint doesn't know Blacksmith's custom runner label; it resolves on the real runner). No other findings. Additive change — existing Ruby gates and the required `test (x, y)` contexts are unaffected.

## Post-merge (admin, ordering-sensitive)

After the `frontend (vitest)` job reports green once, add `frontend (vitest)` to `main` branch-protection required status checks. Do NOT register it before it has reported at least once, or open PRs will hang on a phantom required check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated frontend test coverage on pull requests to help catch dashboard regressions earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->