### PR TITLE
perf(ci): move bench suite to nightly schedule

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,35 +1,12 @@
 name: bench
 
-# Cost control: `rake bench` measures Ruby throughput only, so it can only be
-# affected by Ruby/bench inputs. Gate the whole workflow (incl. the expensive
-# 8vcpu best-of-3 `compare` job) on those paths so frontend-, docs-, test-, and
-# unrelated-CI-only PRs don't spin up bench runners for nothing. Keep this list
-# in sync with whatever `rake bench` loads. (bench/compare are not required
-# checks — a skipped run leaves no pending status to block merges.)
+# Cost control (#289): bench gates nothing (not a required check), so it runs
+# nightly against main plus on demand instead of on every PR. Regressions
+# surface within a day and `workflow_dispatch` covers pre-merge spot checks.
 on:
-  pull_request:
-    paths:
-      - 'lib/**'
-      - 'exe/**'
-      - 'bench/**'
-      - 'bin/bench-compare'
-      - 'Rakefile'
-      - 'Gemfile'
-      - 'Gemfile.lock'
-      - '*.gemspec'
-      - '.github/workflows/bench.yml'
-  push:
-    branches: [main]
-    paths:
-      - 'lib/**'
-      - 'exe/**'
-      - 'bench/**'
-      - 'bin/bench-compare'
-      - 'Rakefile'
-      - 'Gemfile'
-      - 'Gemfile.lock'
-      - '*.gemspec'
-      - '.github/workflows/bench.yml'
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -65,82 +42,3 @@ jobs:
         with:
           name: bench-results
           path: bench-results.txt
-
-  # PR-only: run the benches on base and head, comment the per-benchmark delta,
-  # and fail only on a noise-aware regression — a slowdown that clears both
-  # runs' reported ± variance plus BENCH_REGRESSION_PCT (default 5). ips on CI
-  # is noisy (~±7%), so a flat threshold false-positives; this gates on signal.
-  # Make it a required check in branch protection only once it proves stable.
-  compare:
-    if: github.event_name == 'pull_request'
-    runs-on: blacksmith-8vcpu-ubuntu-2404
-    timeout-minutes: 45
-    permissions:
-      contents: read
-      pull-requests: write
-    services:
-      redis:
-        image: redis:7.4
-        ports: ["6379:6379"]
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 5s
-    env:
-      REDIS_URL: redis://localhost:6379/0
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1
-        with:
-          ruby-version: "3.4"
-          bundler-cache: true
-      # Keep the comparator from this PR available after we check out the base.
-      - name: stage comparator
-        run: cp bin/bench-compare /tmp/bench-compare
-      # Best-of-N: run the suite BENCH_RUNS times per side and concatenate; the
-      # comparator keeps the fastest run per benchmark, which damps the
-      # cross-process noise that false-positives low-throughput benches (#250).
-      - name: bench head
-        env:
-          BENCH_RUNS: 3
-        run: |
-          : > /tmp/bench-head.txt
-          for i in $(seq 1 "$BENCH_RUNS"); do
-            echo "::group::bench head run $i"
-            bundle exec rake bench | tee -a /tmp/bench-head.txt
-            echo "::endgroup::"
-          done
-      - name: bench base
-        env:
-          BENCH_RUNS: 3
-        run: |
-          git checkout --quiet ${{ github.event.pull_request.base.sha }}
-          bundle install --quiet
-          : > /tmp/bench-base.txt
-          for i in $(seq 1 "$BENCH_RUNS"); do
-            echo "::group::bench base run $i"
-            bundle exec rake bench | tee -a /tmp/bench-base.txt
-            echo "::endgroup::"
-          done
-      - name: compare, comment, gate
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set +e
-          /tmp/bench-compare /tmp/bench-base.txt /tmp/bench-head.txt > /tmp/bench-comment.md
-          code=$?
-          set -e
-          cat /tmp/bench-comment.md
-          marker='<!-- bench-compare -->'
-          existing=$(gh api --paginate "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-            --jq ".[] | select(.body | startswith(\"$marker\")) | .id" | head -1)
-          if [ -n "$existing" ]; then
-            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$existing" \
-              -F body=@/tmp/bench-comment.md >/dev/null
-          else
-            gh api -X POST "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-              -F body=@/tmp/bench-comment.md >/dev/null
-          fi
-          exit $code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ Skip step 3 → leaked sockets in children. Skip step 5 → children corrupt eac
 - **Parity tests are oracles.** When Wurk diverges from a parity test, Wurk is wrong unless the divergence is explicitly documented as intentional.
 - **Never mock Redis** in integration or parity tests. Real Redis, unique namespace.
 - **Coverage gate.** SimpleCov **line** and **branch** coverage on `lib/` must both stay ≥90% (blocking; `minimum_coverage line: 90, branch: 90`). Branch was ratcheted from ~78% to ≥90% in #67 — keep new code at parity. The Cobertura report is still uploaded for per-file inspection. Coverage runs merge across the `minitest-parallel_fork` workers via `SimpleCov.at_fork`.
-- **CI** on GitHub Actions / Blacksmith runners. Benchmark bot comments deltas on every PR; >5% regression flags it.
+- **CI** on GitHub Actions / Blacksmith runners. Bench suite runs nightly against main (plus `workflow_dispatch` for pre-merge spot checks) and uploads results as artifacts; compare against `bin/bench-compare` locally when chasing a regression.
 - **CI standard.** Runners are Blacksmith (`blacksmith-4vcpu-ubuntu-2404`; 8vcpu for bench — larger SKUs are deliberate, don't downsize). Every workflow declares a `concurrency` group with cancel-in-progress, and every job sets `timeout-minutes`. Deploy/publish workflows (deploy-demo, pages, release) never auto-cancel: `cancel-in-progress: false`.
 
 ## Platforms


### PR DESCRIPTION
Closes #289

Context: https://github.com/developerz-ai/infrastructure/issues/681

## What

- `bench.yml` triggers change from `pull_request` + `push` (path-filtered) to `schedule` (nightly, `0 3 * * *` UTC) + `workflow_dispatch`. The suite ran ~6x per PR on `blacksmith-8vcpu` runners while gating nothing — neither job is a required status check (branch protection requires only the `test` matrix jobs, verified via the API), so no required check is renamed or removed.
- The PR-only `compare` job is removed rather than left as dead code: it diffs a PR's base vs head and posts a PR comment, so it cannot run without a `pull_request` event. `bin/bench-compare` remains in-tree for local/manual base-vs-head comparisons, and `workflow_dispatch` covers pre-merge spot checks.
- CLAUDE.md's Testing section updated to match (it previously said the benchmark bot comments deltas on every PR).

## Merge

**Human merge — Din.** Do not auto-merge.

---

Authored by a developerz.ai fleet agent (automated dev-worker; bot discloses, always).

🤖 Generated with [Claude Code](https://claude.com/claude-code)