### PR TITLE
chore(dev,ci): one-command dashboard dev loop + GHCR demo-image pruning

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -92,3 +92,20 @@ jobs:
             ${{ env.IMAGE }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Prune old wurk-demo images so GHCR storage doesn't grow unbounded — each
+      # deploy pushes a fresh digest (tagged :sha + :latest) and every prior
+      # build keeps its :sha tag forever otherwise. Keep the newest few (current
+      # + a rollback window; the Image Updater serves the demo by digest, and the
+      # newest version is the one :latest points at, so it is always retained).
+      # Non-blocking: a cleanup hiccup (e.g. GITHUB_TOKEN lacking package-delete
+      # on the org package — then provision a PAT) must never fail a deploy.
+      - name: prune old GHCR images
+        continue-on-error: true
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5
+        with:
+          owner: developerz-ai
+          package-name: wurk-demo
+          package-type: container
+          min-versions-to-keep: 5
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -109,3 +109,18 @@ jobs:
           package-type: container
           min-versions-to-keep: 5
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Guard against a "successful but destructive" prune. min-versions-to-keep
+      # is version-based, not digest-aware, so it can orphan a child manifest
+      # still referenced by a tag we meant to keep — a failure continue-on-error
+      # above would silently hide. imagetools inspect resolves the full manifest
+      # (and children) from GHCR without pulling layers, so this fails the run
+      # loudly if the deploy-critical :latest or the just-pushed :sha stopped
+      # resolving. Not continue-on-error: a broken :latest breaks the Image
+      # Updater deploy, so it must surface.
+      - name: verify retained images still resolve
+        run: |
+          for ref in "${IMAGE}:latest" "${IMAGE}:${{ github.sha }}"; do
+            echo "==> inspecting $ref"
+            docker buildx imagetools inspect "$ref" >/dev/null
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,13 @@ test/dummy/db/*.sqlite3
 test/dummy/db/*.sqlite3-journal
 test/dummy/.bundle/
 test/dummy/Gemfile.lock
+# `bin/dev` installs the dummy app's gems into a project-local path so a
+# read-only/permission-locked global gem home never blocks local dev.
+test/dummy/vendor/bundle/
+
+# Playwright MCP scratch output (snapshots / screenshots / console logs from
+# local browser-driven checks). Never part of the repo.
+.playwright-mcp/
 
 # Frontend sources are gitignored from the gem file list (see gemspec),
 # but the source itself IS committed to the repo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Wurk are recorded here. Format: [Keep a Changelog](https:
 
 ## [Unreleased]
 
+### Changed
+- **Dev — one-command local dashboard loop** — `bin/dev` boots Redis (reused or a throwaway Docker container), the Vite dev server (SolidJS HMR), and the `test/dummy` Rails host wired with `WURK_VITE_DEV=1`, so editing `frontend/src` hot-reloads the dashboard at `/wurk` with no rebuild. `bin/setup` now uses **bun** (not the removed `npm ci`) and installs the dummy app's gems into a project-local path so a permission-locked global gem home no longer fails setup with `Bundler::PermissionError`. Contributor docs updated. (#286)
+- **CI — prune old demo images from GHCR** — `deploy-demo` now deletes stale `wurk-demo` container versions after each push (keeps the newest 5 for rollback; non-blocking), so the registry doesn't grow unbounded across demo deploys. `.playwright-mcp/` and the dummy's local bundle path are gitignored. (#286)
+
 ## [1.1.0] - 2026-07-01
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,36 @@ layers, and the conventions a change has to follow to merge.
 ```sh
 git clone https://github.com/developerz-ai/wurk
 cd wurk
-bundle install
+bin/setup          # gem + frontend (bun) deps + dummy app db:prepare
 ```
 
 You'll need a local **Redis ≥ 7.0** running (tests use real Redis, never a mock).
-Node is only needed if you touch the dashboard frontend (`frontend/`); the
-precompiled bundle is committed under `vendor/assets/`.
+[**bun**](https://bun.sh) is only needed if you touch the dashboard frontend
+(`frontend/`, a SolidJS SPA); the precompiled bundle is committed under
+`vendor/assets/`, so consumers run neither Node nor bun.
+
+`bin/setup` installs the dummy app's gems into a **project-local** path
+(`test/dummy/vendor/bundle`) so a read-only or permission-locked global gem home
+never blocks setup with `Bundler::PermissionError`.
+
+## Dashboard development (live reload)
+
+```sh
+bin/dev            # Redis + Vite (SolidJS HMR) + the dummy Rails host
+```
+
+Open <http://localhost:3000/wurk>. `bin/dev` reuses a Redis already on `:6379`
+or starts a throwaway Docker one, runs the Vite dev server, and boots
+`test/dummy` with `WURK_VITE_DEV=1` so the dashboard shell pulls modules and the
+HMR client straight from Vite. Edit anything under `frontend/src` and the browser
+updates instantly — no rebuild, no gem repackage.
+
+- `NO_VITE=1 bin/dev` serves the prebuilt bundle instead (run
+  `bin/rake frontend:build` first) — useful to sanity-check the shipped artifact.
+- `PORT` / `VITE_PORT` override the defaults (3000 / 5173).
+
+Frontend unit + integration tests (Vitest, SolidJS Testing Library) run with
+`bun run test` in `frontend/`.
 
 ## Running the tests
 

--- a/bin/dev
+++ b/bin/dev
@@ -14,7 +14,7 @@
 #
 # Env knobs:
 #   PORT        Rails port           (default 3000)
-#   VITE_PORT   Vite dev port        (default 5173, must match vite.config.ts)
+#   VITE_PORT   Vite dev port        (default 5173; wired into vite.config.ts)
 #   NO_VITE=1   skip Vite/HMR and serve the prebuilt bundle instead
 #               (run `bin/rake frontend:build` first)
 set -euo pipefail
@@ -22,7 +22,9 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 ROOT="$PWD"
 PORT="${PORT:-3000}"
-VITE_PORT="${VITE_PORT:-5173}"
+# Exported so the Vite subprocess (vite.config.ts) reads the same port bin/dev
+# logs — otherwise the log line and the real server could disagree.
+export VITE_PORT="${VITE_PORT:-5173}"
 
 pids=()
 redis_cid=""
@@ -41,7 +43,12 @@ if redis_up; then
 elif command -v docker >/dev/null 2>&1; then
   redis_cid="$(docker run -d --rm -p 6379:6379 redis:7-alpine)"
   echo "    started Docker Redis ($redis_cid)"
-  for _ in $(seq 1 30); do redis_up && break; sleep 0.5; done
+  ready=0
+  for _ in $(seq 1 30); do redis_up && { ready=1; break; }; sleep 0.5; done
+  if [ "$ready" != "1" ]; then
+    echo "    ERROR: Redis container didn't become ready in time." >&2
+    exit 1
+  fi
 else
   echo "    ERROR: no Redis on :6379 and Docker is unavailable." >&2
   echo "    Start a Redis (e.g. \`docker run -p 6379:6379 redis:7\`) and retry." >&2
@@ -74,4 +81,7 @@ echo "==> Rails on http://localhost:$PORT/wurk  (Ctrl-C to stop everything)"
 echo
 cd test/dummy
 if [ "$vite_dev" = "1" ]; then export WURK_VITE_DEV=1; fi
-exec bin/rails server -p "$PORT"
+# Not `exec`: the shell must stay alive so the EXIT trap runs cleanup() on
+# Ctrl-C — exec would replace this process and leak the Vite job + Redis
+# container.
+bin/rails server -p "$PORT"

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Run the Wurk dashboard locally with hot-reload.
+#
+# One command boots the whole dev loop:
+#   • Redis          — reuses one already on :6379, else starts a throwaway
+#                      Docker container (removed on exit).
+#   • Vite dev server — SolidJS HMR for the dashboard SPA (frontend/, bun).
+#   • test/dummy      — the Rails host app that mounts the engine at /wurk,
+#                      run with WURK_VITE_DEV=1 so its shell pulls modules +
+#                      the HMR client straight from Vite.
+#
+# Edit anything under frontend/src and the browser updates instantly — no
+# rebuild, no gem repackage. Open http://localhost:3000/wurk.
+#
+# Env knobs:
+#   PORT        Rails port           (default 3000)
+#   VITE_PORT   Vite dev port        (default 5173, must match vite.config.ts)
+#   NO_VITE=1   skip Vite/HMR and serve the prebuilt bundle instead
+#               (run `bin/rake frontend:build` first)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+ROOT="$PWD"
+PORT="${PORT:-3000}"
+VITE_PORT="${VITE_PORT:-5173}"
+
+pids=()
+redis_cid=""
+cleanup() {
+  trap - INT TERM EXIT
+  for pid in "${pids[@]}"; do kill "$pid" 2>/dev/null || true; done
+  [ -n "$redis_cid" ] && docker rm -f "$redis_cid" >/dev/null 2>&1 || true
+}
+trap cleanup INT TERM EXIT
+
+redis_up() { (exec 3<>/dev/tcp/127.0.0.1/6379) 2>/dev/null; }
+
+echo "==> Redis"
+if redis_up; then
+  echo "    reusing Redis already on :6379"
+elif command -v docker >/dev/null 2>&1; then
+  redis_cid="$(docker run -d --rm -p 6379:6379 redis:7-alpine)"
+  echo "    started Docker Redis ($redis_cid)"
+  for _ in $(seq 1 30); do redis_up && break; sleep 0.5; done
+else
+  echo "    ERROR: no Redis on :6379 and Docker is unavailable." >&2
+  echo "    Start a Redis (e.g. \`docker run -p 6379:6379 redis:7\`) and retry." >&2
+  exit 1
+fi
+
+echo "==> frontend deps (bun)"
+(cd frontend && bun install >/dev/null)
+
+echo "==> dummy app (gems → project-local path, then db:prepare)"
+(
+  cd test/dummy
+  bundle config set --local path vendor/bundle
+  bundle check >/dev/null 2>&1 || bundle install
+  bin/rails db:prepare >/dev/null
+)
+
+vite_dev=0
+if [ "${NO_VITE:-0}" != "1" ]; then
+  echo "==> Vite dev server (SolidJS HMR) on :$VITE_PORT"
+  (cd frontend && bun run dev) &
+  pids+=("$!")
+  vite_dev=1
+else
+  echo "==> NO_VITE=1 — serving the prebuilt bundle (run bin/rake frontend:build if stale)"
+fi
+
+echo
+echo "==> Rails on http://localhost:$PORT/wurk  (Ctrl-C to stop everything)"
+echo
+cd test/dummy
+if [ "$vite_dev" = "1" ]; then export WURK_VITE_DEV=1; fi
+exec bin/rails server -p "$PORT"

--- a/bin/setup
+++ b/bin/setup
@@ -3,19 +3,25 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-echo "==> bundle install"
+echo "==> bundle install (gem)"
 bundle check >/dev/null 2>&1 || bundle install
 
 if [ -d frontend ]; then
-  echo "==> frontend deps"
-  (cd frontend && npm ci)
+  echo "==> frontend deps (bun)"
+  (cd frontend && bun install)
 fi
 
 echo "==> dummy app setup"
 (
   cd test/dummy
+  # Install the dummy app's gems into a project-local path (test/dummy/.bundle
+  # points bundler at vendor/bundle). A read-only or permission-locked global
+  # gem home would otherwise fail the install with Bundler::PermissionError;
+  # a local path keeps `bin/setup` working on any machine. Both dirs are
+  # gitignored.
+  bundle config set --local path vendor/bundle
   bundle check >/dev/null 2>&1 || bundle install
   bin/rails db:prepare
 )
 
-echo "==> ready. try: bin/rake test"
+echo "==> ready. try: bin/rake test   (or bin/dev for the live dashboard)"

--- a/bin/setup
+++ b/bin/setup
@@ -7,8 +7,15 @@ echo "==> bundle install (gem)"
 bundle check >/dev/null 2>&1 || bundle install
 
 if [ -d frontend ]; then
-  echo "==> frontend deps (bun)"
-  (cd frontend && bun install)
+  # bun is only needed to touch the dashboard frontend (CONTRIBUTING.md); the
+  # precompiled bundle ships in vendor/assets/. Skip gracefully rather than
+  # hard-fail under `set -e` for contributors without bun.
+  if command -v bun >/dev/null 2>&1; then
+    echo "==> frontend deps (bun)"
+    (cd frontend && bun install)
+  else
+    echo "==> skipping frontend deps (bun not installed; only needed if you touch frontend/)"
+  fi
 fi
 
 echo "==> dummy app setup"

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,11 @@ import { resolve } from "path";
 
 // Built artifacts land in ../vendor/assets/dashboard at gem release time.
 // See docs/idea/09-precompiled-assets.md.
+//
+// Dev-server port comes from VITE_PORT (exported by bin/dev) so the logged port
+// and the real server never disagree; defaults to 5173.
+const devPort = Number(process.env.VITE_PORT) || 5173;
+
 export default defineConfig({
   plugins: [
     solid(),
@@ -42,15 +47,15 @@ export default defineConfig({
     emptyOutDir: true,
   },
   server: {
-    port: 5173,
+    port: devPort,
     strictPort: true,
     // HMR dev: the Rails dummy serves the page at :3000/wurk and fetches the
     // shell from this server (WURK_VITE_DEV=1). `origin` makes Vite emit
-    // absolute asset/HMR URLs (http://localhost:5173/wurk-assets/…) so the
+    // absolute asset/HMR URLs (http://localhost:<devPort>/wurk-assets/…) so the
     // browser loads modules + the HMR client straight from Vite instead of
     // hitting :3000/wurk-assets (which the engine only serves from the built
     // bundle). `cors` lets that cross-origin fetch through. See issue #181.
-    origin: "http://localhost:5173",
+    origin: `http://localhost:${devPort}`,
     cors: true,
   },
 });


### PR DESCRIPTION
Follow-ups to the SolidJS migration (#285).

## Dev experience — `bin/dev`
One command boots the full local dashboard loop:
- **Redis** — reuses one already on `:6379`, else a throwaway Docker container (removed on exit).
- **Vite dev server** — SolidJS **HMR** for `frontend/`.
- **`test/dummy`** — the Rails host that mounts the engine at `/wurk`, run with `WURK_VITE_DEV=1` so the shell pulls modules + the HMR client from Vite.

Edit `frontend/src` → the browser updates instantly (no rebuild, no gem repackage). `NO_VITE=1` serves the prebuilt bundle; `PORT`/`VITE_PORT` override defaults.

`bin/setup` now uses **bun** (the stale `npm ci` predated the bun migration) and installs the dummy app's gems into a **project-local path** — a permission-locked global gem home was failing setup with `Bundler::PermissionError`. Verified end-to-end locally: `bin/dev` boots and serves the v1.1.0 dashboard at `/wurk`.

## CI — prune old demo images from GHCR
`deploy-demo` deletes stale `wurk-demo` container versions after each push (keeps the newest **5** for rollback; `continue-on-error` so a cleanup hiccup never fails a deploy). Each deploy pushes a fresh digest and every prior build kept its `:sha` tag forever, so GHCR grew unbounded. Pin verified: `actions/delete-package-versions@e5bc658` == v5.

## Housekeeping
- `.gitignore`: `.playwright-mcp/` and the dummy's local bundle path.
- CONTRIBUTING documents the dev loop; CHANGELOG `[Unreleased]` notes both changes (no gem-behavior change → no new release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a one-command local development workflow for the dashboard with automatic Redis setup and optional live reload.
  * Frontend dependencies now install with Bun during setup.

* **Bug Fixes**
  * Local gem installs now use a project-specific bundle path, avoiding permission issues.
  * Old demo container image versions are automatically cleaned up after deployments.

* **Documentation**
  * Updated setup and contributor guides with the new development flow, testing requirements, and frontend build options.

* **Chores**
  * Improved ignore rules for locally generated files and folders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->