### PR TITLE
fix(dashboard): tolerate null error_class/error_message on dead/retry rows (closes #272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Wurk are recorded here. Format: [Keep a Changelog](https:
 
 ### Fixed
 - **Dashboard — null `error_class`/`error_message` white-screen** — `/wurk/dead`, `/wurk/search`, and `/wurk/retries` crashed to a blank page when a dead/retry entry had no error fields. Only `JobRetry#stamp_error` stamps those fields, so any job that reached the dead set via `DeadSet#kill`, "kill all", encryption route-to-dead, or a direct Sidekiq migration carried `null` — and the SPA fed it straight into `truncate(s: string)`, throwing `null.length`. `truncate` is now null-safe and the dead-set serializer coerces both fields to `""` (the `DeadSet#kill` stored payload stays raw/Sidekiq-wire-compatible). The `error_class`/`error_message` TS types are corrected to `string | null` so `tsc` enforces the contract. (#272)
+- **Dashboard — nav icons jump right on collapse** — clicking the rail collapse toggle applied `justify-content: center` to the nav items instantly while the nav width animated 248→64px, so the icons/logo re-centred against the still-wide nav and leapt right before gliding back. The collapsed controls are now pinned to a fixed rail-width box anchored at the nav's start edge, so each glyph's centre stays on the constant rail mid-line throughout the animation. (#272)
 
 ## [1.0.4] - 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Wurk are recorded here. Format: [Keep a Changelog](https:
 
 ## [Unreleased]
 
+## [1.0.5] - 2026-06-25
+
+### Fixed
+- **Dashboard — null `error_class`/`error_message` white-screen** — `/wurk/dead`, `/wurk/search`, and `/wurk/retries` crashed to a blank page when a dead/retry entry had no error fields. Only `JobRetry#stamp_error` stamps those fields, so any job that reached the dead set via `DeadSet#kill`, "kill all", encryption route-to-dead, or a direct Sidekiq migration carried `null` — and the SPA fed it straight into `truncate(s: string)`, throwing `null.length`. `truncate` is now null-safe and the dead-set serializer coerces both fields to `""` (the `DeadSet#kill` stored payload stays raw/Sidekiq-wire-compatible). The `error_class`/`error_message` TS types are corrected to `string | null` so `tsc` enforces the contract. (#272)
+
 ## [1.0.4] - 2026-06-22
 
 ### Changed

--- a/app/controllers/wurk/api/serializers.rb
+++ b/app/controllers/wurk/api/serializers.rb
@@ -56,8 +56,8 @@ module Wurk
         job_record(entry).merge(
           score: entry.score,
           at: entry.at.to_f,
-          error_class: entry['error_class'],
-          error_message: entry['error_message'],
+          error_class: entry['error_class'].to_s,
+          error_message: entry['error_message'].to_s,
           retry_count: entry['retry_count'],
           error_backtrace: entry.error_backtrace
         )

--- a/frontend/src/components/JobDetailModal.tsx
+++ b/frontend/src/components/JobDetailModal.tsx
@@ -16,8 +16,8 @@ export interface JobEntry {
   created_at?: number | null;
   at?: number;
   retry_count?: number;
-  error_class?: string;
-  error_message?: string;
+  error_class?: string | null;
+  error_message?: string | null;
   error_backtrace?: string[] | null;
   // [label, value] rows contributed by third-party extensions via
   // Sidekiq::Web.custom_job_info_rows (spec §25.2).

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -346,7 +346,12 @@ export default function Nav({ open, onClose, collapsed, onToggleCollapse }: NavP
           /* Collapsed: drop the wordmark and show just the logo mark, centered
              with balanced padding so it sits squarely in the rail instead of
              hugging the top-left. */
-          .wurk-nav--collapsed .nav-brand-wrap { padding: 0.9rem 0; }
+          /* !important: the wrap carries an inline padding (1.25rem 1rem 0.75rem)
+             whose 1rem sides a plain class rule can't beat — leaving it in place
+             offsets the fixed-width brand box below by 16px, so the centred logo
+             lands right-of-centre in the rail. Zero the sides so the box anchors
+             at the nav's start edge and the logo sits on the rail mid-line. */
+          .wurk-nav--collapsed .nav-brand-wrap { padding: 0.9rem 0 !important; }
           /* Same fixed rail-width box as the nav controls above, so the logo
              centres on the constant rail mid-line instead of leaping right
              against the animating nav width on collapse. */

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -307,9 +307,19 @@ export default function Nav({ open, onClose, collapsed, onToggleCollapse }: NavP
              that outranks any class rule. Zero it in the rail so the fixed-size
              round glyph container — not link padding — defines the footprint;
              the horizontal inline padding would otherwise cramp the circle in
-             the 64px rail and make it shift when the active background appears. */
+             the 64px rail and make it shift when the active background appears.
+             width/margin pin each control to a fixed rail-width box anchored at
+             the nav's start edge, so the centred glyph sits on a constant x
+             (rail/2). Without this, justify-content:center re-centres against the
+             *animating* nav width (248→64px), so the icons leap right on collapse
+             and glide back — a visible jump (#272 follow-up). */
           .wurk-nav--collapsed .wurk-navlink,
-          .wurk-nav--collapsed .nav-collapse-toggle { justify-content: center; padding: 0 !important; }
+          .wurk-nav--collapsed .nav-collapse-toggle {
+            justify-content: center;
+            width: var(--nav-rail) !important;
+            margin-inline: 0 !important;
+            padding: 0 !important;
+          }
           .wurk-nav--collapsed .wurk-navlink__icon {
             display: grid;
             place-items: center;
@@ -337,7 +347,10 @@ export default function Nav({ open, onClose, collapsed, onToggleCollapse }: NavP
              with balanced padding so it sits squarely in the rail instead of
              hugging the top-left. */
           .wurk-nav--collapsed .nav-brand-wrap { padding: 0.9rem 0; }
-          .wurk-nav--collapsed .nav-brand-wrap a { justify-content: center; gap: 0; }
+          /* Same fixed rail-width box as the nav controls above, so the logo
+             centres on the constant rail mid-line instead of leaping right
+             against the animating nav width on collapse. */
+          .wurk-nav--collapsed .nav-brand-wrap a { justify-content: center; gap: 0; width: var(--nav-rail); }
           .wurk-nav--collapsed .nav-brand-wrap img { height: 38px !important; }
         }
         @media (min-width: 768px) and (prefers-reduced-motion: reduce) {

--- a/frontend/src/pages/Dead.tsx
+++ b/frontend/src/pages/Dead.tsx
@@ -18,8 +18,8 @@ interface DeadEntry {
   jid: string;
   klass: string;
   args: unknown;
-  error_class: string;
-  error_message: string;
+  error_class: string | null;
+  error_message: string | null;
   // `at` is the death epoch (the sorted-set score); see api/serializers.rb#sorted_entry.
   at: number;
   score: number;
@@ -138,10 +138,10 @@ export default function Dead() {
                       </td>
                       <td style={{ fontWeight: 500 }}>{entry.klass}</td>
                       <td><ArgsValue str={argsStr} max={40} /></td>
-                      <td title={entry.error_class} style={{ color: 'var(--danger)' }}>
+                      <td title={entry.error_class ?? ''} style={{ color: 'var(--danger)' }}>
                         {truncate(entry.error_class, 25)}
                       </td>
-                      <td title={entry.error_message}>{truncate(entry.error_message, 40)}</td>
+                      <td title={entry.error_message ?? ''}>{truncate(entry.error_message, 40)}</td>
                       <td title={isoTime(entry.at)}>
                         {relativeTime(entry.at)}
                       </td>

--- a/frontend/src/pages/Retries.tsx
+++ b/frontend/src/pages/Retries.tsx
@@ -18,8 +18,8 @@ interface RetryEntry {
   jid: string;
   klass: string;
   args: unknown;
-  error_class: string;
-  error_message: string;
+  error_class: string | null;
+  error_message: string | null;
   // `at` is the next-retry epoch (the sorted-set score); see api/serializers.rb#sorted_entry.
   at: number;
   retry_count: number;
@@ -139,10 +139,10 @@ export default function Retries() {
                       )}
                       <td style={{ fontWeight: 500 }}>{entry.klass}</td>
                       <td><ArgsValue str={argsStr} max={40} /></td>
-                      <td title={entry.error_class} style={{ color: 'var(--danger)' }}>
+                      <td title={entry.error_class ?? ''} style={{ color: 'var(--danger)' }}>
                         {truncate(entry.error_class, 30)}
                       </td>
-                      <td title={entry.error_message}>{truncate(entry.error_message, 50)}</td>
+                      <td title={entry.error_message ?? ''}>{truncate(entry.error_message, 50)}</td>
                       <td style={{ color: 'var(--warning)' }}>{entry.retry_count}</td>
                       <td title={isoTime(entry.at)}>
                         {relativeTime(entry.at)}

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -8,8 +8,8 @@ interface RetryEntry {
   jid: string;
   klass: string;
   args: unknown;
-  error_class: string;
-  error_message: string;
+  error_class: string | null;
+  error_message: string | null;
   failed_at: number;
   retry_at: number;
   retried_at: number | null;
@@ -29,8 +29,8 @@ interface DeadEntry {
   jid: string;
   klass: string;
   args: unknown;
-  error_class: string;
-  error_message: string;
+  error_class: string | null;
+  error_message: string | null;
   failed_at: number;
   score: number;
 }
@@ -210,7 +210,7 @@ export default function Search() {
                       </td>
                       <td style={{ fontWeight: 500 }}>{entry.klass}</td>
                       <td title={argsStr}>{truncate(argsStr, 40)}</td>
-                      <td title={entry.error_class} style={{ color: 'var(--danger)' }}>
+                      <td title={entry.error_class ?? ''} style={{ color: 'var(--danger)' }}>
                         {truncate(entry.error_class, 25)}
                       </td>
                       <td>{entry.retry_count}</td>
@@ -285,7 +285,7 @@ export default function Search() {
                       </td>
                       <td style={{ fontWeight: 500 }}>{entry.klass}</td>
                       <td title={argsStr}>{truncate(argsStr, 40)}</td>
-                      <td title={entry.error_class} style={{ color: 'var(--danger)' }}>
+                      <td title={entry.error_class ?? ''} style={{ color: 'var(--danger)' }}>
                         {truncate(entry.error_class, 25)}
                       </td>
                       <td>{relativeTime(entry.failed_at)}</td>

--- a/frontend/src/utils.test.ts
+++ b/frontend/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatDuration, formatKb } from './utils';
+import { formatDuration, formatKb, truncate } from './utils';
 
 describe('formatDuration', () => {
   it('guards non-finite input', () => {
@@ -47,5 +47,19 @@ describe('formatKb', () => {
     expect(formatKb(500)).toBe('500 KB');
     expect(formatKb(524288)).toBe('512 MB');
     expect(formatKb(16777216)).toBe('16.0 GB');
+  });
+});
+
+describe('truncate', () => {
+  // Killed/migrated dead jobs carry null error_class/error_message; the dead-row
+  // map fed those straight in and null.length white-screened /dead (issue #272).
+  it('renders null/undefined as empty string instead of throwing', () => {
+    expect(truncate(null)).toBe('');
+    expect(truncate(undefined)).toBe('');
+  });
+
+  it('passes short strings through and ellipsizes long ones', () => {
+    expect(truncate('short', 25)).toBe('short');
+    expect(truncate('x'.repeat(30), 25)).toBe(`${'x'.repeat(25)}…`);
   });
 });

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -54,7 +54,8 @@ export function formatKb(kb: number): string {
   return `${(mb / 1024).toFixed(1)} GB`;
 }
 
-export function truncate(s: string, max = 80): string {
+export function truncate(s: string | null | undefined, max = 80): string {
+  if (s == null) return '';
   if (s.length <= max) return s;
   return s.slice(0, max) + '…';
 }

--- a/lib/wurk/version.rb
+++ b/lib/wurk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wurk
-  VERSION = "1.0.4"
+  VERSION = "1.0.5"
 end

--- a/test/unit/api_serializers_test.rb
+++ b/test/unit/api_serializers_test.rb
@@ -45,6 +45,21 @@ class ApiSerializersTest < Wurk::Test::UnitCase
     assert_equal [%w[OK abc]], Wurk::Api::Serializers.job_record(record)[:custom_rows]
   end
 
+  # A dead/retry entry that reached the set via kill/"kill all"/encryption
+  # route-to-dead, or a direct Sidekiq migration, carries no error_class /
+  # error_message — only JobRetry#stamp_error sets them. The serializer must
+  # emit "" not null, or the SPA's truncate() throws on null.length and white-
+  # screens /dead, /search, /retries (issue #272).
+  def test_sorted_entry_coerces_absent_error_fields_to_empty_string
+    entry = Wurk::SortedEntry.new(nil, 100.0,
+                                  { 'class' => 'MyJob', 'args' => [1], 'jid' => 'abc', 'queue' => 'default' })
+
+    out = Wurk::Api::Serializers.sorted_entry(entry)
+
+    assert_equal '', out[:error_class]
+    assert_equal '', out[:error_message]
+  end
+
   private
 
   def record


### PR DESCRIPTION
## Summary

`/wurk/dead`, `/wurk/search`, and `/wurk/retries` white-screened when a dead/retry entry had no `error_class`/`error_message`. Only `JobRetry#stamp_error` stamps those fields, so any job that reached the set via `DeadSet#kill`, "kill all", encryption route-to-dead, or a **direct Sidekiq migration** carried `null` — and the SPA fed it straight into `truncate(s: string)`, so `null.length` threw and React unmounted the whole page. Reported by @sebyx07 on a migrated app, triaged by @ivndev001 (#272).

## Fix

- **Frontend chokepoint** — `truncate()` is null-safe (`s == null → ''`), covering every error cell on all three pages in one place.
- **Honest wire contract** — the dead-set serializer coerces both fields to `""`. The `DeadSet#kill` *stored* payload stays raw/Sidekiq-wire-compatible — only the JSON response is normalized.
- **Stop the type lie** — `error_class`/`error_message` are now `string | null` in `Dead.tsx`, `Retries.tsx`, `Search.tsx`, and `JobDetailModal`'s `JobEntry`, so `tsc` enforces reality (it surfaced the downstream `title=` attrs, now guarded).
- **Regression tests** — serializer coerces absent error fields to `""`; `truncate(null)`/`truncate(undefined)` return `''`.

Version bump **1.0.4 → 1.0.5** + CHANGELOG for the release/infra pickup.

## Verification (run locally)

- `GET /wurk/api/dead` on a kill-shaped set → **200**, every row `error_class=""`/`error_message=""` (0 nulls). Page renders instead of white-screening.
- Behavioral driver (real Redis + real serializer + mimic of the dead-row `truncate`): **PASS**.
- `tsc -b` clean · 27 vitest · full backend suite **2349 runs / 0 failures** · parity **23 / 0**.

## How to test in prod

After deploying a build with this change, seed a kill-shaped dead job (no error fields) and confirm the dashboard renders:

```ruby
# rails console (or a one-off task) against your wurk Redis
payload = { 'class' => 'AnyJob', 'args' => [], 'jid' => SecureRandom.hex(12),
            'queue' => 'default', 'created_at' => Time.now.to_f }
Wurk::DeadSet.new.kill(Wurk.dump_json(payload), notify_failure: false)
```

Then open `/wurk/dead` (and `/wurk/search`, `/wurk/retries`) — the table renders with empty Error columns. Equivalently, hit **Kill** on a never-failed job, or check a freshly migrated-from-Sidekiq dead set.

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made dashboard error rendering null-safe so missing error details no longer cause blank-page crashes.
  * Updated job/retry/dead tables to safely handle missing or null error fields (including null-safe truncation/display).
  * Improved collapsed navigation so icons and branding remain correctly aligned during rail width animation.

* **Chores**
  * Updated the app version to **v1.0.5**.

* **Tests**
  * Added unit tests to confirm null-safe error display and truncation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->