### PR TITLE
style(dashboard): nav collapse motion on the shared --dur/--ease scale

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -116,10 +116,12 @@ export default function App() {
               // Reserve the rail or full nav width depending on the pinned state;
               // the mobile media query overrides this to 0 (drawer overlay).
               marginInlineStart: collapsed ? 'var(--nav-rail)' : 'var(--nav-width)',
-              // Match the nav rail: drop the slide for users who asked for
-              // less motion, so toggling collapse doesn't shove the content
-              // sideways for them.
-              transition: prefersReducedMotion() ? 'none' : 'margin 0.2s ease',
+              // Match the nav rail exactly (same --dur-slow / --ease-standard)
+              // so the content glides in lockstep with the width change; drop it
+              // for users who asked for less motion.
+              transition: prefersReducedMotion()
+                ? 'none'
+                : 'margin var(--dur-slow) var(--ease-standard)',
             }}
           >
             <ReadOnlyBanner />

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -137,7 +137,8 @@ export default function Nav({ open, onClose, collapsed, onToggleCollapse }: NavP
                   fontWeight: isActive ? 600 : 400,
                   fontSize: 14,
                   textDecoration: 'none',
-                  transition: 'background 0.15s, color 0.15s, box-shadow 0.15s',
+                  transition:
+                    'background var(--dur-base) var(--ease-standard), color var(--dur-base) var(--ease-standard), box-shadow var(--dur-base) var(--ease-standard)',
                 })}
               >
                 <i className={`fa-solid ${icon} wurk-navlink__icon`} aria-hidden="true" />
@@ -178,7 +179,8 @@ export default function Nav({ open, onClose, collapsed, onToggleCollapse }: NavP
                   fontWeight: isActive ? 600 : 400,
                   fontSize: 14,
                   textDecoration: 'none',
-                  transition: 'background 0.15s, color 0.15s, box-shadow 0.15s',
+                  transition:
+                    'background var(--dur-base) var(--ease-standard), color var(--dur-base) var(--ease-standard), box-shadow var(--dur-base) var(--ease-standard)',
                 })}
               >
                 <i className="fa-solid fa-puzzle-piece wurk-navlink__icon" aria-hidden="true" />
@@ -239,7 +241,7 @@ export default function Nav({ open, onClose, collapsed, onToggleCollapse }: NavP
             color: 'var(--text-muted)',
             fontSize: 13,
             textDecoration: 'none',
-            transition: 'background 0.15s, color 0.15s',
+            transition: 'background var(--dur-base) var(--ease-standard), color var(--dur-base) var(--ease-standard)',
           }}
         >
           <i className="fa-brands fa-github" style={{ fontSize: 16, width: 20, textAlign: 'center', flex: 'none' }} />
@@ -248,7 +250,7 @@ export default function Nav({ open, onClose, collapsed, onToggleCollapse }: NavP
       </nav>
 
       <style>{`
-        .wurk-nav { width: var(--nav-width); transition: width 0.2s ease; }
+        .wurk-nav { width: var(--nav-width); transition: width var(--dur-slow) var(--ease-standard); }
         .wurk-navlink:hover {
           background: var(--surface-hover) !important;
           color: var(--accent) !important;
@@ -258,17 +260,17 @@ export default function Nav({ open, onClose, collapsed, onToggleCollapse }: NavP
            colour on hover, no filled pill/active box. */
         .nav-collapse-toggle:hover { color: var(--text) !important; }
         .nav-label { white-space: nowrap; }
-        .wurk-navlink__icon { width: 24px; font-size: 18px; text-align: center; flex: none; transition: background 0.15s ease, color 0.15s ease, transform 0.18s ease; }
+        .wurk-navlink__icon { width: 24px; font-size: 18px; text-align: center; flex: none; transition: background var(--dur-base) var(--ease-standard), color var(--dur-base) var(--ease-standard), transform var(--dur-base) var(--ease-standard); }
         /* Subtle lift on hover so the nav feels reactive. */
         .wurk-navlink:hover .wurk-navlink__icon { transform: scale(1.12); }
         @media (prefers-reduced-motion: reduce) {
-          .wurk-navlink__icon { transition: background 0.15s ease, color 0.15s ease; }
+          .wurk-navlink__icon { transition: background var(--dur-base) var(--ease-standard), color var(--dur-base) var(--ease-standard); }
           .wurk-navlink:hover .wurk-navlink__icon { transform: none; }
         }
         @media (max-width: 767px) {
           .wurk-nav {
             transform: translateX(-100%);
-            transition: transform 0.25s ease;
+            transition: transform var(--dur-slow) var(--ease-standard);
           }
           .wurk-nav--open {
             transform: translateX(0);


### PR DESCRIPTION
Follow-up to #279. `Nav.tsx` is inline-styled and was the last place still using hardcoded transition durations, off the `--dur-*` / `--ease-*` scale the rest of the dashboard moved onto.

- **Rail width + content margin now share `var(--dur-slow) var(--ease-standard)` (240ms)** — the `.wurk-nav` width and `App.tsx`'s `main` `margin-inline-start` animate in exact lockstep on collapse/expand instead of at slightly different hardcoded rates.
- Nav-link/icon hover + the GitHub footer link → `var(--dur-base)`.
- Mobile drawer slide → `var(--dur-slow)`.
- Reduced-motion carve-outs preserved (the desktop `.wurk-nav { transition: none }` and the icon rule).

Behaviour is unchanged apart from the unified, ~40ms-slower collapse glide. Build green, 27/27 vitest pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation rail and main content animations to feel smoother and stay perfectly in sync when expanding or collapsing.
  * Kept reduced-motion behavior intact so transitions are disabled for users who prefer less animation.
* **Style**
  * Standardized transition timing across navigation elements for a more consistent visual experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->