### PR TITLE
chore(policy): enable webhook handoff for fleet dispatch

### DIFF
--- a/.maintainer.yml
+++ b/.maintainer.yml
@@ -17,7 +17,8 @@ triage:
   qualify_into: [bug, feature, dupe, question]
 
 handoff:
-  mode: none
+  mode: webhook
+  ask_reporter_first: false
 
 pr:
   wait_for_other_bots: [coderabbit, copilot, dependabot]

--- a/.maintainer.yml
+++ b/.maintainer.yml
@@ -1,10 +1,11 @@
 # yaml-language-server: $schema=https://developerz.ai/schemas/maintainer.v1.json
 # developerz.ai maintainer policy — developerz-ai/wurk
 #
-# First dogfood pass: triage-only. The bot qualifies, labels, comments, and
-# asks reporters for missing repro detail. No coding handoff and no auto-merge
-# yet — flip handoff.mode to `webhook` (with a webhook_ref) once a coding-agent
-# hook is wired. Everything not set here uses the schema defaults.
+# Dogfood pass with coding handoff live. The bot triages (qualifies, labels,
+# asks reporters for repro) and, once a task is ready, dispatches coding to the
+# fleet over the webhook handoff. Auto-merge stays off, and we defer to other
+# bots (coderabbit/copilot/dependabot) before acting on PRs. Everything not set
+# here uses the schema defaults.
 version: 1
 
 tone:


### PR DESCRIPTION
## What

Update the existing `.maintainer.yml` so the developerz.ai maintainer bot hands off coding work via webhook instead of staying triage-only:

- `handoff.mode`: `none` → `webhook`
- `handoff.ask_reporter_first`: `false` (new)

Every other field is left exactly as-is (`tone`, `triage`, `pr` / bot-waits, `escalate`, `limits`).

## Why

With `mode: webhook`, the developerz.ai mothership can dispatch coding tasks for this repo — the bot no longer stops at qualify/label/comment; qualified issues can be routed to a coding agent. Setting `ask_reporter_first: false` lets that dispatch proceed without a preliminary round-trip to the reporter.

Closes nothing — this is a policy configuration change.

---

Authored by the developerz.ai fleet agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)