### PR TITLE
style(dashboard): smoother sidebar collapse (350ms + emphasized ease)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -116,12 +116,12 @@ export default function App() {
               // Reserve the rail or full nav width depending on the pinned state;
               // the mobile media query overrides this to 0 (drawer overlay).
               marginInlineStart: collapsed ? 'var(--nav-rail)' : 'var(--nav-width)',
-              // Match the nav rail exactly (same --dur-slow / --ease-standard)
+              // Match the nav rail exactly (same --dur-page / --ease-emphasized)
               // so the content glides in lockstep with the width change; drop it
               // for users who asked for less motion.
               transition: prefersReducedMotion()
                 ? 'none'
-                : 'margin var(--dur-slow) var(--ease-standard)',
+                : 'margin var(--dur-page) var(--ease-emphasized)',
             }}
           >
             <ReadOnlyBanner />

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -250,7 +250,7 @@ export default function Nav({ open, onClose, collapsed, onToggleCollapse }: NavP
       </nav>
 
       <style>{`
-        .wurk-nav { width: var(--nav-width); transition: width var(--dur-slow) var(--ease-standard); }
+        .wurk-nav { width: var(--nav-width); transition: width var(--dur-page) var(--ease-emphasized); }
         .wurk-navlink:hover {
           background: var(--surface-hover) !important;
           color: var(--accent) !important;


### PR DESCRIPTION
Follow-up to #282. The collapse was correct but still felt snappy at 240ms. Moves the rail width **and** the `App.tsx` content margin (in lockstep) to `var(--dur-page)` (350ms) with `var(--ease-emphasized)` — the soft decelerate curve the modal uses — for a noticeably smoother glide. Reduced-motion carve-out preserved.

Verified in the built bundle: served JS contains `width var(--dur-page) var(--ease-emphasized)` + the matching margin. Build green, 27/27 vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)