### PR TITLE
ci(bench): skip bench + compare when no Ruby/bench inputs change

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,9 +1,35 @@
 name: bench
 
+# Cost control: `rake bench` measures Ruby throughput only, so it can only be
+# affected by Ruby/bench inputs. Gate the whole workflow (incl. the expensive
+# 8vcpu best-of-3 `compare` job) on those paths so frontend-, docs-, test-, and
+# unrelated-CI-only PRs don't spin up bench runners for nothing. Keep this list
+# in sync with whatever `rake bench` loads. (bench/compare are not required
+# checks — a skipped run leaves no pending status to block merges.)
 on:
   pull_request:
+    paths:
+      - 'lib/**'
+      - 'exe/**'
+      - 'bench/**'
+      - 'bin/bench-compare'
+      - 'Rakefile'
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - '*.gemspec'
+      - '.github/workflows/bench.yml'
   push:
     branches: [main]
+    paths:
+      - 'lib/**'
+      - 'exe/**'
+      - 'bench/**'
+      - 'bin/bench-compare'
+      - 'Rakefile'
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - '*.gemspec'
+      - '.github/workflows/bench.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why

`rake bench` measures **Ruby throughput only**. It cannot be affected by a CSS, docs, test, or unrelated-CI change — yet the `bench` workflow (including the expensive **8vcpu best-of-3 `compare`** job that runs the suite 3× on base *and* 3× on head) fired on **every** PR and every push to `main`. That's a lot of pricey bench-runner minutes spent measuring nothing.

## What

Gate the whole `bench` workflow on a `paths` allowlist for both `pull_request` and `push`:

```
lib/**  ·  exe/**  ·  bench/**  ·  bin/bench-compare
Rakefile  ·  Gemfile  ·  Gemfile.lock  ·  *.gemspec  ·  .github/workflows/bench.yml
```

Frontend-, docs-, test-, and unrelated-CI-only PRs now skip bench entirely (e.g. the dashboard SCSS PR would no longer spin up 8vcpu bench + compare runners).

## Safety

- **Zero methodology change.** When bench *does* run it's the same best-of-3, same-machine base-vs-head, same 8vcpu SKU — the noise-aware regression gate (`base_err% + head_err% + 5%`) is untouched. This only stops the workflow when there's nothing to measure.
- `bench` / `compare` are **not required checks** (per the in-file note, `compare` becomes required "only once it proves stable"), so a skipped run leaves no pending status to block merges.
- YAML validated; the `paths` list is kept in sync with what `rake bench` loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)