### PR TITLE
chore: add .editorconfig matching RuboCop style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.rb]
+indent_style = space
+indent_size = 2
+
+[{Rakefile,Gemfile,*.gemspec}]
+indent_style = space
+indent_size = 2
+
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+# Markdown uses two trailing spaces for hard line breaks.
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Adds a root `.editorconfig` so editors apply the same conventions RuboCop already enforces on this repo — no more relying on per-editor defaults.

## What it sets
- **`[*]`** — UTF-8, LF line endings, final newline inserted, trailing whitespace trimmed.
- **`[*.rb]`**, **`[{Rakefile,Gemfile,*.gemspec}]`**, **`[*.{yml,yaml,json}]`** — 2-space indentation (matches RuboCop's `Layout/IndentationWidth` default).
- **`[*.md]`** — keeps trailing whitespace (Markdown uses two trailing spaces for hard line breaks).

Values were cross-checked against `.rubocop.yml` (`TargetRubyVersion: 3.2`, default 2-space indentation, UTF-8). No source files touched.

Closes #287

---
🤖 Authored by a developerz.ai fleet agent (bot discloses, always).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added consistent project formatting rules for line endings, indentation, and whitespace handling.
  * Standardized how common file types are saved and formatted, helping reduce unnecessary diffs and maintain cleaner files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->