### PR TITLE
chore: add .maintainer.yml (developerz.ai maintainer policy)

### DIFF
--- a/.maintainer.yml
+++ b/.maintainer.yml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://developerz.ai/schemas/maintainer.v1.json
+# developerz.ai maintainer policy — developerz-ai/wurk
+#
+# First dogfood pass: triage-only. The bot qualifies, labels, comments, and
+# asks reporters for missing repro detail. No coding handoff and no auto-merge
+# yet — flip handoff.mode to `webhook` (with a webhook_ref) once a coding-agent
+# hook is wired. Everything not set here uses the schema defaults.
+version: 1
+
+tone:
+  voice: friendly
+  language: en
+
+triage:
+  ask_for_repro: true
+  required_fields: [steps, expected, actual, version]
+  qualify_into: [bug, feature, dupe, question]
+
+handoff:
+  mode: none
+
+pr:
+  wait_for_other_bots: [coderabbit, copilot, dependabot]
+  auto_merge: false
+
+escalate:
+  always: [security, license, cla]
+  ask_before_acting: [breaking_change, major_dep_bump, first_time_contributor, large_pr]
+
+limits:
+  max_comments_per_issue_per_day: 10


### PR DESCRIPTION
Adds the `.maintainer.yml` policy that the **developerz.ai** maintainer agent loads for this repo.

**Triage-only to start** — the bot qualifies, labels, comments, and asks reporters for missing repro detail (`steps`/`expected`/`actual`/`version`). Conservative by design:

- `handoff.mode: none` — no coding handoff yet (flip to `webhook` + a `webhook_ref` once a coding-agent hook is wired).
- `pr.auto_merge: false`; waits for `coderabbit`/`copilot`/`dependabot` (no bot-on-bot loops).
- Escalates `security`/`license`/`cla` always; asks before acting on `breaking_change`/`major_dep_bump`/`first_time_contributor`/`large_pr`.

Everything else uses the v1 schema defaults. Validated against the policy schema (`parseYaml` + `validate` → ok).

Merge this once the developerz.ai GitHub App is installed on the repo, and the agent will start triaging new issues/PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added maintainer policy settings to standardize issue and pull request handling.
  * Enabled triage-focused responses that request reproduction details and categorize incoming issues.
  * Set safeguards for sensitive cases such as security, licensing, and contributor agreements.
  * Added extra checks before major changes and limited repeated issue comments to reduce noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->