### PR TITLE
feat(dashboard): migrate SPA from React to SolidJS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           bun-version: "1.3.14"
 
-      # Precompile the React SPA into vendor/assets/ (bun install + vite build).
+      # Precompile the SolidJS SPA into vendor/assets/ (bun install + vite build).
       - name: build dashboard SPA
         run: bundle exec rake frontend:build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to Wurk are recorded here. Format: [Keep a Changelog](https:
 
 ## [1.1.0] - 2026-07-01
 
+### Added
+- **Dashboard — gem version in the nav** — the running Wurk version now renders as a small monospace chip next to the "Wurk" wordmark in the sidebar (above the System Status line), sourced from a new `version` field on `/wurk/api/meta`. The field is optional, so a dashboard talking to an older server just hides the chip. (#285)
+
 ### Changed
 - **Dashboard — full rewrite from React to SolidJS** — the entire dashboard SPA was migrated off React 19 onto **SolidJS 1.9** with `@solidjs/router`, `@tanstack/solid-query`, and a hand-rolled dependency-free SVG chart module replacing Recharts. Solid's fine-grained reactivity compiles the JSX to direct DOM updates (no virtual DOM / re-render), so the shipped bundle is dramatically smaller and faster: the initial entry chunk drops from ~305 kB to **~35 kB (12.6 kB gzip)**, every page stays a lazy-loaded code-split chunk behind the route-level `<Suspense>` skeleton, and the charts split into their own ~13 kB chunk loaded only on the Dashboard/Metrics tabs. This is an **internal rewrite only** — the dashboard is visually and behaviorally identical (same routes, SSE live updates, i18n, RTL, dark-only Obsidian design system, read-only mode, extension tabs, skeleton loaders), the Redis/JSON/SSE wire contracts are untouched, and the precompiled bundle still ships in the gem (contributors need bun; consumers run neither Node nor bun). Recharts is replaced by a small internal `components/charts/` module (responsive SVG area/line/bar charts with gradient fills, monospace axes, hover crosshair + tooltip) so no charting dependency ships at all. The Vitest suite is rebuilt on `@solidjs/testing-library` with expanded unit (utils, i18n, hooks, charts) and integration (routing, read-only banner, bulk-action flows, page rendering) coverage, running fast in parallel across a worker-thread pool. (#285)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Wurk are recorded here. Format: [Keep a Changelog](https:
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-01
+
+### Changed
+- **Dashboard — full rewrite from React to SolidJS** — the entire dashboard SPA was migrated off React 19 onto **SolidJS 1.9** with `@solidjs/router`, `@tanstack/solid-query`, and a hand-rolled dependency-free SVG chart module replacing Recharts. Solid's fine-grained reactivity compiles the JSX to direct DOM updates (no virtual DOM / re-render), so the shipped bundle is dramatically smaller and faster: the initial entry chunk drops from ~305 kB to **~35 kB (12.6 kB gzip)**, every page stays a lazy-loaded code-split chunk behind the route-level `<Suspense>` skeleton, and the charts split into their own ~13 kB chunk loaded only on the Dashboard/Metrics tabs. This is an **internal rewrite only** — the dashboard is visually and behaviorally identical (same routes, SSE live updates, i18n, RTL, dark-only Obsidian design system, read-only mode, extension tabs, skeleton loaders), the Redis/JSON/SSE wire contracts are untouched, and the precompiled bundle still ships in the gem (contributors need bun; consumers run neither Node nor bun). Recharts is replaced by a small internal `components/charts/` module (responsive SVG area/line/bar charts with gradient fills, monospace axes, hover crosshair + tooltip) so no charting dependency ships at all. The Vitest suite is rebuilt on `@solidjs/testing-library` with expanded unit (utils, i18n, hooks, charts) and integration (routing, read-only banner, bulk-action flows, page rendering) coverage, running fast in parallel across a worker-thread pool. (#285)
+
 ## [1.0.7] - 2026-07-01
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Layers and ownership — one reason to change per class. Don't blur these.
 | Processor | Pops private list, runs middleware chain, invokes perform | `lib/wurk/processor.rb` |
 | Client | Enqueue, Lua bulk path, Redis-outage local buffer | `lib/wurk/client.rb` |
 | Middleware | Client + server chains (Sidekiq contract) | `lib/wurk/middleware/` |
-| Web | Rack app serving the precompiled React SPA + JSON APIs | `lib/wurk/web.rb`, `app/` |
+| Web | Rack app serving the precompiled SolidJS SPA + JSON APIs | `lib/wurk/web.rb`, `app/` |
 | RedisPool | Per-process pool over redis-client | `lib/wurk/redis_pool.rb` |
 
 User-facing code (mount, controllers, views, generators, assets) lives in the engine. Non-user-facing (swarm, fetcher, processor, client, middleware) lives in plain Ruby under `lib/`. **Standalone mode must run without loading the engine.**
@@ -103,7 +103,7 @@ Ruby `>= 3.2.0`, Redis `>= 7.0.0`. JRuby / TruffleRuby / Windows fall back to th
 
 ## Dashboard
 
-React + TypeScript + Vite SPA mounted under the engine, built with **bun** (`bun install` + `vite build`; contributors need bun, consumers never run Node or bun). **Precompiled bundle ships in the gem** (`vendor/assets/`). SSE for live updates, TanStack Query for state, Recharts for charts. Pages are **lazy-loaded behind a route-level `<Suspense>`** (code-split chunks) with **skeleton loaders** (`components/Skeleton.tsx`) as the fallback. Left-rail nav (drawer on mobile), dark-only, mobile-first, i18n with host-app override. AI panes (anomaly detection, NL queries, error triage, capacity advisor) are opt-in and require an Anthropic API token.
+SolidJS + TypeScript + Vite SPA mounted under the engine, built with **bun** (`bun install` + `vite build`; contributors need bun, consumers never run Node or bun). **Precompiled bundle ships in the gem** (`vendor/assets/`). SSE for live updates, TanStack Query (`@tanstack/solid-query`) for state, `@solidjs/router` for routing, and a hand-rolled dependency-free SolidJS SVG chart module for charts. Pages are **lazy-loaded behind a route-level `<Suspense>`** (code-split chunks) with **skeleton loaders** (`components/Skeleton.tsx`) as the fallback. Left-rail nav (drawer on mobile), dark-only, mobile-first, i18n with host-app override. AI panes (anomaly detection, NL queries, error triage, capacity advisor) are opt-in and require an Anthropic API token.
 
 **Styles** are a SOLID/SRP **SCSS** architecture under `frontend/src/styles/` — `abstracts/` (Sass maps, `to-rem()`/`breakpoint()`/`z()` functions, `respond-down()`/`transition()`/`surface()` mixins, CSS-var `:root` tokens, keyframes) → `base/` (reset, typography, scrollbar, reduced-motion policy) → `components/` (one file per atom: button, badge, card, table, modal, skeleton…) → `layout/` (shell, nav, page-header) → `pages/` (dashboard hero, Obsidian system, search, extension), composed by `main.scss`. Tailwind + daisyUI directives stay in the sibling `tailwind.css`; the SCSS `:root` tokens (unlayered) override daisyUI's theme. All lengths are `to-rem()`; motion runs off a shared duration/easing scale (`--dur-*` / `--ease-*`). `rem` is a reserved Sass calc name — the px→rem helper is `to-rem()`, not `rem()`.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Everything below is in the one free gem. The "Sidekiq tier" column is only there
 | **Limiters** | Concurrent, bucket, window, leaky, and points rate limiters via `Sidekiq::Limiter` | Enterprise |
 | **Periodic** | Cron/periodic jobs, leader-elected so each tick fires exactly once across the cluster | Enterprise |
 | **Encryption** | Transparent AES-256-GCM job-argument encryption with zero-downtime key rotation | Enterprise |
-| **Dashboard** | Mountable Rails engine, precompiled React SPA (no Node needed), live SSE, charts, host-app auth hook | OSS + Pro/Ent |
+| **Dashboard** | Mountable Rails engine, precompiled SolidJS SPA (no Node needed), live SSE, charts, host-app auth hook | OSS + Pro/Ent |
 
 Plus Wurk extras: a worker topology DSL, a Kubernetes liveness/readiness listener, and opt-in AI dashboard panes (anomaly detection, NL queries, backlog forecasting).
 

--- a/Rakefile
+++ b/Rakefile
@@ -121,7 +121,7 @@ namespace :frontend do
     sh "bun", "install", "--frozen-lockfile", chdir: FRONTEND_DIR
   end
 
-  desc "Build the React SPA into vendor/assets/"
+  desc "Build the SolidJS SPA into vendor/assets/"
   task :build do
     sh "bun", "install", "--frozen-lockfile", chdir: FRONTEND_DIR
     sh "bun", "run", "build", chdir: FRONTEND_DIR

--- a/app/controllers/wurk/api/serializers.rb
+++ b/app/controllers/wurk/api/serializers.rb
@@ -9,7 +9,7 @@ module Wurk
     module Serializers
       module_function
 
-      # Wire-shape consumed by the React dashboard's landing page + SSE feed.
+      # Wire-shape consumed by the SolidJS dashboard's landing page + SSE feed.
       # Field names match the SPA's `StatsSnapshot` interface in
       # frontend/src/hooks/useSSE.ts — keep them in sync. The canonical
       # Sidekiq-compatible accessors on Wurk::Stats use `_size` suffixes;

--- a/app/controllers/wurk/api_controller.rb
+++ b/app/controllers/wurk/api_controller.rb
@@ -5,7 +5,7 @@ require_relative 'api/pagination'
 require 'wurk/web'
 
 module Wurk
-  # JSON APIs consumed by the React SPA. Action methods stay thin; mapping to
+  # JSON APIs consumed by the SolidJS SPA. Action methods stay thin; mapping to
   # the wire shape lives in `Wurk::Api::Serializers`, and pagination lives in
   # `Wurk::Api::Pagination`. SSE lives in #stream.
   #

--- a/app/controllers/wurk/api_controller.rb
+++ b/app/controllers/wurk/api_controller.rb
@@ -44,6 +44,7 @@ module Wurk
     def meta
       config = ::Wurk::Web.config
       render json: {
+        version: ::Wurk::VERSION,
         read_only: config.read_only? || !mutations_authorized?(config),
         read_only_message: config.read_only_message,
         custom_tabs: config.custom_tabs

--- a/app/controllers/wurk/extensions_controller.rb
+++ b/app/controllers/wurk/extensions_controller.rb
@@ -23,7 +23,7 @@ module Wurk
         name: params[:name], method: request.request_method,
         subpath: "/#{params[:subpath]}", env: request.env, mount: request.script_name
       )
-      return index unless result # not an extension → SPA client route; let React handle it
+      return index unless result # not an extension → SPA client route; let the SolidJS router handle it
 
       respond_with(result)
     end

--- a/bin/gem-build
+++ b/bin/gem-build
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build the release artifact: compile the React dashboard into vendor/assets,
+# Build the release artifact: compile the SolidJS dashboard into vendor/assets,
 # then package the gem into pkg/. No push, no network — safe to run anytime.
 set -euo pipefail
 cd "$(dirname "$0")/.."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,6 @@ Wurk::Engine.routes.draw do
   get 'ext-assets/:name/*file', to: 'extensions#asset', as: :extension_asset,
                                 format: false, constraints: { name: %r{[^/]+} }
 
-  # SPA catch-all — let React Router handle the rest.
+  # SPA catch-all — let the SolidJS router handle the rest.
   get '*path', to: 'dashboard#index', constraints: ->(req) { req.format == :html }
 end

--- a/docs/idea/00-seed.md
+++ b/docs/idea/00-seed.md
@@ -34,7 +34,7 @@
 | 05-features.md | Parity map: Sidekiq OSS / Pro / Ent → Wurk modules |
 | 06-performance.md | Every optimization, with rationale |
 | 07-rails-engine.md | Mountable engine, configurable mount point |
-| 08-dashboard.md | React SPA, right-side menu, mobile, dark theme, i18n, AI |
+| 08-dashboard.md | SolidJS SPA, right-side menu, mobile, dark theme, i18n, AI |
 | 09-precompiled-assets.md | Assets baked into the gem at build time |
 | 10-dummy-app.md | `test/dummy/` Rails app for engine tests |
 | 11-testing-ci.md | Minitest parallel + Blacksmith GitHub workers |

--- a/docs/idea/02-architecture.md
+++ b/docs/idea/02-architecture.md
@@ -12,7 +12,7 @@
 | Processor | Pops from private list, runs middleware chain, invokes the user's perform |
 | Client | Enqueue interface. Bulk enqueue via Lua. Redis-outage local buffer |
 | Middleware | Server and client chains, same contract as Sidekiq |
-| Web | Rack app mounted under the engine. Serves the React SPA (precompiled) and JSON APIs |
+| Web | Rack app mounted under the engine. Serves the SolidJS SPA (precompiled) and JSON APIs |
 | RedisPool | Per-process connection pool using redis-client |
 
 ## Process tree at runtime

--- a/docs/idea/06-performance.md
+++ b/docs/idea/06-performance.md
@@ -35,7 +35,7 @@ Speed is a pillar, not a side effect. Wurk must beat stock Sidekiq on every benc
 
 ## Asset path
 
-Precompiled dashboard assets ship inside the gem — see 09-precompiled-assets.md. No runtime asset compilation, no Sprockets reach for the React bundle. The dashboard loads as a static file from the gem's path.
+Precompiled dashboard assets ship inside the gem — see 09-precompiled-assets.md. No runtime asset compilation, no Sprockets reach for the SolidJS bundle. The dashboard loads as a static file from the gem's path.
 
 ## Things explicitly NOT done
 

--- a/docs/idea/07-rails-engine.md
+++ b/docs/idea/07-rails-engine.md
@@ -3,7 +3,7 @@
 Wurk is packaged as a mountable Rails engine. That gives us:
 
 - A dashboard mount point with no host-app boilerplate.
-- Asset path for the precompiled React SPA.
+- Asset path for the precompiled SolidJS SPA.
 - A railtie hook for post-init forking.
 - Generators for the install flow.
 

--- a/docs/idea/08-dashboard.md
+++ b/docs/idea/08-dashboard.md
@@ -21,10 +21,10 @@ A modern, faster, easier-to-use replacement for Sidekiq Web. Same data shape and
 
 | Layer | Choice | Why |
 |---|---|---|
-| Frontend | React + TypeScript + Vite | Faster than Sidekiq's ERB+jQuery, modern DX |
-| State | TanStack Query | Cache + revalidate, pairs well with SSE |
+| Frontend | SolidJS + TypeScript + Vite | Faster than Sidekiq's ERB+jQuery, modern DX |
+| State | TanStack Query (`@tanstack/solid-query`) | Cache + revalidate, pairs well with SSE |
 | Realtime | Server-Sent Events | One-way push, simpler than WebSocket |
-| Charts | Recharts | Good defaults, small bundle, themeable |
+| Charts | Hand-rolled dependency-free SolidJS SVG charts | No chart-lib dependency, themeable, tiny bundle |
 | Styling | CSS variables + container queries | Themeable, mobile-friendly without a heavy CSS framework |
 | i18n runtime | A small, dependency-free translator that reads the bundled JSON locale files | Avoid pulling i18next-size deps for what is mostly key lookup |
 | Server | Rack app inside the engine | No Node runtime in production — see precompiled assets |

--- a/docs/idea/09-precompiled-assets.md
+++ b/docs/idea/09-precompiled-assets.md
@@ -1,6 +1,6 @@
 # Precompiled Assets
 
-The dashboard is a React SPA. Building it requires bun, Vite. **Consumers of the gem must never need any of that.**
+The dashboard is a SolidJS SPA. Building it requires bun, Vite. **Consumers of the gem must never need any of that.**
 
 ## Policy
 
@@ -8,7 +8,7 @@ Assets are built once, at gem release time, and shipped inside the gem. Installi
 
 ## What ships in the gem
 
-- A minified production bundle of the React SPA (one JS file, one CSS file, plus any static images and fonts).
+- A minified production bundle of the SolidJS SPA (one JS file, one CSS file, plus any static images and fonts).
 - Source maps, optional, gated by a build flag.
 - A simple manifest mapping logical names to digested filenames.
 

--- a/docs/idea/13-roadmap.md
+++ b/docs/idea/13-roadmap.md
@@ -23,7 +23,7 @@ Ship parity incrementally. Every milestone produces a usable gem.
 ## M2 — Web dashboard parity
 
 - Engine mounted at `/wurk`.
-- Precompiled React SPA bundle baked into the gem.
+- Precompiled SolidJS SPA bundle baked into the gem.
 - Parity panes: dashboard, queues, retries, scheduled, dead, busy.
 - SSE live updates.
 

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -358,7 +358,7 @@ gem <span class="add">"wurk"</span></pre>
             <span class="edge-light" aria-hidden="true"></span>
             <span class="feature__ic"><i class="fa-solid fa-gauge-high" aria-hidden="true"></i></span>
             <h3>A dashboard you'll keep open</h3>
-            <p>A precompiled React SPA ships inside the gem — consumers never touch Node. Live queues, retries, busy workers, batches, limiters, cron, and metrics, with click-through job detail.</p>
+            <p>A precompiled SolidJS SPA ships inside the gem — consumers never touch Node. Live queues, retries, busy workers, batches, limiters, cron, and metrics, with click-through job detail.</p>
             <span class="feature__tier"><i class="fa-solid fa-check free" aria-hidden="true"></i> Sidekiq OSS + Pro/Ent</span>
           </div>
         </div>
@@ -370,7 +370,7 @@ gem <span class="add">"wurk"</span></pre>
       <section id="dashboard" class="reveal">
         <h2>A dashboard you'll actually want open</h2>
         <p class="section-lede">
-          Dark, fast, and mobile-first — a precompiled React SPA that ships inside the gem (consumers
+          Dark, fast, and mobile-first — a precompiled SolidJS SPA that ships inside the gem (consumers
           never run Node). Live queues, retries, scheduled, dead, busy workers, batches, limiters, cron,
           and throughput/failure metrics. Click any job for its full args, error, and backtrace.
         </p>

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -8,30 +8,29 @@
         "@fontsource/geist-sans": "^5.2.5",
         "@fontsource/jetbrains-mono": "^5.2.8",
         "@fortawesome/fontawesome-free": "^7.2.0",
-        "@tanstack/react-query": "^5.100.0",
-        "react": "^19.2.0",
-        "react-dom": "^19.2.0",
-        "react-router-dom": "^7.16.0",
-        "recharts": "^3.8.0",
+        "@solidjs/router": "^0.15.3",
+        "@tanstack/solid-query": "^5.100.0",
+        "solid-js": "^1.9.9",
       },
       "devDependencies": {
+        "@solidjs/testing-library": "^0.8.10",
         "@tailwindcss/vite": "^4.3.0",
         "@testing-library/dom": "^10.4.1",
-        "@testing-library/react": "^16.3.2",
-        "@types/react": "^19.2.0",
-        "@types/react-dom": "^19.2.0",
-        "@vitejs/plugin-react": "^6.0.0",
+        "@testing-library/jest-dom": "^6.9.1",
         "daisyui": "^5.5.20",
         "jsdom": "^29.1.1",
         "sass": "^1.83.0",
         "tailwindcss": "^4.3.0",
         "typescript": "^6.0.0",
         "vite": "^8.0.0",
+        "vite-plugin-solid": "^2.11.9",
         "vitest": "^4.1.8",
       },
     },
   },
   "packages": {
+    "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
+
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
 
     "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.1.1", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ=="],
@@ -42,9 +41,41 @@
 
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
+    "@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
+
+    "@babel/core": ["@babel/core@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-compilation-targets": "^7.29.7", "@babel/helper-module-transforms": "^7.29.7", "@babel/helpers": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.29.7", "", { "dependencies": { "@babel/compat-data": "^7.29.7", "@babel/helper-validator-option": "^7.29.7", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.29.7", "", { "dependencies": { "@babel/helper-module-imports": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7", "@babel/traverse": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.29.7", "", {}, "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.7", "", { "dependencies": { "@babel/template": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg=="],
+
+    "@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+
+    "@babel/plugin-syntax-jsx": ["@babel/plugin-syntax-jsx@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A=="],
+
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
+
+    "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
@@ -86,7 +117,7 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.137.0", "", {}, "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="],
+    "@oxc-project/types": ["@oxc-project/types@0.138.0", "", {}, "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA=="],
 
     "@parcel/watcher": ["@parcel/watcher@2.5.6", "", { "dependencies": { "detect-libc": "^2.0.3", "is-glob": "^4.0.3", "node-addon-api": "^7.0.0", "picomatch": "^4.0.3" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.6", "@parcel/watcher-darwin-arm64": "2.5.6", "@parcel/watcher-darwin-x64": "2.5.6", "@parcel/watcher-freebsd-x64": "2.5.6", "@parcel/watcher-linux-arm-glibc": "2.5.6", "@parcel/watcher-linux-arm-musl": "2.5.6", "@parcel/watcher-linux-arm64-glibc": "2.5.6", "@parcel/watcher-linux-arm64-musl": "2.5.6", "@parcel/watcher-linux-x64-glibc": "2.5.6", "@parcel/watcher-linux-x64-musl": "2.5.6", "@parcel/watcher-win32-arm64": "2.5.6", "@parcel/watcher-win32-ia32": "2.5.6", "@parcel/watcher-win32-x64": "2.5.6" } }, "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ=="],
 
@@ -116,43 +147,43 @@
 
     "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw=="],
 
-    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.12.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw=="],
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.4", "", { "os": "android", "cpu": "arm64" }, "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw=="],
 
-    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.3", "", { "os": "android", "cpu": "arm64" }, "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g=="],
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ=="],
 
-    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw=="],
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg=="],
 
-    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw=="],
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ=="],
 
-    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw=="],
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.4", "", { "os": "linux", "cpu": "arm" }, "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA=="],
 
-    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.3", "", { "os": "linux", "cpu": "arm" }, "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg=="],
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w=="],
 
-    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA=="],
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng=="],
 
-    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w=="],
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg=="],
 
-    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw=="],
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ=="],
 
-    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA=="],
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw=="],
 
-    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.3", "", { "os": "linux", "cpu": "x64" }, "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg=="],
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ=="],
 
-    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.3", "", { "os": "linux", "cpu": "x64" }, "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g=="],
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.4", "", { "os": "none", "cpu": "arm64" }, "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA=="],
 
-    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.3", "", { "os": "none", "cpu": "arm64" }, "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ=="],
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.4", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg=="],
 
-    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.3", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg=="],
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA=="],
 
-    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g=="],
-
-    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.3", "", { "os": "win32", "cpu": "x64" }, "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA=="],
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.4", "", { "os": "win32", "cpu": "x64" }, "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
-    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+    "@solidjs/router": ["@solidjs/router@0.15.4", "", { "peerDependencies": { "solid-js": "^1.8.6" } }, "sha512-WOpgg9a9T638cR+5FGbFi/IV4l2FpmBs1GpIMSPa0Ce9vyJN7Wts+X2PqMf9IYn0zUj2MlSJtm1gp7/HI/n5TQ=="],
 
-    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
+    "@solidjs/testing-library": ["@solidjs/testing-library@0.8.10", "", { "dependencies": { "@testing-library/dom": "^10.4.0" }, "peerDependencies": { "@solidjs/router": ">=0.9.0", "solid-js": ">=1.0.0" }, "optionalPeers": ["@solidjs/router"] }, "sha512-qdeuIerwyq7oQTIrrKvV0aL9aFeuwTd86VYD3afdq5HYEwoox1OBTJy4y8A3TFZr8oAR0nujYgCzY/8wgHGfeQ=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.3.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "5.21.6", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.2" } }, "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg=="],
 
@@ -186,47 +217,29 @@
 
     "@tanstack/query-core": ["@tanstack/query-core@5.101.2", "", {}, "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw=="],
 
-    "@tanstack/react-query": ["@tanstack/react-query@5.101.2", "", { "dependencies": { "@tanstack/query-core": "5.101.2" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg=="],
+    "@tanstack/solid-query": ["@tanstack/solid-query@5.101.2", "", { "dependencies": { "@tanstack/query-core": "5.101.2" }, "peerDependencies": { "solid-js": "^1.6.0" } }, "sha512-IbCeM23gEbU0lW4wWFQhS4ELjgdmVXjhyCUh8pFemdMIuA5UswlkqEMryEE+lCMtxLS7m0oN1yWMocKi7vwXdw=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
-    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
-
-    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
-
-    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
-
-    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
-
-    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
-
-    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
-
-    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
-
-    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
-
-    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
-
-    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
-
-    "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
-
-    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
-
-    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
-
-    "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.3", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg=="],
 
     "@vitest/expect": ["@vitest/expect@4.1.9", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA=="],
 
@@ -250,51 +263,37 @@
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
+    "babel-plugin-jsx-dom-expressions": ["babel-plugin-jsx-dom-expressions@0.40.7", "", { "dependencies": { "@babel/helper-module-imports": "7.18.6", "@babel/plugin-syntax-jsx": "^7.18.6", "@babel/types": "^7.20.7", "html-entities": "2.3.3", "parse5": "^7.1.2" }, "peerDependencies": { "@babel/core": "^7.20.12" } }, "sha512-/O6JWUmjv03OI9lL2ry9bUjpD5S3PclM55RRJEyCdcFZ5W2SEA/59d+l2hNsk3gI6kiWRdRPdOtqZmsQzFN1pQ=="],
+
+    "babel-preset-solid": ["babel-preset-solid@1.9.12", "", { "dependencies": { "babel-plugin-jsx-dom-expressions": "^0.40.6" }, "peerDependencies": { "@babel/core": "^7.0.0", "solid-js": "^1.9.12" }, "optionalPeers": ["solid-js"] }, "sha512-LLqnuKVDlKpyBlMPcH6qEvs/wmS9a+NczppxJ3ryS/c0O5IiSFOIBQi9GzyiGDSbcJpx4Gr87jyFTos1MyEuWg=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.40", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw=="],
+
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
+
+    "browserslist": ["browserslist@4.28.4", "", { "dependencies": { "baseline-browser-mapping": "^2.10.38", "caniuse-lite": "^1.0.30001799", "electron-to-chromium": "^1.5.376", "node-releases": "^2.0.48", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001800", "", {}, "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
-    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
-
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
-
-    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
 
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
-
-    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
-
-    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
-
-    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
-
-    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
-
-    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
-
-    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
-
-    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
-
-    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
-
-    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
-
-    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
-
-    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
 
     "daisyui": ["daisyui@5.6.6", "", {}, "sha512-UFiuIZYucF7ylrnY3PT1SqwaEbVB10mqTZRyeRchZk0bud+HihYLLhXdxGDVmR/ftrM9G9YVr9FFPRVVIZJ5hA=="],
 
     "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
 
-    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
@@ -302,17 +301,17 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
+    "electron-to-chromium": ["electron-to-chromium@1.5.383", "", {}, "sha512-I2484/KkAvl8lm9VyjH2JnbOIV0d/UCqT7gbzs6l+o6Vmn9wgB66uVcKX+Vk6HrXtY6fbWTOEXuv8waDTuFNCw=="],
+
     "enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
 
     "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
     "es-module-lexer": ["es-module-lexer@2.2.0", "", {}, "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ=="],
 
-    "es-toolkit": ["es-toolkit@1.49.0", "", {}, "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g=="],
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
-
-    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
@@ -320,15 +319,17 @@
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
-    "immer": ["immer@11.1.8", "", {}, "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA=="],
+    "html-entities": ["html-entities@2.3.3", "", {}, "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="],
 
     "immutable": ["immutable@5.1.9", "", {}, "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg=="],
 
-    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -336,11 +337,17 @@
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
+    "is-what": ["is-what@4.1.16", "", {}, "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A=="],
+
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -374,9 +381,17 @@
 
     "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
 
+    "merge-anything": ["merge-anything@5.1.7", "", { "dependencies": { "is-what": "^4.1.8" } }, "sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ=="],
+
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
     "nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+
+    "node-releases": ["node-releases@2.0.50", "", {}, "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg=="],
 
     "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
 
@@ -394,41 +409,31 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
-
-    "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
-
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
-
-    "react-redux": ["react-redux@9.3.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g=="],
-
-    "react-router": ["react-router@7.18.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg=="],
-
-    "react-router-dom": ["react-router-dom@7.18.1", "", { "dependencies": { "react-router": "7.18.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg=="],
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
-    "recharts": ["recharts@3.9.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^11.1.8", "react-redux": "8.x.x || 9.x.x", "reselect": "5.2.0", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-WMcwlXcB7l+BbxiEdyClkG+1sxrMHNZpzT577LEvU4+rXPd8oTAy1wXk72hnk2KOOmxuLvw3z5DtXT7HEAydtg=="],
-
-    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
-
-    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
-    "reselect": ["reselect@5.2.0", "", {}, "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="],
-
-    "rolldown": ["rolldown@1.1.3", "", { "dependencies": { "@oxc-project/types": "=0.137.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.3", "@rolldown/binding-darwin-arm64": "1.1.3", "@rolldown/binding-darwin-x64": "1.1.3", "@rolldown/binding-freebsd-x64": "1.1.3", "@rolldown/binding-linux-arm-gnueabihf": "1.1.3", "@rolldown/binding-linux-arm64-gnu": "1.1.3", "@rolldown/binding-linux-arm64-musl": "1.1.3", "@rolldown/binding-linux-ppc64-gnu": "1.1.3", "@rolldown/binding-linux-s390x-gnu": "1.1.3", "@rolldown/binding-linux-x64-gnu": "1.1.3", "@rolldown/binding-linux-x64-musl": "1.1.3", "@rolldown/binding-openharmony-arm64": "1.1.3", "@rolldown/binding-wasm32-wasi": "1.1.3", "@rolldown/binding-win32-arm64-msvc": "1.1.3", "@rolldown/binding-win32-x64-msvc": "1.1.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g=="],
+    "rolldown": ["rolldown@1.1.4", "", { "dependencies": { "@oxc-project/types": "=0.138.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.4", "@rolldown/binding-darwin-arm64": "1.1.4", "@rolldown/binding-darwin-x64": "1.1.4", "@rolldown/binding-freebsd-x64": "1.1.4", "@rolldown/binding-linux-arm-gnueabihf": "1.1.4", "@rolldown/binding-linux-arm64-gnu": "1.1.4", "@rolldown/binding-linux-arm64-musl": "1.1.4", "@rolldown/binding-linux-ppc64-gnu": "1.1.4", "@rolldown/binding-linux-s390x-gnu": "1.1.4", "@rolldown/binding-linux-x64-gnu": "1.1.4", "@rolldown/binding-linux-x64-musl": "1.1.4", "@rolldown/binding-openharmony-arm64": "1.1.4", "@rolldown/binding-wasm32-wasi": "1.1.4", "@rolldown/binding-win32-arm64-msvc": "1.1.4", "@rolldown/binding-win32-x64-msvc": "1.1.4" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA=="],
 
     "sass": ["sass@1.101.0", "", { "dependencies": { "chokidar": "^5.0.0", "immutable": "^5.1.5", "source-map-js": ">=0.6.2 <2.0.0" }, "optionalDependencies": { "@parcel/watcher": "^2.4.1" }, "bin": { "sass": "sass.js" } }, "sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw=="],
 
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
-    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
+    "seroval": ["seroval@1.5.4", "", {}, "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw=="],
+
+    "seroval-plugins": ["seroval-plugins@1.5.4", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "solid-js": ["solid-js@1.9.13", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.0", "seroval-plugins": "~1.5.0" } }, "sha512-6hJeJMOcEX8ktqjpDoJZEmld3ijvcvWBDtiXBm7f4332SiFN66QeAQI1REQshvyUoISsSeJ4PHDauKYbwao9JQ=="],
+
+    "solid-refresh": ["solid-refresh@0.6.3", "", { "dependencies": { "@babel/generator": "^7.23.6", "@babel/helper-module-imports": "^7.22.15", "@babel/types": "^7.23.6" }, "peerDependencies": { "solid-js": "^1.3" } }, "sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -436,13 +441,13 @@
 
     "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
     "tailwindcss": ["tailwindcss@4.3.2", "", {}, "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
-
-    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
@@ -466,11 +471,13 @@
 
     "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
-    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
-
-    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "vite": ["vite@8.1.2", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.16", "rolldown": "~1.1.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-6YYPbRXTxx6bRXmOn7XdnQAy5DQNHhDgtjhDHI13oe4pY93kkcdGJWxpGwOm++/Wh0QpQhDrpIoVMrmrsI5AGQ=="],
+
+    "vite-plugin-solid": ["vite-plugin-solid@2.11.12", "", { "dependencies": { "@babel/core": "^7.23.3", "@types/babel__core": "^7.20.4", "babel-preset-solid": "^1.8.4", "merge-anything": "^5.1.7", "solid-refresh": "^0.6.3", "vitefu": "^1.0.4" }, "peerDependencies": { "@testing-library/jest-dom": "^5.16.6 || ^5.17.0 || ^6.*", "solid-js": "^1.7.2", "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@testing-library/jest-dom"] }, "sha512-FgjPcx2OwX9h6f28jli7A4bG7PP3te8uyakE5iqsmpq3Jqi1TWLgSroC9N6cMfGRU2zXsl4Q6ISvTr2VL0QHpA=="],
+
+    "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
     "vitest": ["vitest@4.1.9", "", { "dependencies": { "@vitest/expect": "4.1.9", "@vitest/mocker": "4.1.9", "@vitest/pretty-format": "4.1.9", "@vitest/runner": "4.1.9", "@vitest/snapshot": "4.1.9", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.9", "@vitest/browser-preview": "4.1.9", "@vitest/browser-webdriverio": "4.1.9", "@vitest/coverage-istanbul": "4.1.9", "@vitest/coverage-v8": "4.1.9", "@vitest/ui": "4.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ=="],
 
@@ -488,6 +495,10 @@
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
@@ -499,5 +510,15 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@testing-library/jest-dom/aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
+    "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+
+    "babel-plugin-jsx-dom-expressions/@babel/helper-module-imports": ["@babel/helper-module-imports@7.18.6", "", { "dependencies": { "@babel/types": "^7.18.6" } }, "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA=="],
+
+    "babel-plugin-jsx-dom-expressions/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "babel-plugin-jsx-dom-expressions/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,25 +14,22 @@
     "@fontsource/geist-sans": "^5.2.5",
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@fortawesome/fontawesome-free": "^7.2.0",
-    "@tanstack/react-query": "^5.100.0",
-    "react": "^19.2.0",
-    "react-dom": "^19.2.0",
-    "react-router-dom": "^7.16.0",
-    "recharts": "^3.8.0"
+    "@solidjs/router": "^0.15.3",
+    "@tanstack/solid-query": "^5.100.0",
+    "solid-js": "^1.9.9"
   },
   "devDependencies": {
+    "@solidjs/testing-library": "^0.8.10",
     "@tailwindcss/vite": "^4.3.0",
     "@testing-library/dom": "^10.4.1",
-    "@testing-library/react": "^16.3.2",
-    "@types/react": "^19.2.0",
-    "@types/react-dom": "^19.2.0",
-    "@vitejs/plugin-react": "^6.0.0",
+    "@testing-library/jest-dom": "^6.9.1",
     "daisyui": "^5.5.20",
     "jsdom": "^29.1.1",
     "sass": "^1.83.0",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.0",
     "vite": "^8.0.0",
+    "vite-plugin-solid": "^2.11.9",
     "vitest": "^4.1.8"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,7 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { Suspense, lazy } from 'react';
-import { useState } from 'react';
-import { useSSE } from './hooks/useSSE';
+import { Router, Route } from '@solidjs/router';
+import { QueryClient, QueryClientProvider } from '@tanstack/solid-query';
+import { Suspense, lazy, createSignal, type ParentProps } from 'solid-js';
+import { Show } from 'solid-js';
 import { useMeta } from './hooks/useMeta';
 import { t } from './i18n';
 import Nav from './components/Nav';
@@ -10,8 +9,9 @@ import { PageSkeleton } from './components/Skeleton';
 import ErrorBoundary from './components/ErrorBoundary';
 
 // Each page is a lazy chunk: the initial load ships only the shell + landing
-// page, and every other tab streams in on navigation behind a Suspense skeleton
-// (see the <Suspense> boundary below). Keeps first paint small and fast.
+// page, and every other tab streams in on navigation behind the Suspense
+// skeleton in the layout. Keeps first paint small and fast. Solid's `lazy`
+// pairs with the layout's <Suspense> the same way React.lazy did.
 const Dashboard = lazy(() => import('./pages/Dashboard'));
 const Queues = lazy(() => import('./pages/Queues'));
 const Retries = lazy(() => import('./pages/Retries'));
@@ -36,27 +36,27 @@ const qc = new QueryClient({
   },
 });
 
-function ReadOnlyBanner() {
-  const { data: meta } = useMeta();
-  if (!meta?.read_only) return null;
-
+export function ReadOnlyBanner() {
+  const meta = useMeta();
   return (
-    <div
-      role="status"
-      style={{
-        background: 'var(--warning)',
-        color: '#1a1a1a',
-        textAlign: 'center',
-        padding: '0.5rem 1rem',
-        fontWeight: 600,
-        fontSize: 13,
-        letterSpacing: '0.01em',
-        borderRadius: 8,
-        marginBottom: '1.75rem',
-      }}
-    >
-      {meta.read_only_message || t('readonly.banner')}
-    </div>
+    <Show when={meta.data?.read_only}>
+      <div
+        role="status"
+        style={{
+          background: 'var(--warning)',
+          color: '#1a1a1a',
+          'text-align': 'center',
+          padding: '0.5rem 1rem',
+          'font-weight': 600,
+          'font-size': '13px',
+          'letter-spacing': '0.01em',
+          'border-radius': '8px',
+          'margin-bottom': '1.75rem',
+        }}
+      >
+        {meta.data?.read_only_message || t('readonly.banner')}
+      </div>
+    </Show>
   );
 }
 
@@ -69,20 +69,24 @@ function prefersReducedMotion() {
   );
 }
 
-export default function App() {
-  const [navOpen, setNavOpen] = useState(false);
+// Root layout: the persistent shell (hamburger, main content, nav) that wraps
+// every route. Solid Router renders the matched route into `props.children`,
+// which lives inside the <Suspense> so lazy chunks fall back to the skeleton.
+function Layout(props: ParentProps) {
+  const [navOpen, setNavOpen] = createSignal(false);
   // Desktop-only: pin the rail collapsed (icons) or expanded (full), persisted
-  // so the choice survives reloads. Replaces the old hover-to-expand rail that
-  // moved on its own as the pointer crossed it.
-  const [collapsed, setCollapsed] = useState(() => {
-    // localStorage can throw SecurityError / QuotaExceededError in private mode
-    // or cross-origin iframes — same guard the write path uses.
-    try {
-      return typeof localStorage !== 'undefined' && localStorage.getItem(NAV_COLLAPSED_KEY) === '1';
-    } catch {
-      return false;
-    }
-  });
+  // so the choice survives reloads.
+  const [collapsed, setCollapsed] = createSignal(
+    (() => {
+      // localStorage can throw SecurityError / QuotaExceededError in private mode
+      // or cross-origin iframes — same guard the write path uses.
+      try {
+        return typeof localStorage !== 'undefined' && localStorage.getItem(NAV_COLLAPSED_KEY) === '1';
+      } catch {
+        return false;
+      }
+    })(),
+  );
   const toggleCollapsed = () =>
     setCollapsed((c) => {
       const next = !c;
@@ -93,68 +97,67 @@ export default function App() {
       }
       return next;
     });
-  const sse = useSSE();
 
   return (
     <QueryClientProvider client={qc}>
-      <BrowserRouter basename="/wurk">
-        <div style={{ display: 'flex', minHeight: '100vh' }}>
-          <button
-            className="hamburger"
-            style={{ position: 'fixed', top: 12, insetInlineStart: 12, zIndex: 200 }}
-            onClick={() => setNavOpen((o) => !o)}
-            aria-label="Toggle navigation"
-          >
-            <i className="fa-solid fa-bars" />
-          </button>
+      <div style={{ display: 'flex', 'min-height': '100vh' }}>
+        <button
+          class="hamburger"
+          style={{ position: 'fixed', top: '12px', 'inset-inline-start': '12px', 'z-index': 200 }}
+          onClick={() => setNavOpen((o) => !o)}
+          aria-label="Toggle navigation"
+        >
+          <i class="fa-solid fa-bars" />
+        </button>
 
-          <main
-            className="main-content"
-            style={{
-              flex: 1,
-              padding: '1.5rem',
-              // Reserve the rail or full nav width depending on the pinned state;
-              // the mobile media query overrides this to 0 (drawer overlay).
-              marginInlineStart: collapsed ? 'var(--nav-rail)' : 'var(--nav-width)',
-              // Match the nav rail exactly (same --dur-page / --ease-emphasized)
-              // so the content glides in lockstep with the width change; drop it
-              // for users who asked for less motion.
-              transition: prefersReducedMotion()
-                ? 'none'
-                : 'margin var(--dur-page) var(--ease-emphasized)',
-            }}
-          >
-            <ReadOnlyBanner />
-            <ErrorBoundary>
-              <Suspense fallback={<PageSkeleton />}>
-                <Routes>
-                <Route path="/" element={<Dashboard sse={sse} />} />
-                <Route path="/queues" element={<Queues />} />
-                <Route path="/retries" element={<Retries />} />
-                <Route path="/scheduled" element={<Scheduled />} />
-                <Route path="/dead" element={<Dead />} />
-                <Route path="/busy" element={<Busy />} />
-                <Route path="/batches" element={<Batches />} />
-                <Route path="/batches/:bid" element={<BatchDetail />} />
-                <Route path="/limiters" element={<Limiters />} />
-                <Route path="/cron" element={<Cron />} />
-                <Route path="/metrics" element={<Metrics />} />
-                <Route path="/profiles" element={<Profiles />} />
-                <Route path="/search" element={<Search />} />
-                <Route path="/ext/:tab" element={<Extension />} />
-              </Routes>
-              </Suspense>
-            </ErrorBoundary>
-          </main>
+        <main
+          class="main-content"
+          style={{
+            flex: 1,
+            padding: '1.5rem',
+            // Reserve the rail or full nav width depending on the pinned state;
+            // the mobile media query overrides this to 0 (drawer overlay).
+            'margin-inline-start': collapsed() ? 'var(--nav-rail)' : 'var(--nav-width)',
+            // Match the nav rail exactly (same --dur-page / --ease-emphasized)
+            // so the content glides in lockstep with the width change; drop it
+            // for users who asked for less motion.
+            transition: prefersReducedMotion() ? 'none' : 'margin var(--dur-page) var(--ease-emphasized)',
+          }}
+        >
+          <ReadOnlyBanner />
+          <ErrorBoundary>
+            <Suspense fallback={<PageSkeleton />}>{props.children}</Suspense>
+          </ErrorBoundary>
+        </main>
 
-          <Nav
-            open={navOpen}
-            onClose={() => setNavOpen(false)}
-            collapsed={collapsed}
-            onToggleCollapse={toggleCollapsed}
-          />
-        </div>
-      </BrowserRouter>
+        <Nav
+          open={navOpen()}
+          onClose={() => setNavOpen(false)}
+          collapsed={collapsed()}
+          onToggleCollapse={toggleCollapsed}
+        />
+      </div>
     </QueryClientProvider>
+  );
+}
+
+export default function App() {
+  return (
+    <Router root={Layout} base="/wurk">
+      <Route path="/" component={Dashboard} />
+      <Route path="/queues" component={Queues} />
+      <Route path="/retries" component={Retries} />
+      <Route path="/scheduled" component={Scheduled} />
+      <Route path="/dead" component={Dead} />
+      <Route path="/busy" component={Busy} />
+      <Route path="/batches" component={Batches} />
+      <Route path="/batches/:bid" component={BatchDetail} />
+      <Route path="/limiters" component={Limiters} />
+      <Route path="/cron" component={Cron} />
+      <Route path="/metrics" component={Metrics} />
+      <Route path="/profiles" component={Profiles} />
+      <Route path="/search" component={Search} />
+      <Route path="/ext/:tab" component={Extension} />
+    </Router>
   );
 }

--- a/frontend/src/components/AnimatedNumber.tsx
+++ b/frontend/src/components/AnimatedNumber.tsx
@@ -7,7 +7,7 @@ interface AnimatedNumberProps {
 // Locale-formatted integer that counts up to `value`. Rounds the in-flight
 // tween so intermediate frames read as whole counts; the final frame lands
 // exactly on the target.
-export function AnimatedNumber({ value }: AnimatedNumberProps) {
-  const display = useCountUp(value);
-  return <>{Math.round(display).toLocaleString()}</>;
+export function AnimatedNumber(props: AnimatedNumberProps) {
+  const display = useCountUp(() => props.value);
+  return <>{Math.round(display()).toLocaleString()}</>;
 }

--- a/frontend/src/components/ArgsValue.tsx
+++ b/frontend/src/components/ArgsValue.tsx
@@ -1,10 +1,15 @@
+import { Show } from 'solid-js';
 import { truncate } from '../utils';
 
 // Job args table cell. Empty args (`[]`) render as a muted em-dash rather than
 // a literal "[]", which reads as noise; non-empty args show the truncated JSON.
-export function ArgsValue({ str, max }: { str: string; max: number }) {
-  if (str === '[]' || str === '') {
-    return <span style={{ color: 'var(--text-muted)' }}>—</span>;
-  }
-  return <span title={str}>{truncate(str, max)}</span>;
+export function ArgsValue(props: { str: string; max: number }) {
+  return (
+    <Show
+      when={props.str !== '[]' && props.str !== ''}
+      fallback={<span style={{ color: 'var(--text-muted)' }}>—</span>}
+    >
+      <span title={props.str}>{truncate(props.str, props.max)}</span>
+    </Show>
+  );
 }

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,46 +1,43 @@
-import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { ErrorBoundary as SolidErrorBoundary, type ParentProps } from 'solid-js';
 import { t } from '../i18n';
-
-interface Props {
-  children: ReactNode;
-}
-
-interface State {
-  error: Error | null;
-}
 
 // Catches render/lazy-load failures so a single broken route (most commonly a
 // `ChunkLoadError` when a client on an old index.html requests a code-split
 // chunk that a fresh deploy has already replaced) shows a recoverable message
-// instead of a blank white screen. Error boundaries must be class components —
-// there is no hook equivalent. Wraps the route <Suspense> in App.tsx.
-export default class ErrorBoundary extends Component<Props, State> {
-  state: State = { error: null };
-
-  static getDerivedStateFromError(error: Error): State {
-    return { error };
-  }
-
-  componentDidCatch(error: Error, info: ErrorInfo) {
-    // Surface it for whatever error reporting the host wires up.
-    console.error('Dashboard route error:', error, info.componentStack);
-  }
-
-  render() {
-    if (!this.state.error) return this.props.children;
-
-    return (
-      <div className="empty-state" role="alert">
-        <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--text)', marginBottom: '0.4rem' }}>
-          {t('common.load_failed')}
-        </div>
-        <p style={{ maxWidth: '26rem', margin: '0 auto 1.1rem', fontSize: 13 }}>
-          {t('common.load_failed_hint')}
-        </p>
-        <button className="btn btn-accent" onClick={() => window.location.reload()}>
-          {t('common.reload')}
-        </button>
-      </div>
-    );
-  }
+// instead of a blank white screen. Wraps the route <Suspense> in App.tsx.
+//
+// Solid ships a first-class <ErrorBoundary> (no class component needed); this
+// thin wrapper supplies the localized fallback + a full reload, which fetches
+// the current index.html and its up-to-date chunk manifest.
+export default function ErrorBoundary(props: ParentProps) {
+  return (
+    <SolidErrorBoundary
+      fallback={(err: Error) => {
+        // Surface it for whatever error reporting the host wires up.
+        console.error('Dashboard route error:', err);
+        return (
+          <div class="empty-state" role="alert">
+            <div
+              style={{
+                'font-size': '15px',
+                'font-weight': 600,
+                color: 'var(--text)',
+                'margin-bottom': '0.4rem',
+              }}
+            >
+              {t('common.load_failed')}
+            </div>
+            <p style={{ 'max-width': '26rem', margin: '0 auto 1.1rem', 'font-size': '13px' }}>
+              {t('common.load_failed_hint')}
+            </p>
+            <button class="btn btn-accent" onClick={() => window.location.reload()}>
+              {t('common.reload')}
+            </button>
+          </div>
+        );
+      }}
+    >
+      {props.children}
+    </SolidErrorBoundary>
+  );
 }

--- a/frontend/src/components/JobDetailModal.tsx
+++ b/frontend/src/components/JobDetailModal.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react';
+import { For, Show, type JSX } from 'solid-js';
 import Modal from './Modal';
 import { t } from '../i18n';
 import { formatArgs, isoTime, relativeTime } from '../utils';
@@ -24,14 +24,14 @@ export interface JobEntry {
   custom_rows?: [string, string][];
 }
 
-function Field({ label, children, mono }: { label: string; children: ReactNode; mono?: boolean }) {
+function Field(props: { label: string; children: JSX.Element; mono?: boolean }) {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-      <span style={{ fontSize: 11, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
-        {label}
+    <div style={{ display: 'flex', 'flex-direction': 'column', gap: '3px' }}>
+      <span style={{ 'font-size': '11px', color: 'var(--text-muted)', 'text-transform': 'uppercase', 'letter-spacing': '0.04em' }}>
+        {props.label}
       </span>
-      <span style={{ fontSize: 13, fontFamily: mono ? 'ui-monospace, monospace' : undefined, wordBreak: 'break-word' }}>
-        {children}
+      <span style={{ 'font-size': '13px', 'font-family': props.mono ? 'ui-monospace, monospace' : undefined, 'word-break': 'break-word' }}>
+        {props.children}
       </span>
     </div>
   );
@@ -50,80 +50,86 @@ interface JobDetailModalProps {
   onClose: () => void;
 }
 
-export default function JobDetailModal({ entry, atLabel, actions, onAction, pending = false, onClose }: JobDetailModalProps) {
+export default function JobDetailModal(props: JobDetailModalProps) {
   const footer =
-    actions && actions.length > 0 && onAction ? (
-      <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end', flexWrap: 'wrap' }}>
-        {actions.map((a) => (
-          <button
-            key={a.cmd}
-            className={`btn btn-sm${a.danger ? ' btn-danger' : ''}`}
-            disabled={pending}
-            onClick={() => {
-              if (pending) return;
-              if (a.danger && !window.confirm(t('actions.confirm', { action: a.label, scope: t('job.detail').toLowerCase() }))) return;
-              onAction(a.cmd);
-            }}
-          >
-            {a.label}
-          </button>
-        ))}
+    props.actions && props.actions.length > 0 && props.onAction ? (
+      <div style={{ display: 'flex', gap: '0.5rem', 'justify-content': 'flex-end', 'flex-wrap': 'wrap' }}>
+        <For each={props.actions}>
+          {(a) => (
+            <button
+              class={`btn btn-sm${a.danger ? ' btn-danger' : ''}`}
+              disabled={props.pending}
+              onClick={() => {
+                if (props.pending) return;
+                if (a.danger && !window.confirm(t('actions.confirm', { action: a.label, scope: t('job.detail').toLowerCase() }))) return;
+                props.onAction?.(a.cmd);
+              }}
+            >
+              {a.label}
+            </button>
+          )}
+        </For>
       </div>
     ) : undefined;
 
   return (
-    <Modal open={entry !== null} onClose={onClose} title={entry?.klass ?? t('job.detail')} width={680} footer={footer}>
-      {entry && (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: '0.9rem' }}>
-            <Field label={t('job.class')}>{entry.klass}</Field>
-            {entry.queue && <Field label={t('job.queue')}>{entry.queue}</Field>}
-            <Field label={t('job.jid')} mono>{entry.jid}</Field>
-            {typeof entry.retry_count === 'number' && (
-              <Field label={t('job.retries')}>{entry.retry_count}</Field>
-            )}
-            {entry.enqueued_at != null && (
-              <Field label={t('job.enqueued')} mono>{isoTime(entry.enqueued_at)} ({relativeTime(entry.enqueued_at)})</Field>
-            )}
-            {entry.at != null && (
-              <Field label={atLabel ?? t('job.at')} mono>{isoTime(entry.at)} ({relativeTime(entry.at)})</Field>
-            )}
-          </div>
-
-          <Field label={t('job.args')} mono>
-            {formatArgs(entry.args) === '[]' || formatArgs(entry.args) === '' ? (
-              <span style={{ color: 'var(--text-muted)' }}>—</span>
-            ) : (
-              <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{formatArgs(entry.args)}</pre>
-            )}
-          </Field>
-
-          {(entry.error_class || entry.error_message) && (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-              <span style={{ fontSize: 11, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
-                {t('job.error')}
-              </span>
-              <span style={{ fontSize: 13, color: 'var(--danger)', wordBreak: 'break-word' }}>
-                {entry.error_class}{entry.error_message ? `: ${entry.error_message}` : ''}
-              </span>
+    <Modal open={props.entry !== null} onClose={props.onClose} title={props.entry?.klass ?? t('job.detail')} width={680} footer={footer}>
+      <Show when={props.entry}>
+        {(entry) => (
+          <div style={{ display: 'flex', 'flex-direction': 'column', gap: '1rem' }}>
+            <div style={{ display: 'grid', 'grid-template-columns': 'repeat(auto-fit, minmax(160px, 1fr))', gap: '0.9rem' }}>
+              <Field label={t('job.class')}>{entry().klass}</Field>
+              <Show when={entry().queue}>
+                <Field label={t('job.queue')}>{entry().queue}</Field>
+              </Show>
+              <Field label={t('job.jid')} mono>{entry().jid}</Field>
+              <Show when={typeof entry().retry_count === 'number'}>
+                <Field label={t('job.retries')}>{entry().retry_count}</Field>
+              </Show>
+              <Show when={entry().enqueued_at != null}>
+                <Field label={t('job.enqueued')} mono>{isoTime(entry().enqueued_at!)} ({relativeTime(entry().enqueued_at!)})</Field>
+              </Show>
+              <Show when={entry().at != null}>
+                <Field label={props.atLabel ?? t('job.at')} mono>{isoTime(entry().at!)} ({relativeTime(entry().at!)})</Field>
+              </Show>
             </div>
-          )}
 
-          {entry.error_backtrace && entry.error_backtrace.length > 0 && (
-            <Field label={t('job.backtrace')}>
-              <pre className="job-backtrace">{entry.error_backtrace.join('\n')}</pre>
+            <Field label={t('job.args')} mono>
+              <Show
+                when={formatArgs(entry().args) === '[]' || formatArgs(entry().args) === ''}
+                fallback={<pre style={{ margin: 0, 'white-space': 'pre-wrap', 'word-break': 'break-word' }}>{formatArgs(entry().args)}</pre>}
+              >
+                <span style={{ color: 'var(--text-muted)' }}>—</span>
+              </Show>
             </Field>
-          )}
 
-          {entry.custom_rows && entry.custom_rows.length > 0 && (
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: '0.9rem' }}>
-              {entry.custom_rows.map(([label, value], idx) => (
-                <Field key={`${label}-${idx}`} label={label}>{value}</Field>
-              ))}
-            </div>
-          )}
-        </div>
-      )}
+            <Show when={entry().error_class || entry().error_message}>
+              <div style={{ display: 'flex', 'flex-direction': 'column', gap: '3px' }}>
+                <span style={{ 'font-size': '11px', color: 'var(--text-muted)', 'text-transform': 'uppercase', 'letter-spacing': '0.04em' }}>
+                  {t('job.error')}
+                </span>
+                <span style={{ 'font-size': '13px', color: 'var(--danger)', 'word-break': 'break-word' }}>
+                  {entry().error_class}{entry().error_message ? `: ${entry().error_message}` : ''}
+                </span>
+              </div>
+            </Show>
+
+            <Show when={entry().error_backtrace && entry().error_backtrace!.length > 0}>
+              <Field label={t('job.backtrace')}>
+                <pre class="job-backtrace">{entry().error_backtrace!.join('\n')}</pre>
+              </Field>
+            </Show>
+
+            <Show when={entry().custom_rows && entry().custom_rows!.length > 0}>
+              <div style={{ display: 'grid', 'grid-template-columns': 'repeat(auto-fit, minmax(160px, 1fr))', gap: '0.9rem' }}>
+                <For each={entry().custom_rows}>
+                  {([label, value]) => <Field label={label}>{value}</Field>}
+                </For>
+              </div>
+            </Show>
+          </div>
+        )}
+      </Show>
     </Modal>
   );
 }

--- a/frontend/src/components/JobSetActionBar.tsx
+++ b/frontend/src/components/JobSetActionBar.tsx
@@ -1,3 +1,4 @@
+import { For } from 'solid-js';
 import { t } from '../i18n';
 
 // One button's worth of config: the wire `cmd`, its localized label, whether
@@ -22,46 +23,40 @@ interface JobSetActionBarProps {
 // Toolbar shown above a mutable job-set table: bulk actions over the current
 // selection on the left, whole-set ("all") actions on the right. Rendered only
 // when the dashboard is read-write — callers gate on useMeta().read_only.
-export default function JobSetActionBar({
-  bulk,
-  all,
-  selectedCount,
-  total,
-  pending,
-  onBulk,
-  onAll,
-}: JobSetActionBarProps) {
+export default function JobSetActionBar(props: JobSetActionBarProps) {
   const confirmDanger = (a: ActionDef, scope: string) =>
     !a.danger || window.confirm(t('actions.confirm', { action: a.label, scope }));
 
   return (
-    <div className="action-bar">
-      <div className="action-bar-group">
-        <span className="action-bar-count">
-          {selectedCount > 0 ? t('actions.selected', { n: selectedCount }) : t('actions.select_hint')}
+    <div class="action-bar">
+      <div class="action-bar-group">
+        <span class="action-bar-count">
+          {props.selectedCount > 0 ? t('actions.selected', { n: props.selectedCount }) : t('actions.select_hint')}
         </span>
-        {bulk.map((a) => (
-          <button
-            key={a.cmd}
-            className={`btn btn-sm${a.danger ? ' btn-danger' : ''}`}
-            disabled={pending || selectedCount === 0}
-            onClick={() => confirmDanger(a, t('actions.scope_selected', { n: selectedCount })) && onBulk(a.cmd)}
-          >
-            {a.label}
-          </button>
-        ))}
+        <For each={props.bulk}>
+          {(a) => (
+            <button
+              class={`btn btn-sm${a.danger ? ' btn-danger' : ''}`}
+              disabled={props.pending || props.selectedCount === 0}
+              onClick={() => confirmDanger(a, t('actions.scope_selected', { n: props.selectedCount })) && props.onBulk(a.cmd)}
+            >
+              {a.label}
+            </button>
+          )}
+        </For>
       </div>
-      <div className="action-bar-group">
-        {all.map((a) => (
-          <button
-            key={a.cmd}
-            className={`btn btn-sm btn-ghost${a.danger ? ' btn-danger' : ''}`}
-            disabled={pending || total === 0}
-            onClick={() => confirmDanger(a, t('actions.scope_all')) && onAll(a.cmd)}
-          >
-            {`${a.label} ${t('actions.all_suffix')}`}
-          </button>
-        ))}
+      <div class="action-bar-group">
+        <For each={props.all}>
+          {(a) => (
+            <button
+              class={`btn btn-sm btn-ghost${a.danger ? ' btn-danger' : ''}`}
+              disabled={props.pending || props.total === 0}
+              onClick={() => confirmDanger(a, t('actions.scope_all')) && props.onAll(a.cmd)}
+            >
+              {`${a.label} ${t('actions.all_suffix')}`}
+            </button>
+          )}
+        </For>
       </div>
     </div>
   );

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,12 +1,12 @@
-import { useEffect, useRef, type ReactNode } from 'react';
+import { createEffect, createSignal, onCleanup, onMount, Show, type JSX } from 'solid-js';
 
 interface ModalProps {
   open: boolean;
   onClose: () => void;
-  title: ReactNode;
-  children: ReactNode;
+  title: JSX.Element;
+  children: JSX.Element;
   /** Optional footer (e.g. action buttons). */
-  footer?: ReactNode;
+  footer?: JSX.Element;
   /** Max width of the dialog; defaults to a roomy detail width. */
   width?: number;
 }
@@ -16,56 +16,59 @@ interface ModalProps {
 // stays mounted (not conditionally rendered) and is driven by showModal()/close(),
 // so enter AND exit animate via CSS (@starting-style + allow-discrete in
 // styles/components/_modal.scss).
-export default function Modal({ open, onClose, title, children, footer, width = 640 }: ModalProps) {
-  const ref = useRef<HTMLDialogElement>(null);
-  const titleId = useRef(`modal-title-${Math.random().toString(36).slice(2)}`).current;
+export default function Modal(props: ModalProps) {
+  let dlg!: HTMLDialogElement;
+  const titleId = `modal-title-${Math.random().toString(36).slice(2)}`;
 
   // Hold the last content + title so the panel isn't blank while it animates out
   // (consumers typically clear their data the moment `open` flips false).
-  const held = useRef<{ title: ReactNode; children: ReactNode }>({ title, children });
-  if (open) held.current = { title, children };
-  const shown = open ? { title, children } : held.current;
+  const [held, setHeld] = createSignal<{ title: JSX.Element; children: JSX.Element }>({
+    title: props.title,
+    children: props.children,
+  });
+  createEffect(() => {
+    if (props.open) setHeld({ title: props.title, children: props.children });
+  });
+  const shown = () => (props.open ? { title: props.title, children: props.children } : held());
 
-  useEffect(() => {
-    const dlg = ref.current;
-    if (!dlg) return;
-    if (open && !dlg.open) dlg.showModal();
-    else if (!open && dlg.open) dlg.close();
-  }, [open]);
+  createEffect(() => {
+    if (props.open && !dlg.open) dlg.showModal();
+    else if (!props.open && dlg.open) dlg.close();
+  });
 
-  // Esc fires the native `cancel`; route it through onClose so React state stays
+  // Esc fires the native `cancel`; route it through onClose so app state stays
   // the source of truth.
-  useEffect(() => {
-    const dlg = ref.current;
-    if (!dlg) return;
+  onMount(() => {
     const onCancel = (e: Event) => {
       e.preventDefault();
-      onClose();
+      props.onClose();
     };
     dlg.addEventListener('cancel', onCancel);
-    return () => dlg.removeEventListener('cancel', onCancel);
-  }, [onClose]);
+    onCleanup(() => dlg.removeEventListener('cancel', onCancel));
+  });
 
   return (
     <dialog
-      ref={ref}
-      className="modal"
+      ref={dlg}
+      class="modal"
       aria-labelledby={titleId}
       // Close only when the click lands on the <dialog> itself (the backdrop area),
       // not the panel inside it.
       onClick={(e) => {
-        if (e.target === ref.current) onClose();
+        if (e.target === dlg) props.onClose();
       }}
     >
-      <div className="modal-panel" style={{ maxWidth: width }}>
-        <div className="modal-header">
-          <h2 id={titleId} className="modal-title">{shown.title}</h2>
-          <button className="modal-close" onClick={onClose} aria-label="Close">
-            <i className="fa-solid fa-xmark" />
+      <div class="modal-panel" style={{ 'max-width': `${props.width ?? 640}px` }}>
+        <div class="modal-header">
+          <h2 id={titleId} class="modal-title">{shown().title}</h2>
+          <button class="modal-close" onClick={() => props.onClose()} aria-label="Close">
+            <i class="fa-solid fa-xmark" />
           </button>
         </div>
-        <div className="modal-body">{shown.children}</div>
-        {footer && <div className="modal-footer">{footer}</div>}
+        <div class="modal-body">{shown().children}</div>
+        <Show when={props.footer}>
+          <div class="modal-footer">{props.footer}</div>
+        </Show>
       </div>
     </dialog>
   );

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -101,8 +101,28 @@ export default function Nav(props: NavProps) {
               }}
             />
             <span class="nav-label" style={{ display: 'flex', 'flex-direction': 'column', 'line-height': 1.15 }}>
-              <span style={{ 'font-size': '18px', 'font-weight': 700, 'letter-spacing': '-0.02em', color: 'var(--text-bright)' }}>
-                Wurk
+              <span style={{ display: 'inline-flex', 'align-items': 'baseline', gap: '0.4rem' }}>
+                <span style={{ 'font-size': '18px', 'font-weight': 700, 'letter-spacing': '-0.02em', color: 'var(--text-bright)' }}>
+                  Wurk
+                </span>
+                {/* Gem version from /wurk/api/meta, next to the wordmark. */}
+                <Show when={meta.data?.version}>
+                  <span
+                    style={{
+                      'font-family': 'var(--font-mono)',
+                      'font-size': '10px',
+                      'font-weight': 500,
+                      'letter-spacing': '0.02em',
+                      color: 'var(--text-muted)',
+                      background: 'var(--surface-strong)',
+                      border: '1px solid var(--border)',
+                      'border-radius': '5px',
+                      padding: '0.05rem 0.3rem',
+                    }}
+                  >
+                    v{meta.data?.version}
+                  </span>
+                </Show>
               </span>
               <span
                 style={{

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -1,4 +1,5 @@
-import { NavLink, Link } from 'react-router-dom';
+import { A } from '@solidjs/router';
+import { For, Show } from 'solid-js';
 import { t } from '../i18n';
 import { useMeta } from '../hooks/useMeta';
 import logoUrl from '../assets/wurk-logo.png';
@@ -27,230 +28,243 @@ const LINKS = [
   { to: '/search', label: t('nav.search'), icon: 'fa-magnifying-glass', end: false },
 ];
 
-export default function Nav({ open, onClose, collapsed, onToggleCollapse }: NavProps) {
+export default function Nav(props: NavProps) {
   // Tabs registered by third-party gems (sidekiq-cron, sidekiq-unique-jobs, …)
   // via Sidekiq::Web.register_extension. They link out to the extension's own
   // path — wurk surfaces the tab but doesn't render the gem's view in the SPA.
-  const { data: meta } = useMeta();
-  const customTabs = meta?.custom_tabs ?? [];
+  const meta = useMeta();
+  const customTabs = () => meta.data?.custom_tabs ?? [];
 
   // Close the mobile drawer on navigation. The desktop rail no longer expands on
   // hover/focus, so there's nothing to blur back.
-  const handleNavClick = () => onClose();
+  const handleNavClick = () => props.onClose();
 
   return (
     <>
       {/* Overlay for mobile */}
-      {open && (
+      <Show when={props.open}>
         <div
           onClick={handleNavClick}
           style={{
             position: 'fixed',
             inset: 0,
             background: 'rgba(0,0,0,0.5)',
-            zIndex: 99,
+            'z-index': 99,
             display: 'none',
           }}
-          className="nav-overlay"
+          class="nav-overlay"
         />
-      )}
+      </Show>
       <nav
-        className={`wurk-nav${open ? ' wurk-nav--open' : ''}${collapsed ? ' wurk-nav--collapsed' : ''}`}
+        classList={{
+          'wurk-nav': true,
+          'wurk-nav--open': props.open,
+          'wurk-nav--collapsed': props.collapsed,
+        }}
         style={{
           position: 'fixed',
           top: 0,
-          insetInlineStart: 0,
+          'inset-inline-start': 0,
           bottom: 0,
           background: 'var(--surface)',
-          borderInlineEnd: '1px solid var(--border)',
+          'border-inline-end': '1px solid var(--border)',
           display: 'flex',
-          flexDirection: 'column',
-          zIndex: 100,
-          overflowY: 'auto',
-          overflowX: 'hidden',
+          'flex-direction': 'column',
+          'z-index': 100,
+          'overflow-y': 'auto',
+          'overflow-x': 'hidden',
         }}
       >
-        <div className="nav-brand-wrap" style={{ padding: '1.25rem 1rem 0.75rem' }}>
-          <Link
-            to="/"
+        <div class="nav-brand-wrap" style={{ padding: '1.25rem 1rem 0.75rem' }}>
+          <A
+            href="/"
+            end
             onClick={handleNavClick}
             aria-label="Wurk — dashboard home"
             style={{
               color: 'var(--text)',
-              textDecoration: 'none',
+              'text-decoration': 'none',
               display: 'flex',
-              alignItems: 'center',
+              'align-items': 'center',
               gap: '0.6rem',
             }}
           >
             <img
               src={logoUrl}
               alt="Wurk"
-              style={{ height: 36, width: 'auto', display: 'block', flex: 'none', filter: 'drop-shadow(0 2px 6px rgba(0,0,0,0.45))' }}
+              style={{
+                height: '36px',
+                width: 'auto',
+                display: 'block',
+                flex: 'none',
+                filter: 'drop-shadow(0 2px 6px rgba(0,0,0,0.45))',
+              }}
             />
-            <span className="nav-label" style={{ display: 'flex', flexDirection: 'column', lineHeight: 1.15 }}>
-              <span style={{ fontSize: 18, fontWeight: 700, letterSpacing: '-0.02em', color: 'var(--text-bright)' }}>Wurk</span>
+            <span class="nav-label" style={{ display: 'flex', 'flex-direction': 'column', 'line-height': 1.15 }}>
+              <span style={{ 'font-size': '18px', 'font-weight': 700, 'letter-spacing': '-0.02em', color: 'var(--text-bright)' }}>
+                Wurk
+              </span>
               <span
                 style={{
-                  fontFamily: 'var(--font-mono)',
-                  fontSize: 9,
-                  fontWeight: 500,
-                  letterSpacing: '0.1em',
-                  textTransform: 'uppercase',
+                  'font-family': 'var(--font-mono)',
+                  'font-size': '9px',
+                  'font-weight': 500,
+                  'letter-spacing': '0.1em',
+                  'text-transform': 'uppercase',
                   color: 'var(--text-muted)',
-                  marginTop: 2,
+                  'margin-top': '2px',
                   display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: 5,
+                  'align-items': 'center',
+                  gap: '5px',
                 }}
               >
-                <span className="live-dot" style={{ width: 6, height: 6 }} />
+                <span class="live-dot" style={{ width: '6px', height: '6px' }} />
                 System Status: Active
               </span>
             </span>
-          </Link>
+          </A>
         </div>
 
-        <div style={{ height: 1, background: 'var(--border)', margin: '0 1rem 0.5rem' }} />
+        <div style={{ height: '1px', background: 'var(--border)', margin: '0 1rem 0.5rem' }} />
 
-        <ul style={{ listStyle: 'none', flex: 1 }}>
-          {LINKS.map(({ to, label, icon, end }) => (
-            <li key={to}>
-              <NavLink
-                to={to}
-                end={end}
-                onClick={handleNavClick}
-                title={label}
-                className="wurk-navlink"
-                style={({ isActive }) => ({
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '0.625rem',
-                  padding: '0.5rem 0.85rem',
-                  borderRadius: 8,
-                  margin: '2px 8px',
-                  // Text stays white for every item; the active one is marked by
-                  // a subtle dark raised pill + hairline, not a bright white box.
-                  color: isActive ? 'var(--accent)' : 'var(--text)',
-                  background: isActive ? 'var(--surface-strong)' : 'transparent',
-                  boxShadow: isActive ? 'inset 0 0 0 1px var(--border)' : 'none',
-                  fontWeight: isActive ? 600 : 400,
-                  fontSize: 14,
-                  textDecoration: 'none',
-                  transition:
-                    'background var(--dur-base) var(--ease-standard), color var(--dur-base) var(--ease-standard), box-shadow var(--dur-base) var(--ease-standard)',
-                })}
+        <ul style={{ 'list-style': 'none', flex: 1 }}>
+          <For each={LINKS}>
+            {(link) => (
+              <li>
+                <A
+                  href={link.to}
+                  end={link.end}
+                  onClick={handleNavClick}
+                  title={link.label}
+                  class="wurk-navlink"
+                  activeClass="active"
+                >
+                  <i class={`fa-solid ${link.icon} wurk-navlink__icon`} aria-hidden="true" />
+                  <span class="nav-label">{link.label}</span>
+                </A>
+              </li>
+            )}
+          </For>
+
+          <Show when={customTabs().length > 0}>
+            <li aria-hidden="true" style={{ padding: '0.5rem 0.95rem 0.2rem', 'margin-top': '0.4rem' }}>
+              <div style={{ height: '1px', background: 'var(--border)', 'margin-bottom': '0.45rem' }} />
+              <span
+                class="nav-label"
+                style={{ 'font-size': '10px', 'font-weight': 600, 'letter-spacing': '0.06em', 'text-transform': 'uppercase', color: 'var(--text-muted)' }}
               >
-                <i className={`fa-solid ${icon} wurk-navlink__icon`} aria-hidden="true" />
-                <span className="nav-label">{label}</span>
-              </NavLink>
-            </li>
-          ))}
-
-          {customTabs.length > 0 && (
-            <li aria-hidden="true" style={{ padding: '0.5rem 0.95rem 0.2rem', marginTop: '0.4rem' }}>
-              <div style={{ height: 1, background: 'var(--border)', marginBottom: '0.45rem' }} />
-              <span className="nav-label" style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'var(--text-muted)' }}>
                 {t('nav.extensions')}
               </span>
             </li>
-          )}
-          {customTabs.map((tab) => (
-            <li key={tab.path}>
-              {/* In-SPA route: /ext/:tab renders an Extension page (native
-                  server-rendered view, or an iframe for bare tabs[]= tabs).
-                  Registered index paths end in "/" ("locks/"); strip it so the
-                  route param round-trips to the same tab. */}
-              <NavLink
-                to={`/ext/${tab.path.replace(/\/+$/, '')}`}
-                onClick={handleNavClick}
-                title={tab.name}
-                className="wurk-navlink"
-                style={({ isActive }) => ({
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '0.625rem',
-                  padding: '0.5rem 0.85rem',
-                  borderRadius: 8,
-                  margin: '2px 8px',
-                  color: isActive ? 'var(--accent)' : 'var(--text)',
-                  background: isActive ? 'var(--surface-strong)' : 'transparent',
-                  boxShadow: isActive ? 'inset 0 0 0 1px var(--border)' : 'none',
-                  fontWeight: isActive ? 600 : 400,
-                  fontSize: 14,
-                  textDecoration: 'none',
-                  transition:
-                    'background var(--dur-base) var(--ease-standard), color var(--dur-base) var(--ease-standard), box-shadow var(--dur-base) var(--ease-standard)',
-                })}
-              >
-                <i className="fa-solid fa-puzzle-piece wurk-navlink__icon" aria-hidden="true" />
-                <span className="nav-label">{tab.name}</span>
-              </NavLink>
-            </li>
-          ))}
+          </Show>
+          <For each={customTabs()}>
+            {(tab) => (
+              <li>
+                {/* In-SPA route: /ext/:tab renders an Extension page (native
+                    server-rendered view, or an iframe for bare tabs[]= tabs).
+                    Registered index paths end in "/" ("locks/"); strip it so the
+                    route param round-trips to the same tab. */}
+                <A
+                  href={`/ext/${tab.path.replace(/\/+$/, '')}`}
+                  onClick={handleNavClick}
+                  title={tab.name}
+                  class="wurk-navlink"
+                  activeClass="active"
+                >
+                  <i class="fa-solid fa-puzzle-piece wurk-navlink__icon" aria-hidden="true" />
+                  <span class="nav-label">{tab.name}</span>
+                </A>
+              </li>
+            )}
+          </For>
         </ul>
 
         {/* Desktop-only: pin the rail collapsed (icons) or expanded (full).
             Hidden on mobile, where the nav is a full-width drawer. */}
-        <div style={{ height: 1, background: 'var(--border)', margin: '0.5rem 1rem 0' }} />
+        <div style={{ height: '1px', background: 'var(--border)', margin: '0.5rem 1rem 0' }} />
         <button
           type="button"
-          onClick={onToggleCollapse}
-          className="nav-collapse-toggle"
-          aria-label={collapsed ? t('nav.expand') : t('nav.collapse')}
-          aria-expanded={!collapsed}
-          title={collapsed ? t('nav.expand') : t('nav.collapse')}
+          onClick={() => props.onToggleCollapse()}
+          class="nav-collapse-toggle"
+          aria-label={props.collapsed ? t('nav.expand') : t('nav.collapse')}
+          aria-expanded={!props.collapsed}
+          title={props.collapsed ? t('nav.expand') : t('nav.collapse')}
           style={{
             display: 'flex',
-            alignItems: 'center',
+            'align-items': 'center',
             gap: '0.625rem',
             width: 'calc(100% - 16px)',
             padding: '0.5rem 0.85rem',
             margin: '4px 8px',
-            borderRadius: 8,
+            'border-radius': '8px',
             border: 'none',
             background: 'transparent',
             color: 'var(--text-muted)',
-            fontSize: 13,
+            'font-size': '13px',
             cursor: 'pointer',
             font: 'inherit',
           }}
         >
           <i
-            className={`fa-solid ${collapsed ? 'fa-angles-right' : 'fa-angles-left'} wurk-navlink__icon`}
+            class={`fa-solid ${props.collapsed ? 'fa-angles-right' : 'fa-angles-left'} wurk-navlink__icon`}
             aria-hidden="true"
           />
-          <span className="nav-label">{t('nav.collapse')}</span>
+          <span class="nav-label">{t('nav.collapse')}</span>
         </button>
 
         {/* Footer: link out to the source repo. Pinned to the bottom because the
             nav list above is flex:1. Muted by default; hover lifts like a nav item. */}
-        <div style={{ height: 1, background: 'var(--border)', margin: '0.5rem 1rem' }} />
+        <div style={{ height: '1px', background: 'var(--border)', margin: '0.5rem 1rem' }} />
         <a
           href="https://github.com/developerz-ai/wurk"
           target="_blank"
           rel="noopener noreferrer"
-          className="wurk-navlink"
+          class="wurk-navlink"
           style={{
             display: 'flex',
-            alignItems: 'center',
+            'align-items': 'center',
             gap: '0.625rem',
             padding: '0.5rem 0.85rem',
             margin: '2px 8px 0.85rem',
-            borderRadius: 8,
+            'border-radius': '8px',
             color: 'var(--text-muted)',
-            fontSize: 13,
-            textDecoration: 'none',
+            'font-size': '13px',
+            'text-decoration': 'none',
             transition: 'background var(--dur-base) var(--ease-standard), color var(--dur-base) var(--ease-standard)',
           }}
         >
-          <i className="fa-brands fa-github" style={{ fontSize: 16, width: 20, textAlign: 'center', flex: 'none' }} />
-          <span className="nav-label">GitHub</span>
+          <i class="fa-brands fa-github" style={{ 'font-size': '16px', width: '20px', 'text-align': 'center', flex: 'none' }} />
+          <span class="nav-label">GitHub</span>
         </a>
       </nav>
 
       <style>{`
         .wurk-nav { width: var(--nav-width); transition: width var(--dur-page) var(--ease-emphasized); }
+        /* Base nav-item chrome (was an inline style function under React; Solid's
+           <A> toggles the .active class, so the active look lives in CSS now). */
+        .wurk-navlink {
+          display: flex;
+          align-items: center;
+          gap: 0.625rem;
+          padding: 0.5rem 0.85rem;
+          border-radius: 8px;
+          margin: 2px 8px;
+          color: var(--text);
+          background: transparent;
+          box-shadow: none;
+          font-weight: 400;
+          font-size: 14px;
+          text-decoration: none;
+          transition: background var(--dur-base) var(--ease-standard), color var(--dur-base) var(--ease-standard), box-shadow var(--dur-base) var(--ease-standard);
+        }
+        /* Text stays white for every item; the active one is marked by a subtle
+           dark raised pill + hairline, not a bright white box. */
+        .wurk-navlink.active {
+          color: var(--accent);
+          background: var(--surface-strong);
+          box-shadow: inset 0 0 0 1px var(--border);
+          font-weight: 600;
+        }
         .wurk-navlink:hover {
           background: var(--surface-hover) !important;
           color: var(--accent) !important;
@@ -305,7 +319,7 @@ export default function Nav({ open, onClose, collapsed, onToggleCollapse }: NavP
              background colour, never its size — the icon never shifts when you
              click it, and the highlight is always a circle, never a square link
              box. Tight link padding keeps the icons from drifting apart. */
-          /* !important: the NavLink carries an inline padding (0.5rem 0.85rem)
+          /* !important: the <A> carries an inline padding (0.5rem 0.85rem)
              that outranks any class rule. Zero it in the rail so the fixed-size
              round glyph container — not link padding — defines the footprint;
              the horizontal inline padding would otherwise cramp the circle in

--- a/frontend/src/components/PageHeader.tsx
+++ b/frontend/src/components/PageHeader.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react';
+import { Show, type JSX } from 'solid-js';
 
 interface PageHeaderProps {
   /** Font Awesome solid icon class, e.g. `fa-layer-group` (matches the nav). */
@@ -6,22 +6,24 @@ interface PageHeaderProps {
   title: string;
   summary: string;
   /** Optional right-aligned slot — typically the count badge. */
-  children?: ReactNode;
+  children?: JSX.Element;
 }
 
 // Consistent header for each tab page: the tab's icon, its title, and a one-line
 // summary of what the page shows. Keeps every page oriented and on-brand.
-export function PageHeader({ icon, title, summary, children }: PageHeaderProps) {
+export function PageHeader(props: PageHeaderProps) {
   return (
-    <div className="page-header">
-      <span className="page-header__icon">
-        <i className={`fa-solid ${icon}`} />
+    <div class="page-header">
+      <span class="page-header__icon">
+        <i class={`fa-solid ${props.icon}`} />
       </span>
-      <div className="page-header__text">
-        <h1 className="page-header__title">{title}</h1>
-        <p className="page-header__summary">{summary}</p>
+      <div class="page-header__text">
+        <h1 class="page-header__title">{props.title}</h1>
+        <p class="page-header__summary">{props.summary}</p>
       </div>
-      {children != null && <div className="page-header__aside">{children}</div>}
+      <Show when={props.children != null}>
+        <div class="page-header__aside">{props.children}</div>
+      </Show>
     </div>
   );
 }

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -7,27 +7,27 @@ interface PaginationProps {
   onChange: (p: number) => void;
 }
 
-export function Pagination({ page, total, count, onChange }: PaginationProps) {
-  const totalPages = Math.max(1, Math.ceil(total / count));
+export function Pagination(props: PaginationProps) {
+  const totalPages = () => Math.max(1, Math.ceil(props.total / props.count));
 
   return (
-    <div className="pagination">
+    <div class="pagination">
       <button
-        className="btn"
-        disabled={page <= 1}
-        onClick={() => onChange(page - 1)}
-        style={{ opacity: page <= 1 ? 0.4 : 1 }}
+        class="btn"
+        disabled={props.page <= 1}
+        onClick={() => props.onChange(props.page - 1)}
+        style={{ opacity: props.page <= 1 ? 0.4 : 1 }}
       >
         {t('actions.prev')}
       </button>
       <span>
-        {t('common.page')} {page} {t('common.of')} {totalPages}
+        {t('common.page')} {props.page} {t('common.of')} {totalPages()}
       </span>
       <button
-        className="btn"
-        disabled={page >= totalPages}
-        onClick={() => onChange(page + 1)}
-        style={{ opacity: page >= totalPages ? 0.4 : 1 }}
+        class="btn"
+        disabled={props.page >= totalPages()}
+        onClick={() => props.onChange(props.page + 1)}
+        style={{ opacity: props.page >= totalPages() ? 0.4 : 1 }}
       >
         {t('actions.next')}
       </button>

--- a/frontend/src/components/Skeleton.tsx
+++ b/frontend/src/components/Skeleton.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from 'react';
+import { Index, type JSX } from 'solid-js';
 
 // Content-shaped loading placeholders. Prefer these over a lone spinner: they
 // hint at the layout that's coming, so the swap to real data doesn't shift the
@@ -10,56 +10,64 @@ import type { CSSProperties } from 'react';
 
 type Size = number | string;
 
+// Solid does not auto-suffix numeric style lengths with px (React did), so a
+// numeric width/height/radius prop must be coerced to a px string.
+const px = (v?: Size): string | undefined => (typeof v === 'number' ? `${v}px` : v);
+
 interface SkeletonProps {
   width?: Size;
   height?: Size;
   radius?: Size;
   circle?: boolean;
-  className?: string;
-  style?: CSSProperties;
+  class?: string;
+  style?: JSX.CSSProperties;
 }
 
 /** A single shimmering block. Size it via props or let it fill its container. */
-export function Skeleton({ width, height, radius, circle, className = '', style }: SkeletonProps) {
+export function Skeleton(props: SkeletonProps) {
   return (
     <span
       aria-hidden="true"
-      className={`skeleton${circle ? ' skeleton--circle' : ''}${className ? ` ${className}` : ''}`}
-      style={{ width, height, borderRadius: radius, ...style }}
+      class={`skeleton${props.circle ? ' skeleton--circle' : ''}${props.class ? ` ${props.class}` : ''}`}
+      style={{ width: px(props.width), height: px(props.height), 'border-radius': px(props.radius), ...props.style }}
     />
   );
 }
 
 /** A single line of placeholder text. `width` gives a natural ragged edge. */
-export function SkeletonText({ width = '100%', style }: { width?: Size; style?: CSSProperties }) {
-  return <span aria-hidden="true" className="skeleton skeleton--text" style={{ width, ...style }} />;
+export function SkeletonText(props: { width?: Size; style?: JSX.CSSProperties }) {
+  return <span aria-hidden="true" class="skeleton skeleton--text" style={{ width: px(props.width ?? '100%'), ...props.style }} />;
 }
 
 /** Table placeholder that mirrors `.table-wrapper` chrome for a seamless swap. */
-export function SkeletonTable({ rows = 6, cols = 4 }: { rows?: number; cols?: number }) {
+export function SkeletonTable(props: { rows?: number; cols?: number }) {
   return (
-    <div className="skeleton-table" role="status" aria-busy="true" aria-label="Loading">
-      {Array.from({ length: rows }, (_, r) => (
-        <div className="skeleton-table__row" key={r}>
-          {Array.from({ length: cols }, (_, c) => (
-            <span className="skeleton skeleton-table__cell" aria-hidden="true" key={c} />
-          ))}
-        </div>
-      ))}
+    <div class="skeleton-table" role="status" aria-busy="true" aria-label="Loading">
+      <Index each={Array.from({ length: props.rows ?? 6 })}>
+        {() => (
+          <div class="skeleton-table__row">
+            <Index each={Array.from({ length: props.cols ?? 4 })}>
+              {() => <span class="skeleton skeleton-table__cell" aria-hidden="true" />}
+            </Index>
+          </div>
+        )}
+      </Index>
     </div>
   );
 }
 
 /** Grid of metric-card placeholders for dashboard-style stat rows. */
-export function SkeletonCards({ count = 4 }: { count?: number }) {
+export function SkeletonCards(props: { count?: number }) {
   return (
-    <div className="skeleton-cards" role="status" aria-busy="true" aria-label="Loading">
-      {Array.from({ length: count }, (_, i) => (
-        <div className="skeleton-card" key={i}>
-          <SkeletonText width="45%" />
-          <Skeleton height="1.6rem" width="60%" />
-        </div>
-      ))}
+    <div class="skeleton-cards" role="status" aria-busy="true" aria-label="Loading">
+      <Index each={Array.from({ length: props.count ?? 4 })}>
+        {() => (
+          <div class="skeleton-card">
+            <SkeletonText width="45%" />
+            <Skeleton height="1.6rem" width="60%" />
+          </div>
+        )}
+      </Index>
     </div>
   );
 }
@@ -68,9 +76,9 @@ export function SkeletonCards({ count = 4 }: { count?: number }) {
 export function PageSkeleton() {
   return (
     <div role="status" aria-busy="true" aria-label="Loading">
-      <div className="page-header" style={{ animation: 'none' }}>
+      <div class="page-header" style={{ animation: 'none' }}>
         <Skeleton width="2.75rem" height="2.75rem" radius="var(--radius)" />
-        <div className="skeleton-stack" style={{ flex: 1, maxWidth: '18rem' }}>
+        <div class="skeleton-stack" style={{ flex: 1, 'max-width': '18rem' }}>
           <Skeleton height="1.4rem" width="45%" />
           <SkeletonText width="70%" />
         </div>

--- a/frontend/src/components/SortableTh.tsx
+++ b/frontend/src/components/SortableTh.tsx
@@ -1,32 +1,35 @@
-import { type CSSProperties, type ReactNode } from 'react';
+import { type JSX } from 'solid-js';
 import type { SortState } from '../hooks/useSort';
 
 interface SortableThProps {
-  label: ReactNode;
+  label: JSX.Element;
   /** Must match a key in the page's `useSort` accessors map. */
   sortKey: string;
+  // The current sort value (pages pass `sort={sort()}`); Solid's fine-grained
+  // bindings re-read it reactively at the call site, so a plain value is enough.
   sort: SortState;
   onSort: (key: string) => void;
-  style?: CSSProperties;
+  style?: JSX.CSSProperties;
 }
 
 // A sortable table header. The clickable target is a real <button> so it is
 // keyboard-focusable and operable (Enter/Space); the <th> keeps `aria-sort`
 // for assistive tech. Shows a neutral sort glyph until active, then an up/down
 // arrow for the current direction.
-export function SortableTh({ label, sortKey, sort, onSort, style }: SortableThProps) {
-  const active = sort.key === sortKey;
-  const icon = !active ? 'fa-sort' : sort.dir === 'asc' ? 'fa-arrow-up-short-wide' : 'fa-arrow-down-wide-short';
+export function SortableTh(props: SortableThProps) {
+  const active = () => props.sort.key === props.sortKey;
+  const icon = () =>
+    !active() ? 'fa-sort' : props.sort.dir === 'asc' ? 'fa-arrow-up-short-wide' : 'fa-arrow-down-wide-short';
 
   return (
     <th
-      className="th-sortable"
-      aria-sort={active ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}
-      style={style}
+      class="th-sortable"
+      aria-sort={active() ? (props.sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}
+      style={props.style}
     >
-      <button type="button" className="th-sortable__btn" onClick={() => onSort(sortKey)}>
-        {label}
-        <i className={`fa-solid ${icon} th-sortable__icon${active ? ' is-active' : ''}`} aria-hidden="true" />
+      <button type="button" class="th-sortable__btn" onClick={() => props.onSort(props.sortKey)}>
+        {props.label}
+        <i class={`fa-solid ${icon()} th-sortable__icon${active() ? ' is-active' : ''}`} aria-hidden="true" />
       </button>
     </th>
   );

--- a/frontend/src/components/StatCard.tsx
+++ b/frontend/src/components/StatCard.tsx
@@ -1,3 +1,4 @@
+import { Show } from 'solid-js';
 import { AnimatedNumber } from './AnimatedNumber';
 
 interface StatCardProps {
@@ -6,37 +7,39 @@ interface StatCardProps {
   color?: string;
 }
 
-export function StatCard({ label, value, color }: StatCardProps) {
+export function StatCard(props: StatCardProps) {
   return (
     <div
-      className="card card--stat"
+      class="card card--stat"
       style={{
         display: 'flex',
-        flexDirection: 'column',
+        'flex-direction': 'column',
         gap: '0.25rem',
       }}
     >
       <span
         style={{
-          fontSize: 12,
-          fontWeight: 500,
-          textTransform: 'uppercase',
-          letterSpacing: '0.05em',
+          'font-size': '12px',
+          'font-weight': 500,
+          'text-transform': 'uppercase',
+          'letter-spacing': '0.05em',
           color: 'var(--text-muted)',
         }}
       >
-        {label}
+        {props.label}
       </span>
       <span
         style={{
-          fontSize: 28,
-          fontWeight: 700,
-          lineHeight: 1.1,
-          color: color ?? 'var(--text)',
-          fontVariantNumeric: 'tabular-nums',
+          'font-size': '28px',
+          'font-weight': 700,
+          'line-height': 1.1,
+          color: props.color ?? 'var(--text)',
+          'font-variant-numeric': 'tabular-nums',
         }}
       >
-        {typeof value === 'number' ? <AnimatedNumber value={value} /> : value}
+        <Show when={typeof props.value === 'number'} fallback={props.value}>
+          <AnimatedNumber value={props.value as number} />
+        </Show>
       </span>
     </div>
   );

--- a/frontend/src/components/Tooltip.tsx
+++ b/frontend/src/components/Tooltip.tsx
@@ -1,24 +1,26 @@
-import { useState, useRef, useId, cloneElement, isValidElement, type ReactNode, type ReactElement } from 'react';
-import { createPortal } from 'react-dom';
+import { createSignal, createUniqueId, createEffect, children, Show, type JSX } from 'solid-js';
+import { Portal } from 'solid-js/web';
 
 // A tooltip rendered into a body-level portal with position: fixed, so it
 // escapes the `overflow: auto` clipping of scroll containers (e.g. the table
 // wrapper) that swallows an absolutely-positioned CSS tooltip. Positioned above
 // the trigger and horizontally centered on it.
-export function Tooltip({ tip, children }: { tip: string; children: ReactNode }) {
-  const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
-  const ref = useRef<HTMLSpanElement>(null);
-  const tipId = useId();
+export function Tooltip(props: { tip: string; children: JSX.Element }) {
+  const [pos, setPos] = createSignal<{ x: number; y: number } | null>(null);
+  let ref!: HTMLSpanElement;
+  const tipId = createUniqueId();
 
   const show = () => {
-    const r = ref.current?.getBoundingClientRect();
+    const r = ref?.getBoundingClientRect();
     if (r) setPos({ x: r.left + r.width / 2, y: r.top });
   };
 
   // Associate the trigger with the tooltip for screen readers.
-  const trigger = isValidElement(children)
-    ? cloneElement(children as ReactElement<{ 'aria-describedby'?: string }>, { 'aria-describedby': tipId })
-    : children;
+  const trigger = children(() => props.children);
+  createEffect(() => {
+    const el = trigger();
+    if (el instanceof HTMLElement) el.setAttribute('aria-describedby', tipId);
+  });
 
   return (
     <span
@@ -27,34 +29,36 @@ export function Tooltip({ tip, children }: { tip: string; children: ReactNode })
       onMouseLeave={() => setPos(null)}
       style={{ display: 'inline-flex' }}
     >
-      {trigger}
-      {pos &&
-        createPortal(
-          <div
-            id={tipId}
-            role="tooltip"
-            style={{
-              position: 'fixed',
-              left: pos.x,
-              top: pos.y - 8,
-              transform: 'translate(-50%, -100%)',
-              maxWidth: 260,
-              background: 'var(--surface-strong)',
-              color: 'var(--text)',
-              border: '1px solid var(--border-strong)',
-              padding: '0.4rem 0.6rem',
-              borderRadius: 6,
-              fontSize: 12,
-              lineHeight: 1.35,
-              zIndex: 9999,
-              pointerEvents: 'none',
-              boxShadow: '0 4px 14px rgba(0, 0, 0, 0.45)',
-            }}
-          >
-            {tip}
-          </div>,
-          document.body
+      {trigger()}
+      <Show when={pos()}>
+        {(p) => (
+          <Portal>
+            <div
+              id={tipId}
+              role="tooltip"
+              style={{
+                position: 'fixed',
+                left: `${p().x}px`,
+                top: `${p().y - 8}px`,
+                transform: 'translate(-50%, -100%)',
+                'max-width': '260px',
+                background: 'var(--surface-strong)',
+                color: 'var(--text)',
+                border: '1px solid var(--border-strong)',
+                padding: '0.4rem 0.6rem',
+                'border-radius': '6px',
+                'font-size': '12px',
+                'line-height': 1.35,
+                'z-index': 9999,
+                'pointer-events': 'none',
+                'box-shadow': '0 4px 14px rgba(0, 0, 0, 0.45)',
+              }}
+            >
+              {props.tip}
+            </div>
+          </Portal>
         )}
+      </Show>
     </span>
   );
 }

--- a/frontend/src/components/VirtualList.tsx
+++ b/frontend/src/components/VirtualList.tsx
@@ -1,49 +1,52 @@
-import { useState, useRef, useCallback, type ReactNode } from 'react';
+import { createSignal, For, type JSX } from 'solid-js';
 
 interface VirtualListProps<T> {
   items: T[];
   rowHeight: number;
   visibleCount: number;
-  renderItem: (item: T, i: number) => ReactNode;
+  renderItem: (item: T, i: number) => JSX.Element;
 }
 
-export function VirtualList<T>({ items, rowHeight, visibleCount, renderItem }: VirtualListProps<T>) {
-  const [scrollTop, setScrollTop] = useState(0);
-  const containerRef = useRef<HTMLDivElement>(null);
+export function VirtualList<T>(props: VirtualListProps<T>) {
+  const [scrollTop, setScrollTop] = createSignal(0);
+  let containerRef!: HTMLDivElement;
 
-  const containerHeight = rowHeight * visibleCount;
-  const totalHeight = rowHeight * items.length;
+  const containerHeight = () => props.rowHeight * props.visibleCount;
+  const totalHeight = () => props.rowHeight * props.items.length;
 
-  const startIndex = Math.floor(scrollTop / rowHeight);
-  const endIndex = Math.min(items.length - 1, startIndex + visibleCount + 2);
-  const paddingTop = startIndex * rowHeight;
-  const paddingBottom = Math.max(0, totalHeight - paddingTop - (endIndex - startIndex + 1) * rowHeight);
+  const startIndex = () => Math.floor(scrollTop() / props.rowHeight);
+  const endIndex = () => Math.min(props.items.length - 1, startIndex() + props.visibleCount + 2);
+  const paddingTop = () => startIndex() * props.rowHeight;
+  const paddingBottom = () =>
+    Math.max(0, totalHeight() - paddingTop() - (endIndex() - startIndex() + 1) * props.rowHeight);
 
-  const visibleItems = items.slice(startIndex, endIndex + 1);
+  const visibleItems = () => props.items.slice(startIndex(), endIndex() + 1);
 
-  const onScroll = useCallback(() => {
-    if (containerRef.current) {
-      setScrollTop(containerRef.current.scrollTop);
+  const onScroll = () => {
+    if (containerRef) {
+      setScrollTop(containerRef.scrollTop);
     }
-  }, []);
+  };
 
   return (
     <div
       ref={containerRef}
       onScroll={onScroll}
       style={{
-        height: containerHeight,
-        overflowY: 'auto',
-        overflowX: 'auto',
+        height: `${containerHeight()}px`,
+        'overflow-y': 'auto',
+        'overflow-x': 'auto',
       }}
     >
-      <div style={{ height: totalHeight, position: 'relative' }}>
-        <div style={{ paddingTop, paddingBottom }}>
-          {visibleItems.map((item, i) => (
-            <div key={startIndex + i} style={{ height: rowHeight, overflow: 'hidden' }}>
-              {renderItem(item, startIndex + i)}
-            </div>
-          ))}
+      <div style={{ height: `${totalHeight()}px`, position: 'relative' }}>
+        <div style={{ 'padding-top': `${paddingTop()}px`, 'padding-bottom': `${paddingBottom()}px` }}>
+          <For each={visibleItems()}>
+            {(item, i) => (
+              <div style={{ height: `${props.rowHeight}px`, overflow: 'hidden' }}>
+                {props.renderItem(item, startIndex() + i())}
+              </div>
+            )}
+          </For>
         </div>
       </div>
     </div>

--- a/frontend/src/components/charts/AreaChart.tsx
+++ b/frontend/src/components/charts/AreaChart.tsx
@@ -1,0 +1,157 @@
+import { createSignal, createMemo, createUniqueId, For, Show, type JSX } from 'solid-js';
+import {
+  type Datum,
+  type TooltipRow,
+  ChartTooltip,
+  Frame,
+  geometry,
+  xAt,
+  yAt,
+  yScale,
+  pickXTicks,
+  smoothPath,
+  useSize,
+  nearestPoint,
+  localXY,
+  CURSOR,
+  DOT_STROKE,
+} from './util';
+
+export interface AreaSeries {
+  /** Numeric field on each datum. */
+  key: string;
+  /** Legend/tooltip label; falls back to `key`. */
+  name?: string;
+  stroke: string;
+  strokeWidth?: number;
+  /** Dashed stroke, e.g. `'5 4'`. */
+  strokeDasharray?: string;
+  /** `'gradient'` fades the stroke colour to transparent; `'none'` = line only. */
+  fill?: 'gradient' | 'none';
+  /** Top opacity of the gradient fill (default 0.22). */
+  fillOpacity?: number;
+}
+
+export interface AreaChartProps {
+  data: Datum[];
+  series: AreaSeries[];
+  /** Total container height in px. */
+  height: number;
+  /** Reserve this many px for a Y axis; omit to hide it. */
+  yAxisWidth?: number;
+  yDecimals?: boolean;
+  xMinTickGap?: number;
+}
+
+// Gradient-filled area chart with a smooth monotone stroke, a crosshair + active
+// dots on hover, and an HTML tooltip. Replaces recharts' <AreaChart>.
+export function AreaChart(props: AreaChartProps): JSX.Element {
+  const { setRef, size } = useSize();
+  const [hover, setHover] = createSignal<number | null>(null);
+  const gid = createUniqueId();
+  let svg: SVGSVGElement | undefined;
+
+  const g = createMemo(() => geometry(size().w, size().h, props.yAxisWidth ?? 0));
+  const maxY = createMemo(() => {
+    let m = 0;
+    for (const d of props.data) for (const s of props.series) m = Math.max(m, Number(d[s.key]) || 0);
+    return m;
+  });
+  const scale = createMemo(() => yScale(maxY(), props.yDecimals ?? true));
+  const labels = createMemo(() => props.data.map((d) => d.label));
+  const xTicks = createMemo(() => pickXTicks(labels(), g().plotW, props.xMinTickGap ?? 56));
+
+  const px = (i: number) => xAt(i, props.data.length, g());
+  const py = (v: number) => yAt(v, scale().max, g());
+
+  const onMove = (e: MouseEvent) => {
+    if (!svg) return;
+    const { x } = localXY(e, svg);
+    setHover(nearestPoint(x, props.data.length, g()));
+  };
+
+  const rows = (): TooltipRow[] => {
+    const i = hover();
+    if (i === null) return [];
+    return props.series.map((s) => ({ name: s.name ?? s.key, value: Number(props.data[i]?.[s.key]) || 0, color: s.stroke }));
+  };
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height: `${props.height}px` }}>
+      <div ref={setRef} style={{ position: 'relative', width: '100%', height: '100%' }}>
+        <Show when={size().w > 0 && size().h > 0}>
+          <svg
+            ref={svg}
+            width={size().w}
+            height={size().h}
+            onMouseMove={onMove}
+            onMouseLeave={() => setHover(null)}
+          >
+            <defs>
+              <For each={props.series}>
+                {(s) => (
+                  <Show when={(s.fill ?? 'gradient') === 'gradient'}>
+                    <linearGradient id={`${gid}-${s.key}`} x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stop-color={s.stroke} stop-opacity={s.fillOpacity ?? 0.22} />
+                      <stop offset="95%" stop-color={s.stroke} stop-opacity={0} />
+                    </linearGradient>
+                  </Show>
+                )}
+              </For>
+            </defs>
+
+            <Frame geo={g()} yTicks={scale().ticks} yAt={py} showY={props.yAxisWidth != null} xTicks={xTicks()} xAt={px} labels={labels()} />
+
+            <For each={props.series}>
+              {(s) => {
+                const pts = (): Array<[number, number]> => props.data.map((d, i) => [px(i), py(Number(d[s.key]) || 0)]);
+                const line = () => smoothPath(pts());
+                const area = () => {
+                  const p = pts();
+                  if (p.length === 0) return '';
+                  const base = g().height - g().bottom;
+                  return `${smoothPath(p)} L${p[p.length - 1][0]},${base} L${p[0][0]},${base} Z`;
+                };
+                return (
+                  <>
+                    <Show when={(s.fill ?? 'gradient') === 'gradient'}>
+                      <path d={area()} fill={`url(#${gid}-${s.key})`} stroke="none" />
+                    </Show>
+                    <path
+                      d={line()}
+                      fill="none"
+                      stroke={s.stroke}
+                      stroke-width={s.strokeWidth ?? 2}
+                      stroke-dasharray={s.strokeDasharray}
+                      stroke-linejoin="round"
+                      stroke-linecap="round"
+                    />
+                  </>
+                );
+              }}
+            </For>
+
+            <Show when={hover() !== null}>
+              <line x1={px(hover()!)} x2={px(hover()!)} y1={g().top} y2={g().height - g().bottom} stroke={CURSOR} stroke-width="1" />
+              <For each={props.series}>
+                {(s) => (
+                  <circle
+                    cx={px(hover()!)}
+                    cy={py(Number(props.data[hover()!]?.[s.key]) || 0)}
+                    r="4"
+                    fill={s.stroke}
+                    stroke={DOT_STROKE}
+                    stroke-width="2"
+                  />
+                )}
+              </For>
+            </Show>
+          </svg>
+        </Show>
+      </div>
+      <Show when={hover() !== null}>
+        <ChartTooltip x={px(hover()!)} containerW={size().w} label={labels()[hover()!]} rows={rows()} />
+      </Show>
+    </div>
+  );
+}

--- a/frontend/src/components/charts/BarChart.tsx
+++ b/frontend/src/components/charts/BarChart.tsx
@@ -1,0 +1,109 @@
+import { createSignal, createMemo, For, Show, type JSX } from 'solid-js';
+import {
+  type TooltipRow,
+  ChartTooltip,
+  Frame,
+  geometry,
+  yAt,
+  yScale,
+  pickXTicks,
+  useSize,
+  nearestBand,
+  localXY,
+  BAR_CURSOR,
+} from './util';
+
+export interface BarDatum {
+  label: string;
+  value: number;
+  /** Per-bar fill (recharts <Cell> replacement). */
+  color: string;
+}
+
+export interface BarChartProps {
+  data: BarDatum[];
+  height: number;
+  /** Tooltip series label (recharts `name`). */
+  name?: string;
+  yAxisWidth?: number;
+  yDecimals?: boolean;
+  xMinTickGap?: number;
+  /** Top corner radius in px (default 3). */
+  radius?: number;
+}
+
+// Vertical bar chart with per-bar colours, rounded tops, and a faint band
+// highlight + tooltip on hover. Replaces recharts' <BarChart> + <Cell>.
+export function BarChart(props: BarChartProps): JSX.Element {
+  const { setRef, size } = useSize();
+  const [hover, setHover] = createSignal<number | null>(null);
+  let svg: SVGSVGElement | undefined;
+
+  const g = createMemo(() => geometry(size().w, size().h, props.yAxisWidth ?? 0));
+  const maxY = createMemo(() => Math.max(0, ...props.data.map((d) => d.value)));
+  const scale = createMemo(() => yScale(maxY(), props.yDecimals ?? true));
+  const labels = createMemo(() => props.data.map((d) => d.label));
+  const xTicks = createMemo(() => pickXTicks(labels(), g().plotW, props.xMinTickGap ?? 40));
+
+  const py = (v: number) => yAt(v, scale().max, g());
+  const band = () => (props.data.length > 0 ? g().plotW / props.data.length : 0);
+  const barW = () => Math.max(1, band() * 0.62);
+  const bandCenter = (i: number) => g().left + band() * (i + 0.5);
+
+  const onMove = (e: MouseEvent) => {
+    if (!svg) return;
+    const { x } = localXY(e, svg);
+    setHover(nearestBand(x, props.data.length, g()));
+  };
+
+  const rows = (): TooltipRow[] => {
+    const i = hover();
+    if (i === null || !props.data[i]) return [];
+    return [{ name: props.name ?? 'Value', value: props.data[i].value, color: props.data[i].color }];
+  };
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height: `${props.height}px` }}>
+      <div ref={setRef} style={{ position: 'relative', width: '100%', height: '100%' }}>
+        <Show when={size().w > 0 && size().h > 0}>
+          <svg
+            ref={svg}
+            width={size().w}
+            height={size().h}
+            onMouseMove={onMove}
+            onMouseLeave={() => setHover(null)}
+          >
+            <Frame geo={g()} yTicks={scale().ticks} yAt={py} showY={props.yAxisWidth != null} xTicks={xTicks()} xAt={bandCenter} labels={labels()} />
+
+            <Show when={hover() !== null}>
+              <rect x={g().left + band() * hover()!} y={g().top} width={band()} height={g().plotH} fill={BAR_CURSOR} />
+            </Show>
+
+            <For each={props.data}>
+              {(d, i) => {
+                const top = () => py(d.value);
+                const base = () => g().height - g().bottom;
+                const h = () => Math.max(0, base() - top());
+                const r = () => Math.min(props.radius ?? 3, barW() / 2, h());
+                return (
+                  <rect
+                    x={bandCenter(i()) - barW() / 2}
+                    y={top()}
+                    width={barW()}
+                    height={h()}
+                    rx={r()}
+                    ry={r()}
+                    fill={d.color}
+                  />
+                );
+              }}
+            </For>
+          </svg>
+        </Show>
+      </div>
+      <Show when={hover() !== null}>
+        <ChartTooltip x={bandCenter(hover()!)} containerW={size().w} label={labels()[hover()!]} rows={rows()} />
+      </Show>
+    </div>
+  );
+}

--- a/frontend/src/components/charts/LineChart.tsx
+++ b/frontend/src/components/charts/LineChart.tsx
@@ -1,0 +1,143 @@
+import { createSignal, createMemo, For, Show, type JSX } from 'solid-js';
+import {
+  type Datum,
+  type TooltipRow,
+  ChartTooltip,
+  Frame,
+  geometry,
+  xAt,
+  yAt,
+  yScale,
+  pickXTicks,
+  smoothPath,
+  useSize,
+  nearestPoint,
+  localXY,
+  MONO,
+  CURSOR,
+  DOT_STROKE,
+} from './util';
+
+export interface LineSeries {
+  key: string;
+  name?: string;
+  stroke: string;
+  strokeWidth?: number;
+}
+
+export interface LineChartProps {
+  data: Datum[];
+  series: LineSeries[];
+  height: number;
+  /** Render a monospace legend row below the plot. */
+  legend?: boolean;
+  yAxisWidth?: number;
+  yDecimals?: boolean;
+  xMinTickGap?: number;
+}
+
+// Multi-series smooth line chart with an optional legend and hover crosshair.
+// Replaces recharts' <LineChart> + <Legend>.
+export function LineChart(props: LineChartProps): JSX.Element {
+  const { setRef, size } = useSize();
+  const [hover, setHover] = createSignal<number | null>(null);
+  let svg: SVGSVGElement | undefined;
+
+  const g = createMemo(() => geometry(size().w, size().h, props.yAxisWidth ?? 0));
+  const maxY = createMemo(() => {
+    let m = 0;
+    for (const d of props.data) for (const s of props.series) m = Math.max(m, Number(d[s.key]) || 0);
+    return m;
+  });
+  const scale = createMemo(() => yScale(maxY(), props.yDecimals ?? true));
+  const labels = createMemo(() => props.data.map((d) => d.label));
+  const xTicks = createMemo(() => pickXTicks(labels(), g().plotW, props.xMinTickGap ?? 48));
+
+  const px = (i: number) => xAt(i, props.data.length, g());
+  const py = (v: number) => yAt(v, scale().max, g());
+
+  const onMove = (e: MouseEvent) => {
+    if (!svg) return;
+    const { x } = localXY(e, svg);
+    setHover(nearestPoint(x, props.data.length, g()));
+  };
+
+  const rows = (): TooltipRow[] => {
+    const i = hover();
+    if (i === null) return [];
+    return props.series.map((s) => ({ name: s.name ?? s.key, value: Number(props.data[i]?.[s.key]) || 0, color: s.stroke }));
+  };
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height: `${props.height}px`, display: 'flex', 'flex-direction': 'column' }}>
+      <div ref={setRef} style={{ position: 'relative', width: '100%', flex: 1, 'min-height': 0 }}>
+        <Show when={size().w > 0 && size().h > 0}>
+          <svg
+            ref={svg}
+            width={size().w}
+            height={size().h}
+            onMouseMove={onMove}
+            onMouseLeave={() => setHover(null)}
+          >
+            <Frame geo={g()} yTicks={scale().ticks} yAt={py} showY={props.yAxisWidth != null} xTicks={xTicks()} xAt={px} labels={labels()} />
+
+            <For each={props.series}>
+              {(s) => (
+                <path
+                  d={smoothPath(props.data.map((d, i) => [px(i), py(Number(d[s.key]) || 0)]))}
+                  fill="none"
+                  stroke={s.stroke}
+                  stroke-width={s.strokeWidth ?? 2}
+                  stroke-linejoin="round"
+                  stroke-linecap="round"
+                />
+              )}
+            </For>
+
+            <Show when={hover() !== null}>
+              <line x1={px(hover()!)} x2={px(hover()!)} y1={g().top} y2={g().height - g().bottom} stroke={CURSOR} stroke-width="1" />
+              <For each={props.series}>
+                {(s) => (
+                  <circle
+                    cx={px(hover()!)}
+                    cy={py(Number(props.data[hover()!]?.[s.key]) || 0)}
+                    r="4"
+                    fill={s.stroke}
+                    stroke={DOT_STROKE}
+                    stroke-width="2"
+                  />
+                )}
+              </For>
+            </Show>
+          </svg>
+        </Show>
+      </div>
+      <Show when={props.legend}>
+        <div
+          style={{
+            display: 'flex',
+            'flex-wrap': 'wrap',
+            'justify-content': 'center',
+            gap: '12px',
+            'font-size': '11px',
+            'font-family': MONO,
+            color: '#a1a1aa',
+            'padding-top': '6px',
+          }}
+        >
+          <For each={props.series}>
+            {(s) => (
+              <span style={{ display: 'inline-flex', 'align-items': 'center', gap: '5px' }}>
+                <span style={{ width: '10px', height: '2px', background: s.stroke, display: 'inline-block' }} />
+                {s.name ?? s.key}
+              </span>
+            )}
+          </For>
+        </div>
+      </Show>
+      <Show when={hover() !== null}>
+        <ChartTooltip x={px(hover()!)} containerW={size().w} label={labels()[hover()!]} rows={rows()} />
+      </Show>
+    </div>
+  );
+}

--- a/frontend/src/components/charts/charts.test.tsx
+++ b/frontend/src/components/charts/charts.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { render, screen } from '@solidjs/testing-library';
+import { AreaChart, LineChart, BarChart } from './index';
+
+// jsdom has no layout engine and (in v29) no ResizeObserver, so the charts —
+// which only draw once their container reports a non-zero size — would render an
+// empty <svg>. Give every element a fixed box and a no-op ResizeObserver so the
+// structural output (paths, bars, axis ticks) is exercised.
+const origRO = globalThis.ResizeObserver;
+let cw: PropertyDescriptor | undefined;
+let ch: PropertyDescriptor | undefined;
+
+beforeAll(() => {
+  cw = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
+  ch = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, get: () => 600 });
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, get: () => 300 });
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+afterAll(() => {
+  if (cw) Object.defineProperty(HTMLElement.prototype, 'clientWidth', cw);
+  if (ch) Object.defineProperty(HTMLElement.prototype, 'clientHeight', ch);
+  globalThis.ResizeObserver = origRO;
+});
+
+const DATA = [
+  { label: 'A', processed: 5, failed: 1 },
+  { label: 'B', processed: 8, failed: 2 },
+  { label: 'C', processed: 3, failed: 0 },
+];
+
+describe('LineChart', () => {
+  it('emits one stroked path per series plus a legend and axis ticks', () => {
+    const { container } = render(() => (
+      <LineChart
+        data={DATA}
+        height={300}
+        legend
+        yAxisWidth={36}
+        series={[
+          { key: 'processed', name: 'Proc', stroke: '#fafafa' },
+          { key: 'failed', stroke: '#a1a1aa' },
+        ]}
+      />
+    ));
+
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    // One smooth line per series.
+    expect(svg!.querySelectorAll('path[stroke]')).toHaveLength(2);
+    // Legend uses name ?? key.
+    expect(screen.getByText('Proc')).toBeInTheDocument();
+    expect(screen.getByText('failed')).toBeInTheDocument();
+    // X category ticks + a Y axis tick (max rounds to 8).
+    expect(screen.getAllByText('B').length).toBeGreaterThan(0);
+    expect(screen.getByText('8')).toBeInTheDocument();
+  });
+});
+
+describe('AreaChart', () => {
+  it('renders an svg with a stroked path per series', () => {
+    const { container } = render(() => (
+      <AreaChart
+        data={DATA}
+        height={300}
+        yAxisWidth={36}
+        series={[
+          { key: 'processed', stroke: '#fafafa', fill: 'gradient' },
+          { key: 'failed', stroke: '#a1a1aa', fill: 'none' },
+        ]}
+      />
+    ));
+
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    // gradient series → area + line path; line-only series → line path.
+    expect(svg!.querySelectorAll('path').length).toBeGreaterThanOrEqual(3);
+    expect(svg!.querySelector('linearGradient')).not.toBeNull();
+    expect(screen.getAllByText('A').length).toBeGreaterThan(0);
+  });
+});
+
+describe('BarChart', () => {
+  it('renders one rect per datum with axis ticks', () => {
+    const { container } = render(() => (
+      <BarChart
+        data={[
+          { label: 'A', value: 5, color: '#fafafa' },
+          { label: 'B', value: 8, color: '#3f3f46' },
+          { label: 'C', value: 3, color: '#3f3f46' },
+        ]}
+        height={240}
+        name="Depth"
+        yAxisWidth={36}
+      />
+    ));
+
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    // No hover → the only rects are the three bars.
+    expect(svg!.querySelectorAll('rect')).toHaveLength(3);
+    expect(screen.getAllByText('C').length).toBeGreaterThan(0);
+    expect(screen.getByText('8')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/charts/index.ts
+++ b/frontend/src/components/charts/index.ts
@@ -1,0 +1,7 @@
+// Dependency-free SolidJS SVG charts — the recharts replacement. Dark Obsidian
+// palette, responsive to container width/height, smooth monotone paths, hover
+// crosshair + tooltip. See ./util for the shared primitives.
+export { AreaChart, type AreaSeries, type AreaChartProps } from './AreaChart';
+export { LineChart, type LineSeries, type LineChartProps } from './LineChart';
+export { BarChart, type BarDatum, type BarChartProps } from './BarChart';
+export type { Datum } from './util';

--- a/frontend/src/components/charts/util.tsx
+++ b/frontend/src/components/charts/util.tsx
@@ -1,0 +1,299 @@
+import { createSignal, onCleanup, onMount, For, Show, type JSX } from 'solid-js';
+
+// Shared primitives for the hand-rolled SVG charts that replace recharts. No
+// deps beyond Solid + SVG — the dark Obsidian palette is baked in here so every
+// chart reads identically (ticks #71717a, faint white grid, JetBrains Mono).
+
+export const AXIS_TICK = '#71717a';
+export const GRID = 'rgba(255,255,255,0.06)';
+export const MONO = 'JetBrains Mono, monospace';
+export const CURSOR = 'rgba(255,255,255,0.25)';
+export const BAR_CURSOR = 'rgba(255,255,255,0.04)';
+export const TOOLTIP_BG = '#161618';
+export const TOOLTIP_BORDER = '#272729';
+export const TOOLTIP_FG = '#e4e4e7';
+export const TOOLTIP_LABEL = '#a1a1aa';
+export const DOT_STROKE = '#09090b';
+
+export interface Datum {
+  label: string;
+  [key: string]: string | number;
+}
+
+// Plot geometry in pixels. `left` reserves room for the optional Y axis; the
+// other margins mirror recharts' defaults (top/right 8, bottom for x labels).
+export interface Geo {
+  width: number;
+  height: number;
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  plotW: number;
+  plotH: number;
+}
+
+export function geometry(width: number, height: number, yAxisWidth = 0): Geo {
+  const left = yAxisWidth;
+  const right = 8;
+  const top = 8;
+  const bottom = 22;
+  return {
+    width,
+    height,
+    left,
+    right,
+    top,
+    bottom,
+    plotW: Math.max(0, width - left - right),
+    plotH: Math.max(0, height - top - bottom),
+  };
+}
+
+// Category x: evenly spaced points (line/area sit on them; bars centre bands on
+// them). Single point centres in the plot so a lone bucket isn't glued to the
+// left edge.
+export function xAt(i: number, n: number, g: Geo): number {
+  if (n <= 1) return g.left + g.plotW / 2;
+  return g.left + (i * g.plotW) / (n - 1);
+}
+
+export function yAt(v: number, maxY: number, g: Geo): number {
+  const bottom = g.height - g.bottom;
+  if (maxY <= 0) return bottom;
+  return bottom - (v / maxY) * g.plotH;
+}
+
+// Catmull-Rom → cubic bézier: the "monotone"-ish smooth recharts draws with
+// type="monotone". Endpoints duplicate their neighbour so the curve starts/ends
+// flat instead of flaring.
+export function smoothPath(pts: Array<[number, number]>): string {
+  if (pts.length === 0) return '';
+  if (pts.length === 1) return `M${pts[0][0]},${pts[0][1]}`;
+  let d = `M${pts[0][0]},${pts[0][1]}`;
+  for (let i = 0; i < pts.length - 1; i++) {
+    const p0 = pts[i - 1] ?? pts[i];
+    const p1 = pts[i];
+    const p2 = pts[i + 1];
+    const p3 = pts[i + 2] ?? p2;
+    const c1x = p1[0] + (p2[0] - p0[0]) / 6;
+    const c1y = p1[1] + (p2[1] - p0[1]) / 6;
+    const c2x = p2[0] - (p3[0] - p1[0]) / 6;
+    const c2y = p2[1] - (p3[1] - p1[1]) / 6;
+    d += ` C${c1x},${c1y} ${c2x},${c2y} ${p2[0]},${p2[1]}`;
+  }
+  return d;
+}
+
+function niceNum(range: number, round: boolean): number {
+  const exp = Math.floor(Math.log10(range));
+  const frac = range / Math.pow(10, exp);
+  let nice: number;
+  if (round) {
+    if (frac < 1.5) nice = 1;
+    else if (frac < 3) nice = 2;
+    else if (frac < 7) nice = 5;
+    else nice = 10;
+  } else {
+    if (frac <= 1) nice = 1;
+    else if (frac <= 2) nice = 2;
+    else if (frac <= 5) nice = 5;
+    else nice = 10;
+  }
+  return nice * Math.pow(10, exp);
+}
+
+// "Nice" y ticks from 0 to a rounded max. `allowDecimals=false` snaps the step
+// to whole numbers (job counts, queue depth) so the axis never shows "2.5 jobs".
+export function yScale(maxVal: number, allowDecimals = true): { max: number; ticks: number[] } {
+  if (!(maxVal > 0)) return { max: 1, ticks: [0, 1] };
+  const count = 4;
+  let step = niceNum(maxVal / count, true);
+  if (!allowDecimals) step = Math.max(1, Math.round(step));
+  const max = Math.ceil(maxVal / step) * step;
+  const ticks: number[] = [];
+  for (let v = 0; v <= max + step / 1000; v += step) ticks.push(Number(v.toFixed(6)));
+  return { max, ticks };
+}
+
+export function fmtTick(v: number): string {
+  return Number.isInteger(v) ? v.toLocaleString() : v.toFixed(v < 10 ? 2 : 1);
+}
+
+// preserveStartEnd + minTickGap: keep both endpoints and thin the interior to
+// whatever fits without overlapping, estimating label width from char count at
+// 11px monospace.
+export function pickXTicks(labels: string[], plotW: number, minGap: number): number[] {
+  const n = labels.length;
+  if (n <= 1) return n === 1 ? [0] : [];
+  const maxLabelPx = Math.max(...labels.map((l) => l.length)) * 6.6;
+  const slot = maxLabelPx + minGap;
+  const maxTicks = Math.max(2, Math.floor(plotW / slot));
+  if (maxTicks >= n) return labels.map((_, i) => i);
+  const step = Math.ceil((n - 1) / (maxTicks - 1));
+  const idx: number[] = [];
+  for (let i = 0; i < n; i += step) idx.push(i);
+  if (idx[idx.length - 1] !== n - 1) idx.push(n - 1);
+  return idx;
+}
+
+// Measures the plot box (width AND height) so charts fill their container and
+// react to resizes — the responsive-container replacement. `flex:1` inside a
+// fixed-height wrapper means legends shrink the plot without extra math.
+export function useSize(): { setRef: (el: HTMLDivElement) => void; size: () => { w: number; h: number } } {
+  const [size, setSize] = createSignal({ w: 0, h: 0 });
+  let el: HTMLDivElement | undefined;
+  const setRef = (e: HTMLDivElement) => {
+    el = e;
+  };
+  onMount(() => {
+    const measure = () => {
+      if (el) setSize({ w: el.clientWidth, h: el.clientHeight });
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    if (el) ro.observe(el);
+    onCleanup(() => ro.disconnect());
+  });
+  return { setRef, size };
+}
+
+// Grid (faint dashed horizontals at each y tick) + axis ticks. axisLine/tickLine
+// are always off (design), matching every recharts axis on these pages.
+export function Frame(props: {
+  geo: Geo;
+  yTicks: number[];
+  yAt: (v: number) => number;
+  showY: boolean;
+  xTicks: number[];
+  xAt: (i: number) => number;
+  labels: string[];
+}): JSX.Element {
+  const last = () => props.labels.length - 1;
+  return (
+    <>
+      <For each={props.yTicks}>
+        {(v) => (
+          <line
+            x1={props.geo.left}
+            x2={props.geo.width - props.geo.right}
+            y1={props.yAt(v)}
+            y2={props.yAt(v)}
+            stroke={GRID}
+            stroke-dasharray="3 3"
+          />
+        )}
+      </For>
+      <Show when={props.showY}>
+        <For each={props.yTicks}>
+          {(v) => (
+            <text
+              x={props.geo.left - 6}
+              y={props.yAt(v)}
+              text-anchor="end"
+              dominant-baseline="middle"
+              fill={AXIS_TICK}
+              font-size="11"
+              font-family={MONO}
+            >
+              {fmtTick(v)}
+            </text>
+          )}
+        </For>
+      </Show>
+      <For each={props.xTicks}>
+        {(i) => (
+          <text
+            x={props.xAt(i)}
+            y={props.geo.height - props.geo.bottom + 14}
+            text-anchor={i === 0 ? 'start' : i === last() ? 'end' : 'middle'}
+            fill={AXIS_TICK}
+            font-size="11"
+            font-family={MONO}
+          >
+            {props.labels[i]}
+          </text>
+        )}
+      </For>
+    </>
+  );
+}
+
+export interface TooltipRow {
+  name: string;
+  value: number;
+  color: string;
+}
+
+function fmtVal(v: number): string {
+  return Number.isInteger(v) ? v.toLocaleString() : v.toFixed(2);
+}
+
+// HTML overlay tooltip (crisp text, unlike SVG <text>). Flips to the other side
+// of the cursor near the right edge so it never spills out of the plot.
+export function ChartTooltip(props: { x: number; containerW: number; label: string; rows: TooltipRow[] }): JSX.Element {
+  const flip = () => props.x > props.containerW / 2;
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: `${props.x}px`,
+        top: '8px',
+        transform: flip() ? 'translateX(calc(-100% - 12px))' : 'translateX(12px)',
+        background: TOOLTIP_BG,
+        border: `1px solid ${TOOLTIP_BORDER}`,
+        color: TOOLTIP_FG,
+        'border-radius': '6px',
+        'font-size': '12px',
+        'font-family': MONO,
+        padding: '8px 10px',
+        'pointer-events': 'none',
+        'white-space': 'nowrap',
+        'z-index': 10,
+      }}
+    >
+      <div style={{ color: TOOLTIP_LABEL, 'margin-bottom': '4px' }}>{props.label}</div>
+      <For each={props.rows}>
+        {(row) => (
+          <div style={{ display: 'flex', 'align-items': 'center', gap: '6px' }}>
+            <span
+              style={{
+                width: '8px',
+                height: '8px',
+                'border-radius': '2px',
+                background: row.color,
+                display: 'inline-block',
+                flex: 'none',
+              }}
+            />
+            <span>{row.name}</span>
+            <span style={{ 'margin-inline-start': 'auto', 'padding-inline-start': '10px' }}>{fmtVal(row.value)}</span>
+          </div>
+        )}
+      </For>
+    </div>
+  );
+}
+
+// Nearest category index from a local x, for line/area (points) charts.
+export function nearestPoint(localX: number, n: number, g: Geo): number {
+  if (n <= 1) return 0;
+  const stepX = g.plotW / (n - 1);
+  const i = Math.round((localX - g.left) / stepX);
+  return Math.max(0, Math.min(n - 1, i));
+}
+
+// Nearest band index from a local x, for bar charts.
+export function nearestBand(localX: number, n: number, g: Geo): number {
+  if (n <= 0) return -1;
+  const band = g.plotW / n;
+  const i = Math.floor((localX - g.left) / band);
+  return Math.max(0, Math.min(n - 1, i));
+}
+
+// Local x/y from a pointer event relative to the SVG's top-left, robust to
+// nested target elements (getBoundingClientRect, not offsetX).
+export function localXY(e: MouseEvent, svg: SVGSVGElement): { x: number; y: number } {
+  const r = svg.getBoundingClientRect();
+  return { x: e.clientX - r.left, y: e.clientY - r.top };
+}

--- a/frontend/src/hooks/hooks.test.tsx
+++ b/frontend/src/hooks/hooks.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@solidjs/testing-library';
+import { MemoryRouter, Route, createMemoryHistory, useLocation } from '@solidjs/router';
+import type { JSX } from 'solid-js';
+import { useSort, type Accessors } from './useSort';
+import { useSelection } from './useSelection';
+import { useCountUp } from './useCountUp';
+import { usePageParam } from './usePageParam';
+
+interface Row {
+  name: string;
+  n: number;
+  opt: number | null;
+}
+
+const DATA: Row[] = [
+  { name: 'banana', n: 10, opt: 5 },
+  { name: 'apple', n: 2, opt: null },
+  { name: 'cherry', n: 1, opt: 3 },
+];
+
+const ACC: Accessors<Row> = {
+  name: (r) => r.name,
+  n: (r) => r.n,
+  opt: (r) => r.opt,
+};
+
+describe('useSort', () => {
+  it('starts unsorted, then toggles asc → desc on the active column', () => {
+    const { result } = renderHook(() => useSort(() => DATA, ACC));
+    // No key selected: rows pass through in source order.
+    expect(result.sorted().map((r) => r.name)).toEqual(['banana', 'apple', 'cherry']);
+
+    result.toggle('n');
+    expect(result.sort()).toEqual({ key: 'n', dir: 'asc' });
+    expect(result.sorted().map((r) => r.n)).toEqual([1, 2, 10]); // numeric, not lexicographic
+
+    result.toggle('n');
+    expect(result.sort()).toEqual({ key: 'n', dir: 'desc' });
+    expect(result.sorted().map((r) => r.n)).toEqual([10, 2, 1]);
+  });
+
+  it('sorts strings and keeps nulls last regardless of direction', () => {
+    const { result } = renderHook(() => useSort(() => DATA, ACC));
+
+    result.toggle('name');
+    expect(result.sorted().map((r) => r.name)).toEqual(['apple', 'banana', 'cherry']);
+
+    result.toggle('opt'); // asc: 3, 5, null
+    expect(result.sorted().map((r) => r.opt)).toEqual([3, 5, null]);
+
+    result.toggle('opt'); // desc: 5, 3, null — null stays last
+    expect(result.sorted().map((r) => r.opt)).toEqual([5, 3, null]);
+  });
+});
+
+describe('useSelection', () => {
+  it('toggles a single key on and off', () => {
+    const { result } = renderHook(() => useSelection());
+    expect(result.count()).toBe(0);
+
+    result.toggle('a');
+    expect(result.count()).toBe(1);
+    expect(result.selected().has('a')).toBe(true);
+
+    result.toggle('a');
+    expect(result.count()).toBe(0);
+  });
+
+  it('toggleAll selects the page, then clears when everything is already on', () => {
+    const { result } = renderHook(() => useSelection());
+    const keys = ['a', 'b', 'c'];
+
+    result.toggleAll(keys);
+    expect(result.count()).toBe(3);
+
+    result.toggleAll(keys); // all on → clear
+    expect(result.count()).toBe(0);
+
+    // Partial selection is not "all on", so toggleAll fills the rest in.
+    result.toggle('a');
+    result.toggleAll(keys);
+    expect(result.count()).toBe(3);
+
+    result.clear();
+    expect(result.count()).toBe(0);
+  });
+});
+
+describe('useCountUp', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('snaps straight to the target under prefers-reduced-motion', async () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockReturnValue({
+        matches: true,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      }),
+    );
+    const { result } = renderHook(() => useCountUp(() => 42));
+    await waitFor(() => expect(result()).toBe(42));
+  });
+
+  it('snaps (never animates) when the target is non-finite', async () => {
+    // No matchMedia stub → prefers-reduced-motion is false, so the finite guard
+    // is what short-circuits the rAF tween.
+    const { result } = renderHook(() => useCountUp(() => Number.POSITIVE_INFINITY));
+    await waitFor(() => expect(result()).toBe(Number.POSITIVE_INFINITY));
+  });
+});
+
+function routerWrapper(path: string) {
+  return (props: { children: JSX.Element }) => {
+    const history = createMemoryHistory();
+    history.set({ value: path, replace: true });
+    // Router primitives (useSearchParams/useLocation) require a matched Route,
+    // not just the Router context — mount the hook harness inside a wildcard one.
+    return (
+      <MemoryRouter history={history}>
+        <Route path="*" component={() => <>{props.children}</>} />
+      </MemoryRouter>
+    );
+  };
+}
+
+describe('usePageParam', () => {
+  it('reads ?page from the URL', () => {
+    const { result } = renderHook(() => usePageParam(), { wrapper: routerWrapper('/dead?page=3') });
+    expect(result[0]()).toBe(3);
+  });
+
+  it('clamps invalid or out-of-range pages to 1', () => {
+    const nan = renderHook(() => usePageParam(), { wrapper: routerWrapper('/dead?page=abc') });
+    expect(nan.result[0]()).toBe(1);
+
+    const neg = renderHook(() => usePageParam(), { wrapper: routerWrapper('/dead?page=-2') });
+    expect(neg.result[0]()).toBe(1);
+  });
+
+  it('writes higher pages to the URL and drops page=1 to keep it clean', async () => {
+    const { result } = renderHook(
+      () => {
+        const [page, setPage] = usePageParam();
+        const loc = useLocation();
+        return { page, setPage, loc };
+      },
+      { wrapper: routerWrapper('/dead?page=3') },
+    );
+
+    result.setPage(5);
+    await waitFor(() => expect(result.loc.search).toContain('page=5'));
+
+    result.setPage(1);
+    await waitFor(() => expect(result.loc.search).not.toContain('page'));
+  });
+});

--- a/frontend/src/hooks/useCountUp.ts
+++ b/frontend/src/hooks/useCountUp.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { createSignal, createEffect, onCleanup, type Accessor } from 'solid-js';
 
 const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3);
 
@@ -7,39 +7,41 @@ const prefersReducedMotion = () =>
   window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
 
 // Tween a displayed number toward `target` with requestAnimationFrame so a stat
-// counts up to its real value instead of snapping. Each render starts from
-// whatever is currently on screen (tracked in displayRef), so the first landing
-// counts up from zero while later live SSE updates ease smoothly between values
-// rather than restarting from zero. Honors prefers-reduced-motion by snapping.
-export function useCountUp(target: number, duration = 700): number {
-  const [display, setDisplay] = useState(0);
-  const displayRef = useRef(0);
-  const rafRef = useRef<number | null>(null);
+// counts up to its real value instead of snapping. `target` is an accessor; the
+// effect re-runs whenever it changes. Each run starts from whatever is currently
+// on screen (tracked in `current`), so the first landing counts up from zero
+// while later live SSE updates ease smoothly between values rather than
+// restarting from zero. Honors prefers-reduced-motion by snapping.
+export function useCountUp(target: Accessor<number>, duration = 700): Accessor<number> {
+  const [display, setDisplay] = createSignal(0);
+  let current = 0;
+  let raf: number | null = null;
 
-  useEffect(() => {
-    if (prefersReducedMotion() || !Number.isFinite(target)) {
-      displayRef.current = target;
-      setDisplay(target);
+  createEffect(() => {
+    const tgt = target();
+    if (prefersReducedMotion() || !Number.isFinite(tgt)) {
+      current = tgt;
+      setDisplay(tgt);
       return;
     }
 
-    const from = displayRef.current;
-    if (from === target) return;
+    const from = current;
+    if (from === tgt) return;
 
     const start = performance.now();
     const tick = (now: number) => {
       const t = Math.min((now - start) / duration, 1);
-      const value = from + (target - from) * easeOutCubic(t);
-      displayRef.current = value;
+      const value = from + (tgt - from) * easeOutCubic(t);
+      current = value;
       setDisplay(value);
-      if (t < 1) rafRef.current = requestAnimationFrame(tick);
+      if (t < 1) raf = requestAnimationFrame(tick);
     };
-    rafRef.current = requestAnimationFrame(tick);
+    raf = requestAnimationFrame(tick);
 
-    return () => {
-      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
-    };
-  }, [target, duration]);
+    onCleanup(() => {
+      if (raf !== null) cancelAnimationFrame(raf);
+    });
+  });
 
   return display;
 }

--- a/frontend/src/hooks/useJobSetActions.ts
+++ b/frontend/src/hooks/useJobSetActions.ts
@@ -1,7 +1,7 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/solid-query';
 
 // The three mutable sorted-set views. The string doubles as the API path
-// segment (`/wurk/api/<set>`) and the TanStack Query key the pages cache under.
+// segment (`/wurk/api/<set>`) and the query key the pages cache under.
 export type JobSetName = 'retries' | 'scheduled' | 'dead';
 
 // Re-targets the exact (score, jid) pair server-side. Mirrors
@@ -26,7 +26,8 @@ async function postJSON(url: string, body?: unknown): Promise<Response> {
 
 // Single/bulk/all mutations for one job set. Each invalidates both the set's
 // own query and `stats` (the nav badges + dashboard counts read from it) so
-// the UI reflects the change without a manual refresh.
+// the UI reflects the change without a manual refresh. solid-query's
+// useMutation takes an options accessor; call `single.mutate({ key, cmd })`.
 export function useJobSetActions(set: JobSetName) {
   const qc = useQueryClient();
   const invalidate = () => {
@@ -34,22 +35,22 @@ export function useJobSetActions(set: JobSetName) {
     qc.invalidateQueries({ queryKey: ['stats'] });
   };
 
-  const single = useMutation({
+  const single = useMutation(() => ({
     mutationFn: ({ key, cmd }: { key: string; cmd: string }) =>
       postJSON(`/wurk/api/${set}/${encodeURIComponent(key)}`, { cmd }),
     onSuccess: invalidate,
-  });
+  }));
 
-  const bulk = useMutation({
+  const bulk = useMutation(() => ({
     mutationFn: ({ keys, cmd }: { keys: string[]; cmd: string }) =>
       postJSON(`/wurk/api/${set}`, { keys, cmd }),
     onSuccess: invalidate,
-  });
+  }));
 
-  const all = useMutation({
+  const all = useMutation(() => ({
     mutationFn: (cmd: string) => postJSON(`/wurk/api/${set}/all/${cmd}`),
     onSuccess: invalidate,
-  });
+  }));
 
   return { single, bulk, all };
 }

--- a/frontend/src/hooks/useMeta.ts
+++ b/frontend/src/hooks/useMeta.ts
@@ -12,6 +12,8 @@ export interface CustomTab {
 }
 
 export interface Meta {
+  // Gem version (e.g. "1.1.0"), shown next to the wordmark in the nav.
+  version?: string;
   read_only: boolean;
   // Optional host-supplied banner copy; null → SPA uses its localized default.
   read_only_message: string | null;

--- a/frontend/src/hooks/useMeta.ts
+++ b/frontend/src/hooks/useMeta.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/solid-query';
 
 // A dashboard tab registered by a third-party gem via
 // Sidekiq::Web.register_extension. When ext_name is present, the Extension page
@@ -20,11 +20,13 @@ export interface Meta {
 }
 
 // Boot-time dashboard flags. Fetched once and cached forever — these only
-// change on a server restart, so there's no point re-polling.
+// change on a server restart, so there's no point re-polling. Returns the
+// solid-query result store; read `query.data?.read_only` reactively (never
+// destructure it — that severs the store's reactivity).
 export function useMeta() {
-  return useQuery<Meta>({
+  return useQuery<Meta>(() => ({
     queryKey: ['meta'],
     queryFn: () => fetch('/wurk/api/meta').then((r) => r.json() as Promise<Meta>),
     staleTime: Infinity,
-  });
+  }));
 }

--- a/frontend/src/hooks/usePageParam.ts
+++ b/frontend/src/hooks/usePageParam.ts
@@ -1,24 +1,21 @@
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from '@solidjs/router';
+import type { Accessor } from 'solid-js';
 
 // Pagination state that lives in the URL (`?page=N`) instead of component state,
 // so a page is shareable, bookmarkable, and survives back/forward navigation.
 // Page 1 is the canonical default and is kept out of the URL to stay clean.
-export function usePageParam(): [number, (p: number) => void] {
+// Returns `[page, setPage]` where `page` is a reactive accessor — read `page()`.
+export function usePageParam(): [Accessor<number>, (p: number) => void] {
   const [params, setParams] = useSearchParams();
-  const raw = parseInt(params.get('page') ?? '1', 10);
-  const page = Number.isFinite(raw) && raw > 0 ? raw : 1;
 
-  const setPage = (p: number) => {
-    setParams(
-      (prev) => {
-        const next = new URLSearchParams(prev);
-        if (p <= 1) next.delete('page');
-        else next.set('page', String(p));
-        return next;
-      },
-      { replace: false },
-    );
+  const page = () => {
+    const raw = parseInt((params.page as string) ?? '1', 10);
+    return Number.isFinite(raw) && raw > 0 ? raw : 1;
   };
+
+  // Setting a param to undefined removes it from the URL; the router merges the
+  // rest, so page 1 stays clean while other query params are preserved.
+  const setPage = (p: number) => setParams({ page: p <= 1 ? undefined : String(p) });
 
   return [page, setPage];
 }

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { createSignal, onCleanup, onMount, type Accessor } from 'solid-js';
 
 export interface StatsSnapshot {
   processed: number;
@@ -15,15 +15,19 @@ export interface StatsSnapshot {
   at: number;
 }
 
-export function useSSE(enabled = true) {
-  const [stats, setStats] = useState<StatsSnapshot | null>(null);
-  const [connected, setConnected] = useState(false);
-  const esRef = useRef<EventSource | null>(null);
+// Live stats over Server-Sent Events. Returns signal accessors — read them as
+// `stats()` / `connected()` inside JSX or a memo so they track reactively.
+// The EventSource is opened on mount and closed on cleanup (component dispose),
+// so exactly one connection lives per mounted consumer.
+export function useSSE(
+  enabled = true,
+): { stats: Accessor<StatsSnapshot | null>; connected: Accessor<boolean> } {
+  const [stats, setStats] = createSignal<StatsSnapshot | null>(null);
+  const [connected, setConnected] = createSignal(false);
 
-  useEffect(() => {
+  onMount(() => {
     if (!enabled) return;
     const es = new EventSource('/wurk/api/stream');
-    esRef.current = es;
     es.addEventListener('stats', (e) => {
       try {
         setStats(JSON.parse((e as MessageEvent).data) as StatsSnapshot);
@@ -33,11 +37,11 @@ export function useSSE(enabled = true) {
     });
     es.onopen = () => setConnected(true);
     es.onerror = () => setConnected(false);
-    return () => {
+    onCleanup(() => {
       es.close();
       setConnected(false);
-    };
-  }, [enabled]);
+    });
+  });
 
   return { stats, connected };
 }

--- a/frontend/src/hooks/useSelection.ts
+++ b/frontend/src/hooks/useSelection.ts
@@ -1,31 +1,34 @@
-import { useCallback, useMemo, useState } from 'react';
+import { createSignal, type Accessor } from 'solid-js';
 
 // Row-selection state for the bulk-action tables (retries/scheduled/dead).
 // Keyed by the entry's composite key (see entryKey) so a selection survives
 // re-sorting; `toggleAll` works against the currently visible page's keys.
-export function useSelection() {
-  const [selected, setSelected] = useState<Set<string>>(new Set());
+// `selected` and `count` are signal accessors — call them (`count()`) to read.
+export function useSelection(): {
+  selected: Accessor<Set<string>>;
+  toggle: (key: string) => void;
+  toggleAll: (keys: string[]) => void;
+  clear: () => void;
+  count: Accessor<number>;
+} {
+  const [selected, setSelected] = createSignal<Set<string>>(new Set());
 
-  const toggle = useCallback((key: string) => {
+  const toggle = (key: string) =>
     setSelected((prev) => {
       const next = new Set(prev);
       if (next.has(key)) next.delete(key);
       else next.add(key);
       return next;
     });
-  }, []);
 
-  const toggleAll = useCallback((keys: string[]) => {
+  const toggleAll = (keys: string[]) =>
     setSelected((prev) => {
       const allOn = keys.length > 0 && keys.every((k) => prev.has(k));
-      return allOn ? new Set() : new Set(keys);
+      return allOn ? new Set<string>() : new Set(keys);
     });
-  }, []);
 
-  const clear = useCallback(() => setSelected(new Set()), []);
+  const clear = () => setSelected(new Set<string>());
+  const count = () => selected().size;
 
-  return useMemo(
-    () => ({ selected, toggle, toggleAll, clear, count: selected.size }),
-    [selected, toggle, toggleAll, clear]
-  );
+  return { selected, toggle, toggleAll, clear, count };
 }

--- a/frontend/src/hooks/useSort.ts
+++ b/frontend/src/hooks/useSort.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { createMemo, createSignal, type Accessor } from 'solid-js';
 
 export type SortDir = 'asc' | 'desc';
 export interface SortState {
@@ -11,16 +11,23 @@ export type Accessors<T> = Record<string, (row: T) => SortValue>;
 
 // Client-side column sorting for a table's currently-loaded rows.
 //
-// Define `accessors` as a module-level constant (one entry per sortable column)
-// so its identity is stable across renders. For server-paginated tables this
-// sorts the visible page only — which matches how the dashboard's job lists load.
-export function useSort<T>(rows: T[], accessors: Accessors<T>, initial?: SortState) {
-  const [sort, setSort] = useState<SortState>(initial ?? { key: null, dir: 'asc' });
+// `rows` is an accessor (e.g. `() => query.data ?? []`) so the sort tracks the
+// live data. Define `accessors` as a module-level constant (one entry per
+// sortable column). For server-paginated tables this sorts the visible page
+// only — which matches how the dashboard's job lists load.
+export function useSort<T>(
+  rows: Accessor<T[]>,
+  accessors: Accessors<T>,
+  initial?: SortState,
+): { sorted: Accessor<T[]>; sort: Accessor<SortState>; toggle: (key: string) => void } {
+  const [sort, setSort] = createSignal<SortState>(initial ?? { key: null, dir: 'asc' });
 
-  const sorted = useMemo(() => {
-    const acc = sort.key ? accessors[sort.key] : undefined;
-    if (!acc) return rows;
-    const copy = [...rows];
+  const sorted = createMemo(() => {
+    const s = sort();
+    const acc = s.key ? accessors[s.key] : undefined;
+    const data = rows();
+    if (!acc) return data;
+    const copy = [...data];
     copy.sort((a, b) => {
       const va = acc(a);
       const vb = acc(b);
@@ -32,10 +39,10 @@ export function useSort<T>(rows: T[], accessors: Accessors<T>, initial?: SortSta
         typeof va === 'number' && typeof vb === 'number'
           ? va - vb
           : String(va).localeCompare(String(vb), undefined, { numeric: true, sensitivity: 'base' });
-      return sort.dir === 'asc' ? cmp : -cmp;
+      return s.dir === 'asc' ? cmp : -cmp;
     });
     return copy;
-  }, [rows, sort, accessors]);
+  });
 
   // First click on a column sorts ascending; clicking the active column flips direction.
   const toggle = (key: string) =>

--- a/frontend/src/i18n/i18n.test.ts
+++ b/frontend/src/i18n/i18n.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { t, directionFor } from './index';
+
+describe('t()', () => {
+  it('resolves a nested key path', () => {
+    expect(t('nav.dashboard')).toBe('Dashboard');
+    expect(t('busy.heartbeat')).toBe('Heartbeat');
+  });
+
+  it('interpolates {var} placeholders', () => {
+    expect(t('busy.hosts', { n: 3 })).toBe('3 hosts');
+    expect(t('actions.selected', { n: 7 })).toBe('7 selected');
+    expect(t('actions.confirm', { action: 'Retry', scope: 'this job' })).toBe(
+      'Retry this job? This cannot be undone.',
+    );
+  });
+
+  it('leaves placeholders untouched when no vars are given', () => {
+    expect(t('busy.hosts')).toBe('{n} hosts');
+  });
+
+  it('returns the path when the key is missing', () => {
+    expect(t('nope.not.here')).toBe('nope.not.here');
+    // A path that resolves to an object (not a leaf string) also falls back.
+    expect(t('nav')).toBe('nav');
+  });
+});
+
+describe('directionFor()', () => {
+  it('flips RTL languages', () => {
+    expect(directionFor('ar')).toBe('rtl');
+    expect(directionFor('he')).toBe('rtl');
+    expect(directionFor('fa')).toBe('rtl');
+    // The base subtag drives direction, so region-tagged locales still flip.
+    expect(directionFor('ar-EG')).toBe('rtl');
+  });
+
+  it('leaves LTR languages alone', () => {
+    expect(directionFor('en')).toBe('ltr');
+    expect(directionFor('de')).toBe('ltr');
+    expect(directionFor('zh-CN')).toBe('ltr');
+  });
+});
+
+describe('host overrides', () => {
+  afterEach(() => {
+    document.getElementById('wurk-i18n')?.remove();
+    vi.resetModules();
+  });
+
+  it('deep-merges a #wurk-i18n script tag over the base bundle', async () => {
+    const el = document.createElement('script');
+    el.id = 'wurk-i18n';
+    el.type = 'application/json';
+    // Override one leaf; siblings and untouched branches must survive the merge.
+    el.textContent = JSON.stringify({ nav: { dashboard: 'Control Center' } });
+    document.head.appendChild(el);
+
+    // The bundle reads the override at module-eval time, so re-evaluate it with
+    // the script tag present.
+    vi.resetModules();
+    const mod = await import('./index');
+    expect(mod.t('nav.dashboard')).toBe('Control Center');
+    expect(mod.t('nav.queues')).toBe('Queues');
+  });
+});

--- a/frontend/src/integration.test.tsx
+++ b/frontend/src/integration.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@solidjs/testing-library';
+import { QueryClient, QueryClientProvider } from '@tanstack/solid-query';
+import { MemoryRouter, Route, createMemoryHistory } from '@solidjs/router';
+import type { ParentProps } from 'solid-js';
+import Nav from './components/Nav';
+import { ReadOnlyBanner } from './App';
+import Retries from './pages/Retries';
+
+function client() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+describe('routing + nav', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  function mockMeta() {
+    return vi.fn((url: string) => {
+      const body = url.includes('/api/meta') ? { read_only: false, custom_tabs: [] } : {};
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body) } as Response);
+    });
+  }
+
+  function Shell(props: ParentProps) {
+    return (
+      <>
+        <Nav open={false} onClose={() => {}} collapsed={false} onToggleCollapse={() => {}} />
+        {props.children}
+      </>
+    );
+  }
+
+  function renderApp() {
+    const history = createMemoryHistory();
+    history.set({ value: '/', replace: true });
+    return render(() => (
+      <QueryClientProvider client={client()}>
+        <MemoryRouter history={history} root={Shell}>
+          <Route path="/" component={() => <main>DASHBOARD PAGE</main>} />
+          <Route path="/queues" component={() => <main>QUEUES PAGE</main>} />
+          <Route path="/retries" component={() => <main>RETRIES PAGE</main>} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    ));
+  }
+
+  it('swaps the page and marks the nav link active on navigation', async () => {
+    vi.stubGlobal('fetch', mockMeta());
+    renderApp();
+
+    expect(await screen.findByText('DASHBOARD PAGE')).toBeInTheDocument();
+    const dashLink = screen.getByRole('link', { name: 'Wurk — dashboard home' });
+    expect(dashLink).toHaveAttribute('aria-current', 'page');
+
+    const queuesLink = screen.getByRole('link', { name: 'Queues' });
+    fireEvent.click(queuesLink);
+
+    expect(await screen.findByText('QUEUES PAGE')).toBeInTheDocument();
+    expect(queuesLink).toHaveClass('active');
+    expect(queuesLink).toHaveAttribute('aria-current', 'page');
+    // The home link only matches "/" exactly, so it drops active off the root.
+    expect(dashLink).not.toHaveAttribute('aria-current');
+  });
+});
+
+describe('read-only banner', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  function mockMeta(meta: unknown) {
+    return vi.fn((url: string) => {
+      const body = url.includes('/api/meta') ? meta : {};
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body) } as Response);
+    });
+  }
+
+  it('renders host-supplied copy when read_only is true', async () => {
+    vi.stubGlobal('fetch', mockMeta({ read_only: true, read_only_message: 'Maintenance in progress' }));
+    render(() => (
+      <QueryClientProvider client={client()}>
+        <ReadOnlyBanner />
+      </QueryClientProvider>
+    ));
+    expect(await screen.findByText('Maintenance in progress')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('stays hidden when read_only is false', async () => {
+    const fetchMock = mockMeta({ read_only: false, read_only_message: null });
+    vi.stubGlobal('fetch', fetchMock);
+    render(() => (
+      <QueryClientProvider client={client()}>
+        <ReadOnlyBanner />
+      </QueryClientProvider>
+    ));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+});
+
+describe('Retries bulk-action flow', () => {
+  const NOW = Date.now() / 1000;
+  const ENTRIES = [
+    { jid: 'j1', klass: 'AlphaJob', args: [1], error_class: 'RuntimeError', error_message: 'boom', at: NOW + 60, retry_count: 1, score: 111.5 },
+    { jid: 'j2', klass: 'BetaJob', args: [], error_class: 'ArgumentError', error_message: 'bad', at: NOW + 120, retry_count: 2, score: 222.25 },
+  ];
+
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    HTMLDialogElement.prototype.showModal = vi.fn();
+    HTMLDialogElement.prototype.close = vi.fn();
+    vi.stubGlobal('confirm', vi.fn(() => true));
+    fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      let body: unknown = {};
+      if (url.includes('/api/meta')) body = { read_only: false, custom_tabs: [] };
+      else if (url.includes('/api/retries') && (!init || init.method !== 'POST'))
+        body = { total: ENTRIES.length, page: 0, count: ENTRIES.length, entries: ENTRIES };
+      else if (url.includes('/api/stats')) body = { processed: 0, failed: 0, latency: 0, processes: 0 };
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body) } as Response);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  function renderRetries() {
+    const history = createMemoryHistory();
+    history.set({ value: '/retries', replace: true });
+    const qc = client();
+    const spy = vi.spyOn(qc, 'invalidateQueries');
+    render(() => (
+      <QueryClientProvider client={qc}>
+        <MemoryRouter history={history}>
+          <Route path="/retries" component={Retries} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    ));
+    return { spy };
+  }
+
+  it('selects a row and POSTs a bulk retry, then re-fetches the set', async () => {
+    const { spy } = renderRetries();
+
+    // Wait for the rows to render.
+    expect(await screen.findByText('AlphaJob')).toBeInTheDocument();
+
+    // Select the first job row.
+    const checkboxes = screen.getAllByLabelText('Select job');
+    fireEvent.click(checkboxes[0]);
+    expect((checkboxes[0] as HTMLInputElement).checked).toBe(true);
+
+    // The bulk "Retry" button lives in the action bar (the "Retry All" button is
+    // in the same bar but has a distinct accessible name).
+    const bar = document.querySelector('.action-bar') as HTMLElement;
+    const retryBtn = within(bar).getByRole('button', { name: 'Retry' });
+    fireEvent.click(retryBtn);
+
+    // The bulk endpoint is POSTed with the selected (score|jid) key.
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find(
+        (c) => String(c[0]) === '/wurk/api/retries' && (c[1] as RequestInit)?.method === 'POST',
+      );
+      expect(post).toBeTruthy();
+      expect(JSON.parse((post![1] as RequestInit).body as string)).toEqual({ keys: ['111.5|j1'], cmd: 'retry' });
+    });
+
+    // onSuccess re-fetches by invalidating the set's own query and the stats
+    // badges that read from it.
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith({ queryKey: ['retries'] });
+      expect(spy).toHaveBeenCalledWith({ queryKey: ['stats'] });
+    });
+    // Selection is cleared once the bulk action resolves.
+    await waitFor(() => expect((checkboxes[0] as HTMLInputElement).checked).toBe(false));
+  });
+});

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
+import { render } from 'solid-js/web';
 // Obsidian design system fonts, self-hosted in the bundle (no CDN / Node at
 // runtime). Geist for UI text + metrics, JetBrains Mono for labels/metadata.
 import '@fontsource/geist-sans/400.css';
@@ -30,15 +29,25 @@ const embedded =
 const root = document.getElementById('wurk-root');
 if (root) {
   root.dir = dir;
-  ReactDOM.createRoot(root).render(
-    embedded ? (
-      <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-muted)', fontSize: 14, lineHeight: 1.6 }}>
-        {t('extension.notRendered')}
-      </div>
-    ) : (
-      <React.StrictMode>
+  // Solid's render takes a component factory (a function returning JSX), not an
+  // element — it establishes the reactive root that owns the whole app.
+  render(
+    () =>
+      embedded ? (
+        <div
+          style={{
+            padding: '2rem',
+            'text-align': 'center',
+            color: 'var(--text-muted)',
+            'font-size': '14px',
+            'line-height': 1.6,
+          }}
+        >
+          {t('extension.notRendered')}
+        </div>
+      ) : (
         <App />
-      </React.StrictMode>
-    )
+      ),
+    root,
   );
 }

--- a/frontend/src/pages/BatchDetail.tsx
+++ b/frontend/src/pages/BatchDetail.tsx
@@ -1,6 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
-import { useEffect, type ReactNode } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/solid-query';
+import { onMount, For, Show, Switch, Match, type JSX } from 'solid-js';
+import { A, useParams } from '@solidjs/router';
 import { t } from '../i18n';
 import { relativeTime } from '../utils';
 import { SkeletonCards } from '../components/Skeleton';
@@ -24,108 +24,123 @@ interface BatchDetailData {
   dead_jids: string[];
 }
 
-function Field({ label, children }: { label: string; children: ReactNode }) {
+function Field(props: { label: string; children: JSX.Element }) {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-      <span style={{ fontSize: 11, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
-        {label}
+    <div style={{ display: 'flex', 'flex-direction': 'column', gap: '2px' }}>
+      <span style={{ 'font-size': '11px', color: 'var(--text-muted)', 'text-transform': 'uppercase', 'letter-spacing': '0.04em' }}>
+        {props.label}
       </span>
-      <span style={{ fontVariantNumeric: 'tabular-nums' }}>{children}</span>
+      <span style={{ 'font-variant-numeric': 'tabular-nums' }}>{props.children}</span>
     </div>
   );
 }
 
-function JidList({ label, jids }: { label: string; jids: string[] }) {
-  if (jids.length === 0) return null;
+function JidList(props: { label: string; jids: string[] }) {
   return (
-    <div style={{ marginTop: '1.5rem' }}>
-      <h2 style={{ fontSize: 14, margin: '0 0 0.5rem' }}>
-        {label} <span className="badge badge-muted">{jids.length}</span>
-      </h2>
-      <div className="table-wrapper">
-        <table>
-          <tbody>
-            {jids.map((jid) => (
-              <tr key={jid}>
-                <td style={{ fontFamily: 'monospace', fontSize: 12 }}>{jid}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+    <Show when={props.jids.length > 0}>
+      <div style={{ 'margin-top': '1.5rem' }}>
+        <h2 style={{ 'font-size': '14px', margin: '0 0 0.5rem' }}>
+          {props.label} <span class="badge badge-muted">{props.jids.length}</span>
+        </h2>
+        <div class="table-wrapper">
+          <table>
+            <tbody>
+              <For each={props.jids}>
+                {(jid) => (
+                  <tr>
+                    <td style={{ 'font-family': 'monospace', 'font-size': '12px' }}>{jid}</td>
+                  </tr>
+                )}
+              </For>
+            </tbody>
+          </table>
+        </div>
       </div>
-    </div>
+    </Show>
   );
 }
 
 export default function BatchDetail() {
-  const { bid = '' } = useParams();
+  const params = useParams();
+  const bid = () => params.bid ?? '';
 
-  useEffect(() => {
+  onMount(() => {
     document.title = `${t('nav.batches')} — Wurk`;
-  }, []);
+  });
 
-  const { data, isLoading, isError } = useQuery<BatchDetailData>({
-    queryKey: ['batch', bid],
+  const q = useQuery<BatchDetailData>(() => ({
+    queryKey: ['batch', bid()],
     queryFn: () =>
-      fetch(`/wurk/api/batches/${encodeURIComponent(bid)}`).then((r) => {
+      fetch(`/wurk/api/batches/${encodeURIComponent(bid())}`).then((r) => {
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
         return r.json() as Promise<BatchDetailData>;
       }),
-  });
-
-  if (isLoading)
-    return (
-      <div>
-        <div className="section-header" style={{ gap: '0.75rem' }}>
-          <Link to="/batches" className="btn btn-sm">← {t('nav.batches')}</Link>
-        </div>
-        <div style={{ marginTop: '1rem' }}>
-          <SkeletonCards count={8} />
-        </div>
-      </div>
-    );
-  if (isError || !data) return <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>;
-
-  const done = data.total - data.pending;
-  const pct = data.total > 0 ? Math.round((done / data.total) * 100) : 0;
+  }));
 
   return (
-    <div>
-      <div className="section-header" style={{ gap: '0.75rem' }}>
-        <Link to="/batches" className="btn btn-sm">← {t('nav.batches')}</Link>
-        <h1 className="page-title" style={{ margin: 0, fontFamily: 'monospace', fontSize: 16 }}>{data.bid}</h1>
-        {data.complete ? (
-          <span className="badge badge-success">complete</span>
-        ) : (
-          <span className="badge badge-accent">{pct}%</span>
-        )}
-        {data.invalidated && <span className="badge badge-danger">invalidated</span>}
-      </div>
+    <Switch>
+      <Match when={q.isPending}>
+        <div>
+          <div class="section-header" style={{ gap: '0.75rem' }}>
+            <A href="/batches" class="btn btn-sm">← {t('nav.batches')}</A>
+          </div>
+          <div style={{ 'margin-top': '1rem' }}>
+            <SkeletonCards count={8} />
+          </div>
+        </div>
+      </Match>
+      <Match when={q.isError || !q.data}>
+        <div class="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>
+      </Match>
+      <Match when={q.data}>
+        {(data) => {
+          const done = () => data().total - data().pending;
+          const pct = () => (data().total > 0 ? Math.round((done() / data().total) * 100) : 0);
+          return (
+            <div>
+              <div class="section-header" style={{ gap: '0.75rem' }}>
+                <A href="/batches" class="btn btn-sm">← {t('nav.batches')}</A>
+                <h1 class="page-title" style={{ margin: 0, 'font-family': 'monospace', 'font-size': '16px' }}>{data().bid}</h1>
+                <Show when={data().complete} fallback={<span class="badge badge-accent">{pct()}%</span>}>
+                  <span class="badge badge-success">complete</span>
+                </Show>
+                <Show when={data().invalidated}>
+                  <span class="badge badge-danger">invalidated</span>
+                </Show>
+              </div>
 
-      {data.description && (
-        <p style={{ color: 'var(--text-muted)', marginTop: 0 }}>{data.description}</p>
-      )}
+              <Show when={data().description}>
+                <p style={{ color: 'var(--text-muted)', 'margin-top': 0 }}>{data().description}</p>
+              </Show>
 
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))',
-          gap: '1rem',
-          marginTop: '1rem',
+              <div
+                style={{
+                  display: 'grid',
+                  'grid-template-columns': 'repeat(auto-fill, minmax(140px, 1fr))',
+                  gap: '1rem',
+                  'margin-top': '1rem',
+                }}
+              >
+                <Field label="Total">{data().total.toLocaleString()}</Field>
+                <Field label="Pending">{data().pending.toLocaleString()}</Field>
+                <Field label="Failures">{data().failures.toLocaleString()}</Field>
+                <Field label="Children">{data().child_count.toLocaleString()}</Field>
+                <Field label="Created">{data().created_at ? relativeTime(data().created_at!) : '—'}</Field>
+                <Field label="Completed">{data().complete_at ? relativeTime(data().complete_at!) : '—'}</Field>
+                <Show when={data().parent_bid}>
+                  <Field label="Parent">{data().parent_bid}</Field>
+                </Show>
+                <Show when={data().tags.length > 0}>
+                  <Field label="Tags">{data().tags.join(', ')}</Field>
+                </Show>
+              </div>
+
+              <JidList label="Failed jobs" jids={data().failed_jids} />
+              <JidList label="Dead jobs" jids={data().dead_jids} />
+            </div>
+          );
         }}
-      >
-        <Field label="Total">{data.total.toLocaleString()}</Field>
-        <Field label="Pending">{data.pending.toLocaleString()}</Field>
-        <Field label="Failures">{data.failures.toLocaleString()}</Field>
-        <Field label="Children">{data.child_count.toLocaleString()}</Field>
-        <Field label="Created">{data.created_at ? relativeTime(data.created_at) : '—'}</Field>
-        <Field label="Completed">{data.complete_at ? relativeTime(data.complete_at) : '—'}</Field>
-        {data.parent_bid && <Field label="Parent">{data.parent_bid}</Field>}
-        {data.tags.length > 0 && <Field label="Tags">{data.tags.join(', ')}</Field>}
-      </div>
-
-      <JidList label="Failed jobs" jids={data.failed_jids} />
-      <JidList label="Dead jobs" jids={data.dead_jids} />
-    </div>
+      </Match>
+    </Switch>
   );
 }

--- a/frontend/src/pages/Batches.tsx
+++ b/frontend/src/pages/Batches.tsx
@@ -1,6 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
-import { useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/solid-query';
+import { onMount, For, Switch, Match, Show } from 'solid-js';
+import { A } from '@solidjs/router';
 import { Pagination } from '../components/Pagination';
 import { SortableTh } from '../components/SortableTh';
 import { useSort, type Accessors } from '../hooks/useSort';
@@ -43,97 +43,101 @@ const SORT: Accessors<Batch> = {
 export default function Batches() {
   const [page, setPage] = usePageParam();
 
-  useEffect(() => {
+  onMount(() => {
     document.title = `${t('nav.batches')} — Wurk`;
-  }, []);
-
-  const { data, isLoading, isError } = useQuery<BatchesResponse>({
-    queryKey: ['batches', page],
-    queryFn: () =>
-      fetch(`/wurk/api/batches?page=${page - 1}&count=${PAGE_SIZE}`).then(
-        (r) => r.json() as Promise<BatchesResponse>
-      ),
   });
 
-  const { sorted, sort, toggle } = useSort(data?.batches ?? [], SORT);
+  const q = useQuery<BatchesResponse>(() => ({
+    queryKey: ['batches', page()],
+    queryFn: () =>
+      fetch(`/wurk/api/batches?page=${page() - 1}&count=${PAGE_SIZE}`).then(
+        (r) => r.json() as Promise<BatchesResponse>
+      ),
+  }));
 
-  if (isLoading)
-    return (
-      <div>
-        <PageHeader icon="fa-table-cells-large" title={t('nav.batches')} summary={t('summaries.batches')} />
-        <SkeletonTable rows={8} cols={7} />
-      </div>
-    );
-  if (isError || !data) return <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>;
+  const { sorted, sort, toggle } = useSort(() => q.data?.batches ?? [], SORT);
 
   return (
-    <div>
-      <PageHeader icon="fa-table-cells-large" title={t('nav.batches')} summary={t('summaries.batches')}>
-        <span className="badge badge-accent">{data.total.toLocaleString()}</span>
-      </PageHeader>
+    <Switch>
+      <Match when={q.isPending}>
+        <div>
+          <PageHeader icon="fa-table-cells-large" title={t('nav.batches')} summary={t('summaries.batches')} />
+          <SkeletonTable rows={8} cols={7} />
+        </div>
+      </Match>
+      <Match when={q.isError || !q.data}>
+        <div class="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>
+      </Match>
+      <Match when={q.data}>
+        {(data) => (
+          <div>
+            <PageHeader icon="fa-table-cells-large" title={t('nav.batches')} summary={t('summaries.batches')}>
+              <span class="badge badge-accent">{data().total.toLocaleString()}</span>
+            </PageHeader>
 
-      {sorted.length === 0 ? (
-        <div className="empty-state">{t('common.empty')}</div>
-      ) : (
-        <>
-          <div className="table-wrapper">
-            <table>
-              <thead>
-                <tr>
-                  <SortableTh label="BID" sortKey="bid" sort={sort} onSort={toggle} />
-                  <SortableTh label="Description" sortKey="description" sort={sort} onSort={toggle} />
-                  <SortableTh label={t('table.total')} sortKey="total" sort={sort} onSort={toggle} />
-                  <SortableTh label={t('table.pending')} sortKey="pending" sort={sort} onSort={toggle} />
-                  <SortableTh label="Failures" sortKey="failures" sort={sort} onSort={toggle} />
-                  <SortableTh label="Progress" sortKey="progress" sort={sort} onSort={toggle} />
-                  <SortableTh label="Created" sortKey="created" sort={sort} onSort={toggle} />
-                </tr>
-              </thead>
-              <tbody>
-                {sorted.map((batch) => {
-                  const done = batch.total - batch.pending;
-                  const pct = batch.total > 0 ? (done / batch.total) * 100 : 0;
-                  return (
-                    <tr key={batch.bid}>
-                      <td style={{ fontFamily: 'monospace', fontSize: 12 }}>
-                        <Link to={`/batches/${batch.bid}`} title={batch.bid}>
-                          {truncate(batch.bid, 14)}
-                        </Link>
-                      </td>
-                      <td title={batch.description ?? ''}>{truncate(batch.description ?? '—', 40)}</td>
-                      <td>{batch.total.toLocaleString()}</td>
-                      <td style={{ color: batch.pending > 0 ? 'var(--warning)' : 'var(--success)' }}>
-                        {batch.pending.toLocaleString()}
-                      </td>
-                      <td style={{ color: batch.failures > 0 ? 'var(--danger)' : undefined }}>
-                        {batch.failures.toLocaleString()}
-                      </td>
-                      <td style={{ width: 100 }}>
-                        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                          <div className="progress-bar-track" style={{ flex: 1 }}>
-                            <div
-                              className="progress-bar-fill"
-                              style={{
-                                width: `${pct}%`,
-                                background: batch.failures > 0 ? 'var(--danger)' : 'var(--success)',
-                              }}
-                            />
-                          </div>
-                          <span style={{ fontSize: 11, color: 'var(--text-muted)', minWidth: 32 }}>
-                            {Math.round(pct)}%
-                          </span>
-                        </div>
-                      </td>
-                      <td>{batch.created_at ? relativeTime(batch.created_at) : '—'}</td>
+            <Show when={sorted().length > 0} fallback={<div class="empty-state">{t('common.empty')}</div>}>
+              <div class="table-wrapper">
+                <table>
+                  <thead>
+                    <tr>
+                      <SortableTh label="BID" sortKey="bid" sort={sort()} onSort={toggle} />
+                      <SortableTh label="Description" sortKey="description" sort={sort()} onSort={toggle} />
+                      <SortableTh label={t('table.total')} sortKey="total" sort={sort()} onSort={toggle} />
+                      <SortableTh label={t('table.pending')} sortKey="pending" sort={sort()} onSort={toggle} />
+                      <SortableTh label="Failures" sortKey="failures" sort={sort()} onSort={toggle} />
+                      <SortableTh label="Progress" sortKey="progress" sort={sort()} onSort={toggle} />
+                      <SortableTh label="Created" sortKey="created" sort={sort()} onSort={toggle} />
                     </tr>
-                  );
-                })}
-              </tbody>
-            </table>
+                  </thead>
+                  <tbody>
+                    <For each={sorted()}>
+                      {(batch) => {
+                        const done = batch.total - batch.pending;
+                        const pct = batch.total > 0 ? (done / batch.total) * 100 : 0;
+                        return (
+                          <tr>
+                            <td style={{ 'font-family': 'monospace', 'font-size': '12px' }}>
+                              <A href={`/batches/${batch.bid}`} title={batch.bid}>
+                                {truncate(batch.bid, 14)}
+                              </A>
+                            </td>
+                            <td title={batch.description ?? ''}>{truncate(batch.description ?? '—', 40)}</td>
+                            <td>{batch.total.toLocaleString()}</td>
+                            <td style={{ color: batch.pending > 0 ? 'var(--warning)' : 'var(--success)' }}>
+                              {batch.pending.toLocaleString()}
+                            </td>
+                            <td style={{ color: batch.failures > 0 ? 'var(--danger)' : undefined }}>
+                              {batch.failures.toLocaleString()}
+                            </td>
+                            <td style={{ width: '100px' }}>
+                              <div style={{ display: 'flex', 'align-items': 'center', gap: '0.5rem' }}>
+                                <div class="progress-bar-track" style={{ flex: 1 }}>
+                                  <div
+                                    class="progress-bar-fill"
+                                    style={{
+                                      width: `${pct}%`,
+                                      background: batch.failures > 0 ? 'var(--danger)' : 'var(--success)',
+                                    }}
+                                  />
+                                </div>
+                                <span style={{ 'font-size': '11px', color: 'var(--text-muted)', 'min-width': '32px' }}>
+                                  {Math.round(pct)}%
+                                </span>
+                              </div>
+                            </td>
+                            <td>{batch.created_at ? relativeTime(batch.created_at) : '—'}</td>
+                          </tr>
+                        );
+                      }}
+                    </For>
+                  </tbody>
+                </table>
+              </div>
+              <Pagination page={page()} total={data().total} count={PAGE_SIZE} onChange={setPage} />
+            </Show>
           </div>
-          <Pagination page={page} total={data.total} count={PAGE_SIZE} onChange={setPage} />
-        </>
-      )}
-    </div>
+        )}
+      </Match>
+    </Switch>
   );
 }

--- a/frontend/src/pages/Busy.test.tsx
+++ b/frontend/src/pages/Busy.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, cleanup } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent } from '@solidjs/testing-library';
+import { QueryClient, QueryClientProvider } from '@tanstack/solid-query';
 import Busy from './Busy';
 
 const NOW = Date.now() / 1000;
@@ -98,41 +98,40 @@ function mockFetch() {
 
 function renderBusy() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(
+  return render(() => (
     <QueryClientProvider client={client}>
       <Busy />
     </QueryClientProvider>
-  );
+  ));
 }
 
 describe('Busy', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', mockFetch());
     // jsdom has no <dialog> top-layer support; the modal's content visibility
-    // is React-state driven, so stubbing these is enough.
+    // is signal-driven, so stubbing these is enough for showModal()/close().
     HTMLDialogElement.prototype.showModal = vi.fn();
     HTMLDialogElement.prototype.close = vi.fn();
   });
   afterEach(() => {
-    cleanup();
     vi.unstubAllGlobals();
   });
 
   it('groups processes into one section per host', async () => {
     renderBusy();
-    expect(await screen.findByText('host-a')).toBeDefined();
-    expect(screen.getByText('host-b')).toBeDefined();
+    expect(await screen.findByText('host-a')).toBeInTheDocument();
+    expect(screen.getByText('host-b')).toBeInTheDocument();
     // Host badge: total processes; host-a folds two processes into one header.
-    expect(screen.getByText('2 hosts')).toBeDefined();
-    expect(screen.getByText('3 processes')).toBeDefined();
+    expect(screen.getByText('2 hosts')).toBeInTheDocument();
+    expect(screen.getByText('3 processes')).toBeInTheDocument();
   });
 
   it('shows host hardware facts: CPU model, cores and RAM usage', async () => {
     renderBusy();
-    expect(await screen.findByText(/AMD EPYC 7702P/)).toBeDefined();
-    expect(screen.getByText('64 cores')).toBeDefined();
+    expect(await screen.findByText(/AMD EPYC 7702P/)).toBeInTheDocument();
+    expect(screen.getByText('64 cores')).toBeInTheDocument();
     // host-a: 2 × 256 MB RSS of 16 GB total.
-    expect(screen.getByText(/512 MB \/ 16\.0 GB/)).toBeDefined();
+    expect(screen.getByText(/512 MB \/ 16\.0 GB/)).toBeInTheDocument();
   });
 
   it('renders a live heartbeat from the API `beat` field', async () => {
@@ -148,8 +147,8 @@ describe('Busy', () => {
     expect(card).not.toBeNull();
     fireEvent.click(card!);
 
-    expect(await screen.findByText('HardJob')).toBeDefined();
-    expect(screen.getByText('host-a:100:aaaa')).toBeDefined();
+    expect(await screen.findByText('HardJob')).toBeInTheDocument();
+    expect(screen.getByText('host-a:100:aaaa')).toBeInTheDocument();
     // Only this process's in-flight jobs — host-b's job stays out.
     expect(screen.queryByText('OtherJob')).toBeNull();
   });

--- a/frontend/src/pages/Busy.tsx
+++ b/frontend/src/pages/Busy.tsx
@@ -1,5 +1,5 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useEffect, useState, type ReactNode } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/solid-query';
+import { createSignal, onMount, For, Show, Switch, Match, type JSX } from 'solid-js';
 import { t } from '../i18n';
 import { PageHeader } from '../components/PageHeader';
 import Modal from '../components/Modal';
@@ -85,58 +85,58 @@ function utilizationColor(pct: number): string {
 }
 
 const statLabelStyle = {
-  fontSize: 11,
+  'font-size': '11px',
   color: 'var(--text-muted)',
-  textTransform: 'uppercase',
-  letterSpacing: '0.04em',
+  'text-transform': 'uppercase',
+  'letter-spacing': '0.04em',
 } as const;
 
-function ProcessDetail({ proc }: { proc: Process }) {
-  const { data: work } = useQuery<WorkRow[]>({
+function ProcessDetail(props: { proc: Process }) {
+  const work = useQuery<WorkRow[]>(() => ({
     queryKey: ['workers'],
     queryFn: () => fetch('/wurk/api/workers').then((r) => r.json() as Promise<WorkRow[]>),
     refetchInterval: 5000,
-  });
-  const rows = (work ?? []).filter((w) => w.process_id === proc.identity);
+  }));
+  const rows = () => (work.data ?? []).filter((w) => w.process_id === props.proc.identity);
 
-  const facts: Array<[string, ReactNode]> = [
-    [t('busy.identity'), <code style={{ fontSize: 12 }}>{proc.identity}</code>],
-    ['PID', proc.pid],
-    [t('busy.started'), proc.started_at ? <span title={isoTime(proc.started_at)}>{relativeTime(proc.started_at)}</span> : '—'],
-    [t('busy.heartbeat'), <span title={isoTime(proc.beat)}>{relativeTime(proc.beat)}</span>],
-    [`${t('table.busy')} / ${t('table.concurrency')}`, `${proc.busy} / ${proc.concurrency}`],
-    [t('busy.rss'), formatKb(proc.rss ?? 0)],
-    [t('busy.rtt'), proc.rtt_us ? `${(proc.rtt_us / 1000).toFixed(1)} ${t('common.ms')}` : '—'],
-    [t('busy.version'), proc.version ?? '—'],
-    [t('busy.tag'), proc.tag || '—'],
-    [t('busy.labels'), proc.labels?.length ? proc.labels.join(', ') : '—'],
+  const facts = (): Array<[string, JSX.Element]> => [
+    [t('busy.identity'), <code style={{ 'font-size': '12px' }}>{props.proc.identity}</code>],
+    ['PID', props.proc.pid],
+    [t('busy.started'), props.proc.started_at ? <span title={isoTime(props.proc.started_at)}>{relativeTime(props.proc.started_at)}</span> : '—'],
+    [t('busy.heartbeat'), <span title={isoTime(props.proc.beat)}>{relativeTime(props.proc.beat)}</span>],
+    [`${t('table.busy')} / ${t('table.concurrency')}`, `${props.proc.busy} / ${props.proc.concurrency}`],
+    [t('busy.rss'), formatKb(props.proc.rss ?? 0)],
+    [t('busy.rtt'), props.proc.rtt_us ? `${(props.proc.rtt_us / 1000).toFixed(1)} ${t('common.ms')}` : '—'],
+    [t('busy.version'), props.proc.version ?? '—'],
+    [t('busy.tag'), props.proc.tag || '—'],
+    [t('busy.labels'), props.proc.labels?.length ? props.proc.labels.join(', ') : '—'],
   ];
 
   return (
     <div>
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: '0.75rem', marginBottom: '1rem' }}>
-        {facts.map(([label, value]) => (
-          <div key={String(label)}>
-            <div style={statLabelStyle}>{label}</div>
-            <div style={{ fontSize: 14 }}>{value}</div>
-          </div>
-        ))}
+      <div style={{ display: 'grid', 'grid-template-columns': 'repeat(auto-fill, minmax(200px, 1fr))', gap: '0.75rem', 'margin-bottom': '1rem' }}>
+        <For each={facts()}>
+          {([label, value]) => (
+            <div>
+              <div style={statLabelStyle}>{label}</div>
+              <div style={{ 'font-size': '14px' }}>{value}</div>
+            </div>
+          )}
+        </For>
       </div>
 
-      <div style={{ ...statLabelStyle, marginBottom: '0.25rem' }}>{t('table.queues')}</div>
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem', marginBottom: '1rem' }}>
-        {proc.queues.map((q) => (
-          <span key={q} className="badge badge-muted">{q}</span>
-        ))}
+      <div style={{ ...statLabelStyle, 'margin-bottom': '0.25rem' }}>{t('table.queues')}</div>
+      <div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '0.25rem', 'margin-bottom': '1rem' }}>
+        <For each={props.proc.queues}>
+          {(q) => <span class="badge badge-muted">{q}</span>}
+        </For>
       </div>
 
-      <h3 className="section-title" style={{ marginBottom: '0.5rem' }}>
-        {t('busy.running_jobs')} <span className="badge badge-muted">{rows.length}</span>
+      <h3 class="section-title" style={{ 'margin-bottom': '0.5rem' }}>
+        {t('busy.running_jobs')} <span class="badge badge-muted">{rows().length}</span>
       </h3>
-      {rows.length === 0 ? (
-        <div className="empty-state" style={{ padding: '1rem' }}>{t('busy.no_running')}</div>
-      ) : (
-        <div className="table-wrapper">
+      <Show when={rows().length > 0} fallback={<div class="empty-state" style={{ padding: '1rem' }}>{t('busy.no_running')}</div>}>
+        <div class="table-wrapper">
           <table>
             <thead>
               <tr>
@@ -148,83 +148,85 @@ function ProcessDetail({ proc }: { proc: Process }) {
               </tr>
             </thead>
             <tbody>
-              {rows.map((w) => (
-                <tr key={`${w.thread_id}-${w.jid}`}>
-                  <td title={w.jid} style={{ fontFamily: 'monospace', fontSize: 12, color: 'var(--text-muted)' }}>
-                    {truncate(w.jid, 12)}
-                  </td>
-                  <td style={{ fontWeight: 500 }}>{w.klass}</td>
-                  <td><span className="badge badge-muted">{w.queue}</span></td>
-                  <td><ArgsValue str={formatArgs(w.args)} max={40} /></td>
-                  <td title={isoTime(w.run_at)}>{relativeTime(w.run_at)}</td>
-                </tr>
-              ))}
+              <For each={rows()}>
+                {(w) => (
+                  <tr>
+                    <td title={w.jid} style={{ 'font-family': 'monospace', 'font-size': '12px', color: 'var(--text-muted)' }}>
+                      {truncate(w.jid, 12)}
+                    </td>
+                    <td style={{ 'font-weight': 500 }}>{w.klass}</td>
+                    <td><span class="badge badge-muted">{w.queue}</span></td>
+                    <td><ArgsValue str={formatArgs(w.args)} max={40} /></td>
+                    <td title={isoTime(w.run_at)}>{relativeTime(w.run_at)}</td>
+                  </tr>
+                )}
+              </For>
             </tbody>
           </table>
         </div>
-      )}
+      </Show>
     </div>
   );
 }
 
-function HostHeader({ group }: { group: HostGroup }) {
-  const ramPct = group.memoryTotalKb ? Math.min(100, (group.rssKb / group.memoryTotalKb) * 100) : null;
+function HostHeader(props: { group: HostGroup }) {
+  const ramPct = () => props.group.memoryTotalKb ? Math.min(100, (props.group.rssKb / props.group.memoryTotalKb) * 100) : null;
 
   return (
-    <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '0.75rem', marginBottom: '0.75rem' }}>
-      <span style={{ fontWeight: 600, fontSize: 15 }}>
-        <i className="fa-solid fa-server" style={{ color: 'var(--text-muted)', marginRight: '0.5rem' }} />
-        {group.hostname}
+    <div style={{ display: 'flex', 'flex-wrap': 'wrap', 'align-items': 'center', gap: '0.75rem', 'margin-bottom': '0.75rem' }}>
+      <span style={{ 'font-weight': 600, 'font-size': '15px' }}>
+        <i class="fa-solid fa-server" style={{ color: 'var(--text-muted)', 'margin-right': '0.5rem' }} />
+        {props.group.hostname}
       </span>
-      <span className="badge badge-muted">
-        {group.processes.length} {t('dashboard.processes').toLowerCase()}
+      <span class="badge badge-muted">
+        {props.group.processes.length} {t('dashboard.processes').toLowerCase()}
       </span>
-      {group.cpuModel && (
-        <span className="badge badge-muted" title={group.cpuModel}>
-          <i className="fa-solid fa-microchip" style={{ marginRight: '0.35rem' }} />
-          {truncate(group.cpuModel, 40)}
+      <Show when={props.group.cpuModel}>
+        <span class="badge badge-muted" title={props.group.cpuModel ?? undefined}>
+          <i class="fa-solid fa-microchip" style={{ 'margin-right': '0.35rem' }} />
+          {truncate(props.group.cpuModel, 40)}
         </span>
-      )}
-      {group.cores != null && group.cores > 0 && (
-        <span className="badge badge-muted">{t('busy.cores', { n: group.cores })}</span>
-      )}
-      {group.rssKb > 0 && (
+      </Show>
+      <Show when={props.group.cores != null && props.group.cores > 0}>
+        <span class="badge badge-muted">{t('busy.cores', { n: props.group.cores! })}</span>
+      </Show>
+      <Show when={props.group.rssKb > 0}>
         <span
-          className="badge badge-muted"
-          title={ramPct != null ? `${ramPct.toFixed(1)}% ${t('busy.of_total_ram')}` : undefined}
+          class="badge badge-muted"
+          title={ramPct() != null ? `${ramPct()!.toFixed(1)}% ${t('busy.of_total_ram')}` : undefined}
         >
-          <i className="fa-solid fa-memory" style={{ marginRight: '0.35rem' }} />
-          {formatKb(group.rssKb)}
-          {group.memoryTotalKb ? ` / ${formatKb(group.memoryTotalKb)}` : ''}
+          <i class="fa-solid fa-memory" style={{ 'margin-right': '0.35rem' }} />
+          {formatKb(props.group.rssKb)}
+          {props.group.memoryTotalKb ? ` / ${formatKb(props.group.memoryTotalKb)}` : ''}
         </span>
-      )}
-      <span className="badge badge-muted" style={{ fontVariantNumeric: 'tabular-nums' }}>
-        {t('table.busy')} {group.busy} / {group.concurrency}
+      </Show>
+      <span class="badge badge-muted" style={{ 'font-variant-numeric': 'tabular-nums' }}>
+        {t('table.busy')} {props.group.busy} / {props.group.concurrency}
       </span>
     </div>
   );
 }
 
 export default function Busy() {
-  const { data: meta } = useMeta();
-  const readOnly = meta?.read_only ?? false;
+  const meta = useMeta();
+  const readOnly = () => meta.data?.read_only ?? false;
   const qc = useQueryClient();
-  const [selected, setSelected] = useState<string | null>(null);
+  const [selected, setSelected] = createSignal<string | null>(null);
 
-  useEffect(() => {
+  onMount(() => {
     document.title = `${t('nav.busy')} — Wurk`;
-  }, []);
+  });
 
-  const { data, isLoading, isError } = useQuery<Process[]>({
+  const query = useQuery<Process[]>(() => ({
     queryKey: ['processes'],
     queryFn: () => fetch('/wurk/api/processes').then((r) => r.json() as Promise<Process[]>),
     refetchInterval: 5000,
-  });
+  }));
 
   // Quiet (SIGTSTP) / stop (SIGTERM) one process by identity, or all when
   // scope is 'all'. Both are async — the process reacts on its next
   // heartbeat — so we just refetch rather than optimistically updating.
-  const control = useMutation({
+  const control = useMutation(() => ({
     mutationFn: async (target: ControlTarget) => {
       const { signal } = target;
       const identity = target.scope === 'all' ? 'all' : target.identity;
@@ -237,166 +239,173 @@ export default function Busy() {
       return res;
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ['processes'] }),
-  });
+  }));
 
   const confirmStop = (scope: string) =>
     window.confirm(t('actions.confirm', { action: t('actions.stop'), scope }));
 
-  if (isLoading)
-    return (
-      <div>
-        <PageHeader icon="fa-gears" title={t('nav.busy')} summary={t('summaries.busy')} />
-        <SkeletonCards count={6} />
-      </div>
-    );
-  if (isError || !data) return <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>;
-
-  const controllable = data.some((p) => !p.embedded);
-  const hosts = groupByHost(data);
-  const selectedProc = data.find((p) => p.identity === selected) ?? null;
+  const controllable = () => (query.data ?? []).some((p) => !p.embedded);
+  const hosts = () => groupByHost(query.data ?? []);
+  const selectedProc = () => (query.data ?? []).find((p) => p.identity === selected()) ?? null;
 
   return (
-    <div>
-      <PageHeader icon="fa-gears" title={t('nav.busy')} summary={t('summaries.busy')}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '0.6rem' }}>
-          <span className="badge badge-muted">
-            {data.length} {t('dashboard.processes').toLowerCase()}
-          </span>
-          {hosts.length > 1 && (
-            <span className="badge badge-muted">{t('busy.hosts', { n: hosts.length })}</span>
-          )}
-          {!readOnly && controllable && (
-            <>
-              <button
-                className="btn btn-sm btn-ghost"
-                disabled={control.isPending}
-                onClick={() => control.mutate({ signal: 'quiet', scope: 'all' })}
-              >
-                {`${t('actions.quiet')} ${t('actions.all_suffix')}`}
-              </button>
-              <button
-                className="btn btn-sm btn-ghost btn-danger"
-                disabled={control.isPending}
-                onClick={() => confirmStop(t('actions.scope_all_processes')) && control.mutate({ signal: 'stop', scope: 'all' })}
-              >
-                {`${t('actions.stop')} ${t('actions.all_suffix')}`}
-              </button>
-            </>
-          )}
+    <Switch>
+      <Match when={query.isPending}>
+        <div>
+          <PageHeader icon="fa-gears" title={t('nav.busy')} summary={t('summaries.busy')} />
+          <SkeletonCards count={6} />
         </div>
-      </PageHeader>
+      </Match>
+      <Match when={query.isError || !query.data}>
+        <div class="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>
+      </Match>
+      <Match when={query.data}>
+        {(data) => (
+          <div>
+            <PageHeader icon="fa-gears" title={t('nav.busy')} summary={t('summaries.busy')}>
+              <div style={{ display: 'flex', 'align-items': 'center', gap: '0.6rem' }}>
+                <span class="badge badge-muted">
+                  {data().length} {t('dashboard.processes').toLowerCase()}
+                </span>
+                <Show when={hosts().length > 1}>
+                  <span class="badge badge-muted">{t('busy.hosts', { n: hosts().length })}</span>
+                </Show>
+                <Show when={!readOnly() && controllable()}>
+                  <>
+                    <button
+                      class="btn btn-sm btn-ghost"
+                      disabled={control.isPending}
+                      onClick={() => control.mutate({ signal: 'quiet', scope: 'all' })}
+                    >
+                      {`${t('actions.quiet')} ${t('actions.all_suffix')}`}
+                    </button>
+                    <button
+                      class="btn btn-sm btn-ghost btn-danger"
+                      disabled={control.isPending}
+                      onClick={() => confirmStop(t('actions.scope_all_processes')) && control.mutate({ signal: 'stop', scope: 'all' })}
+                    >
+                      {`${t('actions.stop')} ${t('actions.all_suffix')}`}
+                    </button>
+                  </>
+                </Show>
+              </div>
+            </PageHeader>
 
-      {data.length === 0 ? (
-        <div className="empty-state">{t('common.empty')}</div>
-      ) : (
-        hosts.map((group) => (
-          <section key={group.hostname} style={{ marginBottom: '1.5rem' }}>
-            <HostHeader group={group} />
-            <div
-              style={{
-                display: 'grid',
-                gridTemplateColumns: 'repeat(auto-fill, minmax(min(100%, 320px), 1fr))',
-                gap: '1rem',
-              }}
+            <Show when={data().length > 0} fallback={<div class="empty-state">{t('common.empty')}</div>}>
+              <For each={hosts()}>
+                {(group) => (
+                  <section style={{ 'margin-bottom': '1.5rem' }}>
+                    <HostHeader group={group} />
+                    <div
+                      style={{
+                        display: 'grid',
+                        'grid-template-columns': 'repeat(auto-fill, minmax(min(100%, 320px), 1fr))',
+                        gap: '1rem',
+                      }}
+                    >
+                      <For each={group.processes}>
+                        {(proc) => {
+                          const utilization = proc.concurrency > 0 ? (proc.busy / proc.concurrency) * 100 : 0;
+                          const isRecent = Date.now() / 1000 - proc.beat < 30;
+
+                          return (
+                            <div
+                              class="card row-clickable"
+                              onClick={() => proc.identity && setSelected(proc.identity)}
+                            >
+                              <div style={{ display: 'flex', 'justify-content': 'space-between', 'align-items': 'flex-start', 'margin-bottom': '0.75rem' }}>
+                                <div>
+                                  <div style={{ 'font-weight': 600, 'font-size': '15px' }}>PID {proc.pid}</div>
+                                  <div style={{ color: 'var(--text-muted)', 'font-size': '12px' }}>
+                                    {proc.tag || proc.hostname}
+                                    {proc.started_at ? ` · ${t('busy.up_for')} ${formatDuration(Date.now() / 1000 - proc.started_at)}` : ''}
+                                  </div>
+                                </div>
+                                <div style={{ display: 'flex', gap: '0.375rem' }}>
+                                  <Show when={isRecent}><span class="live-dot" title="Heartbeat OK" /></Show>
+                                  <Show when={proc.quiet}><span class="badge badge-warning">Quiet</span></Show>
+                                  <Show when={proc.embedded}><span class="badge badge-muted">embedded</span></Show>
+                                </div>
+                              </div>
+
+                              <div style={{ display: 'grid', 'grid-template-columns': '1fr 1fr 1fr', gap: '0.5rem', 'margin-bottom': '0.75rem' }}>
+                                <div>
+                                  <div style={statLabelStyle}>
+                                    {t('table.busy')} / {t('table.concurrency')}
+                                  </div>
+                                  <div style={{ 'font-weight': 600, 'font-size': '18px', 'font-variant-numeric': 'tabular-nums' }}>
+                                    {proc.busy} / {proc.concurrency}
+                                  </div>
+                                </div>
+                                <div>
+                                  <div style={statLabelStyle}>{t('busy.heartbeat')}</div>
+                                  <div style={{ 'font-size': '13px', color: isRecent ? 'var(--success)' : 'var(--danger)' }}>
+                                    {relativeTime(proc.beat)}
+                                  </div>
+                                </div>
+                                <div>
+                                  <div style={statLabelStyle}>{t('busy.rss')}</div>
+                                  <div style={{ 'font-size': '13px' }}>{formatKb(proc.rss ?? 0)}</div>
+                                </div>
+                              </div>
+
+                              <div class="progress-bar-track" style={{ 'margin-bottom': '0.75rem' }}>
+                                <div
+                                  class="progress-bar-fill"
+                                  style={{ width: `${utilization}%`, background: utilizationColor(utilization) }}
+                                />
+                              </div>
+
+                              <div>
+                                <div style={{ ...statLabelStyle, 'margin-bottom': '0.25rem' }}>
+                                  {t('table.queues')}
+                                </div>
+                                <div style={{ display: 'flex', 'flex-wrap': 'wrap', gap: '0.25rem' }}>
+                                  <For each={proc.queues}>
+                                    {(q) => <span class="badge badge-muted">{q}</span>}
+                                  </For>
+                                </div>
+                              </div>
+
+                              <Show when={!readOnly() && !proc.embedded}>
+                                <div style={{ display: 'flex', gap: '0.4rem', 'margin-top': '0.85rem' }} onClick={(e) => e.stopPropagation()}>
+                                  <button
+                                    class="btn btn-sm"
+                                    disabled={control.isPending}
+                                    onClick={() => control.mutate({ signal: 'quiet', scope: 'one', identity: proc.identity })}
+                                  >
+                                    {t('actions.quiet')}
+                                  </button>
+                                  <button
+                                    class="btn btn-sm btn-danger"
+                                    disabled={control.isPending}
+                                    onClick={() => confirmStop(t('actions.scope_this_process')) && control.mutate({ signal: 'stop', scope: 'one', identity: proc.identity })}
+                                  >
+                                    {t('actions.stop')}
+                                  </button>
+                                </div>
+                              </Show>
+                            </div>
+                          );
+                        }}
+                      </For>
+                    </div>
+                  </section>
+                )}
+              </For>
+            </Show>
+
+            <Modal
+              open={selectedProc() !== null}
+              onClose={() => setSelected(null)}
+              title={selectedProc() ? `${selectedProc()!.hostname} · PID ${selectedProc()!.pid}` : ''}
+              width={780}
             >
-              {group.processes.map((proc) => {
-                const utilization = proc.concurrency > 0 ? (proc.busy / proc.concurrency) * 100 : 0;
-                const isRecent = Date.now() / 1000 - proc.beat < 30;
-
-                return (
-                  <div
-                    key={proc.identity ?? `${proc.hostname}-${proc.pid}`}
-                    className="card row-clickable"
-                    onClick={() => proc.identity && setSelected(proc.identity)}
-                  >
-                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '0.75rem' }}>
-                      <div>
-                        <div style={{ fontWeight: 600, fontSize: 15 }}>PID {proc.pid}</div>
-                        <div style={{ color: 'var(--text-muted)', fontSize: 12 }}>
-                          {proc.tag || proc.hostname}
-                          {proc.started_at ? ` · ${t('busy.up_for')} ${formatDuration(Date.now() / 1000 - proc.started_at)}` : ''}
-                        </div>
-                      </div>
-                      <div style={{ display: 'flex', gap: '0.375rem' }}>
-                        {isRecent && <span className="live-dot" title="Heartbeat OK" />}
-                        {proc.quiet && <span className="badge badge-warning">Quiet</span>}
-                        {proc.embedded && <span className="badge badge-muted">embedded</span>}
-                      </div>
-                    </div>
-
-                    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: '0.5rem', marginBottom: '0.75rem' }}>
-                      <div>
-                        <div style={statLabelStyle}>
-                          {t('table.busy')} / {t('table.concurrency')}
-                        </div>
-                        <div style={{ fontWeight: 600, fontSize: 18, fontVariantNumeric: 'tabular-nums' }}>
-                          {proc.busy} / {proc.concurrency}
-                        </div>
-                      </div>
-                      <div>
-                        <div style={statLabelStyle}>{t('busy.heartbeat')}</div>
-                        <div style={{ fontSize: 13, color: isRecent ? 'var(--success)' : 'var(--danger)' }}>
-                          {relativeTime(proc.beat)}
-                        </div>
-                      </div>
-                      <div>
-                        <div style={statLabelStyle}>{t('busy.rss')}</div>
-                        <div style={{ fontSize: 13 }}>{formatKb(proc.rss ?? 0)}</div>
-                      </div>
-                    </div>
-
-                    <div className="progress-bar-track" style={{ marginBottom: '0.75rem' }}>
-                      <div
-                        className="progress-bar-fill"
-                        style={{ width: `${utilization}%`, background: utilizationColor(utilization) }}
-                      />
-                    </div>
-
-                    <div>
-                      <div style={{ ...statLabelStyle, marginBottom: '0.25rem' }}>
-                        {t('table.queues')}
-                      </div>
-                      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem' }}>
-                        {proc.queues.map((q) => (
-                          <span key={q} className="badge badge-muted">{q}</span>
-                        ))}
-                      </div>
-                    </div>
-
-                    {!readOnly && !proc.embedded && (
-                      <div style={{ display: 'flex', gap: '0.4rem', marginTop: '0.85rem' }} onClick={(e) => e.stopPropagation()}>
-                        <button
-                          className="btn btn-sm"
-                          disabled={control.isPending}
-                          onClick={() => control.mutate({ signal: 'quiet', scope: 'one', identity: proc.identity })}
-                        >
-                          {t('actions.quiet')}
-                        </button>
-                        <button
-                          className="btn btn-sm btn-danger"
-                          disabled={control.isPending}
-                          onClick={() => confirmStop(t('actions.scope_this_process')) && control.mutate({ signal: 'stop', scope: 'one', identity: proc.identity })}
-                        >
-                          {t('actions.stop')}
-                        </button>
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          </section>
-        ))
-      )}
-
-      <Modal
-        open={selectedProc !== null}
-        onClose={() => setSelected(null)}
-        title={selectedProc ? `${selectedProc.hostname} · PID ${selectedProc.pid}` : ''}
-        width={780}
-      >
-        {selectedProc && <ProcessDetail proc={selectedProc} />}
-      </Modal>
-    </div>
+              <Show when={selectedProc()}>{(proc) => <ProcessDetail proc={proc()} />}</Show>
+            </Modal>
+          </div>
+        )}
+      </Match>
+    </Switch>
   );
 }

--- a/frontend/src/pages/Cron.tsx
+++ b/frontend/src/pages/Cron.tsx
@@ -1,5 +1,5 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/solid-query';
+import { onMount, createSignal, For, Switch, Match, Show } from 'solid-js';
 import { t } from '../i18n';
 import { PageHeader } from '../components/PageHeader';
 import { SkeletonTable } from '../components/Skeleton';
@@ -35,169 +35,180 @@ const SORT: Accessors<CronLoop> = {
 
 export default function Cron() {
   const qc = useQueryClient();
-  const { data: meta } = useMeta();
-  const readOnly = meta?.read_only ?? false;
-  const [historyLoop, setHistoryLoop] = useState<CronLoop | null>(null);
+  const meta = useMeta();
+  const readOnly = () => meta.data?.read_only ?? false;
+  const [historyLoop, setHistoryLoop] = createSignal<CronLoop | null>(null);
 
-  useEffect(() => {
+  onMount(() => {
     document.title = `${t('nav.cron')} — Wurk`;
-  }, []);
+  });
 
-  const { data, isLoading, isError } = useQuery<CronLoop[]>({
+  const q = useQuery<CronLoop[]>(() => ({
     queryKey: ['cron'],
     queryFn: () => fetch('/wurk/api/cron').then((r) => r.json() as Promise<CronLoop[]>),
     refetchInterval: 15000,
-  });
+  }));
 
   // pause/unpause/enqueue skip CSRF (see ApiController#skip_forgery_protection).
   const post = (lid: string, action: string) =>
     fetch(`/wurk/api/cron/${lid}/${action}`, { method: 'POST' });
 
-  const setPaused = useMutation({
+  const setPaused = useMutation(() => ({
     mutationFn: ({ lid, paused }: { lid: string; paused: boolean }) =>
       post(lid, paused ? 'unpause' : 'pause'),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['cron'] }),
-  });
+  }));
 
-  const enqueueNow = useMutation({
+  const enqueueNow = useMutation(() => ({
     mutationFn: (lid: string) => post(lid, 'enqueue'),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['cron'] }),
-  });
+  }));
 
   // Per-loop run history — fetched on demand when a row opens the modal.
-  const { data: history, isLoading: historyLoading, isError: historyError } = useQuery<HistoryEntry[]>({
-    queryKey: ['cron-history', historyLoop?.lid],
+  const historyQ = useQuery<HistoryEntry[]>(() => ({
+    queryKey: ['cron-history', historyLoop()?.lid],
     queryFn: () =>
-      fetch(`/wurk/api/cron/${historyLoop!.lid}/history`)
+      fetch(`/wurk/api/cron/${historyLoop()!.lid}/history`)
         .then((r) => r.json() as Promise<{ history: HistoryEntry[] }>)
         .then((d) => d.history),
-    enabled: historyLoop !== null,
-  });
+    enabled: historyLoop() !== null,
+  }));
 
-  const { sorted, sort, toggle } = useSort(data ?? [], SORT);
-
-  if (isLoading) {
-    return (
-      <div>
-        <PageHeader icon="fa-stopwatch" title={t('nav.cron')} summary={t('summaries.cron')} />
-        <SkeletonTable rows={8} cols={readOnly ? 6 : 7} />
-      </div>
-    );
-  }
-  if (isError || !data) return <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>;
+  const { sorted, sort, toggle } = useSort(() => q.data ?? [], SORT);
 
   return (
-    <div>
-      <PageHeader icon="fa-stopwatch" title={t('nav.cron')} summary={t('summaries.cron')}>
-        <span className="badge badge-muted">{data.length}</span>
-      </PageHeader>
-
-      {data.length === 0 ? (
-        <div className="empty-state">{t('common.empty')}</div>
-      ) : (
-        <div className="table-wrapper">
-          <table>
-            <thead>
-              <tr>
-                <SortableTh label="Schedule" sortKey="schedule" sort={sort} onSort={toggle} />
-                <SortableTh label={t('table.class')} sortKey="klass" sort={sort} onSort={toggle} />
-                <SortableTh label={t('table.queue')} sortKey="queue" sort={sort} onSort={toggle} />
-                <SortableTh label="Last fire" sortKey="last_fire" sort={sort} onSort={toggle} />
-                <SortableTh label="Next fire" sortKey="next_fire" sort={sort} onSort={toggle} />
-                <SortableTh label={t('table.status')} sortKey="status" sort={sort} onSort={toggle} />
-                {!readOnly && <th />}
-              </tr>
-            </thead>
-            <tbody>
-              {sorted.map((loop) => (
-                <tr
-                  key={loop.lid}
-                  className="row-clickable"
-                  onClick={() => setHistoryLoop(loop)}
-                >
-                  <td style={{ fontFamily: 'monospace', fontSize: 12 }} title={loop.tz ?? undefined}>
-                    {loop.schedule}
-                  </td>
-                  <td title={loop.klass}>{truncate(loop.klass, 32)}</td>
-                  <td>{loop.queue}</td>
-                  <td style={{ color: 'var(--text-muted)' }}>
-                    {loop.last_fire_at ? relativeTime(loop.last_fire_at) : '—'}
-                  </td>
-                  <td style={{ color: loop.paused ? 'var(--text-muted)' : 'var(--accent)' }}>
-                    {loop.paused ? '—' : loop.next_fire_at ? relativeTime(loop.next_fire_at) : '—'}
-                  </td>
-                  <td>
-                    {loop.paused ? (
-                      <span className="badge badge-muted">paused</span>
-                    ) : (
-                      <span className="badge badge-success">active</span>
-                    )}
-                  </td>
-                  {!readOnly && (
-                    <td onClick={(e) => e.stopPropagation()}>
-                      <div style={{ display: 'flex', gap: '0.4rem' }}>
-                        <button
-                          className="btn btn-sm"
-                          disabled={setPaused.isPending}
-                          onClick={() => setPaused.mutate({ lid: loop.lid, paused: loop.paused })}
-                        >
-                          {loop.paused ? 'Resume' : 'Pause'}
-                        </button>
-                        <button
-                          className="btn btn-sm"
-                          disabled={enqueueNow.isPending}
-                          onClick={() => enqueueNow.mutate(loop.lid)}
-                        >
-                          Enqueue
-                        </button>
-                      </div>
-                    </td>
-                  )}
-                </tr>
-              ))}
-            </tbody>
-          </table>
+    <Switch>
+      <Match when={q.isPending}>
+        <div>
+          <PageHeader icon="fa-stopwatch" title={t('nav.cron')} summary={t('summaries.cron')} />
+          <SkeletonTable rows={8} cols={readOnly() ? 6 : 7} />
         </div>
-      )}
+      </Match>
+      <Match when={q.isError || !q.data}>
+        <div class="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>
+      </Match>
+      <Match when={q.data}>
+        {(data) => (
+          <div>
+            <PageHeader icon="fa-stopwatch" title={t('nav.cron')} summary={t('summaries.cron')}>
+              <span class="badge badge-muted">{data().length}</span>
+            </PageHeader>
 
-      <Modal
-        open={historyLoop !== null}
-        onClose={() => setHistoryLoop(null)}
-        title={
-          historyLoop
-            ? `${t('cron.history_title')} — ${truncate(historyLoop.klass, 40)}`
-            : t('cron.history_title')
-        }
-      >
-        {historyLoading ? (
-          <SkeletonTable rows={6} cols={2} />
-        ) : historyError ? (
-          <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>
-        ) : !history || history.length === 0 ? (
-          <div className="empty-state">{t('cron.no_history')}</div>
-        ) : (
-          <div className="table-wrapper">
-            <table>
-              <thead>
-                <tr>
-                  <th>{t('cron.fired')}</th>
-                  <th>{t('table.jid')}</th>
-                </tr>
-              </thead>
-              <tbody>
-                {history.map(([firedAt, jid]) => (
-                  <tr key={jid}>
-                    <td style={{ color: 'var(--text-muted)' }} title={isoTime(firedAt)}>
-                      {relativeTime(firedAt)}
-                    </td>
-                    <td style={{ fontFamily: 'monospace', fontSize: 12 }}>{jid}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+            <Show when={data().length > 0} fallback={<div class="empty-state">{t('common.empty')}</div>}>
+              <div class="table-wrapper">
+                <table>
+                  <thead>
+                    <tr>
+                      <SortableTh label="Schedule" sortKey="schedule" sort={sort()} onSort={toggle} />
+                      <SortableTh label={t('table.class')} sortKey="klass" sort={sort()} onSort={toggle} />
+                      <SortableTh label={t('table.queue')} sortKey="queue" sort={sort()} onSort={toggle} />
+                      <SortableTh label="Last fire" sortKey="last_fire" sort={sort()} onSort={toggle} />
+                      <SortableTh label="Next fire" sortKey="next_fire" sort={sort()} onSort={toggle} />
+                      <SortableTh label={t('table.status')} sortKey="status" sort={sort()} onSort={toggle} />
+                      <Show when={!readOnly()}><th /></Show>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <For each={sorted()}>
+                      {(loop) => (
+                        <tr
+                          class="row-clickable"
+                          onClick={() => setHistoryLoop(loop)}
+                        >
+                          <td style={{ 'font-family': 'monospace', 'font-size': '12px' }} title={loop.tz ?? undefined}>
+                            {loop.schedule}
+                          </td>
+                          <td title={loop.klass}>{truncate(loop.klass, 32)}</td>
+                          <td>{loop.queue}</td>
+                          <td style={{ color: 'var(--text-muted)' }}>
+                            {loop.last_fire_at ? relativeTime(loop.last_fire_at) : '—'}
+                          </td>
+                          <td style={{ color: loop.paused ? 'var(--text-muted)' : 'var(--accent)' }}>
+                            {loop.paused ? '—' : loop.next_fire_at ? relativeTime(loop.next_fire_at) : '—'}
+                          </td>
+                          <td>
+                            <Show when={loop.paused} fallback={<span class="badge badge-success">active</span>}>
+                              <span class="badge badge-muted">paused</span>
+                            </Show>
+                          </td>
+                          <Show when={!readOnly()}>
+                            <td onClick={(e) => e.stopPropagation()}>
+                              <div style={{ display: 'flex', gap: '0.4rem' }}>
+                                <button
+                                  class="btn btn-sm"
+                                  disabled={setPaused.isPending}
+                                  onClick={() => setPaused.mutate({ lid: loop.lid, paused: loop.paused })}
+                                >
+                                  {loop.paused ? 'Resume' : 'Pause'}
+                                </button>
+                                <button
+                                  class="btn btn-sm"
+                                  disabled={enqueueNow.isPending}
+                                  onClick={() => enqueueNow.mutate(loop.lid)}
+                                >
+                                  Enqueue
+                                </button>
+                              </div>
+                            </td>
+                          </Show>
+                        </tr>
+                      )}
+                    </For>
+                  </tbody>
+                </table>
+              </div>
+            </Show>
+
+            <Modal
+              open={historyLoop() !== null}
+              onClose={() => setHistoryLoop(null)}
+              title={
+                historyLoop()
+                  ? `${t('cron.history_title')} — ${truncate(historyLoop()!.klass, 40)}`
+                  : t('cron.history_title')
+              }
+            >
+              <Switch>
+                <Match when={historyQ.isPending}>
+                  <SkeletonTable rows={6} cols={2} />
+                </Match>
+                <Match when={historyQ.isError}>
+                  <div class="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>
+                </Match>
+                <Match when={!historyQ.data || historyQ.data.length === 0}>
+                  <div class="empty-state">{t('cron.no_history')}</div>
+                </Match>
+                <Match when={historyQ.data}>
+                  {(history) => (
+                    <div class="table-wrapper">
+                      <table>
+                        <thead>
+                          <tr>
+                            <th>{t('cron.fired')}</th>
+                            <th>{t('table.jid')}</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <For each={history()}>
+                            {([firedAt, jid]) => (
+                              <tr>
+                                <td style={{ color: 'var(--text-muted)' }} title={isoTime(firedAt)}>
+                                  {relativeTime(firedAt)}
+                                </td>
+                                <td style={{ 'font-family': 'monospace', 'font-size': '12px' }}>{jid}</td>
+                              </tr>
+                            )}
+                          </For>
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+                </Match>
+              </Switch>
+            </Modal>
           </div>
         )}
-      </Modal>
-    </div>
+      </Match>
+    </Switch>
   );
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,18 +1,11 @@
-import { useQuery } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
-import {
-  AreaChart,
-  Area,
-  XAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-} from 'recharts';
+import { useQuery } from '@tanstack/solid-query';
+import { createSignal, createMemo, onMount, For, Show, Switch, Match } from 'solid-js';
+import { A } from '@solidjs/router';
+import { AreaChart } from '../components/charts';
 import { AnimatedNumber } from '../components/AnimatedNumber';
 import { Skeleton, SkeletonCards, SkeletonTable } from '../components/Skeleton';
 import { t } from '../i18n';
-import type { StatsSnapshot } from '../hooks/useSSE';
+import { useSSE } from '../hooks/useSSE';
 import { formatDuration } from '../utils';
 
 interface StatsData {
@@ -39,10 +32,6 @@ interface HistoryResponse {
   bucket: string;
   window: number;
   series: HistoryPoint[];
-}
-
-interface DashboardProps {
-  sse: { stats: StatsSnapshot | null; connected: boolean };
 }
 
 // Throughput change over the trailing hour vs the hour before it, derived from
@@ -79,288 +68,271 @@ const fmtBucket = (at: number, bucket: string) => {
     : `${hh}:${String(d.getMinutes()).padStart(2, '0')}`;
 };
 
-function DeltaSub({ pct, goodWhenUp }: { pct: number | null; goodWhenUp: boolean }) {
-  if (pct === null) return <span className="obs-metric__sub">{t('dashboard.vs_last_hour')}</span>;
-  const up = pct >= 0;
-  const good = up === goodWhenUp;
+function DeltaSub(props: { pct: number | null; goodWhenUp: boolean }) {
   return (
-    <span className="obs-metric__sub">
-      <span className={good ? 'up' : 'down'}>
-        {up ? '▲' : '▼'} {up ? '+' : ''}{pct}%
-      </span>{' '}
-      {t('dashboard.vs_last_hour')}
-    </span>
+    <Show when={props.pct !== null} fallback={<span class="obs-metric__sub">{t('dashboard.vs_last_hour')}</span>}>
+      {(() => {
+        const up = () => props.pct! >= 0;
+        const good = () => up() === props.goodWhenUp;
+        return (
+          <span class="obs-metric__sub">
+            <span class={good() ? 'up' : 'down'}>
+              {up() ? '▲' : '▼'} {up() ? '+' : ''}{props.pct}%
+            </span>{' '}
+            {t('dashboard.vs_last_hour')}
+          </span>
+        );
+      })()}
+    </Show>
   );
 }
 
-export default function Dashboard({ sse }: DashboardProps) {
-  const [rangeIdx, setRangeIdx] = useState(0); // default 1h
-  const range = RANGES[rangeIdx];
+export default function Dashboard() {
+  const sse = useSSE();
+  const [rangeIdx, setRangeIdx] = createSignal(0); // default 1h
+  const range = () => RANGES[rangeIdx()];
 
-  useEffect(() => {
+  onMount(() => {
     document.title = `${t('nav.dashboard')} — Wurk`;
-  }, []);
+  });
 
-  const { data: fetched, isLoading, isError } = useQuery<StatsData>({
+  const statsQuery = useQuery(() => ({
     queryKey: ['stats'],
     queryFn: () => fetch('/wurk/api/stats').then((r) => r.json() as Promise<StatsData>),
-    enabled: !sse.connected,
-    refetchInterval: sse.connected ? false : 5000,
-  });
+    enabled: !sse.connected(),
+    refetchInterval: sse.connected() ? false : 5000,
+  }));
 
   // Throughput for the Performance Insight chart over the selected range (same
   // source as Metrics).
-  const { data: history, isPending: historyPending } = useQuery<HistoryResponse>({
-    queryKey: ['history', range.bucket, range.window],
+  const historyQuery = useQuery(() => ({
+    queryKey: ['history', range().bucket, range().window],
     queryFn: () =>
-      fetch(`/wurk/api/history/${range.bucket}?window=${range.window}`).then((r) => r.json() as Promise<HistoryResponse>),
+      fetch(`/wurk/api/history/${range().bucket}?window=${range().window}`).then((r) => r.json() as Promise<HistoryResponse>),
     refetchInterval: 30000,
-  });
+  }));
 
-  const stats: StatsData | null = sse.stats ?? fetched ?? null;
+  const stats = (): StatsData | null => sse.stats() ?? statsQuery.data ?? null;
   // Delta math needs the prior-hour buckets, so keep the full history for
   // hourlyDeltaPct() and slice only for chart rendering. Slicing first would
   // drop the comparison window on the 1h tab and force the 100% fallback.
-  const fullSeries = (history?.series ?? []).map((p) => ({ ...p, label: fmtBucket(p.at, range.bucket) }));
-  const sliceN = 'slice' in range ? range.slice : undefined;
-  const series = sliceN ? fullSeries.slice(-sliceN) : fullSeries;
-  const hasHistory = series.some((p) => p.processed > 0 || p.failed > 0);
-
-  if (isLoading && !stats) {
-    return (
-      <div className="obs">
-        <SkeletonCards count={4} />
-        <SkeletonTable rows={6} cols={4} />
-      </div>
-    );
-  }
-  if (isError && !stats) {
-    return <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>;
-  }
-  if (!stats) {
-    return <div className="empty-state">{t('common.empty')}</div>;
-  }
-
-  const metrics = [
-    {
-      key: 'processed',
-      label: t('dashboard.processed'),
-      value: stats.processed,
-      icon: 'fa-circle-check',
-      to: '/metrics',
-      sub: <DeltaSub pct={hourlyDeltaPct(fullSeries, 'processed')} goodWhenUp />,
-    },
-    {
-      key: 'failed',
-      label: t('dashboard.failed'),
-      value: stats.failed,
-      icon: 'fa-triangle-exclamation',
-      to: '/retries',
-      sub: <DeltaSub pct={hourlyDeltaPct(fullSeries, 'failed')} goodWhenUp={false} />,
-    },
-    {
-      key: 'expired',
-      label: t('dashboard.expired'),
-      value: stats.expired,
-      icon: 'fa-ban',
-      to: '/dead',
-      sub: <span className="obs-metric__sub">{stats.expired === 0 ? t('dashboard.stable_threshold') : t('dashboard.above_threshold')}</span>,
-    },
-    {
-      key: 'busy',
-      label: t('dashboard.busy'),
-      value: stats.busy,
-      icon: 'fa-spinner',
-      to: '/busy',
-      sub: <span className="obs-metric__sub">{stats.busy === 0 ? t('dashboard.system_idle') : t('dashboard.processing')}</span>,
-    },
-  ];
-
-  const secondary = [
-    { key: 'enqueued', label: t('dashboard.enqueued'), value: stats.enqueued, to: '/queues' },
-    { key: 'retries', label: t('dashboard.retries'), value: stats.retries, to: '/retries' },
-    { key: 'scheduled', label: t('dashboard.scheduled'), value: stats.scheduled, to: '/scheduled' },
-    { key: 'dead', label: t('dashboard.dead'), value: stats.dead, to: '/dead' },
-  ];
+  const fullSeries = createMemo(() =>
+    (historyQuery.data?.series ?? []).map((p) => ({ ...p, label: fmtBucket(p.at, range().bucket) })),
+  );
+  const series = createMemo(() => {
+    const r = range();
+    const sliceN = 'slice' in r ? r.slice : undefined;
+    return sliceN ? fullSeries().slice(-sliceN) : fullSeries();
+  });
+  const hasHistory = createMemo(() => series().some((p) => p.processed > 0 || p.failed > 0));
 
   return (
-    <div className="obs">
-      <div className="obs-metrics">
-        {metrics.map((m) => (
-          <Link key={m.key} className="obs-card obs-metric obs-card--link" to={m.to}>
-            <div className="obs-metric__head">
-              <span className="obs-mono">{m.label}</span>
-              <i className={`fa-solid ${m.icon} obs-metric__icon`} aria-hidden="true" />
-            </div>
-            <span className="obs-metric__value">
-              <AnimatedNumber value={m.value} />
-            </span>
-            {m.sub}
-            <i className="fa-solid fa-arrow-right obs-card__go" aria-hidden="true" />
-          </Link>
-        ))}
-      </div>
-
-      <div className="obs-card obs-panel">
-        <div className="obs-panel__head">
-          <div>
-            <h2 className="obs-panel__title">{t('dashboard.performance_insight')}</h2>
-            <p className="obs-panel__sub">{t('dashboard.perf_subtitle', { range: t(range.desc_key) })}</p>
-          </div>
-          <div className="obs-panel__controls">
-            <div className="obs-seg" role="tablist" aria-label="Time range">
-              {RANGES.map((r, i) => (
-                <button
-                  key={r.key}
-                  role="tab"
-                  aria-selected={i === rangeIdx}
-                  className={i === rangeIdx ? 'is-active' : ''}
-                  onClick={() => setRangeIdx(i)}
-                >
-                  {r.key}
-                </button>
-              ))}
-            </div>
-            <div className="obs-legend">
-              <span><i className="dot dot--processed" /> {t('dashboard.processed')}</span>
-              <span><i className="dot dot--failed" /> {t('dashboard.failed')}</span>
-            </div>
-          </div>
+    <Switch>
+      <Match when={statsQuery.isLoading && !stats()}>
+        <div class="obs">
+          <SkeletonCards count={4} />
+          <SkeletonTable rows={6} cols={4} />
         </div>
-        <div className="obs-chartbox">
-          {historyPending ? (
-            <Skeleton height={320} />
-          ) : hasHistory ? (
-            <ResponsiveContainer width="100%" height={320}>
-              <AreaChart data={series} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
-                <defs>
-                  <linearGradient id="obsProcessed" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="0%" stopColor="#fafafa" stopOpacity={0.22} />
-                    <stop offset="95%" stopColor="#fafafa" stopOpacity={0} />
-                  </linearGradient>
-                </defs>
-                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="rgba(255,255,255,0.06)" />
-                <XAxis
-                  dataKey="label"
-                  tick={{ fill: '#71717a', fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }}
-                  axisLine={false}
-                  tickLine={false}
-                  minTickGap={64}
-                  interval="preserveStartEnd"
-                />
-                <Tooltip
-                  contentStyle={{
-                    background: '#161618',
-                    border: '1px solid #272729',
-                    borderRadius: 6,
-                    fontSize: 12,
-                    fontFamily: 'JetBrains Mono, monospace',
-                  }}
-                  labelStyle={{ color: '#a1a1aa' }}
-                  cursor={{ stroke: 'rgba(255,255,255,0.25)', strokeWidth: 1 }}
-                />
-                <Area
-                  type="monotone"
-                  dataKey="processed"
-                  name={t('dashboard.processed')}
-                  stroke="#fafafa"
-                  strokeWidth={2}
-                  fill="url(#obsProcessed)"
-                  dot={false}
-                  activeDot={{ r: 4, fill: '#fafafa', stroke: '#09090b', strokeWidth: 2 }}
-                  animationDuration={1100}
-                  animationEasing="ease-out"
-                />
-                <Area
-                  type="monotone"
-                  dataKey="failed"
-                  name={t('dashboard.failed')}
-                  stroke="#a1a1aa"
-                  strokeWidth={1.5}
-                  strokeDasharray="5 4"
-                  fill="transparent"
-                  dot={false}
-                  activeDot={{ r: 3, fill: '#a1a1aa', stroke: '#09090b', strokeWidth: 2 }}
-                  animationDuration={1100}
-                  animationBegin={250}
-                  animationEasing="ease-out"
-                />
-              </AreaChart>
-            </ResponsiveContainer>
-          ) : (
-            <div className="empty-state" style={{ height: 320, display: 'grid', placeItems: 'center' }}>
-              {t('dashboard.no_history')}
+      </Match>
+      <Match when={statsQuery.isError && !stats()}>
+        <div class="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>
+      </Match>
+      <Match when={!stats()}>
+        <div class="empty-state">{t('common.empty')}</div>
+      </Match>
+      <Match when={stats()}>
+        {(s) => (
+          <div class="obs">
+            <div class="obs-metrics">
+              <A class="obs-card obs-metric obs-card--link" href="/metrics">
+                <div class="obs-metric__head">
+                  <span class="obs-mono">{t('dashboard.processed')}</span>
+                  <i class="fa-solid fa-circle-check obs-metric__icon" aria-hidden="true" />
+                </div>
+                <span class="obs-metric__value">
+                  <AnimatedNumber value={s().processed} />
+                </span>
+                <DeltaSub pct={hourlyDeltaPct(fullSeries(), 'processed')} goodWhenUp />
+                <i class="fa-solid fa-arrow-right obs-card__go" aria-hidden="true" />
+              </A>
+              <A class="obs-card obs-metric obs-card--link" href="/retries">
+                <div class="obs-metric__head">
+                  <span class="obs-mono">{t('dashboard.failed')}</span>
+                  <i class="fa-solid fa-triangle-exclamation obs-metric__icon" aria-hidden="true" />
+                </div>
+                <span class="obs-metric__value">
+                  <AnimatedNumber value={s().failed} />
+                </span>
+                <DeltaSub pct={hourlyDeltaPct(fullSeries(), 'failed')} goodWhenUp={false} />
+                <i class="fa-solid fa-arrow-right obs-card__go" aria-hidden="true" />
+              </A>
+              <A class="obs-card obs-metric obs-card--link" href="/dead">
+                <div class="obs-metric__head">
+                  <span class="obs-mono">{t('dashboard.expired')}</span>
+                  <i class="fa-solid fa-ban obs-metric__icon" aria-hidden="true" />
+                </div>
+                <span class="obs-metric__value">
+                  <AnimatedNumber value={s().expired} />
+                </span>
+                <span class="obs-metric__sub">{s().expired === 0 ? t('dashboard.stable_threshold') : t('dashboard.above_threshold')}</span>
+                <i class="fa-solid fa-arrow-right obs-card__go" aria-hidden="true" />
+              </A>
+              <A class="obs-card obs-metric obs-card--link" href="/busy">
+                <div class="obs-metric__head">
+                  <span class="obs-mono">{t('dashboard.busy')}</span>
+                  <i class="fa-solid fa-spinner obs-metric__icon" aria-hidden="true" />
+                </div>
+                <span class="obs-metric__value">
+                  <AnimatedNumber value={s().busy} />
+                </span>
+                <span class="obs-metric__sub">{s().busy === 0 ? t('dashboard.system_idle') : t('dashboard.processing')}</span>
+                <i class="fa-solid fa-arrow-right obs-card__go" aria-hidden="true" />
+              </A>
             </div>
-          )}
-        </div>
-      </div>
 
-      <div className="obs-stats">
-        {secondary.map((s) => (
-          <Link key={s.key} className="obs-card obs-stat obs-card--link" to={s.to}>
-            <span className="obs-mono">{s.label}</span>
-            <span className="obs-stat__value">
-              <AnimatedNumber value={s.value} />
-            </span>
-            <i className="fa-solid fa-arrow-right obs-card__go" aria-hidden="true" />
-          </Link>
-        ))}
-      </div>
+            <div class="obs-card obs-panel">
+              <div class="obs-panel__head">
+                <div>
+                  <h2 class="obs-panel__title">{t('dashboard.performance_insight')}</h2>
+                  <p class="obs-panel__sub">{t('dashboard.perf_subtitle', { range: t(range().desc_key) })}</p>
+                </div>
+                <div class="obs-panel__controls">
+                  <div class="obs-seg" role="tablist" aria-label="Time range">
+                    <For each={RANGES}>
+                      {(r, i) => (
+                        <button
+                          role="tab"
+                          aria-selected={i() === rangeIdx()}
+                          class={i() === rangeIdx() ? 'is-active' : ''}
+                          onClick={() => setRangeIdx(i())}
+                        >
+                          {r.key}
+                        </button>
+                      )}
+                    </For>
+                  </div>
+                  <div class="obs-legend">
+                    <span><i class="dot dot--processed" /> {t('dashboard.processed')}</span>
+                    <span><i class="dot dot--failed" /> {t('dashboard.failed')}</span>
+                  </div>
+                </div>
+              </div>
+              <div class="obs-chartbox">
+                <Show when={!historyQuery.isPending} fallback={<Skeleton height={320} />}>
+                  <Show
+                    when={hasHistory()}
+                    fallback={
+                      <div class="empty-state" style={{ height: '320px', display: 'grid', 'place-items': 'center' }}>
+                        {t('dashboard.no_history')}
+                      </div>
+                    }
+                  >
+                    <AreaChart
+                      data={series()}
+                      height={320}
+                      xMinTickGap={64}
+                      series={[
+                        { key: 'processed', name: t('dashboard.processed'), stroke: '#fafafa', strokeWidth: 2, fill: 'gradient' },
+                        { key: 'failed', name: t('dashboard.failed'), stroke: '#a1a1aa', strokeWidth: 1.5, strokeDasharray: '5 4', fill: 'none' },
+                      ]}
+                    />
+                  </Show>
+                </Show>
+              </div>
+            </div>
 
-      <div className="obs-card obs-table">
-        <div className="obs-table__head">
-          <h2 className="obs-table__title">{t('table.queues')}</h2>
-          <Link className="obs-table__link" to="/queues">
-            View All <i className="fa-solid fa-arrow-right" aria-hidden="true" />
-          </Link>
-        </div>
-        {stats.queues.length === 0 ? (
-          <div className="empty-state">{t('common.empty')}</div>
-        ) : (
-          <div className="obs-tablescroll">
-          <table>
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>{t('table.size')}</th>
-                <th>{t('table.latency')}</th>
-                <th>{t('table.status')}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {stats.queues.map((q) => (
-                <tr key={q.name}>
-                  <td style={{ fontWeight: 500, color: 'var(--obs-text)' }}>{q.name}</td>
-                  <td><AnimatedNumber value={q.size} /></td>
-                  <td title={`${q.latency.toFixed(3)}s`}>{formatDuration(q.latency)}</td>
-                  <td>
-                    {q.paused ? (
-                      <span className="obs-chip obs-chip--paused">{t('dashboard.paused')}</span>
-                    ) : (
-                      <span className="obs-chip obs-chip--active">{t('dashboard.active')}</span>
-                    )}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+            <div class="obs-stats">
+              <A class="obs-card obs-stat obs-card--link" href="/queues">
+                <span class="obs-mono">{t('dashboard.enqueued')}</span>
+                <span class="obs-stat__value">
+                  <AnimatedNumber value={s().enqueued} />
+                </span>
+                <i class="fa-solid fa-arrow-right obs-card__go" aria-hidden="true" />
+              </A>
+              <A class="obs-card obs-stat obs-card--link" href="/retries">
+                <span class="obs-mono">{t('dashboard.retries')}</span>
+                <span class="obs-stat__value">
+                  <AnimatedNumber value={s().retries} />
+                </span>
+                <i class="fa-solid fa-arrow-right obs-card__go" aria-hidden="true" />
+              </A>
+              <A class="obs-card obs-stat obs-card--link" href="/scheduled">
+                <span class="obs-mono">{t('dashboard.scheduled')}</span>
+                <span class="obs-stat__value">
+                  <AnimatedNumber value={s().scheduled} />
+                </span>
+                <i class="fa-solid fa-arrow-right obs-card__go" aria-hidden="true" />
+              </A>
+              <A class="obs-card obs-stat obs-card--link" href="/dead">
+                <span class="obs-mono">{t('dashboard.dead')}</span>
+                <span class="obs-stat__value">
+                  <AnimatedNumber value={s().dead} />
+                </span>
+                <i class="fa-solid fa-arrow-right obs-card__go" aria-hidden="true" />
+              </A>
+            </div>
+
+            <div class="obs-card obs-table">
+              <div class="obs-table__head">
+                <h2 class="obs-table__title">{t('table.queues')}</h2>
+                <A class="obs-table__link" href="/queues">
+                  View All <i class="fa-solid fa-arrow-right" aria-hidden="true" />
+                </A>
+              </div>
+              <Show
+                when={s().queues.length > 0}
+                fallback={<div class="empty-state">{t('common.empty')}</div>}
+              >
+                <div class="obs-tablescroll">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Name</th>
+                        <th>{t('table.size')}</th>
+                        <th>{t('table.latency')}</th>
+                        <th>{t('table.status')}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <For each={s().queues}>
+                        {(q) => (
+                          <tr>
+                            <td style={{ 'font-weight': 500, color: 'var(--obs-text)' }}>{q.name}</td>
+                            <td><AnimatedNumber value={q.size} /></td>
+                            <td title={`${q.latency.toFixed(3)}s`}>{formatDuration(q.latency)}</td>
+                            <td>
+                              <Show
+                                when={q.paused}
+                                fallback={<span class="obs-chip obs-chip--active">{t('dashboard.active')}</span>}
+                              >
+                                <span class="obs-chip obs-chip--paused">{t('dashboard.paused')}</span>
+                              </Show>
+                            </td>
+                          </tr>
+                        )}
+                      </For>
+                    </tbody>
+                  </table>
+                </div>
+              </Show>
+            </div>
+
+            <div class="obs-card obs-cta">
+              <span class="obs-cta__icon"><i class="fa-solid fa-bolt" aria-hidden="true" /></span>
+              <h2 class="obs-cta__title">{t('dashboard.strapline')}</h2>
+              <p class="obs-cta__text">{t('dashboard.tagline')}</p>
+              <div class="obs-cta__actions">
+                <a class="obs-btn obs-btn--primary" href="https://developerz-ai.github.io/wurk/" target="_blank" rel="noreferrer">
+                  <i class="fa-solid fa-download" aria-hidden="true" /> {t('dashboard.install')}
+                </a>
+                <a class="obs-btn obs-btn--ghost" href="https://github.com/developerz-ai/wurk/wiki" target="_blank" rel="noreferrer">
+                  <i class="fa-solid fa-book" aria-hidden="true" /> {t('dashboard.docs')}
+                </a>
+              </div>
+            </div>
           </div>
         )}
-      </div>
-
-      <div className="obs-card obs-cta">
-        <span className="obs-cta__icon"><i className="fa-solid fa-bolt" aria-hidden="true" /></span>
-        <h2 className="obs-cta__title">{t('dashboard.strapline')}</h2>
-        <p className="obs-cta__text">{t('dashboard.tagline')}</p>
-        <div className="obs-cta__actions">
-          <a className="obs-btn obs-btn--primary" href="https://developerz-ai.github.io/wurk/" target="_blank" rel="noreferrer">
-            <i className="fa-solid fa-download" aria-hidden="true" /> {t('dashboard.install')}
-          </a>
-          <a className="obs-btn obs-btn--ghost" href="https://github.com/developerz-ai/wurk/wiki" target="_blank" rel="noreferrer">
-            <i className="fa-solid fa-book" aria-hidden="true" /> {t('dashboard.docs')}
-          </a>
-        </div>
-      </div>
-    </div>
+      </Match>
+    </Switch>
   );
 }

--- a/frontend/src/pages/Dead.tsx
+++ b/frontend/src/pages/Dead.tsx
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
-import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/solid-query';
+import { createSignal, onMount, For, Show, Switch, Match } from 'solid-js';
 import { Pagination } from '../components/Pagination';
 import { ArgsValue } from '../components/ArgsValue';
 import { SortableTh } from '../components/SortableTh';
@@ -54,123 +54,129 @@ const ACTIONS: ActionDef[] = [
 
 export default function Dead() {
   const [page, setPage] = usePageParam();
-  const [selected, setSelected] = useState<JobEntry | null>(null);
-  const [selectedKey, setSelectedKey] = useState<string | null>(null);
-  const { data: meta } = useMeta();
-  const readOnly = meta?.read_only ?? false;
+  const [selected, setSelected] = createSignal<JobEntry | null>(null);
+  const [selectedKey, setSelectedKey] = createSignal<string | null>(null);
+  const meta = useMeta();
+  const readOnly = () => meta.data?.read_only ?? false;
   const sel = useSelection();
   const { single, bulk, all } = useJobSetActions('dead');
-  const pending = single.isPending || bulk.isPending || all.isPending;
+  const pending = () => single.isPending || bulk.isPending || all.isPending;
 
-  useEffect(() => {
+  onMount(() => {
     document.title = `${t('nav.dead')} — Wurk`;
-  }, []);
-
-  const { data, isLoading, isError } = useQuery<DeadResponse>({
-    queryKey: ['dead', page],
-    queryFn: () =>
-      fetch(`/wurk/api/dead?page=${page - 1}&count=${PAGE_SIZE}`).then(
-        (r) => r.json() as Promise<DeadResponse>
-      ),
   });
 
-  const { sorted, sort, toggle } = useSort(data?.entries ?? [], SORT);
-  const pageKeys = sorted.map(entryKey);
+  const query = useQuery<DeadResponse>(() => ({
+    queryKey: ['dead', page()],
+    queryFn: () =>
+      fetch(`/wurk/api/dead?page=${page() - 1}&count=${PAGE_SIZE}`).then(
+        (r) => r.json() as Promise<DeadResponse>
+      ),
+  }));
 
-  if (isLoading)
-    return (
-      <div>
-        <PageHeader icon="fa-skull" title={t('nav.dead')} summary={t('summaries.dead')} />
-        <SkeletonTable rows={8} cols={7} />
-      </div>
-    );
-  if (isError || !data) return <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>;
-
-  const allChecked = pageKeys.length > 0 && pageKeys.every((k) => sel.selected.has(k));
+  const { sorted, sort, toggle } = useSort(() => query.data?.entries ?? [], SORT);
+  const pageKeys = () => sorted().map(entryKey);
+  const allChecked = () => pageKeys().length > 0 && pageKeys().every((k) => sel.selected().has(k));
 
   return (
-    <div>
-      <PageHeader icon="fa-skull" title={t('nav.dead')} summary={t('summaries.dead')}>
-        <span className="badge badge-danger">{data.total.toLocaleString()}</span>
-      </PageHeader>
+    <Switch>
+      <Match when={query.isPending}>
+        <div>
+          <PageHeader icon="fa-skull" title={t('nav.dead')} summary={t('summaries.dead')} />
+          <SkeletonTable rows={8} cols={7} />
+        </div>
+      </Match>
+      <Match when={query.isError || !query.data}>
+        <div class="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>
+      </Match>
+      <Match when={query.data}>
+        {(data) => (
+          <div>
+            <PageHeader icon="fa-skull" title={t('nav.dead')} summary={t('summaries.dead')}>
+              <span class="badge badge-danger">{data().total.toLocaleString()}</span>
+            </PageHeader>
 
-      {sorted.length === 0 ? (
-        <div className="empty-state">{t('common.empty')}</div>
-      ) : (
-        <>
-          {!readOnly && (
-            <JobSetActionBar
-              bulk={ACTIONS}
-              all={ACTIONS}
-              selectedCount={sel.count}
-              total={data.total}
-              pending={pending}
-              onBulk={(cmd) => bulk.mutate({ keys: [...sel.selected], cmd }, { onSuccess: sel.clear })}
-              onAll={(cmd) => all.mutate(cmd, { onSuccess: sel.clear })}
+            <Show when={sorted().length > 0} fallback={<div class="empty-state">{t('common.empty')}</div>}>
+              <>
+                <Show when={!readOnly()}>
+                  <JobSetActionBar
+                    bulk={ACTIONS}
+                    all={ACTIONS}
+                    selectedCount={sel.count()}
+                    total={data().total}
+                    pending={pending()}
+                    onBulk={(cmd) => bulk.mutate({ keys: [...sel.selected()], cmd }, { onSuccess: sel.clear })}
+                    onAll={(cmd) => all.mutate(cmd, { onSuccess: sel.clear })}
+                  />
+                </Show>
+                <div class="table-wrapper">
+                  <table>
+                    <thead>
+                      <tr>
+                        <Show when={!readOnly()}>
+                          <th class="row-action">
+                            <input type="checkbox" checked={allChecked()} onChange={() => sel.toggleAll(pageKeys())} aria-label="Select all" />
+                          </th>
+                        </Show>
+                        <SortableTh label={t('table.jid')} sortKey="jid" sort={sort()} onSort={toggle} />
+                        <SortableTh label={t('table.class')} sortKey="klass" sort={sort()} onSort={toggle} />
+                        <SortableTh label={t('table.args')} sortKey="args" sort={sort()} onSort={toggle} />
+                        <SortableTh label={t('table.error')} sortKey="error_class" sort={sort()} onSort={toggle} />
+                        <SortableTh label="Message" sortKey="error_message" sort={sort()} onSort={toggle} />
+                        <SortableTh label={t('table.failed_at')} sortKey="failed_at" sort={sort()} onSort={toggle} />
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <For each={sorted()}>
+                        {(entry) => {
+                          const argsStr = formatArgs(entry.args);
+                          const key = entryKey(entry);
+                          return (
+                            <tr class="row-clickable" onClick={() => { setSelected(entry); setSelectedKey(key); }}>
+                              <Show when={!readOnly()}>
+                                <td class="row-action" onClick={(e) => e.stopPropagation()}>
+                                  <input type="checkbox" checked={sel.selected().has(key)} onChange={() => sel.toggle(key)} aria-label="Select job" />
+                                </td>
+                              </Show>
+                              <td
+                                title={entry.jid}
+                                style={{ 'font-family': 'monospace', 'font-size': '12px', color: 'var(--text-muted)' }}
+                              >
+                                {truncate(entry.jid, 12)}
+                              </td>
+                              <td style={{ 'font-weight': 500 }}>{entry.klass}</td>
+                              <td><ArgsValue str={argsStr} max={40} /></td>
+                              <td title={entry.error_class ?? ''} style={{ color: 'var(--danger)' }}>
+                                {truncate(entry.error_class, 25)}
+                              </td>
+                              <td title={entry.error_message ?? ''}>{truncate(entry.error_message, 40)}</td>
+                              <td title={isoTime(entry.at)}>
+                                {relativeTime(entry.at)}
+                              </td>
+                            </tr>
+                          );
+                        }}
+                      </For>
+                    </tbody>
+                  </table>
+                </div>
+                <Pagination page={page()} total={data().total} count={PAGE_SIZE} onChange={setPage} />
+              </>
+            </Show>
+            <JobDetailModal
+              entry={selected()}
+              atLabel={t('table.failed_at')}
+              actions={readOnly() ? undefined : ACTIONS}
+              pending={single.isPending}
+              onAction={(cmd) => {
+                const k = selectedKey();
+                if (k) single.mutate({ key: k, cmd }, { onSuccess: () => { setSelected(null); setSelectedKey(null); } });
+              }}
+              onClose={() => { setSelected(null); setSelectedKey(null); }}
             />
-          )}
-          <div className="table-wrapper">
-            <table>
-              <thead>
-                <tr>
-                  {!readOnly && (
-                    <th className="row-action">
-                      <input type="checkbox" checked={allChecked} onChange={() => sel.toggleAll(pageKeys)} aria-label="Select all" />
-                    </th>
-                  )}
-                  <SortableTh label={t('table.jid')} sortKey="jid" sort={sort} onSort={toggle} />
-                  <SortableTh label={t('table.class')} sortKey="klass" sort={sort} onSort={toggle} />
-                  <SortableTh label={t('table.args')} sortKey="args" sort={sort} onSort={toggle} />
-                  <SortableTh label={t('table.error')} sortKey="error_class" sort={sort} onSort={toggle} />
-                  <SortableTh label="Message" sortKey="error_message" sort={sort} onSort={toggle} />
-                  <SortableTh label={t('table.failed_at')} sortKey="failed_at" sort={sort} onSort={toggle} />
-                </tr>
-              </thead>
-              <tbody>
-                {sorted.map((entry) => {
-                  const argsStr = formatArgs(entry.args);
-                  const key = entryKey(entry);
-                  return (
-                    <tr key={entry.jid} className="row-clickable" onClick={() => { setSelected(entry); setSelectedKey(key); }}>
-                      {!readOnly && (
-                        <td className="row-action" onClick={(e) => e.stopPropagation()}>
-                          <input type="checkbox" checked={sel.selected.has(key)} onChange={() => sel.toggle(key)} aria-label="Select job" />
-                        </td>
-                      )}
-                      <td
-                        title={entry.jid}
-                        style={{ fontFamily: 'monospace', fontSize: 12, color: 'var(--text-muted)' }}
-                      >
-                        {truncate(entry.jid, 12)}
-                      </td>
-                      <td style={{ fontWeight: 500 }}>{entry.klass}</td>
-                      <td><ArgsValue str={argsStr} max={40} /></td>
-                      <td title={entry.error_class ?? ''} style={{ color: 'var(--danger)' }}>
-                        {truncate(entry.error_class, 25)}
-                      </td>
-                      <td title={entry.error_message ?? ''}>{truncate(entry.error_message, 40)}</td>
-                      <td title={isoTime(entry.at)}>
-                        {relativeTime(entry.at)}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
           </div>
-          <Pagination page={page} total={data.total} count={PAGE_SIZE} onChange={setPage} />
-        </>
-      )}
-      <JobDetailModal
-        entry={selected}
-        atLabel={t('table.failed_at')}
-        actions={readOnly ? undefined : ACTIONS}
-        pending={single.isPending}
-        onAction={(cmd) =>
-          selectedKey && single.mutate({ key: selectedKey, cmd }, { onSuccess: () => { setSelected(null); setSelectedKey(null); } })
-        }
-        onClose={() => { setSelected(null); setSelectedKey(null); }}
-      />
-    </div>
+        )}
+      </Match>
+    </Switch>
   );
 }

--- a/frontend/src/pages/Extension.test.tsx
+++ b/frontend/src/pages/Extension.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, waitFor, cleanup } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { render, screen, waitFor } from '@solidjs/testing-library';
+import { QueryClient, QueryClientProvider } from '@tanstack/solid-query';
+import { MemoryRouter, Route, createMemoryHistory } from '@solidjs/router';
 import Extension from './Extension';
 
 // Regression for the trailing-slash mismatch: registered index paths keep
@@ -21,33 +21,36 @@ function mockFetch(meta: unknown, extHtml: string) {
 
 function renderAt(path: string) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(
+  const history = createMemoryHistory();
+  history.set({ value: path, replace: true });
+  return render(() => (
     <QueryClientProvider client={client}>
-      <MemoryRouter initialEntries={[path]}>
-        <Routes>
-          <Route path="/ext/:tab" element={<Extension />} />
-        </Routes>
+      <MemoryRouter history={history}>
+        <Route path="/ext/:tab" component={Extension} />
       </MemoryRouter>
     </QueryClientProvider>
-  );
+  ));
 }
 
 describe('Extension', () => {
   afterEach(() => {
-    cleanup();
     vi.unstubAllGlobals();
   });
 
   it('matches a registered tab whose index path has a trailing slash', async () => {
     const fetchMock = mockFetch(
-      { read_only: false, read_only_message: null, custom_tabs: [{ name: 'Demo Locks', path: 'locks/', ext_name: 'demo_locks' }] },
-      '<h2>Demo Locks</h2><td>WelcomeEmailJob</td>'
+      {
+        read_only: false,
+        read_only_message: null,
+        custom_tabs: [{ name: 'Demo Locks', path: 'locks/', ext_name: 'demo_locks' }],
+      },
+      '<h2>Demo Locks</h2><td>WelcomeEmailJob</td>',
     );
     vi.stubGlobal('fetch', fetchMock);
 
     renderAt('/ext/locks');
 
-    await waitFor(() => expect(screen.getByText('WelcomeEmailJob')).toBeTruthy());
+    await waitFor(() => expect(screen.getByText('WelcomeEmailJob')).toBeInTheDocument());
     const extCalls = fetchMock.mock.calls.map((c) => String(c[0])).filter((u) => u.includes('/ext/'));
     expect(extCalls).toContain('/wurk/ext/demo_locks/locks');
   });
@@ -55,7 +58,10 @@ describe('Extension', () => {
   it('falls back to the iframe embed for a bare tabs[]= tab (no ext_name)', async () => {
     vi.stubGlobal(
       'fetch',
-      mockFetch({ read_only: false, read_only_message: null, custom_tabs: [{ name: 'Legacy', path: 'legacy', ext_name: null }] }, '')
+      mockFetch(
+        { read_only: false, read_only_message: null, custom_tabs: [{ name: 'Legacy', path: 'legacy', ext_name: null }] },
+        '',
+      ),
     );
 
     renderAt('/ext/legacy');

--- a/frontend/src/pages/Extension.tsx
+++ b/frontend/src/pages/Extension.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { createSignal, createEffect, Show } from 'solid-js';
+import { useParams } from '@solidjs/router';
 import { PageHeader } from '../components/PageHeader';
 import { Skeleton, SkeletonTable } from '../components/Skeleton';
 import { useMeta } from '../hooks/useMeta';
@@ -13,53 +13,56 @@ import { t } from '../i18n';
 // stays on this page (#187). Tabs without an extension (bare `tabs[]=`
 // mutation) keep the old iframe embed of their own path.
 export default function Extension() {
-  const { tab = '' } = useParams();
-  const { data: meta } = useMeta();
+  const params = useParams();
+  const tab = () => params.tab ?? '';
+  const meta = useMeta();
   // Registered index paths keep Sidekiq's trailing slash ("locks/") but the
   // route param never has one — compare them normalized.
   const norm = (p: string) => p.replace(/\/+$/, '');
-  const entry = meta?.custom_tabs?.find((tab_) => norm(tab_.path) === norm(tab));
-  const name = entry?.name ?? tab;
+  const entry = () => meta.data?.custom_tabs?.find((tab_) => norm(tab_.path) === norm(tab()));
+  const name = () => entry()?.name ?? tab();
 
-  if (entry?.ext_name) {
-    return <NativeExtension key={entry.ext_name} extName={entry.ext_name} indexPath={tab} title={name} />;
-  }
-  return <IframeExtension tab={tab} title={name} />;
+  return (
+    <Show
+      when={entry()?.ext_name}
+      keyed
+      fallback={<IframeExtension tab={tab()} title={name()} />}
+    >
+      {(extName) => <NativeExtension extName={extName} indexPath={tab()} title={name()} />}
+    </Show>
+  );
 }
 
-function NativeExtension({ extName, indexPath, title }: { extName: string; indexPath: string; title: string }) {
-  const base = `/wurk/ext/${extName}/`;
-  const [html, setHtml] = useState<string | null>(null);
-  const [error, setError] = useState(false);
+function NativeExtension(props: { extName: string; indexPath: string; title: string }) {
+  const base = `/wurk/ext/${props.extName}/`;
+  const [html, setHtml] = createSignal<string | null>(null);
+  const [error, setError] = createSignal(false);
   // Monotonic request id: a response only lands if it's still the latest, so
   // rapid link clicks can't resolve out of order and show stale HTML.
-  const seq = useRef(0);
+  let seq = 0;
 
-  const load = useCallback(
-    async (path: string, init?: RequestInit) => {
-      const id = ++seq.current;
-      try {
-        const res = await fetch(base + path, init);
-        const text = await res.text();
-        if (id !== seq.current) return;
-        setError(!res.ok && res.status !== 404);
-        setHtml(text);
-      } catch {
-        if (id === seq.current) setError(true);
-      }
-    },
-    [base]
-  );
+  const load = async (path: string, init?: RequestInit) => {
+    const id = ++seq;
+    try {
+      const res = await fetch(base + path, init);
+      const text = await res.text();
+      if (id !== seq) return;
+      setError(!res.ok && res.status !== 404);
+      setHtml(text);
+    } catch {
+      if (id === seq) setError(true);
+    }
+  };
 
-  useEffect(() => {
-    void load(indexPath.replace(/\/+$/, ''));
-  }, [load, indexPath]);
+  createEffect(() => {
+    void load(props.indexPath.replace(/\/+$/, ''));
+  });
 
   // Keep extension-internal navigation inside this page: anchors and forms
   // whose target resolves under our embed base are fetched instead of
   // navigating the whole browser away from the SPA. Redirects (delete → list)
   // are followed by fetch transparently.
-  const onClick = (e: React.MouseEvent) => {
+  const onClick = (e: MouseEvent) => {
     const a = (e.target as HTMLElement).closest('a');
     if (!a?.getAttribute('href')) return;
     const url = new URL(a.href, window.location.origin);
@@ -68,7 +71,7 @@ function NativeExtension({ extName, indexPath, title }: { extName: string; index
     void load(url.pathname.slice(base.length) + url.search);
   };
 
-  const onSubmit = (e: React.FormEvent) => {
+  const onSubmit = (e: Event) => {
     const form = e.target as HTMLFormElement;
     const url = new URL(form.getAttribute('action') || window.location.href, window.location.origin);
     if (url.origin !== window.location.origin || !url.pathname.startsWith(base)) return;
@@ -84,47 +87,49 @@ function NativeExtension({ extName, indexPath, title }: { extName: string; index
 
   return (
     <>
-      <PageHeader icon="fa-puzzle-piece" title={title} summary={t('extension.summary')} />
-      {error && <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>}
-      {html === null && !error && (
-        <div className="skeleton-stack">
+      <PageHeader icon="fa-puzzle-piece" title={props.title} summary={t('extension.summary')} />
+      <Show when={error()}>
+        <div class="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>
+      </Show>
+      <Show when={html() === null && !error()}>
+        <div class="skeleton-stack">
           <Skeleton height="1.5rem" width="40%" />
           <SkeletonTable rows={6} cols={4} />
         </div>
-      )}
-      {html !== null && !error && (
+      </Show>
+      <Show when={html() !== null && !error()}>
         <div
-          className="card ext-view"
+          class="card ext-view"
           onClick={onClick}
           onSubmit={onSubmit}
           // Extension HTML is rendered server-side from host-registered gem
           // code — the same trust model as Sidekiq::Web rendering it.
-          dangerouslySetInnerHTML={{ __html: html }}
+          innerHTML={html()!}
         />
-      )}
+      </Show>
     </>
   );
 }
 
-function IframeExtension({ tab, title }: { tab: string; title: string }) {
-  const src = `/wurk/${tab}?wurk_ext_embed=1`;
+function IframeExtension(props: { tab: string; title: string }) {
+  const src = () => `/wurk/${props.tab}?wurk_ext_embed=1`;
   return (
     <>
-      <PageHeader icon="fa-puzzle-piece" title={title} summary={t('extension.summary')}>
-        <a className="btn btn-sm" href={`/wurk/${tab}`} target="_blank" rel="noopener noreferrer">
-          <i className="fa-solid fa-arrow-up-right-from-square" style={{ marginInlineEnd: '0.4rem' }} />
+      <PageHeader icon="fa-puzzle-piece" title={props.title} summary={t('extension.summary')}>
+        <a class="btn btn-sm" href={`/wurk/${props.tab}`} target="_blank" rel="noopener noreferrer">
+          <i class="fa-solid fa-arrow-up-right-from-square" style={{ 'margin-inline-end': '0.4rem' }} />
           {t('extension.open')}
         </a>
       </PageHeader>
 
       <iframe
-        title={title}
-        src={src}
+        title={props.title}
+        src={src()}
         style={{
           width: '100%',
           height: 'calc(100vh - 11rem)',
           border: '1px solid var(--border)',
-          borderRadius: 'var(--radius)',
+          'border-radius': 'var(--radius)',
           background: 'var(--surface)',
         }}
       />

--- a/frontend/src/pages/Limiters.tsx
+++ b/frontend/src/pages/Limiters.tsx
@@ -1,5 +1,5 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/solid-query';
+import { onMount, For, Switch, Match, Show } from 'solid-js';
 import { Pagination } from '../components/Pagination';
 import { SortableTh } from '../components/SortableTh';
 import { useSort, type Accessors } from '../hooks/useSort';
@@ -52,133 +52,138 @@ const SORT: Accessors<Limiter> = {
 
 export default function Limiters() {
   const qc = useQueryClient();
-  const { data: meta } = useMeta();
-  const readOnly = meta?.read_only ?? false;
+  const meta = useMeta();
+  const readOnly = () => meta.data?.read_only ?? false;
   const [page, setPage] = usePageParam();
 
-  useEffect(() => {
+  onMount(() => {
     document.title = `${t('nav.limiters')} — Wurk`;
-  }, []);
+  });
 
   // UI is 1-indexed for humans; the API is 0-indexed, so send page - 1.
-  const { data, isLoading, isError } = useQuery<LimitersResponse>({
-    queryKey: ['limiters', page],
+  const q = useQuery<LimitersResponse>(() => ({
+    queryKey: ['limiters', page()],
     queryFn: () =>
-      fetch(`/wurk/api/limiters?page=${page - 1}&count=${PAGE_SIZE}`).then(
+      fetch(`/wurk/api/limiters?page=${page() - 1}&count=${PAGE_SIZE}`).then(
         (r) => r.json() as Promise<LimitersResponse>
       ),
     refetchInterval: 5000,
-  });
+  }));
 
   // Drops the limiter's stats/state keys (counters → 0); skips CSRF, see
   // ApiController#skip_forgery_protection.
-  const reset = useMutation({
+  const reset = useMutation(() => ({
     mutationFn: (name: string) =>
       fetch(`/wurk/api/limiters/${encodeURIComponent(name)}/reset`, { method: 'POST' }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['limiters'] }),
-  });
+  }));
 
-  const { sorted, sort, toggle } = useSort(data?.limiters ?? [], SORT);
-
-  if (isLoading) {
-    return (
-      <div>
-        <PageHeader icon="fa-gauge" title={t('nav.limiters')} summary={t('summaries.limiters')} />
-        <SkeletonTable rows={8} cols={readOnly ? 6 : 7} />
-      </div>
-    );
-  }
-  if (isError || !data) return <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>;
+  const { sorted, sort, toggle } = useSort(() => q.data?.limiters ?? [], SORT);
 
   return (
-    <div>
-      <PageHeader icon="fa-gauge" title={t('nav.limiters')} summary={t('summaries.limiters')}>
-        <span className="badge badge-muted">{data.total.toLocaleString()}</span>
-      </PageHeader>
+    <Switch>
+      <Match when={q.isPending}>
+        <div>
+          <PageHeader icon="fa-gauge" title={t('nav.limiters')} summary={t('summaries.limiters')} />
+          <SkeletonTable rows={8} cols={readOnly() ? 6 : 7} />
+        </div>
+      </Match>
+      <Match when={q.isError || !q.data}>
+        <div class="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>
+      </Match>
+      <Match when={q.data}>
+        {(data) => (
+          <div>
+            <PageHeader icon="fa-gauge" title={t('nav.limiters')} summary={t('summaries.limiters')}>
+              <span class="badge badge-muted">{data().total.toLocaleString()}</span>
+            </PageHeader>
 
-      {sorted.length === 0 ? (
-        <div className="empty-state">{t('common.empty')}</div>
-      ) : (
-        <>
-          <div className="table-wrapper">
-            <table>
-              <thead>
-                <tr>
-                  <SortableTh label="Name" sortKey="name" sort={sort} onSort={toggle} />
-                  <SortableTh label="Type" sortKey="type" sort={sort} onSort={toggle} />
-                  <SortableTh label="Used" sortKey="used" sort={sort} onSort={toggle} />
-                  <SortableTh label="Limit" sortKey="limit" sort={sort} onSort={toggle} />
-                  <SortableTh label="Usage" sortKey="usage" sort={sort} onSort={toggle} />
-                  <SortableTh label="Status" sortKey="status" sort={sort} onSort={toggle} />
-                  {!readOnly && <th />}
-                </tr>
-              </thead>
-              <tbody>
-                {sorted.map((limiter) => {
-                  const s = limiter.status;
-                  const used = s?.used ?? 0;
-                  const limit = s?.limit ?? null;
-                  const pct = limit && limit > 0 ? Math.min((used / limit) * 100, 100) : 0;
-                  const color = pct > 90 ? 'var(--danger)' : pct > 70 ? 'var(--warning)' : 'var(--success)';
-                  const available = s?.['available?'] ?? true;
-                  // Concurrent rows carry extra metric counters — show them on hover.
-                  const metricTitle = s
-                    ? Object.entries(s)
-                        .filter(([k]) => !['used', 'limit', 'reset_at', 'available?'].includes(k))
-                        .map(([k, v]) => `${k}=${v}`)
-                        .join('  ')
-                    : '';
-                  return (
-                    <tr key={limiter.name}>
-                      <td style={{ fontWeight: 500 }} title={limiter.name}>{limiter.name}</td>
-                      <td><span className="badge badge-accent">{limiter.type}</span></td>
-                      <td style={{ fontVariantNumeric: 'tabular-nums' }} title={metricTitle}>
-                        {used.toLocaleString()}
-                      </td>
-                      <td style={{ fontVariantNumeric: 'tabular-nums' }}>
-                        {limit == null ? '∞' : limit.toLocaleString()}
-                      </td>
-                      <td style={{ width: 160 }}>
-                        {limit == null ? (
-                          <span style={{ color: 'var(--text-muted)' }}>—</span>
-                        ) : (
-                          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                            <div className="progress-bar-track" style={{ flex: 1 }}>
-                              <div className="progress-bar-fill" style={{ width: `${pct}%`, background: color }} />
-                            </div>
-                            <span style={{ fontSize: 12, color: 'var(--text-muted)', minWidth: 36 }}>
-                              {Math.round(pct)}%
-                            </span>
-                          </div>
-                        )}
-                      </td>
-                      <td>
-                        {available ? (
-                          <span className="badge badge-success">available</span>
-                        ) : (
-                          <span className="badge badge-danger">exhausted</span>
-                        )}
-                      </td>
-                      {!readOnly && (
-                        <td>
-                          <button
-                            className="btn btn-sm"
-                            disabled={reset.isPending}
-                            onClick={() => reset.mutate(limiter.name)}
-                          >
-                            Reset
-                          </button>
-                        </td>
-                      )}
+            <Show when={sorted().length > 0} fallback={<div class="empty-state">{t('common.empty')}</div>}>
+              <div class="table-wrapper">
+                <table>
+                  <thead>
+                    <tr>
+                      <SortableTh label="Name" sortKey="name" sort={sort()} onSort={toggle} />
+                      <SortableTh label="Type" sortKey="type" sort={sort()} onSort={toggle} />
+                      <SortableTh label="Used" sortKey="used" sort={sort()} onSort={toggle} />
+                      <SortableTh label="Limit" sortKey="limit" sort={sort()} onSort={toggle} />
+                      <SortableTh label="Usage" sortKey="usage" sort={sort()} onSort={toggle} />
+                      <SortableTh label="Status" sortKey="status" sort={sort()} onSort={toggle} />
+                      <Show when={!readOnly()}><th /></Show>
                     </tr>
-                  );
-                })}
-              </tbody>
-            </table>
+                  </thead>
+                  <tbody>
+                    <For each={sorted()}>
+                      {(limiter) => {
+                        const s = limiter.status;
+                        const used = s?.used ?? 0;
+                        const limit = s?.limit ?? null;
+                        const pct = limit && limit > 0 ? Math.min((used / limit) * 100, 100) : 0;
+                        const color = pct > 90 ? 'var(--danger)' : pct > 70 ? 'var(--warning)' : 'var(--success)';
+                        const available = s?.['available?'] ?? true;
+                        // Concurrent rows carry extra metric counters — show them on hover.
+                        const metricTitle = s
+                          ? Object.entries(s)
+                              .filter(([k]) => !['used', 'limit', 'reset_at', 'available?'].includes(k))
+                              .map(([k, v]) => `${k}=${v}`)
+                              .join('  ')
+                          : '';
+                        return (
+                          <tr>
+                            <td style={{ 'font-weight': 500 }} title={limiter.name}>{limiter.name}</td>
+                            <td><span class="badge badge-accent">{limiter.type}</span></td>
+                            <td style={{ 'font-variant-numeric': 'tabular-nums' }} title={metricTitle}>
+                              {used.toLocaleString()}
+                            </td>
+                            <td style={{ 'font-variant-numeric': 'tabular-nums' }}>
+                              {limit == null ? '∞' : limit.toLocaleString()}
+                            </td>
+                            <td style={{ width: '160px' }}>
+                              <Show
+                                when={limit != null}
+                                fallback={<span style={{ color: 'var(--text-muted)' }}>—</span>}
+                              >
+                                <div style={{ display: 'flex', 'align-items': 'center', gap: '0.5rem' }}>
+                                  <div class="progress-bar-track" style={{ flex: 1 }}>
+                                    <div class="progress-bar-fill" style={{ width: `${pct}%`, background: color }} />
+                                  </div>
+                                  <span style={{ 'font-size': '12px', color: 'var(--text-muted)', 'min-width': '36px' }}>
+                                    {Math.round(pct)}%
+                                  </span>
+                                </div>
+                              </Show>
+                            </td>
+                            <td>
+                              <Show
+                                when={available}
+                                fallback={<span class="badge badge-danger">exhausted</span>}
+                              >
+                                <span class="badge badge-success">available</span>
+                              </Show>
+                            </td>
+                            <Show when={!readOnly()}>
+                              <td>
+                                <button
+                                  class="btn btn-sm"
+                                  disabled={reset.isPending}
+                                  onClick={() => reset.mutate(limiter.name)}
+                                >
+                                  Reset
+                                </button>
+                              </td>
+                            </Show>
+                          </tr>
+                        );
+                      }}
+                    </For>
+                  </tbody>
+                </table>
+              </div>
+              <Pagination page={page()} total={data().total} count={PAGE_SIZE} onChange={setPage} />
+            </Show>
           </div>
-          <Pagination page={page} total={data.total} count={PAGE_SIZE} onChange={setPage} />
-        </>
-      )}
-    </div>
+        )}
+      </Match>
+    </Switch>
   );
 }

--- a/frontend/src/pages/Metrics.test.tsx
+++ b/frontend/src/pages/Metrics.test.tsx
@@ -1,54 +1,54 @@
-import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor, fireEvent } from '@solidjs/testing-library';
+import { QueryClient, QueryClientProvider } from '@tanstack/solid-query';
 import Metrics from './Metrics';
 
-// Stub Recharts so chart logic (one series per queue/field, pivoted rows) is
-// observable without a real layout — ResponsiveContainer renders nothing under
-// jsdom otherwise. Line/Area expose their dataKey via distinct testids so the
-// per-queue line charts and the throughput area chart can be told apart.
-vi.mock('recharts', () => {
-  const Pass = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>;
+// Stub the hand-rolled SVG charts so chart logic (one series per queue/field,
+// pivoted rows) is observable without a real layout — the charts need a measured
+// container width to render under jsdom. Each series' `name ?? key` is rendered
+// into a distinct testid so the per-queue latency lines and the throughput area
+// series can be told apart, mirroring the old recharts <Line>/<Area> mock.
+vi.mock('../components/charts', () => {
+  type Series = { key: string; name?: string };
   return {
-    ResponsiveContainer: Pass,
-    LineChart: ({ children }: { children?: React.ReactNode }) => <div data-testid="linechart">{children}</div>,
-    // Show `name` when it's set (per-queue charts, where the synthetic
-    // `queue_<i>` dataKey carries no human-readable info) and fall back to
-    // `dataKey` for the Historical Snapshots panel, which uses field names
-    // directly as the series key.
-    Line: ({ dataKey, name }: { dataKey: string; name?: string }) => <span data-testid="line">{name ?? dataKey}</span>,
-    AreaChart: ({ children }: { children?: React.ReactNode }) => <div data-testid="areachart">{children}</div>,
-    Area: ({ dataKey }: { dataKey: string }) => <span data-testid="area">{dataKey}</span>,
-    BarChart: ({ children }: { children?: React.ReactNode }) => <div data-testid="barchart">{children}</div>,
-    Bar: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-    Cell: () => null,
-    XAxis: () => null,
-    YAxis: () => null,
-    CartesianGrid: () => null,
-    Tooltip: () => null,
-    Legend: () => null,
+    AreaChart: (props: { series: Series[] }) => (
+      <div data-testid="areachart">
+        {props.series.map((s) => (
+          <span data-testid="area">{s.name ?? s.key}</span>
+        ))}
+      </div>
+    ),
+    LineChart: (props: { series: Series[] }) => (
+      <div data-testid="linechart">
+        {props.series.map((s) => (
+          <span data-testid="line">{s.name ?? s.key}</span>
+        ))}
+      </div>
+    ),
+    BarChart: () => <div data-testid="barchart" />,
   };
 });
 
 function renderMetrics() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(
+  return render(() => (
     <QueryClientProvider client={client}>
       <Metrics />
     </QueryClientProvider>
-  );
+  ));
 }
 
 // Route the component's fetches by URL. Defaults render an empty-but-valid page;
 // each test overrides the payload it cares about.
-function mockFetch(opts: {
-  queueHistory?: unknown;
-  snapshots?: unknown[];
-  topJobs?: unknown[];
-  series?: unknown[];
-  stats?: unknown;
-} = {}) {
+function mockFetch(
+  opts: {
+    queueHistory?: unknown;
+    snapshots?: unknown[];
+    topJobs?: unknown[];
+    series?: unknown[];
+    stats?: unknown;
+  } = {},
+) {
   const { queueHistory = { bucket: '1m', window: 86400, queues: [] }, snapshots = [], topJobs = [], series = [], stats = {} } = opts;
   return vi.fn((url: string) => {
     let body: unknown = {};
@@ -67,43 +67,45 @@ describe('Metrics page', () => {
     vi.stubGlobal('fetch', mockFetch({ stats: { processed: 100, failed: 5, latency: 1.2, processes: 4 } }));
   });
   afterEach(() => {
-    cleanup();
     vi.unstubAllGlobals();
   });
 
   it('renders the four metric cards', async () => {
     renderMetrics();
-    expect(await screen.findByText('Total Processed')).toBeDefined();
-    expect(screen.getByText('Failed Jobs')).toBeDefined();
-    expect(screen.getByText('Avg Latency')).toBeDefined();
-    expect(screen.getByText('Active Workers')).toBeDefined();
+    expect(await screen.findByText('Total Processed')).toBeInTheDocument();
+    expect(screen.getByText('Failed Jobs')).toBeInTheDocument();
+    expect(screen.getByText('Avg Latency')).toBeInTheDocument();
+    expect(screen.getByText('Active Workers')).toBeInTheDocument();
   });
 
   it('renders the throughput, queue depth, and top-job sections', async () => {
     renderMetrics();
-    expect(await screen.findByText('Throughput & Failures')).toBeDefined();
-    expect(screen.getByText('Queue Depth')).toBeDefined();
-    expect(screen.getByText('Top Job Types (Volume)')).toBeDefined();
+    expect(await screen.findByText('Throughput & Failures')).toBeInTheDocument();
+    expect(screen.getByText('Queue Depth')).toBeInTheDocument();
+    expect(screen.getByText('Top Job Types (Volume)')).toBeInTheDocument();
   });
 
   it('lists top job types with their share of total volume', async () => {
-    vi.stubGlobal('fetch', mockFetch({
-      stats: { processed: 100, failed: 5, latency: 1.2, processes: 4 },
-      topJobs: [
-        { klass: 'App::FooJob', processed: 80, failed: 20, runtime_ms: 0 },
-        { klass: 'BarJob', processed: 50, failed: 0, runtime_ms: 0 },
-      ],
-    }));
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        stats: { processed: 100, failed: 5, latency: 1.2, processes: 4 },
+        topJobs: [
+          { klass: 'App::FooJob', processed: 80, failed: 20, runtime_ms: 0 },
+          { klass: 'BarJob', processed: 50, failed: 0, runtime_ms: 0 },
+        ],
+      }),
+    );
     renderMetrics();
     // foo = 100, bar = 50, total = 150 → 67% / 33%.
-    expect(await screen.findByText('FooJob')).toBeDefined();
-    expect(screen.getByText('67%')).toBeDefined();
-    expect(screen.getByText('33%')).toBeDefined();
+    expect(await screen.findByText('FooJob')).toBeInTheDocument();
+    expect(screen.getByText('67%')).toBeInTheDocument();
+    expect(screen.getByText('33%')).toBeInTheDocument();
   });
 
   it('shows the throughput empty state when there is no history', async () => {
     renderMetrics();
-    await waitFor(() => expect(screen.getByText(/No history yet/i)).toBeDefined());
+    await waitFor(() => expect(screen.getByText(/No history yet/i)).toBeInTheDocument());
   });
 
   it('switches the time range when a segment is clicked', async () => {
@@ -116,24 +118,27 @@ describe('Metrics page', () => {
 
 describe('Metrics — queue latency history', () => {
   afterEach(() => {
-    cleanup();
     vi.unstubAllGlobals();
   });
 
   it('renders one latency line per queue when data exists', async () => {
     const at = 1_781_000_000;
-    vi.stubGlobal('fetch', mockFetch({
-      stats: { processed: 1, failed: 0, latency: 0, processes: 1 },
-      queueHistory: {
-        bucket: '1m', window: 86400,
-        queues: [
-          { name: 'default', points: [{ at, size: 5, latency: 1.2 }] },
-          { name: 'critical', points: [{ at, size: 2, latency: 0.4 }] },
-        ],
-      },
-    }));
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        stats: { processed: 1, failed: 0, latency: 0, processes: 1 },
+        queueHistory: {
+          bucket: '1m',
+          window: 86400,
+          queues: [
+            { name: 'default', points: [{ at, size: 5, latency: 1.2 }] },
+            { name: 'critical', points: [{ at, size: 2, latency: 0.4 }] },
+          ],
+        },
+      }),
+    );
     renderMetrics();
-    expect(await screen.findByText('Queue Latency (seconds)')).toBeDefined();
+    expect(await screen.findByText('Queue Latency (seconds)')).toBeInTheDocument();
     const lines = screen.getAllByTestId('line').map((n) => n.textContent);
     expect(lines).toContain('default');
     expect(lines).toContain('critical');
@@ -149,7 +154,6 @@ describe('Metrics — queue latency history', () => {
 
 describe('Metrics — historical snapshots', () => {
   afterEach(() => {
-    cleanup();
     vi.unstubAllGlobals();
   });
 
@@ -164,7 +168,7 @@ describe('Metrics — historical snapshots', () => {
     const snapshots = [{ at: 1_781_000_000, processed: 100, failures: 2, enqueued: 5, dead: 1 }];
     vi.stubGlobal('fetch', mockFetch({ stats: { processed: 1, failed: 0, latency: 0, processes: 1 }, snapshots }));
     renderMetrics();
-    expect(await screen.findByText('Historical Snapshots')).toBeDefined();
+    expect(await screen.findByText('Historical Snapshots')).toBeInTheDocument();
     const lines = screen.getAllByTestId('line').map((n) => n.textContent);
     expect(lines).toContain('enqueued');
     expect(lines).toContain('dead');

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -1,20 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
-import { useState, useEffect } from 'react';
-import {
-  AreaChart,
-  Area,
-  BarChart,
-  Bar,
-  Cell,
-  LineChart,
-  Line,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  Legend,
-  ResponsiveContainer,
-} from 'recharts';
+import { useQuery } from '@tanstack/solid-query';
+import { createSignal, createMemo, onMount, For, Show } from 'solid-js';
+import { AreaChart, BarChart, LineChart, type Datum } from '../components/charts';
 import { Skeleton } from '../components/Skeleton';
 import { t } from '../i18n';
 import { formatDuration, truncate } from '../utils';
@@ -110,14 +96,19 @@ function deltaPct(series: HistoryPoint[], key: 'processed' | 'failed'): number |
   return Math.round(((cur - prev) / prev) * 100);
 }
 
-function Delta({ pct, goodWhenUp }: { pct: number | null; goodWhenUp: boolean }) {
-  if (pct === null) return null;
-  const up = pct >= 0;
-  const good = up === goodWhenUp;
+function Delta(props: { pct: number | null; goodWhenUp: boolean }) {
   return (
-    <span style={{ fontSize: 12, marginInlineStart: 8, color: good ? 'var(--success)' : 'var(--danger)' }}>
-      {up ? '↑' : '↓'}{Math.abs(pct)}%
-    </span>
+    <Show when={props.pct !== null}>
+      {(() => {
+        const up = () => props.pct! >= 0;
+        const good = () => up() === props.goodWhenUp;
+        return (
+          <span style={{ 'font-size': '12px', 'margin-inline-start': '8px', color: good() ? 'var(--success)' : 'var(--danger)' }}>
+            {up() ? '↑' : '↓'}{Math.abs(props.pct!)}%
+          </span>
+        );
+      })()}
+    </Show>
   );
 }
 
@@ -133,262 +124,263 @@ const sample = <T,>(arr: T[], n: number): T[] => {
   return Array.from({ length: n }, (_, i) => arr[Math.round(i * step)]);
 };
 
-const tooltipStyle = {
-  background: '#161618',
-  border: '1px solid #272729',
-  color: '#e4e4e7',
-  borderRadius: 6,
-  fontSize: 12,
-  fontFamily: 'JetBrains Mono, monospace',
-};
-
 // Centered spinner sized to a chart/table box. Shown while a query is pending —
 // i.e. the initial load and every range-filter change, where the query key flips
 // and there's no cached data yet — so the panel doesn't flash an empty state for
 // a beat before the data lands.
-function ChartLoader({ height }: { height: number }) {
+function ChartLoader(props: { height: number }) {
   return (
-    <div style={{ height }} role="status" aria-label={t('common.loading')}>
+    <div style={{ height: `${props.height}px` }} role="status" aria-label={t('common.loading')}>
       <Skeleton height="100%" />
     </div>
   );
 }
 
 export default function Metrics() {
-  const [rangeIdx, setRangeIdx] = useState(2); // default 7d, matching the mock
-  const range = RANGES[rangeIdx];
+  const [rangeIdx, setRangeIdx] = createSignal(2); // default 7d, matching the mock
+  const range = () => RANGES[rangeIdx()];
 
-  useEffect(() => {
+  onMount(() => {
     document.title = `${t('nav.metrics')} — Wurk`;
-  }, []);
+  });
 
-  const { data: stats } = useQuery<StatsData>({
+  const statsQuery = useQuery(() => ({
     queryKey: ['stats'],
     queryFn: () => fetch('/wurk/api/stats').then((r) => r.json() as Promise<StatsData>),
     refetchInterval: 5000,
-  });
+  }));
 
-  const { data: history, isPending: historyPending } = useQuery<HistoryResponse>({
-    queryKey: ['history', range.bucket, range.window],
+  const historyQuery = useQuery(() => ({
+    queryKey: ['history', range().bucket, range().window],
     queryFn: () =>
-      fetch(`/wurk/api/history/${range.bucket}?window=${range.window}`).then((r) => r.json() as Promise<HistoryResponse>),
+      fetch(`/wurk/api/history/${range().bucket}?window=${range().window}`).then((r) => r.json() as Promise<HistoryResponse>),
     refetchInterval: 30000,
-  });
+  }));
 
-  const { data: metrics, isPending: metricsPending } = useQuery<MetricsResponse>({
-    queryKey: ['metrics', range.minutes],
-    queryFn: () => fetch(`/wurk/api/metrics?minutes=${range.minutes}`).then((r) => r.json() as Promise<MetricsResponse>),
+  const metricsQuery = useQuery(() => ({
+    queryKey: ['metrics', range().minutes],
+    queryFn: () => fetch(`/wurk/api/metrics?minutes=${range().minutes}`).then((r) => r.json() as Promise<MetricsResponse>),
     refetchInterval: 30000,
-  });
+  }));
 
-  const { data: queueHistory, isPending: queuePending } = useQuery<QueueHistoryResponse>({
-    queryKey: ['queue-history', range.bucket, range.window],
+  const queueQuery = useQuery(() => ({
+    queryKey: ['queue-history', range().bucket, range().window],
     queryFn: async () => {
-      const r = await fetch(`/wurk/api/queue-history/${range.bucket}?window=${range.window}`);
+      const r = await fetch(`/wurk/api/queue-history/${range().bucket}?window=${range().window}`);
       if (!r.ok) throw new Error(`queue-history failed (${r.status})`);
       return r.json() as Promise<QueueHistoryResponse>;
     },
     refetchInterval: 30000,
-  });
+  }));
 
   // Keep the full history for deltaPct() — slicing first would drop the
   // previous-hour comparison window and force the 100% fallback on the 1h tab.
-  const fullSeries = (history?.series ?? []).map((p) => ({ ...p, label: fmtBucket(p.at, range.bucket) }));
-  const sliceN = 'slice' in range ? range.slice : undefined;
-  const series = sliceN ? fullSeries.slice(-sliceN) : fullSeries;
-  const hasThroughput = series.some((p) => p.processed > 0 || p.failed > 0);
+  const fullSeries = createMemo(() =>
+    (historyQuery.data?.series ?? []).map((p) => ({ ...p, label: fmtBucket(p.at, range().bucket) })),
+  );
+  const series = createMemo(() => {
+    const r = range();
+    const sliceN = 'slice' in r ? r.slice : undefined;
+    return sliceN ? fullSeries().slice(-sliceN) : fullSeries();
+  });
+  const hasThroughput = createMemo(() => series().some((p) => p.processed > 0 || p.failed > 0));
 
   // Queue depth = total jobs enqueued across all queues per bucket, downsampled
   // to a readable number of bars; the busiest bar is highlighted (design spec).
-  const queues = queueHistory?.queues ?? [];
-  const ats = queues[0]?.points.map((p) => p.at) ?? [];
-  const depthRows = sample(
-    ats.map((at, i) => ({
-      label: fmtBucket(at, range.bucket),
-      depth: queues.reduce((s, q) => s + (q.points[i]?.size ?? 0), 0),
-    })),
-    16,
+  const queues = createMemo(() => queueQuery.data?.queues ?? []);
+  const ats = createMemo(() => queues()[0]?.points.map((p) => p.at) ?? []);
+  const depthRows = createMemo(() =>
+    sample(
+      ats().map((at, i) => ({
+        label: fmtBucket(at, range().bucket),
+        depth: queues().reduce((s, q) => s + (q.points[i]?.size ?? 0), 0),
+      })),
+      16,
+    ),
   );
-  const maxDepth = Math.max(0, ...depthRows.map((r) => r.depth));
+  const maxDepth = createMemo(() => Math.max(0, ...depthRows().map((r) => r.depth)));
 
   // % Total compares each top job against the full returned volume — the
   // jobs.slice(0, 6) trims the displayed rows only; computing the total off
   // the slice would let three jobs at 30/30/30 each report 33%.
-  const allJobs = (metrics?.top_jobs ?? [])
-    .map((j) => ({ klass: j.klass, count: j.processed + j.failed }))
-    .sort((a, b) => b.count - a.count);
-  const jobsTotal = allJobs.reduce((s, j) => s + j.count, 0);
-  const jobs = allJobs.slice(0, 6);
+  const allJobs = createMemo(() =>
+    (metricsQuery.data?.top_jobs ?? [])
+      .map((j) => ({ klass: j.klass, count: j.processed + j.failed }))
+      .sort((a, b) => b.count - a.count),
+  );
+  const jobsTotal = createMemo(() => allJobs().reduce((s, j) => s + j.count, 0));
+  const jobs = createMemo(() => allJobs().slice(0, 6));
 
   return (
-    <div className="obs">
-      <div className="obs-toolbar">
-        <span className="obs-toolbar__label"><i className="fa-regular fa-calendar" aria-hidden="true" /> Time Range:</span>
-        <div className="obs-seg" role="tablist" aria-label="Time range">
-          {RANGES.map((r, i) => (
-            <button
-              key={r.key}
-              role="tab"
-              aria-selected={i === rangeIdx}
-              className={i === rangeIdx ? 'is-active' : ''}
-              onClick={() => setRangeIdx(i)}
-            >
-              {r.key}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      <div className="obs-metrics">
-        <div className="obs-card obs-metric">
-          <div className="obs-metric__head">
-            <span className="obs-mono">Total Processed</span>
-            <i className="fa-solid fa-circle-check obs-metric__icon" aria-hidden="true" />
-          </div>
-          <span className="obs-metric__value">
-            {(stats?.processed ?? 0).toLocaleString()}
-            <Delta pct={deltaPct(fullSeries, 'processed')} goodWhenUp />
-          </span>
-          <span className="obs-metric__sub">across all queues</span>
-        </div>
-        <div className="obs-card obs-metric">
-          <div className="obs-metric__head">
-            <span className="obs-mono">Failed Jobs</span>
-            <i className="fa-solid fa-triangle-exclamation obs-metric__icon" aria-hidden="true" />
-          </div>
-          <span className="obs-metric__value">
-            {(stats?.failed ?? 0).toLocaleString()}
-            <Delta pct={deltaPct(fullSeries, 'failed')} goodWhenUp={false} />
-          </span>
-          <span className="obs-metric__sub">total failures</span>
-        </div>
-        <div className="obs-card obs-metric">
-          <div className="obs-metric__head">
-            <span className="obs-mono">Avg Latency</span>
-            <i className="fa-solid fa-stopwatch obs-metric__icon" aria-hidden="true" />
-          </div>
-          <span className="obs-metric__value">{stats ? formatDuration(stats.latency) : '—'}</span>
-          <span className="obs-metric__sub">head-of-line</span>
-        </div>
-        <div className="obs-card obs-metric">
-          <div className="obs-metric__head">
-            <span className="obs-mono">Active Workers</span>
-            <i className="fa-solid fa-gears obs-metric__icon" aria-hidden="true" />
-          </div>
-          <span className="obs-metric__value">{(stats?.processes ?? 0).toLocaleString()}</span>
-          <span className="obs-metric__sub">{(stats?.processes ?? 0) > 0 ? 'Stable' : 'No workers'}</span>
-        </div>
-      </div>
-
-      <div className="obs-card obs-panel">
-        <div className="obs-panel__head">
-          <div>
-            <h2 className="obs-panel__title">Throughput &amp; Failures</h2>
-            <p className="obs-panel__sub">Jobs processed per bucket over the last {range.key}</p>
-          </div>
-          <div className="obs-legend">
-            <span><i className="dot dot--processed" /> Processed</span>
-            <span><i className="dot dot--failed" /> Failed</span>
-          </div>
-        </div>
-        <div className="obs-chartbox">
-          {historyPending ? (
-            <ChartLoader height={300} />
-          ) : hasThroughput ? (
-            <ResponsiveContainer width="100%" height={300}>
-              <AreaChart data={series} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
-                <defs>
-                  <linearGradient id="mProcessed" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="0%" stopColor="#fafafa" stopOpacity={0.22} />
-                    <stop offset="95%" stopColor="#fafafa" stopOpacity={0} />
-                  </linearGradient>
-                </defs>
-                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="rgba(255,255,255,0.06)" />
-                <XAxis dataKey="label" tick={{ fill: '#71717a', fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }} axisLine={false} tickLine={false} minTickGap={56} interval="preserveStartEnd" />
-                <YAxis tick={{ fill: '#71717a', fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }} axisLine={false} tickLine={false} width={36} allowDecimals={false} />
-                <Tooltip contentStyle={tooltipStyle} labelStyle={{ color: '#a1a1aa' }} cursor={{ stroke: 'rgba(255,255,255,0.25)', strokeWidth: 1 }} />
-                <Area type="monotone" dataKey="processed" name="Processed" stroke="#fafafa" strokeWidth={2} fill="url(#mProcessed)" dot={false} activeDot={{ r: 4, fill: '#fafafa', stroke: '#09090b', strokeWidth: 2 }} animationDuration={1100} animationEasing="ease-out" />
-                <Area type="monotone" dataKey="failed" name="Failed" stroke="#a1a1aa" strokeWidth={1.5} strokeDasharray="5 4" fill="transparent" dot={false} animationDuration={1100} animationBegin={250} animationEasing="ease-out" />
-              </AreaChart>
-            </ResponsiveContainer>
-          ) : (
-            <div className="empty-state" style={{ height: 300, display: 'grid', placeItems: 'center' }}>
-              No history yet — the chart fills in as jobs run.
-            </div>
-          )}
-        </div>
-      </div>
-
-      <div className="obs-grid2">
-        <div className="obs-card obs-panel">
-          <div className="obs-panel__head">
-            <h2 className="obs-panel__title" style={{ fontSize: 18 }}>Queue Depth</h2>
-            <span className="obs-mono">{maxDepth > 0 ? `peak ${maxDepth.toLocaleString()}` : ''}</span>
-          </div>
-          <div className="obs-chartbox">
-            {queuePending ? (
-              <ChartLoader height={240} />
-            ) : depthRows.length > 0 ? (
-              <ResponsiveContainer width="100%" height={240}>
-                <BarChart data={depthRows} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="rgba(255,255,255,0.06)" />
-                  <XAxis dataKey="label" tick={{ fill: '#71717a', fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }} axisLine={false} tickLine={false} minTickGap={40} interval="preserveStartEnd" />
-                  <YAxis tick={{ fill: '#71717a', fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }} axisLine={false} tickLine={false} width={36} allowDecimals={false} />
-                  <Tooltip contentStyle={tooltipStyle} labelStyle={{ color: '#a1a1aa' }} cursor={{ fill: 'rgba(255,255,255,0.04)' }} />
-                  <Bar dataKey="depth" name="Depth" radius={[3, 3, 0, 0]} animationDuration={900} animationEasing="ease-out">
-                    {depthRows.map((r, i) => (
-                      <Cell key={i} fill={r.depth === maxDepth && maxDepth > 0 ? '#fafafa' : '#3f3f46'} />
-                    ))}
-                  </Bar>
-                </BarChart>
-              </ResponsiveContainer>
-            ) : (
-              <div className="empty-state" style={{ height: 240, display: 'grid', placeItems: 'center' }}>
-                No queue history yet.
-              </div>
+    <div class="obs">
+      <div class="obs-toolbar">
+        <span class="obs-toolbar__label"><i class="fa-regular fa-calendar" aria-hidden="true" /> Time Range:</span>
+        <div class="obs-seg" role="tablist" aria-label="Time range">
+          <For each={RANGES}>
+            {(r, i) => (
+              <button
+                role="tab"
+                aria-selected={i() === rangeIdx()}
+                class={i() === rangeIdx() ? 'is-active' : ''}
+                onClick={() => setRangeIdx(i())}
+              >
+                {r.key}
+              </button>
             )}
-          </div>
-        </div>
-
-        <div className="obs-card obs-table">
-          <div className="obs-table__head">
-            <h2 className="obs-table__title" style={{ fontSize: 18 }}>Top Job Types (Volume)</h2>
-          </div>
-          {metricsPending ? (
-            <ChartLoader height={240} />
-          ) : jobs.length === 0 ? (
-            <div className="obs-empty">{t('common.empty')}</div>
-          ) : (
-            <div className="obs-tablescroll">
-              <table>
-                <thead>
-                  <tr>
-                    <th>Job Class</th>
-                    <th style={{ textAlign: 'end' }}>Count</th>
-                    <th style={{ textAlign: 'end' }}>% Total</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {jobs.map((j, i) => (
-                    <tr key={j.klass}>
-                      <td style={{ color: 'var(--obs-text)' }} title={j.klass}>
-                        <span className="obs-jobdot" style={{ background: JOB_DOTS[i % JOB_DOTS.length] }} />
-                        {truncate(j.klass.split('::').pop() ?? j.klass, 36)}
-                      </td>
-                      <td style={{ textAlign: 'end', fontVariantNumeric: 'tabular-nums' }}>{j.count.toLocaleString()}</td>
-                      <td className="obs-pct" style={{ textAlign: 'end' }}>
-                        {jobsTotal > 0 ? Math.round((j.count / jobsTotal) * 100) : 0}%
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
+          </For>
         </div>
       </div>
 
-      <QueueLatencyHistory range={range} />
+      <div class="obs-metrics">
+        <div class="obs-card obs-metric">
+          <div class="obs-metric__head">
+            <span class="obs-mono">Total Processed</span>
+            <i class="fa-solid fa-circle-check obs-metric__icon" aria-hidden="true" />
+          </div>
+          <span class="obs-metric__value">
+            {(statsQuery.data?.processed ?? 0).toLocaleString()}
+            <Delta pct={deltaPct(fullSeries(), 'processed')} goodWhenUp />
+          </span>
+          <span class="obs-metric__sub">across all queues</span>
+        </div>
+        <div class="obs-card obs-metric">
+          <div class="obs-metric__head">
+            <span class="obs-mono">Failed Jobs</span>
+            <i class="fa-solid fa-triangle-exclamation obs-metric__icon" aria-hidden="true" />
+          </div>
+          <span class="obs-metric__value">
+            {(statsQuery.data?.failed ?? 0).toLocaleString()}
+            <Delta pct={deltaPct(fullSeries(), 'failed')} goodWhenUp={false} />
+          </span>
+          <span class="obs-metric__sub">total failures</span>
+        </div>
+        <div class="obs-card obs-metric">
+          <div class="obs-metric__head">
+            <span class="obs-mono">Avg Latency</span>
+            <i class="fa-solid fa-stopwatch obs-metric__icon" aria-hidden="true" />
+          </div>
+          <span class="obs-metric__value">{statsQuery.data ? formatDuration(statsQuery.data.latency) : '—'}</span>
+          <span class="obs-metric__sub">head-of-line</span>
+        </div>
+        <div class="obs-card obs-metric">
+          <div class="obs-metric__head">
+            <span class="obs-mono">Active Workers</span>
+            <i class="fa-solid fa-gears obs-metric__icon" aria-hidden="true" />
+          </div>
+          <span class="obs-metric__value">{(statsQuery.data?.processes ?? 0).toLocaleString()}</span>
+          <span class="obs-metric__sub">{(statsQuery.data?.processes ?? 0) > 0 ? 'Stable' : 'No workers'}</span>
+        </div>
+      </div>
+
+      <div class="obs-card obs-panel">
+        <div class="obs-panel__head">
+          <div>
+            <h2 class="obs-panel__title">Throughput &amp; Failures</h2>
+            <p class="obs-panel__sub">Jobs processed per bucket over the last {range().key}</p>
+          </div>
+          <div class="obs-legend">
+            <span><i class="dot dot--processed" /> Processed</span>
+            <span><i class="dot dot--failed" /> Failed</span>
+          </div>
+        </div>
+        <div class="obs-chartbox">
+          <Show when={!historyQuery.isPending} fallback={<ChartLoader height={300} />}>
+            <Show
+              when={hasThroughput()}
+              fallback={
+                <div class="empty-state" style={{ height: '300px', display: 'grid', 'place-items': 'center' }}>
+                  No history yet — the chart fills in as jobs run.
+                </div>
+              }
+            >
+              <AreaChart
+                data={series()}
+                height={300}
+                yAxisWidth={36}
+                yDecimals={false}
+                xMinTickGap={56}
+                series={[
+                  { key: 'processed', name: 'Processed', stroke: '#fafafa', strokeWidth: 2, fill: 'gradient' },
+                  { key: 'failed', name: 'Failed', stroke: '#a1a1aa', strokeWidth: 1.5, strokeDasharray: '5 4', fill: 'none' },
+                ]}
+              />
+            </Show>
+          </Show>
+        </div>
+      </div>
+
+      <div class="obs-grid2">
+        <div class="obs-card obs-panel">
+          <div class="obs-panel__head">
+            <h2 class="obs-panel__title" style={{ 'font-size': '18px' }}>Queue Depth</h2>
+            <span class="obs-mono">{maxDepth() > 0 ? `peak ${maxDepth().toLocaleString()}` : ''}</span>
+          </div>
+          <div class="obs-chartbox">
+            <Show when={!queueQuery.isPending} fallback={<ChartLoader height={240} />}>
+              <Show
+                when={depthRows().length > 0}
+                fallback={
+                  <div class="empty-state" style={{ height: '240px', display: 'grid', 'place-items': 'center' }}>
+                    No queue history yet.
+                  </div>
+                }
+              >
+                <BarChart
+                  data={depthRows().map((r) => ({
+                    label: r.label,
+                    value: r.depth,
+                    color: r.depth === maxDepth() && maxDepth() > 0 ? '#fafafa' : '#3f3f46',
+                  }))}
+                  height={240}
+                  name="Depth"
+                  yAxisWidth={36}
+                  yDecimals={false}
+                  xMinTickGap={40}
+                />
+              </Show>
+            </Show>
+          </div>
+        </div>
+
+        <div class="obs-card obs-table">
+          <div class="obs-table__head">
+            <h2 class="obs-table__title" style={{ 'font-size': '18px' }}>Top Job Types (Volume)</h2>
+          </div>
+          <Show when={!metricsQuery.isPending} fallback={<ChartLoader height={240} />}>
+            <Show when={jobs().length > 0} fallback={<div class="obs-empty">{t('common.empty')}</div>}>
+              <div class="obs-tablescroll">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Job Class</th>
+                      <th style={{ 'text-align': 'end' }}>Count</th>
+                      <th style={{ 'text-align': 'end' }}>% Total</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <For each={jobs()}>
+                      {(j, i) => (
+                        <tr>
+                          <td style={{ color: 'var(--obs-text)' }} title={j.klass}>
+                            <span class="obs-jobdot" style={{ background: JOB_DOTS[i() % JOB_DOTS.length] }} />
+                            {truncate(j.klass.split('::').pop() ?? j.klass, 36)}
+                          </td>
+                          <td style={{ 'text-align': 'end', 'font-variant-numeric': 'tabular-nums' }}>{j.count.toLocaleString()}</td>
+                          <td class="obs-pct" style={{ 'text-align': 'end' }}>
+                            {jobsTotal() > 0 ? Math.round((j.count / jobsTotal()) * 100) : 0}%
+                          </td>
+                        </tr>
+                      )}
+                    </For>
+                  </tbody>
+                </table>
+              </div>
+            </Show>
+          </Show>
+        </div>
+      </div>
+
+      <QueueLatencyHistory range={range()} />
       <HistoricalSnapshots />
     </div>
   );
@@ -396,52 +388,46 @@ export default function Metrics() {
 
 // Per-queue head-of-line latency over the selected window (Ent Historical tab,
 // §5.2) — kept below the mock layout so the feature isn't lost.
-function QueueLatencyHistory({ range }: { range: (typeof RANGES)[number] }) {
-  const { data } = useQuery<QueueHistoryResponse>({
-    queryKey: ['queue-history-lat', range.bucket, range.window],
+function QueueLatencyHistory(props: { range: (typeof RANGES)[number] }) {
+  const data = useQuery(() => ({
+    queryKey: ['queue-history-lat', props.range.bucket, props.range.window],
     queryFn: async () => {
-      const r = await fetch(`/wurk/api/queue-history/${range.bucket}?window=${range.window}`);
+      const r = await fetch(`/wurk/api/queue-history/${props.range.bucket}?window=${props.range.window}`);
       if (!r.ok) throw new Error(`queue-history failed (${r.status})`);
       return r.json() as Promise<QueueHistoryResponse>;
     },
     refetchInterval: 30000,
-  });
+  }));
 
-  const queues = data?.queues ?? [];
-  // Recharts 3.x interprets dots in `dataKey` as nested-object accessors, so
-  // a Sidekiq-compatible queue name like `emails.critical` would silently
-  // fail to render. Pivot through synthetic `queue_<i>` keys and pass the
-  // real queue name via Recharts' `name` prop (legend + tooltip label).
-  const queueKeys = queues.map((q, i) => ({ key: `queue_${i}`, name: q.name }));
-  const ats = queues[0]?.points.map((p) => p.at) ?? [];
-  const rows = ats.map((at, i) => {
-    const row: Record<string, number | string> = { label: fmtBucket(at, range.bucket) };
-    queues.forEach((q, qi) => { row[queueKeys[qi].key] = q.points[i]?.latency ?? 0; });
-    return row;
-  });
-  const hasData = queues.some((q) => q.points.some((p) => p.latency > 0));
-  if (!hasData) return null;
+  const queues = createMemo(() => data.data?.queues ?? []);
+  // Dots in a queue name (`emails.critical`) were a nested-object-accessor
+  // hazard in recharts, so we pivot through synthetic `queue_<i>` keys and carry
+  // the real queue name for the legend + tooltip.
+  const queueKeys = createMemo(() => queues().map((q, i) => ({ key: `queue_${i}`, name: q.name })));
+  const ats = createMemo(() => queues()[0]?.points.map((p) => p.at) ?? []);
+  const rows = createMemo(() =>
+    ats().map((at, i) => {
+      const row: Datum = { label: fmtBucket(at, props.range.bucket) };
+      queues().forEach((q, qi) => { row[queueKeys()[qi].key] = q.points[i]?.latency ?? 0; });
+      return row;
+    }),
+  );
+  const lineSeries = createMemo(() =>
+    queueKeys().map((q, i) => ({ key: q.key, name: q.name, stroke: queueColor(i), strokeWidth: 2 })),
+  );
+  const hasData = createMemo(() => queues().some((q) => q.points.some((p) => p.latency > 0)));
 
   return (
-    <div className="obs-card obs-panel">
-      <div className="obs-panel__head">
-        <h2 className="obs-panel__title" style={{ fontSize: 18 }}>Queue Latency (seconds)</h2>
+    <Show when={hasData()}>
+      <div class="obs-card obs-panel">
+        <div class="obs-panel__head">
+          <h2 class="obs-panel__title" style={{ 'font-size': '18px' }}>Queue Latency (seconds)</h2>
+        </div>
+        <div class="obs-chartbox">
+          <LineChart data={rows()} series={lineSeries()} height={240} legend yAxisWidth={40} xMinTickGap={48} />
+        </div>
       </div>
-      <div className="obs-chartbox">
-        <ResponsiveContainer width="100%" height={240}>
-          <LineChart data={rows} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="rgba(255,255,255,0.06)" />
-            <XAxis dataKey="label" tick={{ fill: '#71717a', fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }} axisLine={false} tickLine={false} minTickGap={48} interval="preserveStartEnd" />
-            <YAxis tick={{ fill: '#71717a', fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }} axisLine={false} tickLine={false} width={40} />
-            <Tooltip contentStyle={tooltipStyle} labelStyle={{ color: '#a1a1aa' }} />
-            <Legend wrapperStyle={{ fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }} />
-            {queueKeys.map((q, i) => (
-              <Line key={q.key} type="monotone" dataKey={q.key} name={q.name} stroke={queueColor(i)} strokeWidth={2} dot={false} />
-            ))}
-          </LineChart>
-        </ResponsiveContainer>
-      </div>
-    </div>
+    </Show>
   );
 }
 
@@ -452,7 +438,7 @@ interface Snapshot {
 const CUMULATIVE_FIELDS = new Set(['processed', 'failures']);
 
 function HistoricalSnapshots() {
-  const { data } = useQuery<{ snapshots: Snapshot[] }>({
+  const data = useQuery(() => ({
     queryKey: ['history-snapshots'],
     queryFn: async () => {
       const r = await fetch('/wurk/api/history/snapshots?limit=1000');
@@ -460,41 +446,40 @@ function HistoricalSnapshots() {
       return r.json() as Promise<{ snapshots: Snapshot[] }>;
     },
     refetchInterval: 30000,
-  });
+  }));
 
-  const snapshots = data?.snapshots ?? [];
-  const fields = Array.from(
-    new Set(
-      snapshots.flatMap((s) =>
-        Object.keys(s).filter((k) => k !== 'at' && !CUMULATIVE_FIELDS.has(k) && typeof s[k] === 'number')
-      )
-    )
+  const snapshots = createMemo(() => data.data?.snapshots ?? []);
+  const fields = createMemo(() =>
+    Array.from(
+      new Set(
+        snapshots().flatMap((s) =>
+          Object.keys(s).filter((k) => k !== 'at' && !CUMULATIVE_FIELDS.has(k) && typeof s[k] === 'number'),
+        ),
+      ),
+    ),
   );
-  const rows = snapshots.map((s) => {
-    const d = new Date(s.at * 1000);
-    return { ...s, label: `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}` };
-  });
-  if (snapshots.length === 0 || fields.length === 0) return null;
+  const rows = createMemo(() =>
+    snapshots().map((s) => {
+      const d = new Date(s.at * 1000);
+      const row: Datum = { label: `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}` };
+      for (const k of Object.keys(s)) row[k] = s[k];
+      return row;
+    }),
+  );
+  const lineSeries = createMemo(() =>
+    fields().map((f, i) => ({ key: f, name: f, stroke: queueColor(i), strokeWidth: 2 })),
+  );
 
   return (
-    <div className="obs-card obs-panel">
-      <div className="obs-panel__head">
-        <h2 className="obs-panel__title" style={{ fontSize: 18 }}>Historical Snapshots</h2>
+    <Show when={snapshots().length > 0 && fields().length > 0}>
+      <div class="obs-card obs-panel">
+        <div class="obs-panel__head">
+          <h2 class="obs-panel__title" style={{ 'font-size': '18px' }}>Historical Snapshots</h2>
+        </div>
+        <div class="obs-chartbox">
+          <LineChart data={rows()} series={lineSeries()} height={240} legend yAxisWidth={40} yDecimals={false} xMinTickGap={48} />
+        </div>
       </div>
-      <div className="obs-chartbox">
-        <ResponsiveContainer width="100%" height={240}>
-          <LineChart data={rows} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="rgba(255,255,255,0.06)" />
-            <XAxis dataKey="label" tick={{ fill: '#71717a', fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }} axisLine={false} tickLine={false} minTickGap={48} interval="preserveStartEnd" />
-            <YAxis tick={{ fill: '#71717a', fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }} axisLine={false} tickLine={false} width={40} allowDecimals={false} />
-            <Tooltip contentStyle={tooltipStyle} labelStyle={{ color: '#a1a1aa' }} />
-            <Legend wrapperStyle={{ fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }} />
-            {fields.map((f, i) => (
-              <Line key={f} type="monotone" dataKey={f} stroke={queueColor(i)} strokeWidth={2} dot={false} />
-            ))}
-          </LineChart>
-        </ResponsiveContainer>
-      </div>
-    </div>
+    </Show>
   );
 }

--- a/frontend/src/pages/Profiles.tsx
+++ b/frontend/src/pages/Profiles.tsx
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { useQuery } from '@tanstack/solid-query';
+import { onMount, For, Switch, Match, Show } from 'solid-js';
 import { SkeletonTable } from '../components/Skeleton';
 import { t } from '../i18n';
 
@@ -25,11 +25,11 @@ function fmtWhen(ts: number | null): string {
 }
 
 export default function Profiles() {
-  useEffect(() => {
+  onMount(() => {
     document.title = `${t('nav.profiles')} — Wurk`;
-  }, []);
+  });
 
-  const { data, isLoading } = useQuery<Profile[]>({
+  const q = useQuery<Profile[]>(() => ({
     queryKey: ['profiles'],
     queryFn: async () => {
       const r = await fetch('/wurk/api/profiles');
@@ -37,70 +37,80 @@ export default function Profiles() {
       return r.json() as Promise<Profile[]>;
     },
     refetchInterval: 5000,
-  });
-
-  if (isLoading) return <div className="obs"><SkeletonTable rows={8} cols={6} /></div>;
-  // Only gate on shape, not isError — with refetchInterval polling, a transient
-  // background refetch failure flips isError true while the last good payload
-  // is still cached. Showing the error state then would blank the page on
-  // every blip; falling through keeps stale data visible until the next poll.
-  if (!Array.isArray(data)) {
-    return <div className="obs"><div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div></div>;
-  }
+  }));
 
   return (
-    <div className="obs">
-      <div className="obs-pagehead">
-        <div>
-          <h1>{t('nav.profiles')}</h1>
-          <p className="obs-panel__sub">{t('summaries.profiles')}</p>
-        </div>
-        <span className="obs-chip obs-chip--active">{data.length.toLocaleString()}</span>
-      </div>
+    <Switch>
+      <Match when={q.isPending}>
+        <div class="obs"><SkeletonTable rows={8} cols={6} /></div>
+      </Match>
+      {/* Only gate on shape, not isError — with refetchInterval polling, a transient
+          background refetch failure flips isError true while the last good payload
+          is still cached. Showing the error state then would blank the page on
+          every blip; falling through keeps stale data visible until the next poll. */}
+      <Match when={!Array.isArray(q.data)}>
+        <div class="obs"><div class="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div></div>
+      </Match>
+      <Match when={Array.isArray(q.data) && q.data}>
+        {(data) => (
+          <div class="obs">
+            <div class="obs-pagehead">
+              <div>
+                <h1>{t('nav.profiles')}</h1>
+                <p class="obs-panel__sub">{t('summaries.profiles')}</p>
+              </div>
+              <span class="obs-chip obs-chip--active">{data().length.toLocaleString()}</span>
+            </div>
 
-      {data.length === 0 ? (
-        <div className="obs-card obs-empty">{t('common.empty')}</div>
-      ) : (
-        <div className="obs-card obs-table">
-          <div className="obs-tablescroll">
-            <table>
-              <thead>
-                <tr>
-                  <th>Type</th>
-                  <th>JID</th>
-                  <th>Started</th>
-                  <th>Elapsed</th>
-                  <th>Size</th>
-                  <th />
-                </tr>
-              </thead>
-              <tbody>
-                {data.map((p) => (
-                  <tr key={p.key}>
-                    <td style={{ fontWeight: 500, color: 'var(--obs-text)' }}>{p.type}</td>
-                    <td><span className="obs-mono-cell">{p.jid}</span></td>
-                    <td>{fmtWhen(p.started_at)}</td>
-                    <td>{p.elapsed.toLocaleString()} ms</td>
-                    <td>{fmtBytes(p.size)}</td>
-                    <td style={{ textAlign: 'end' }}>
-                      {/* Full reload (not client-route): the backend POSTs the blob
-                          to the Firefox profiler then 302s out to profiler.firefox.com. */}
-                      <a
-                        className="obs-btn obs-btn--ghost obs-btn--sm"
-                        href={`/wurk/profiles/${encodeURIComponent(p.key)}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        <i className="fa-solid fa-up-right-from-square" aria-hidden="true" /> Open
-                      </a>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+            <Show
+              when={data().length > 0}
+              fallback={<div class="obs-card obs-empty">{t('common.empty')}</div>}
+            >
+              <div class="obs-card obs-table">
+                <div class="obs-tablescroll">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Type</th>
+                        <th>JID</th>
+                        <th>Started</th>
+                        <th>Elapsed</th>
+                        <th>Size</th>
+                        <th />
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <For each={data()}>
+                        {(p) => (
+                          <tr>
+                            <td style={{ 'font-weight': 500, color: 'var(--obs-text)' }}>{p.type}</td>
+                            <td><span class="obs-mono-cell">{p.jid}</span></td>
+                            <td>{fmtWhen(p.started_at)}</td>
+                            <td>{p.elapsed.toLocaleString()} ms</td>
+                            <td>{fmtBytes(p.size)}</td>
+                            <td style={{ 'text-align': 'end' }}>
+                              {/* Full reload (not client-route): the backend POSTs the blob
+                                  to the Firefox profiler then 302s out to profiler.firefox.com. */}
+                              <a
+                                class="obs-btn obs-btn--ghost obs-btn--sm"
+                                href={`/wurk/profiles/${encodeURIComponent(p.key)}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                <i class="fa-solid fa-up-right-from-square" aria-hidden="true" /> Open
+                              </a>
+                            </td>
+                          </tr>
+                        )}
+                      </For>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </Show>
           </div>
-        </div>
-      )}
-    </div>
+        )}
+      </Match>
+    </Switch>
   );
 }

--- a/frontend/src/pages/Queues.tsx
+++ b/frontend/src/pages/Queues.tsx
@@ -1,5 +1,5 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/solid-query';
+import { createSignal, onMount, For, Show, Switch, Match } from 'solid-js';
 import { Pagination } from '../components/Pagination';
 import { ArgsValue } from '../components/ArgsValue';
 import { SortableTh } from '../components/SortableTh';
@@ -49,25 +49,25 @@ const JOB_SORT: Accessors<QueueJob> = {
   enqueued: (j) => j.enqueued_at,
 };
 
-function QueueJobs({ name }: { name: string }) {
+function QueueJobs(props: { name: string }) {
   const [page, setPage] = usePageParam();
-  const [selected, setSelected] = useState<JobEntry | null>(null);
-  const { data: meta } = useMeta();
-  const readOnly = meta?.read_only ?? false;
+  const [selected, setSelected] = createSignal<JobEntry | null>(null);
+  const meta = useMeta();
+  const readOnly = () => meta.data?.read_only ?? false;
   const qc = useQueryClient();
 
-  const { data, isLoading, isError } = useQuery<QueueDetail>({
-    queryKey: ['queue', name, page],
+  const query = useQuery<QueueDetail>(() => ({
+    queryKey: ['queue', props.name, page()],
     queryFn: () =>
-      fetch(`/wurk/api/queues/${encodeURIComponent(name)}?page=${page - 1}&count=${PAGE_SIZE}`).then(
+      fetch(`/wurk/api/queues/${encodeURIComponent(props.name)}?page=${page() - 1}&count=${PAGE_SIZE}`).then(
         (r) => r.json() as Promise<QueueDetail>
       ),
-  });
+  }));
 
   // Delete one job from the queue by jid (server LREMs the exact payload).
-  const deleteJob = useMutation({
+  const deleteJob = useMutation(() => ({
     mutationFn: async (jid: string) => {
-      const res = await fetch(`/wurk/api/queues/${encodeURIComponent(name)}/delete`, {
+      const res = await fetch(`/wurk/api/queues/${encodeURIComponent(props.name)}/delete`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ jid }),
@@ -76,82 +76,94 @@ function QueueJobs({ name }: { name: string }) {
       return res;
     },
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['queue', name] });
+      qc.invalidateQueries({ queryKey: ['queue', props.name] });
       qc.invalidateQueries({ queryKey: ['queues'] });
       qc.invalidateQueries({ queryKey: ['stats'] });
     },
-  });
+  }));
 
-  const { sorted, sort, toggle } = useSort(data?.jobs ?? [], JOB_SORT);
-
-  if (isLoading) return <SkeletonTable rows={6} cols={5} />;
-  if (isError || !data) return <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>;
+  const { sorted, sort, toggle } = useSort(() => query.data?.jobs ?? [], JOB_SORT);
 
   return (
-    <div className="qjobs">
-      <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '1rem' }}>
-        <span style={{ color: 'var(--text-muted)', fontSize: 13 }}>
-          {data.size.toLocaleString()} jobs · <span title={`${data.latency.toFixed(3)}s`}>latency {formatDuration(data.latency)}</span>
-        </span>
-        {data.paused && <span className="badge badge-warning">{t('dashboard.paused')}</span>}
-      </div>
+    <Switch>
+      <Match when={query.isPending}>
+        <SkeletonTable rows={6} cols={5} />
+      </Match>
+      <Match when={query.isError || !query.data}>
+        <div class="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>
+      </Match>
+      <Match when={query.data}>
+        {(data) => (
+          <div class="qjobs">
+            <div style={{ display: 'flex', 'align-items': 'center', gap: '0.75rem', 'margin-bottom': '1rem' }}>
+              <span style={{ color: 'var(--text-muted)', 'font-size': '13px' }}>
+                {data().size.toLocaleString()} jobs · <span title={`${data().latency.toFixed(3)}s`}>latency {formatDuration(data().latency)}</span>
+              </span>
+              <Show when={data().paused}>
+                <span class="badge badge-warning">{t('dashboard.paused')}</span>
+              </Show>
+            </div>
 
-      {sorted.length === 0 ? (
-        <div className="empty-state">{t('common.empty')}</div>
-      ) : (
-        <>
-          <div className="table-wrapper">
-            <table>
-              <thead>
-                <tr>
-                  <SortableTh label={t('table.jid')} sortKey="jid" sort={sort} onSort={toggle} />
-                  <SortableTh label={t('table.class')} sortKey="class" sort={sort} onSort={toggle} />
-                  <SortableTh label={t('table.args')} sortKey="args" sort={sort} onSort={toggle} />
-                  <SortableTh label={t('table.enqueued_at')} sortKey="enqueued" sort={sort} onSort={toggle} />
-                  {!readOnly && <th className="row-action" />}
-                </tr>
-              </thead>
-              <tbody>
-                {sorted.map((job) => {
-                  const argsStr = formatArgs(job.args);
-                  return (
-                    <tr
-                      key={job.jid}
-                      className="row-clickable"
-                      onClick={() => setSelected({ jid: job.jid, klass: job.class, args: job.args, queue: name, enqueued_at: job.enqueued_at })}
-                    >
-                      <td title={job.jid} style={{ fontFamily: 'monospace', fontSize: 12, color: 'var(--text-muted)' }}>
-                        {truncate(job.jid, 12)}
-                      </td>
-                      <td style={{ fontWeight: 500 }}>{job.class}</td>
-                      <td><ArgsValue str={argsStr} max={60} /></td>
-                      <td>{relativeTime(job.enqueued_at)}</td>
-                      {!readOnly && (
-                        <td className="row-action" onClick={(e) => e.stopPropagation()}>
-                          <button
-                            className="btn btn-sm btn-danger"
-                            disabled={deleteJob.isPending}
-                            onClick={() => {
-                              if (window.confirm(t('actions.confirm', { action: t('actions.delete'), scope: t('actions.scope_this_job') }))) {
-                                deleteJob.mutate(job.jid);
-                              }
-                            }}
-                          >
-                            {t('actions.delete')}
-                          </button>
-                        </td>
-                      )}
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
+            <Show when={sorted().length > 0} fallback={<div class="empty-state">{t('common.empty')}</div>}>
+              <>
+                <div class="table-wrapper">
+                  <table>
+                    <thead>
+                      <tr>
+                        <SortableTh label={t('table.jid')} sortKey="jid" sort={sort()} onSort={toggle} />
+                        <SortableTh label={t('table.class')} sortKey="class" sort={sort()} onSort={toggle} />
+                        <SortableTh label={t('table.args')} sortKey="args" sort={sort()} onSort={toggle} />
+                        <SortableTh label={t('table.enqueued_at')} sortKey="enqueued" sort={sort()} onSort={toggle} />
+                        <Show when={!readOnly()}>
+                          <th class="row-action" />
+                        </Show>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <For each={sorted()}>
+                        {(job) => {
+                          const argsStr = formatArgs(job.args);
+                          return (
+                            <tr
+                              class="row-clickable"
+                              onClick={() => setSelected({ jid: job.jid, klass: job.class, args: job.args, queue: props.name, enqueued_at: job.enqueued_at })}
+                            >
+                              <td title={job.jid} style={{ 'font-family': 'monospace', 'font-size': '12px', color: 'var(--text-muted)' }}>
+                                {truncate(job.jid, 12)}
+                              </td>
+                              <td style={{ 'font-weight': 500 }}>{job.class}</td>
+                              <td><ArgsValue str={argsStr} max={60} /></td>
+                              <td>{relativeTime(job.enqueued_at)}</td>
+                              <Show when={!readOnly()}>
+                                <td class="row-action" onClick={(e) => e.stopPropagation()}>
+                                  <button
+                                    class="btn btn-sm btn-danger"
+                                    disabled={deleteJob.isPending}
+                                    onClick={() => {
+                                      if (window.confirm(t('actions.confirm', { action: t('actions.delete'), scope: t('actions.scope_this_job') }))) {
+                                        deleteJob.mutate(job.jid);
+                                      }
+                                    }}
+                                  >
+                                    {t('actions.delete')}
+                                  </button>
+                                </td>
+                              </Show>
+                            </tr>
+                          );
+                        }}
+                      </For>
+                    </tbody>
+                  </table>
+                </div>
+                <Pagination page={page()} total={data().size} count={PAGE_SIZE} onChange={setPage} />
+              </>
+            </Show>
+            <JobDetailModal entry={selected()} onClose={() => setSelected(null)} />
           </div>
-          <Pagination page={page} total={data.size} count={PAGE_SIZE} onChange={setPage} />
-        </>
-      )}
-      <JobDetailModal entry={selected} onClose={() => setSelected(null)} />
-    </div>
+        )}
+      </Match>
+    </Switch>
   );
 }
 
@@ -163,22 +175,22 @@ const QUEUE_SORT: Accessors<QueueSummary> = {
 };
 
 export default function Queues() {
-  const [selectedQueue, setSelectedQueue] = useState<string | null>(null);
-  const { data: meta } = useMeta();
-  const readOnly = meta?.read_only ?? false;
+  const [selectedQueue, setSelectedQueue] = createSignal<string | null>(null);
+  const meta = useMeta();
+  const readOnly = () => meta.data?.read_only ?? false;
   const qc = useQueryClient();
 
-  useEffect(() => {
+  onMount(() => {
     document.title = `${t('nav.queues')} — Wurk`;
-  }, []);
+  });
 
-  const { data, isLoading, isError } = useQuery<QueueSummary[]>({
+  const query = useQuery<QueueSummary[]>(() => ({
     queryKey: ['queues'],
     queryFn: () => fetch('/wurk/api/queues').then((r) => r.json() as Promise<QueueSummary[]>),
     refetchInterval: 5000,
-  });
+  }));
 
-  const clearQueue = useMutation({
+  const clearQueue = useMutation(() => ({
     mutationFn: async (name: string) => {
       const res = await fetch(`/wurk/api/queues/${encodeURIComponent(name)}/clear`, { method: 'POST' });
       if (!res.ok) throw new Error(`Clear failed (${res.status})`);
@@ -189,11 +201,11 @@ export default function Queues() {
       qc.invalidateQueries({ queryKey: ['queue', name] });
       qc.invalidateQueries({ queryKey: ['stats'] });
     },
-  });
+  }));
 
   // Toggle the queue's membership of the `paused` SET; fetchers stop pulling
   // from a paused queue. POST skips CSRF (ApiController#skip_forgery_protection).
-  const pauseQueue = useMutation({
+  const pauseQueue = useMutation(() => ({
     mutationFn: async ({ name, paused }: { name: string; paused: boolean }) => {
       const action = paused ? 'unpause' : 'pause';
       const res = await fetch(`/wurk/api/queues/${encodeURIComponent(name)}/${action}`, { method: 'POST' });
@@ -207,89 +219,95 @@ export default function Queues() {
       // toggle must refresh it too (mirrors clearQueue).
       qc.invalidateQueries({ queryKey: ['stats'] });
     },
-  });
+  }));
 
-  const { sorted, sort, toggle } = useSort(data ?? [], QUEUE_SORT);
-
-  if (isLoading)
-    return (
-      <div>
-        <PageHeader icon="fa-layer-group" title={t('nav.queues')} summary={t('summaries.queues')} />
-        <SkeletonTable rows={8} cols={5} />
-      </div>
-    );
-  if (isError || !data) return <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>;
+  const { sorted, sort, toggle } = useSort(() => query.data ?? [], QUEUE_SORT);
 
   return (
-    <div>
-      <PageHeader icon="fa-layer-group" title={t('nav.queues')} summary={t('summaries.queues')} />
-
-      {sorted.length === 0 ? (
-        <div className="empty-state">{t('common.empty')}</div>
-      ) : (
-        <div className="table-wrapper">
-          <table>
-            <thead>
-              <tr>
-                <SortableTh label="Name" sortKey="name" sort={sort} onSort={toggle} />
-                <SortableTh label={t('table.size')} sortKey="size" sort={sort} onSort={toggle} />
-                <SortableTh label={t('table.latency')} sortKey="latency" sort={sort} onSort={toggle} />
-                <SortableTh label={t('table.status')} sortKey="status" sort={sort} onSort={toggle} />
-                {!readOnly && <th className="row-action" />}
-              </tr>
-            </thead>
-            <tbody>
-              {sorted.map((q) => (
-                <tr key={q.name} className="row-clickable" onClick={() => setSelectedQueue(q.name)}>
-                  <td style={{ fontWeight: 500 }}>{q.name}</td>
-                  <td>{q.size.toLocaleString()}</td>
-                  <td title={`${q.latency.toFixed(3)}s`}>{formatDuration(q.latency)}</td>
-                  <td>
-                    {q.paused ? (
-                      <span className="badge badge-warning">{t('dashboard.paused')}</span>
-                    ) : (
-                      <span className="badge badge-success">Active</span>
-                    )}
-                  </td>
-                  {!readOnly && (
-                    <td className="row-action" onClick={(e) => e.stopPropagation()}>
-                      <div style={{ display: 'flex', gap: '0.4rem', justifyContent: 'flex-end' }}>
-                        <Tooltip tip={q.paused ? t('actions.unpause_hint') : t('actions.pause_hint')}>
-                          <button
-                            className="btn btn-sm"
-                            disabled={pauseQueue.isPending}
-                            onClick={() => pauseQueue.mutate({ name: q.name, paused: q.paused })}
-                          >
-                            {q.paused ? t('actions.unpause') : t('actions.pause')}
-                          </button>
-                        </Tooltip>
-                        <button
-                          className="btn btn-sm btn-danger"
-                          disabled={clearQueue.isPending}
-                          onClick={() => {
-                            if (window.confirm(t('actions.confirm_clear_queue', { name: q.name }))) clearQueue.mutate(q.name);
-                          }}
-                        >
-                          {t('actions.clear')}
-                        </button>
-                      </div>
-                    </td>
-                  )}
-                </tr>
-              ))}
-            </tbody>
-          </table>
+    <Switch>
+      <Match when={query.isPending}>
+        <div>
+          <PageHeader icon="fa-layer-group" title={t('nav.queues')} summary={t('summaries.queues')} />
+          <SkeletonTable rows={8} cols={5} />
         </div>
-      )}
+      </Match>
+      <Match when={query.isError || !query.data}>
+        <div class="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>
+      </Match>
+      <Match when={query.data}>
+        {(_data) => (
+          <div>
+            <PageHeader icon="fa-layer-group" title={t('nav.queues')} summary={t('summaries.queues')} />
 
-      <Modal
-        open={selectedQueue !== null}
-        onClose={() => setSelectedQueue(null)}
-        title={selectedQueue ?? ''}
-        width={780}
-      >
-        {selectedQueue && <QueueJobs name={selectedQueue} />}
-      </Modal>
-    </div>
+            <Show when={sorted().length > 0} fallback={<div class="empty-state">{t('common.empty')}</div>}>
+              <div class="table-wrapper">
+                <table>
+                  <thead>
+                    <tr>
+                      <SortableTh label="Name" sortKey="name" sort={sort()} onSort={toggle} />
+                      <SortableTh label={t('table.size')} sortKey="size" sort={sort()} onSort={toggle} />
+                      <SortableTh label={t('table.latency')} sortKey="latency" sort={sort()} onSort={toggle} />
+                      <SortableTh label={t('table.status')} sortKey="status" sort={sort()} onSort={toggle} />
+                      <Show when={!readOnly()}>
+                        <th class="row-action" />
+                      </Show>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <For each={sorted()}>
+                      {(q) => (
+                        <tr class="row-clickable" onClick={() => setSelectedQueue(q.name)}>
+                          <td style={{ 'font-weight': 500 }}>{q.name}</td>
+                          <td>{q.size.toLocaleString()}</td>
+                          <td title={`${q.latency.toFixed(3)}s`}>{formatDuration(q.latency)}</td>
+                          <td>
+                            <Show when={q.paused} fallback={<span class="badge badge-success">Active</span>}>
+                              <span class="badge badge-warning">{t('dashboard.paused')}</span>
+                            </Show>
+                          </td>
+                          <Show when={!readOnly()}>
+                            <td class="row-action" onClick={(e) => e.stopPropagation()}>
+                              <div style={{ display: 'flex', gap: '0.4rem', 'justify-content': 'flex-end' }}>
+                                <Tooltip tip={q.paused ? t('actions.unpause_hint') : t('actions.pause_hint')}>
+                                  <button
+                                    class="btn btn-sm"
+                                    disabled={pauseQueue.isPending}
+                                    onClick={() => pauseQueue.mutate({ name: q.name, paused: q.paused })}
+                                  >
+                                    {q.paused ? t('actions.unpause') : t('actions.pause')}
+                                  </button>
+                                </Tooltip>
+                                <button
+                                  class="btn btn-sm btn-danger"
+                                  disabled={clearQueue.isPending}
+                                  onClick={() => {
+                                    if (window.confirm(t('actions.confirm_clear_queue', { name: q.name }))) clearQueue.mutate(q.name);
+                                  }}
+                                >
+                                  {t('actions.clear')}
+                                </button>
+                              </div>
+                            </td>
+                          </Show>
+                        </tr>
+                      )}
+                    </For>
+                  </tbody>
+                </table>
+              </div>
+            </Show>
+
+            <Modal
+              open={selectedQueue() !== null}
+              onClose={() => setSelectedQueue(null)}
+              title={selectedQueue() ?? ''}
+              width={780}
+            >
+              <Show when={selectedQueue()}>{(name) => <QueueJobs name={name()} />}</Show>
+            </Modal>
+          </div>
+        )}
+      </Match>
+    </Switch>
   );
 }

--- a/frontend/src/pages/Retries.tsx
+++ b/frontend/src/pages/Retries.tsx
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
-import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/solid-query';
+import { createSignal, onMount, For, Show, Switch, Match } from 'solid-js';
 import { Pagination } from '../components/Pagination';
 import { ArgsValue } from '../components/ArgsValue';
 import { t } from '../i18n';
@@ -61,118 +61,124 @@ const ALL: ActionDef[] = [
 
 export default function Retries() {
   const [page, setPage] = usePageParam();
-  const [selected, setSelected] = useState<JobEntry | null>(null);
-  const [selectedKey, setSelectedKey] = useState<string | null>(null);
-  const { data: meta } = useMeta();
-  const readOnly = meta?.read_only ?? false;
+  const [selected, setSelected] = createSignal<JobEntry | null>(null);
+  const [selectedKey, setSelectedKey] = createSignal<string | null>(null);
+  const meta = useMeta();
+  const readOnly = () => meta.data?.read_only ?? false;
   const sel = useSelection();
   const { single, bulk, all } = useJobSetActions('retries');
-  const pending = single.isPending || bulk.isPending || all.isPending;
+  const pending = () => single.isPending || bulk.isPending || all.isPending;
 
-  useEffect(() => {
+  onMount(() => {
     document.title = `${t('nav.retries')} — Wurk`;
-  }, []);
-
-  const { data, isLoading, isError } = useQuery<RetriesResponse>({
-    queryKey: ['retries', page],
-    queryFn: () =>
-      fetch(`/wurk/api/retries?page=${page - 1}&count=${PAGE_SIZE}`).then(
-        (r) => r.json() as Promise<RetriesResponse>
-      ),
   });
 
-  const { sorted, sort, toggle } = useSort(data?.entries ?? [], SORT);
-  const pageKeys = sorted.map(entryKey);
+  const query = useQuery<RetriesResponse>(() => ({
+    queryKey: ['retries', page()],
+    queryFn: () =>
+      fetch(`/wurk/api/retries?page=${page() - 1}&count=${PAGE_SIZE}`).then(
+        (r) => r.json() as Promise<RetriesResponse>
+      ),
+  }));
 
-  if (isLoading)
-    return (
-      <div>
-        <PageHeader icon="fa-rotate-right" title={t('nav.retries')} summary={t('summaries.retries')} />
-        <SkeletonTable rows={8} cols={7} />
-      </div>
-    );
-  if (isError || !data) return <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>;
-
-  const allChecked = pageKeys.length > 0 && pageKeys.every((k) => sel.selected.has(k));
+  const { sorted, sort, toggle } = useSort(() => query.data?.entries ?? [], SORT);
+  const pageKeys = () => sorted().map(entryKey);
+  const allChecked = () => pageKeys().length > 0 && pageKeys().every((k) => sel.selected().has(k));
 
   return (
-    <div>
-      <PageHeader icon="fa-rotate-right" title={t('nav.retries')} summary={t('summaries.retries')}>
-        <span className="badge badge-warning">{data.total.toLocaleString()}</span>
-      </PageHeader>
+    <Switch>
+      <Match when={query.isPending}>
+        <div>
+          <PageHeader icon="fa-rotate-right" title={t('nav.retries')} summary={t('summaries.retries')} />
+          <SkeletonTable rows={8} cols={7} />
+        </div>
+      </Match>
+      <Match when={query.isError || !query.data}>
+        <div class="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>
+      </Match>
+      <Match when={query.data}>
+        {(data) => (
+          <div>
+            <PageHeader icon="fa-rotate-right" title={t('nav.retries')} summary={t('summaries.retries')}>
+              <span class="badge badge-warning">{data().total.toLocaleString()}</span>
+            </PageHeader>
 
-      {sorted.length === 0 ? (
-        <div className="empty-state">{t('common.empty')}</div>
-      ) : (
-        <>
-          {!readOnly && (
-            <JobSetActionBar
-              bulk={BULK}
-              all={ALL}
-              selectedCount={sel.count}
-              total={data.total}
-              pending={pending}
-              onBulk={(cmd) => bulk.mutate({ keys: [...sel.selected], cmd }, { onSuccess: sel.clear })}
-              onAll={(cmd) => all.mutate(cmd, { onSuccess: sel.clear })}
+            <Show when={sorted().length > 0} fallback={<div class="empty-state">{t('common.empty')}</div>}>
+              <>
+                <Show when={!readOnly()}>
+                  <JobSetActionBar
+                    bulk={BULK}
+                    all={ALL}
+                    selectedCount={sel.count()}
+                    total={data().total}
+                    pending={pending()}
+                    onBulk={(cmd) => bulk.mutate({ keys: [...sel.selected()], cmd }, { onSuccess: sel.clear })}
+                    onAll={(cmd) => all.mutate(cmd, { onSuccess: sel.clear })}
+                  />
+                </Show>
+                <div class="table-wrapper">
+                  <table>
+                    <thead>
+                      <tr>
+                        <Show when={!readOnly()}>
+                          <th class="row-action">
+                            <input type="checkbox" checked={allChecked()} onChange={() => sel.toggleAll(pageKeys())} aria-label="Select all" />
+                          </th>
+                        </Show>
+                        <SortableTh label={t('table.class')} sortKey="klass" sort={sort()} onSort={toggle} />
+                        <SortableTh label={t('table.args')} sortKey="args" sort={sort()} onSort={toggle} />
+                        <SortableTh label={t('table.error')} sortKey="error_class" sort={sort()} onSort={toggle} />
+                        <SortableTh label={t('table.message')} sortKey="error_message" sort={sort()} onSort={toggle} />
+                        <SortableTh label={t('table.count')} sortKey="retry_count" sort={sort()} onSort={toggle} />
+                        <SortableTh label={t('table.retry_at')} sortKey="at" sort={sort()} onSort={toggle} />
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <For each={sorted()}>
+                        {(entry) => {
+                          const argsStr = formatArgs(entry.args);
+                          const key = entryKey(entry);
+                          return (
+                            <tr class="row-clickable" onClick={() => { setSelected(entry); setSelectedKey(key); }}>
+                              <Show when={!readOnly()}>
+                                <td class="row-action" onClick={(e) => e.stopPropagation()}>
+                                  <input type="checkbox" checked={sel.selected().has(key)} onChange={() => sel.toggle(key)} aria-label="Select job" />
+                                </td>
+                              </Show>
+                              <td style={{ 'font-weight': 500 }}>{entry.klass}</td>
+                              <td><ArgsValue str={argsStr} max={40} /></td>
+                              <td title={entry.error_class ?? ''} style={{ color: 'var(--danger)' }}>
+                                {truncate(entry.error_class, 30)}
+                              </td>
+                              <td title={entry.error_message ?? ''}>{truncate(entry.error_message, 50)}</td>
+                              <td style={{ color: 'var(--warning)' }}>{entry.retry_count}</td>
+                              <td title={isoTime(entry.at)}>
+                                {relativeTime(entry.at)}
+                              </td>
+                            </tr>
+                          );
+                        }}
+                      </For>
+                    </tbody>
+                  </table>
+                </div>
+                <Pagination page={page()} total={data().total} count={PAGE_SIZE} onChange={setPage} />
+              </>
+            </Show>
+            <JobDetailModal
+              entry={selected()}
+              atLabel={t('table.retry_at')}
+              actions={readOnly() ? undefined : BULK}
+              pending={single.isPending}
+              onAction={(cmd) => {
+                const k = selectedKey();
+                if (k) single.mutate({ key: k, cmd }, { onSuccess: () => { setSelected(null); setSelectedKey(null); } });
+              }}
+              onClose={() => { setSelected(null); setSelectedKey(null); }}
             />
-          )}
-          <div className="table-wrapper">
-            <table>
-              <thead>
-                <tr>
-                  {!readOnly && (
-                    <th className="row-action">
-                      <input type="checkbox" checked={allChecked} onChange={() => sel.toggleAll(pageKeys)} aria-label="Select all" />
-                    </th>
-                  )}
-                  <SortableTh label={t('table.class')} sortKey="klass" sort={sort} onSort={toggle} />
-                  <SortableTh label={t('table.args')} sortKey="args" sort={sort} onSort={toggle} />
-                  <SortableTh label={t('table.error')} sortKey="error_class" sort={sort} onSort={toggle} />
-                  <SortableTh label={t('table.message')} sortKey="error_message" sort={sort} onSort={toggle} />
-                  <SortableTh label={t('table.count')} sortKey="retry_count" sort={sort} onSort={toggle} />
-                  <SortableTh label={t('table.retry_at')} sortKey="at" sort={sort} onSort={toggle} />
-                </tr>
-              </thead>
-              <tbody>
-                {sorted.map((entry) => {
-                  const argsStr = formatArgs(entry.args);
-                  const key = entryKey(entry);
-                  return (
-                    <tr key={entry.jid} className="row-clickable" onClick={() => { setSelected(entry); setSelectedKey(key); }}>
-                      {!readOnly && (
-                        <td className="row-action" onClick={(e) => e.stopPropagation()}>
-                          <input type="checkbox" checked={sel.selected.has(key)} onChange={() => sel.toggle(key)} aria-label="Select job" />
-                        </td>
-                      )}
-                      <td style={{ fontWeight: 500 }}>{entry.klass}</td>
-                      <td><ArgsValue str={argsStr} max={40} /></td>
-                      <td title={entry.error_class ?? ''} style={{ color: 'var(--danger)' }}>
-                        {truncate(entry.error_class, 30)}
-                      </td>
-                      <td title={entry.error_message ?? ''}>{truncate(entry.error_message, 50)}</td>
-                      <td style={{ color: 'var(--warning)' }}>{entry.retry_count}</td>
-                      <td title={isoTime(entry.at)}>
-                        {relativeTime(entry.at)}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
           </div>
-          <Pagination page={page} total={data.total} count={PAGE_SIZE} onChange={setPage} />
-        </>
-      )}
-      <JobDetailModal
-        entry={selected}
-        atLabel={t('table.retry_at')}
-        actions={readOnly ? undefined : BULK}
-        pending={single.isPending}
-        onAction={(cmd) =>
-          selectedKey && single.mutate({ key: selectedKey, cmd }, { onSuccess: () => { setSelected(null); setSelectedKey(null); } })
-        }
-        onClose={() => { setSelected(null); setSelectedKey(null); }}
-      />
-    </div>
+        )}
+      </Match>
+    </Switch>
   );
 }

--- a/frontend/src/pages/Scheduled.tsx
+++ b/frontend/src/pages/Scheduled.tsx
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
-import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/solid-query';
+import { createSignal, onMount, For, Show, Switch, Match } from 'solid-js';
 import { Pagination } from '../components/Pagination';
 import { ArgsValue } from '../components/ArgsValue';
 import { SortableTh } from '../components/SortableTh';
@@ -48,117 +48,123 @@ const ACTIONS: ActionDef[] = [
 
 export default function Scheduled() {
   const [page, setPage] = usePageParam();
-  const [selected, setSelected] = useState<JobEntry | null>(null);
-  const [selectedKey, setSelectedKey] = useState<string | null>(null);
-  const { data: meta } = useMeta();
-  const readOnly = meta?.read_only ?? false;
+  const [selected, setSelected] = createSignal<JobEntry | null>(null);
+  const [selectedKey, setSelectedKey] = createSignal<string | null>(null);
+  const meta = useMeta();
+  const readOnly = () => meta.data?.read_only ?? false;
   const sel = useSelection();
   const { single, bulk, all } = useJobSetActions('scheduled');
-  const pending = single.isPending || bulk.isPending || all.isPending;
+  const pending = () => single.isPending || bulk.isPending || all.isPending;
 
-  useEffect(() => {
+  onMount(() => {
     document.title = `${t('nav.scheduled')} — Wurk`;
-  }, []);
-
-  const { data, isLoading, isError } = useQuery<ScheduledResponse>({
-    queryKey: ['scheduled', page],
-    queryFn: () =>
-      fetch(`/wurk/api/scheduled?page=${page - 1}&count=${PAGE_SIZE}`).then(
-        (r) => r.json() as Promise<ScheduledResponse>
-      ),
   });
 
-  const { sorted, sort, toggle } = useSort(data?.entries ?? [], SORT);
-  const pageKeys = sorted.map(entryKey);
+  const query = useQuery<ScheduledResponse>(() => ({
+    queryKey: ['scheduled', page()],
+    queryFn: () =>
+      fetch(`/wurk/api/scheduled?page=${page() - 1}&count=${PAGE_SIZE}`).then(
+        (r) => r.json() as Promise<ScheduledResponse>
+      ),
+  }));
 
-  if (isLoading)
-    return (
-      <div>
-        <PageHeader icon="fa-clock" title={t('nav.scheduled')} summary={t('summaries.scheduled')} />
-        <SkeletonTable rows={8} cols={5} />
-      </div>
-    );
-  if (isError || !data) return <div className="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>;
-
-  const allChecked = pageKeys.length > 0 && pageKeys.every((k) => sel.selected.has(k));
+  const { sorted, sort, toggle } = useSort(() => query.data?.entries ?? [], SORT);
+  const pageKeys = () => sorted().map(entryKey);
+  const allChecked = () => pageKeys().length > 0 && pageKeys().every((k) => sel.selected().has(k));
 
   return (
-    <div>
-      <PageHeader icon="fa-clock" title={t('nav.scheduled')} summary={t('summaries.scheduled')}>
-        <span className="badge badge-accent">{data.total.toLocaleString()}</span>
-      </PageHeader>
+    <Switch>
+      <Match when={query.isPending}>
+        <div>
+          <PageHeader icon="fa-clock" title={t('nav.scheduled')} summary={t('summaries.scheduled')} />
+          <SkeletonTable rows={8} cols={5} />
+        </div>
+      </Match>
+      <Match when={query.isError || !query.data}>
+        <div class="empty-state" style={{ color: 'var(--danger)' }}>{t('common.error')}</div>
+      </Match>
+      <Match when={query.data}>
+        {(data) => (
+          <div>
+            <PageHeader icon="fa-clock" title={t('nav.scheduled')} summary={t('summaries.scheduled')}>
+              <span class="badge badge-accent">{data().total.toLocaleString()}</span>
+            </PageHeader>
 
-      {sorted.length === 0 ? (
-        <div className="empty-state">{t('common.empty')}</div>
-      ) : (
-        <>
-          {!readOnly && (
-            <JobSetActionBar
-              bulk={ACTIONS}
-              all={ACTIONS}
-              selectedCount={sel.count}
-              total={data.total}
-              pending={pending}
-              onBulk={(cmd) => bulk.mutate({ keys: [...sel.selected], cmd }, { onSuccess: sel.clear })}
-              onAll={(cmd) => all.mutate(cmd, { onSuccess: sel.clear })}
+            <Show when={sorted().length > 0} fallback={<div class="empty-state">{t('common.empty')}</div>}>
+              <>
+                <Show when={!readOnly()}>
+                  <JobSetActionBar
+                    bulk={ACTIONS}
+                    all={ACTIONS}
+                    selectedCount={sel.count()}
+                    total={data().total}
+                    pending={pending()}
+                    onBulk={(cmd) => bulk.mutate({ keys: [...sel.selected()], cmd }, { onSuccess: sel.clear })}
+                    onAll={(cmd) => all.mutate(cmd, { onSuccess: sel.clear })}
+                  />
+                </Show>
+                <div class="table-wrapper">
+                  <table>
+                    <thead>
+                      <tr>
+                        <Show when={!readOnly()}>
+                          <th class="row-action">
+                            <input type="checkbox" checked={allChecked()} onChange={() => sel.toggleAll(pageKeys())} aria-label="Select all" />
+                          </th>
+                        </Show>
+                        <SortableTh label={t('table.jid')} sortKey="jid" sort={sort()} onSort={toggle} />
+                        <SortableTh label={t('table.class')} sortKey="klass" sort={sort()} onSort={toggle} />
+                        <SortableTh label={t('table.args')} sortKey="args" sort={sort()} onSort={toggle} />
+                        <SortableTh label={t('table.scheduled_at')} sortKey="at" sort={sort()} onSort={toggle} />
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <For each={sorted()}>
+                        {(entry) => {
+                          const argsStr = formatArgs(entry.args);
+                          const key = entryKey(entry);
+                          return (
+                            <tr class="row-clickable" onClick={() => { setSelected(entry); setSelectedKey(key); }}>
+                              <Show when={!readOnly()}>
+                                <td class="row-action" onClick={(e) => e.stopPropagation()}>
+                                  <input type="checkbox" checked={sel.selected().has(key)} onChange={() => sel.toggle(key)} aria-label="Select job" />
+                                </td>
+                              </Show>
+                              <td
+                                title={entry.jid}
+                                style={{ 'font-family': 'monospace', 'font-size': '12px', color: 'var(--text-muted)' }}
+                              >
+                                {truncate(entry.jid, 12)}
+                              </td>
+                              <td style={{ 'font-weight': 500 }}>{entry.klass}</td>
+                              <td><ArgsValue str={argsStr} max={60} /></td>
+                              <td title={isoTime(entry.at)}>
+                                {relativeTime(entry.at)}
+                              </td>
+                            </tr>
+                          );
+                        }}
+                      </For>
+                    </tbody>
+                  </table>
+                </div>
+                <Pagination page={page()} total={data().total} count={PAGE_SIZE} onChange={setPage} />
+              </>
+            </Show>
+            <JobDetailModal
+              entry={selected()}
+              atLabel={t('table.scheduled_at')}
+              actions={readOnly() ? undefined : ACTIONS}
+              pending={single.isPending}
+              onAction={(cmd) => {
+                const k = selectedKey();
+                if (k) single.mutate({ key: k, cmd }, { onSuccess: () => { setSelected(null); setSelectedKey(null); } });
+              }}
+              onClose={() => { setSelected(null); setSelectedKey(null); }}
             />
-          )}
-          <div className="table-wrapper">
-            <table>
-              <thead>
-                <tr>
-                  {!readOnly && (
-                    <th className="row-action">
-                      <input type="checkbox" checked={allChecked} onChange={() => sel.toggleAll(pageKeys)} aria-label="Select all" />
-                    </th>
-                  )}
-                  <SortableTh label={t('table.jid')} sortKey="jid" sort={sort} onSort={toggle} />
-                  <SortableTh label={t('table.class')} sortKey="klass" sort={sort} onSort={toggle} />
-                  <SortableTh label={t('table.args')} sortKey="args" sort={sort} onSort={toggle} />
-                  <SortableTh label={t('table.scheduled_at')} sortKey="at" sort={sort} onSort={toggle} />
-                </tr>
-              </thead>
-              <tbody>
-                {sorted.map((entry) => {
-                  const argsStr = formatArgs(entry.args);
-                  const key = entryKey(entry);
-                  return (
-                    <tr key={entry.jid} className="row-clickable" onClick={() => { setSelected(entry); setSelectedKey(key); }}>
-                      {!readOnly && (
-                        <td className="row-action" onClick={(e) => e.stopPropagation()}>
-                          <input type="checkbox" checked={sel.selected.has(key)} onChange={() => sel.toggle(key)} aria-label="Select job" />
-                        </td>
-                      )}
-                      <td
-                        title={entry.jid}
-                        style={{ fontFamily: 'monospace', fontSize: 12, color: 'var(--text-muted)' }}
-                      >
-                        {truncate(entry.jid, 12)}
-                      </td>
-                      <td style={{ fontWeight: 500 }}>{entry.klass}</td>
-                      <td><ArgsValue str={argsStr} max={60} /></td>
-                      <td title={isoTime(entry.at)}>
-                        {relativeTime(entry.at)}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
           </div>
-          <Pagination page={page} total={data.total} count={PAGE_SIZE} onChange={setPage} />
-        </>
-      )}
-      <JobDetailModal
-        entry={selected}
-        atLabel={t('table.scheduled_at')}
-        actions={readOnly ? undefined : ACTIONS}
-        pending={single.isPending}
-        onAction={(cmd) =>
-          selectedKey && single.mutate({ key: selectedKey, cmd }, { onSuccess: () => { setSelected(null); setSelectedKey(null); } })
-        }
-        onClose={() => { setSelected(null); setSelectedKey(null); }}
-      />
-    </div>
+        )}
+      </Match>
+    </Switch>
   );
 }

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -1,5 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
-import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/solid-query';
+import { onMount, createSignal, For, Show } from 'solid-js';
+import { useSearchParams } from '@solidjs/router';
 import { t } from '../i18n';
 import { PageHeader } from '../components/PageHeader';
 import { relativeTime, truncate, formatArgs } from '../utils';
@@ -62,43 +63,44 @@ function matches(term: string, jid: string, cls: string): boolean {
 }
 
 export default function Search() {
-  const [query, setQuery] = useState('');
-  const [submitted, setSubmitted] = useState('');
+  const [sp, setSp] = useSearchParams();
+  const [query, setQuery] = createSignal((sp.q as string) ?? '');
+  const submitted = () => (sp.q as string) ?? '';
 
-  useEffect(() => {
+  onMount(() => {
     document.title = `${t('nav.search')} — Wurk`;
-  }, []);
+  });
 
-  const { data: retries } = useQuery<RetriesResponse>({
+  const retries = useQuery<RetriesResponse>(() => ({
     queryKey: ['search-retries'],
     queryFn: () =>
       fetch('/wurk/api/retries?page=0&count=200').then(
         (r) => r.json() as Promise<RetriesResponse>
       ),
-    enabled: submitted.length >= 2,
-  });
+    enabled: submitted().length >= 2,
+  }));
 
-  const { data: scheduled } = useQuery<ScheduledResponse>({
+  const scheduled = useQuery<ScheduledResponse>(() => ({
     queryKey: ['search-scheduled'],
     queryFn: () =>
       fetch('/wurk/api/scheduled?page=0&count=200').then(
         (r) => r.json() as Promise<ScheduledResponse>
       ),
-    enabled: submitted.length >= 2,
-  });
+    enabled: submitted().length >= 2,
+  }));
 
-  const { data: dead } = useQuery<DeadResponse>({
+  const dead = useQuery<DeadResponse>(() => ({
     queryKey: ['search-dead'],
     queryFn: () =>
       fetch('/wurk/api/dead?page=0&count=200').then(
         (r) => r.json() as Promise<DeadResponse>
       ),
-    enabled: submitted.length >= 2,
-  });
+    enabled: submitted().length >= 2,
+  }));
 
   // Live sample of job classes for the empty-state suggestion chips — derived
   // from real data so it works for any app, not hardcoded to the demo.
-  const { data: sample } = useQuery<Array<{ entries?: Array<{ klass?: string }> }>>({
+  const sample = useQuery<Array<{ entries?: Array<{ klass?: string }> }>>(() => ({
     queryKey: ['search-suggest'],
     queryFn: () =>
       Promise.all(
@@ -107,88 +109,91 @@ export default function Search() {
         )
       ),
     staleTime: 30000,
-  });
-  const suggestions = Array.from(
-    new Set(
-      (sample ?? []).flatMap((s) => (s.entries ?? []).map((e) => e.klass)).filter(Boolean) as string[]
-    )
-  ).slice(0, 5);
+  }));
+  const suggestions = () =>
+    Array.from(
+      new Set(
+        (sample.data ?? []).flatMap((s) => (s.entries ?? []).map((e) => e.klass)).filter(Boolean) as string[]
+      )
+    ).slice(0, 5);
 
   const runSearch = (term: string) => {
     setQuery(term);
-    setSubmitted(term);
+    setSp({ q: term || undefined });
   };
 
-  const filteredRetries =
-    submitted.length >= 2
-      ? (retries?.entries ?? []).filter((e) => matches(submitted, e.jid, e.klass))
+  const filteredRetries = () =>
+    submitted().length >= 2
+      ? (retries.data?.entries ?? []).filter((e) => matches(submitted(), e.jid, e.klass))
       : [];
 
-  const filteredScheduled =
-    submitted.length >= 2
-      ? (scheduled?.entries ?? []).filter((e) => matches(submitted, e.jid, e.klass))
+  const filteredScheduled = () =>
+    submitted().length >= 2
+      ? (scheduled.data?.entries ?? []).filter((e) => matches(submitted(), e.jid, e.klass))
       : [];
 
-  const filteredDead =
-    submitted.length >= 2
-      ? (dead?.entries ?? []).filter((e) => matches(submitted, e.jid, e.klass))
+  const filteredDead = () =>
+    submitted().length >= 2
+      ? (dead.data?.entries ?? []).filter((e) => matches(submitted(), e.jid, e.klass))
       : [];
 
-  const handleSearch = (e: React.FormEvent) => {
+  const handleSearch = (e: Event) => {
     e.preventDefault();
-    setSubmitted(query);
+    setSp({ q: query() || undefined });
   };
 
-  const totalResults = filteredRetries.length + filteredScheduled.length + filteredDead.length;
+  const totalResults = () => filteredRetries().length + filteredScheduled().length + filteredDead().length;
 
   return (
     <div>
       <PageHeader icon="fa-magnifying-glass" title={t('nav.search')} summary={t('summaries.search')} />
 
-      <form onSubmit={handleSearch} style={{ display: 'flex', gap: '0.75rem', marginBottom: '2rem' }}>
+      <form onSubmit={handleSearch} style={{ display: 'flex', gap: '0.75rem', 'margin-bottom': '2rem' }}>
         <input
-          className="input"
+          class="input"
           type="text"
           placeholder="Search by JID or class name…"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          style={{ flex: 1, maxWidth: 480 }}
+          value={query()}
+          onInput={(e) => setQuery(e.currentTarget.value)}
+          style={{ flex: 1, 'max-width': '480px' }}
         />
-        <button type="submit" className="btn btn-accent">
+        <button type="submit" class="btn btn-accent">
           {t('actions.search')}
         </button>
       </form>
 
-      {submitted.length < 2 && (
-        <div className="search-empty">
-          <div className="search-empty__icon"><i className="fa-solid fa-magnifying-glass" /></div>
-          <p className="search-empty__title">{t('search.emptyTitle')}</p>
-          <p className="search-empty__hint">{t('search.emptyHint')}</p>
-          {suggestions.length > 0 && (
-            <div className="search-empty__chips">
-              <span className="search-empty__chips-label">{t('search.try')}</span>
-              {suggestions.map((s) => (
-                <button key={s} type="button" className="chip" onClick={() => runSearch(s)}>
-                  {s}
-                </button>
-              ))}
+      <Show when={submitted().length < 2}>
+        <div class="search-empty">
+          <div class="search-empty__icon"><i class="fa-solid fa-magnifying-glass" /></div>
+          <p class="search-empty__title">{t('search.emptyTitle')}</p>
+          <p class="search-empty__hint">{t('search.emptyHint')}</p>
+          <Show when={suggestions().length > 0}>
+            <div class="search-empty__chips">
+              <span class="search-empty__chips-label">{t('search.try')}</span>
+              <For each={suggestions()}>
+                {(s) => (
+                  <button type="button" class="chip" onClick={() => runSearch(s)}>
+                    {s}
+                  </button>
+                )}
+              </For>
             </div>
-          )}
+          </Show>
         </div>
-      )}
+      </Show>
 
-      {submitted.length >= 2 && (
-        <div style={{ marginBottom: '0.75rem', color: 'var(--text-muted)', fontSize: 13 }}>
-          {totalResults} result{totalResults !== 1 ? 's' : ''} for "{submitted}"
+      <Show when={submitted().length >= 2}>
+        <div style={{ 'margin-bottom': '0.75rem', color: 'var(--text-muted)', 'font-size': '13px' }}>
+          {totalResults()} result{totalResults() !== 1 ? 's' : ''} for "{submitted()}"
         </div>
-      )}
+      </Show>
 
-      {filteredRetries.length > 0 && (
-        <div style={{ marginBottom: '2rem' }}>
-          <h2 className="section-title" style={{ marginBottom: '0.75rem' }}>
-            Retries <span className="badge badge-warning">{filteredRetries.length}</span>
+      <Show when={filteredRetries().length > 0}>
+        <div style={{ 'margin-bottom': '2rem' }}>
+          <h2 class="section-title" style={{ 'margin-bottom': '0.75rem' }}>
+            Retries <span class="badge badge-warning">{filteredRetries().length}</span>
           </h2>
-          <div className="table-wrapper">
+          <div class="table-wrapper">
             <table>
               <thead>
                 <tr>
@@ -201,35 +206,37 @@ export default function Search() {
                 </tr>
               </thead>
               <tbody>
-                {filteredRetries.map((entry) => {
-                  const argsStr = formatArgs(entry.args);
-                  return (
-                    <tr key={entry.jid}>
-                      <td title={entry.jid} style={{ fontFamily: 'monospace', fontSize: 12, color: 'var(--text-muted)' }}>
-                        {truncate(entry.jid, 12)}
-                      </td>
-                      <td style={{ fontWeight: 500 }}>{entry.klass}</td>
-                      <td title={argsStr}>{truncate(argsStr, 40)}</td>
-                      <td title={entry.error_class ?? ''} style={{ color: 'var(--danger)' }}>
-                        {truncate(entry.error_class, 25)}
-                      </td>
-                      <td>{entry.retry_count}</td>
-                      <td>{relativeTime(entry.retry_at)}</td>
-                    </tr>
-                  );
-                })}
+                <For each={filteredRetries()}>
+                  {(entry) => {
+                    const argsStr = formatArgs(entry.args);
+                    return (
+                      <tr>
+                        <td title={entry.jid} style={{ 'font-family': 'monospace', 'font-size': '12px', color: 'var(--text-muted)' }}>
+                          {truncate(entry.jid, 12)}
+                        </td>
+                        <td style={{ 'font-weight': 500 }}>{entry.klass}</td>
+                        <td title={argsStr}>{truncate(argsStr, 40)}</td>
+                        <td title={entry.error_class ?? ''} style={{ color: 'var(--danger)' }}>
+                          {truncate(entry.error_class, 25)}
+                        </td>
+                        <td>{entry.retry_count}</td>
+                        <td>{relativeTime(entry.retry_at)}</td>
+                      </tr>
+                    );
+                  }}
+                </For>
               </tbody>
             </table>
           </div>
         </div>
-      )}
+      </Show>
 
-      {filteredScheduled.length > 0 && (
-        <div style={{ marginBottom: '2rem' }}>
-          <h2 className="section-title" style={{ marginBottom: '0.75rem' }}>
-            Scheduled <span className="badge badge-accent">{filteredScheduled.length}</span>
+      <Show when={filteredScheduled().length > 0}>
+        <div style={{ 'margin-bottom': '2rem' }}>
+          <h2 class="section-title" style={{ 'margin-bottom': '0.75rem' }}>
+            Scheduled <span class="badge badge-accent">{filteredScheduled().length}</span>
           </h2>
-          <div className="table-wrapper">
+          <div class="table-wrapper">
             <table>
               <thead>
                 <tr>
@@ -240,31 +247,33 @@ export default function Search() {
                 </tr>
               </thead>
               <tbody>
-                {filteredScheduled.map((entry) => {
-                  const argsStr = formatArgs(entry.args);
-                  return (
-                    <tr key={entry.jid}>
-                      <td title={entry.jid} style={{ fontFamily: 'monospace', fontSize: 12, color: 'var(--text-muted)' }}>
-                        {truncate(entry.jid, 12)}
-                      </td>
-                      <td style={{ fontWeight: 500 }}>{entry.klass}</td>
-                      <td title={argsStr}>{truncate(argsStr, 60)}</td>
-                      <td>{relativeTime(entry.at)}</td>
-                    </tr>
-                  );
-                })}
+                <For each={filteredScheduled()}>
+                  {(entry) => {
+                    const argsStr = formatArgs(entry.args);
+                    return (
+                      <tr>
+                        <td title={entry.jid} style={{ 'font-family': 'monospace', 'font-size': '12px', color: 'var(--text-muted)' }}>
+                          {truncate(entry.jid, 12)}
+                        </td>
+                        <td style={{ 'font-weight': 500 }}>{entry.klass}</td>
+                        <td title={argsStr}>{truncate(argsStr, 60)}</td>
+                        <td>{relativeTime(entry.at)}</td>
+                      </tr>
+                    );
+                  }}
+                </For>
               </tbody>
             </table>
           </div>
         </div>
-      )}
+      </Show>
 
-      {filteredDead.length > 0 && (
-        <div style={{ marginBottom: '2rem' }}>
-          <h2 className="section-title" style={{ marginBottom: '0.75rem' }}>
-            Dead <span className="badge badge-danger">{filteredDead.length}</span>
+      <Show when={filteredDead().length > 0}>
+        <div style={{ 'margin-bottom': '2rem' }}>
+          <h2 class="section-title" style={{ 'margin-bottom': '0.75rem' }}>
+            Dead <span class="badge badge-danger">{filteredDead().length}</span>
           </h2>
-          <div className="table-wrapper">
+          <div class="table-wrapper">
             <table>
               <thead>
                 <tr>
@@ -276,31 +285,33 @@ export default function Search() {
                 </tr>
               </thead>
               <tbody>
-                {filteredDead.map((entry) => {
-                  const argsStr = formatArgs(entry.args);
-                  return (
-                    <tr key={entry.jid}>
-                      <td title={entry.jid} style={{ fontFamily: 'monospace', fontSize: 12, color: 'var(--text-muted)' }}>
-                        {truncate(entry.jid, 12)}
-                      </td>
-                      <td style={{ fontWeight: 500 }}>{entry.klass}</td>
-                      <td title={argsStr}>{truncate(argsStr, 40)}</td>
-                      <td title={entry.error_class ?? ''} style={{ color: 'var(--danger)' }}>
-                        {truncate(entry.error_class, 25)}
-                      </td>
-                      <td>{relativeTime(entry.failed_at)}</td>
-                    </tr>
-                  );
-                })}
+                <For each={filteredDead()}>
+                  {(entry) => {
+                    const argsStr = formatArgs(entry.args);
+                    return (
+                      <tr>
+                        <td title={entry.jid} style={{ 'font-family': 'monospace', 'font-size': '12px', color: 'var(--text-muted)' }}>
+                          {truncate(entry.jid, 12)}
+                        </td>
+                        <td style={{ 'font-weight': 500 }}>{entry.klass}</td>
+                        <td title={argsStr}>{truncate(argsStr, 40)}</td>
+                        <td title={entry.error_class ?? ''} style={{ color: 'var(--danger)' }}>
+                          {truncate(entry.error_class, 25)}
+                        </td>
+                        <td>{relativeTime(entry.failed_at)}</td>
+                      </tr>
+                    );
+                  }}
+                </For>
               </tbody>
             </table>
           </div>
         </div>
-      )}
+      </Show>
 
-      {submitted.length >= 2 && totalResults === 0 && (
-        <div className="empty-state">{t('common.empty')}</div>
-      )}
+      <Show when={submitted().length >= 2 && totalResults() === 0}>
+        <div class="empty-state">{t('common.empty')}</div>
+      </Show>
     </div>
   );
 }

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,0 +1,9 @@
+// Vitest global setup (see vitest.config.ts `setupFiles`).
+//
+// - jest-dom matchers (toBeInTheDocument, toHaveTextContent, …) for the
+//   component + integration suites.
+// - @solidjs/testing-library auto-cleanup: each test's rendered tree is
+//   disposed and removed from the document after it finishes, so parallel
+//   isolated files never inherit a dirty DOM or leaked reactive root.
+import '@testing-library/jest-dom/vitest';
+import '@solidjs/testing-library';

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -4,7 +4,8 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "jsx": "react-jsx",
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
@@ -15,6 +16,7 @@
     "isolatedModules": true,
     "useDefineForClassFields": true,
     "allowSyntheticDefaultImports": true,
+    "types": ["vite/client", "@testing-library/jest-dom"],
     "noEmit": true
   },
   "include": ["src"]

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
+import solid from "vite-plugin-solid";
 import tailwindcss from "@tailwindcss/vite";
 import { readFileSync, writeFileSync } from "fs";
 import { resolve } from "path";
@@ -8,7 +8,7 @@ import { resolve } from "path";
 // See docs/idea/09-precompiled-assets.md.
 export default defineConfig({
   plugins: [
-    react(),
+    solid(),
     tailwindcss(),
     {
       name: "wurk-manifest-generator",

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,14 +1,28 @@
 /// <reference types="vitest/config" />
 import { defineConfig } from 'vitest/config';
-import react from '@vitejs/plugin-react';
+import solid from 'vite-plugin-solid';
 
 // Dedicated test config — kept out of vite.config.ts so the build's
 // manifest-generator plugin (apply: "build") never runs under the test runner.
+//
+// SolidJS compiles JSX at build time via vite-plugin-solid; the same plugin
+// runs here so component tests exercise the real compiled reactive output.
+// `conditions: ['development', 'browser']` pins Solid's dev build (dev warnings
+// + client render) the way @solidjs/testing-library expects.
 export default defineConfig({
-  plugins: [react()],
+  plugins: [solid()],
+  resolve: {
+    conditions: ['development', 'browser'],
+  },
   test: {
     environment: 'jsdom',
     globals: true,
+    setupFiles: ['./src/test-setup.ts'],
     include: ['src/**/*.test.{ts,tsx}'],
+    // Fast + parallel: files run concurrently across a worker-thread pool and
+    // each file is isolated (fresh module registry + DOM) so component/route
+    // tests never leak signals or the document between suites.
+    pool: 'threads',
+    isolate: true,
   },
 });

--- a/lib/wurk/version.rb
+++ b/lib/wurk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wurk
-  VERSION = "1.0.7"
+  VERSION = "1.1.0"
 end

--- a/lib/wurk/web/extension.rb
+++ b/lib/wurk/web/extension.rb
@@ -11,7 +11,7 @@ module Wurk
     # Sidekiq extensions register Sinatra-style routes + ERB views via
     # `Sidekiq::Web.register(Ext, name:, tab:, index:, root_dir:, asset_paths:)`,
     # where `Ext.registered(app)` calls `app.get "/path" do … end` and
-    # `app.helpers SomeModule`. wurk's dashboard is a React SPA with no Sinatra
+    # `app.helpers SomeModule`. wurk's dashboard is a SolidJS SPA with no Sinatra
     # render path, so this module provides a minimal, Sidekiq-Web-compatible
     # renderer: it captures the routes, runs the matched block in an `Action`
     # context (a `WebHelpers` subset + the ext's own helpers + `erb`), and

--- a/test/dummy/FEATURE_CHECKLIST.md
+++ b/test/dummy/FEATURE_CHECKLIST.md
@@ -20,7 +20,7 @@ cd test/dummy && WURK_DEMO=1 WURK_DISABLED=1 bin/rails runner \
 A third terminal for a console is handy: `cd test/dummy && bin/rails console`
 
 - [x] Both processes boot with no errors
-- [x] http://localhost:3000/wurk loads the React dashboard
+- [x] http://localhost:3000/wurk loads the SolidJS dashboard
 
 ---
 

--- a/test/engine/web_authorization_test.rb
+++ b/test/engine/web_authorization_test.rb
@@ -96,6 +96,15 @@ class WebAuthorizationTest < Wurk::Test::EngineCase
     assert_nil body['read_only_message']
   end
 
+  # The SPA shows the running gem version next to the nav wordmark; meta carries
+  # it so the dashboard never has to guess from the asset manifest.
+  def test_meta_reports_the_gem_version
+    get '/wurk/api/meta'
+
+    assert_equal 200, last_response.status
+    assert_equal Wurk::VERSION, JSON.parse(last_response.body)['version']
+  end
+
   def test_meta_reports_read_only_when_enabled
     Wurk::Web.configure { |c| c.read_only = true }
 

--- a/wurk.gemspec
+++ b/wurk.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email       = ["admin@developerz.ai"]
 
   spec.summary     = "100% drop-in replacement for Sidekiq + Sidekiq Pro + Sidekiq Enterprise. Free. Faster."
-  spec.description = "Wire-compatible Ruby background job processor: same Redis schema, same job JSON, same Ruby DSL. Pro + Enterprise feature parity in the same gem, no license check. Fork-based real parallelism. Mountable Rails engine with a precompiled React dashboard."
+  spec.description = "Wire-compatible Ruby background job processor: same Redis schema, same job JSON, same Ruby DSL. Pro + Enterprise feature parity in the same gem, no license check. Fork-based real parallelism. Mountable Rails engine with a precompiled SolidJS dashboard."
   spec.homepage    = "https://github.com/developerz-ai/wurk"
   spec.license     = "MIT"
 


### PR DESCRIPTION
## Summary

Full rewrite of the dashboard frontend **from React 19 to SolidJS 1.9** — one of the three CLAUDE.md pillars is *Faster*, and Solid's fine-grained reactivity compiles JSX straight to DOM updates (no virtual DOM / re-render), so the shipped bundle is dramatically smaller.

- **React → SolidJS 1.9**, `react-router-dom` → `@solidjs/router`, `@tanstack/react-query` → `@tanstack/solid-query`.
- **Recharts removed** — replaced by a dependency-free internal SVG chart module (`components/charts/`: responsive area/line/bar with gradient fills, monospace axes, hover crosshair + tooltip). No charting dependency ships at all.
- **Bundle:** initial entry chunk **~305 kB → ~35 kB (12.6 kB gzip)**; every page stays a lazy code-split chunk behind the route-level `<Suspense>` skeleton; charts split into their own ~13 kB chunk loaded only on Dashboard/Metrics.

## Drop-in / wire-compat

Internal rewrite only. Identical routes, SSE live updates, TanStack Query caching, i18n + RTL, dark-only Obsidian design system, read-only mode, extension tabs, and skeleton loaders. **Redis key schema, job JSON, and the SSE/JSON wire contracts are untouched.** The precompiled bundle still ships in the gem (`vendor/assets/dashboard/`); contributors need bun, consumers run neither Node nor bun. The dev-shell entry (`src/main.tsx`) and asset path are unchanged, so the Rails engine/controller need no changes.

## Tests

Vitest suite rebuilt on `@solidjs/testing-library` — **50 tests / 8 files**, fast + parallel over a worker-thread pool:
- **Unit:** utils, i18n (`t`/interpolation/`directionFor`/host-override merge), all hooks (`useSort`/`useSelection`/`useCountUp`/`usePageParam`), chart rendering.
- **Integration:** routing/nav (active-state swap), read-only banner, Retries bulk-action POST + cache invalidation flow, and the ported Busy/Extension/Metrics regressions.

## Docs

`docs/dashboard.md`-adjacent docs, the GitHub Pages marketing site, `CLAUDE.md`, README, Ruby "React SPA" comments, Rakefile/CI notes all updated to SolidJS. Ships as **v1.1.0** (CHANGELOG updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)