### PR TITLE
fix(release): re-track vendor .keep + harden clean-tree gate (unblocks v1.0.5)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,9 +14,13 @@ DASHBOARD_BUNDLE_DIR = File.join(VENDOR_ASSETS_DIR, "dashboard")
 # The raising assertions live in tasks/release_helpers.rb (testable, not
 # shipped in the gem). Only the clean-tree check stays here — it shells out to
 # git and is meaningful only from a working tree. The dashboard bundle is built,
-# not committed, so the clean-tree check ignores vendor/assets/.
+# not committed, so the clean-tree check ignores vendor/. We match "vendor/"
+# (not "vendor/assets/") on purpose: if the tracked vendor/assets/dashboard/.keep
+# placeholder ever goes missing, vendor/ holds no tracked file and git collapses
+# the whole built bundle to a single "?? vendor/" line — which "vendor/assets/"
+# wouldn't catch, failing the release on its own build output (see #272 fallout).
 def release_tree_clean!
-  dirty = `git status --porcelain`.lines.reject { |line| line.include?("vendor/assets/") }
+  dirty = `git status --porcelain`.lines.reject { |line| line.include?("vendor/") }
   return if dirty.empty?
 
   abort "release:check ✗ working tree has uncommitted changes:\n#{dirty.join}"


### PR DESCRIPTION
## Why

The **v1.0.5 release workflow failed** at the gate:

```
release:check ✗ working tree has uncommitted changes:
?? vendor/
```

PR #275's last commit accidentally deleted the tracked `vendor/assets/dashboard/.keep` placeholder (vite `--emptyOutDir` wiped it; the restore ran from the wrong cwd and `git add -A` committed the deletion). With **no** tracked file under `vendor/`, git collapses the freshly built dashboard bundle into a single `?? vendor/` line — which `release_tree_clean!`'s `vendor/assets/` filter doesn't match — so the release aborts on its own build output.

`.keep` was tracked at v1.0.4 (last good release); this same trap was fixed once before in `dc76691`.

## What

- **Re-track** the empty `vendor/assets/dashboard/.keep` placeholder.
- **Harden** the clean-tree filter to match `vendor/` (not `vendor/assets/`), so a collapsed `?? vendor/` line can't block a release again.

The gem was **not** published (the gate aborts before `gem push`), so once this merges I re-tag `v1.0.5` on the new `main` and the release re-runs cleanly.

## How to test in prod

n/a — release-tooling only. Validation is the green `release` workflow on the re-pushed `v1.0.5` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)