### PR TITLE
perf(ci): trim test matrix to 3 legs, preserve required contexts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,19 +16,21 @@ concurrency:
 
 jobs:
   test:
-    # No explicit `name:` so GitHub's default matrix naming emits
-    # "test (<ruby>, <rails>)" — matching the contexts required by branch
-    # protection (test (3.4, 7.2) and test (4.0, 8.0)). The 4.0/8.0 leg is added
-    # via `include` to satisfy the required context while keeping the #29 matrix
-    # (Ruby 3.2/3.3/3.4 × Rails 7.2/8.0).
+    # No explicit `name:` — GitHub's default matrix naming emits
+    # "test (<ruby>, <rails>)", which branch protection (strict: true) requires
+    # byte-identical for "test (3.4, 7.2)" and "test (4.0, 8.0)" (merge-gated).
+    # Trimmed from the 7-leg 3.2/3.3/3.4 × 7.2/8.0 matrix (#290): the two
+    # required legs plus one non-edge middle combo (3.3/8.0) for coverage.
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2", "3.3", "3.4"]
-        rails: ["7.2", "8.0"]
         include:
+          - ruby: "3.3"
+            rails: "8.0"
+          - ruby: "3.4"
+            rails: "7.2"
           - ruby: "4.0"
             rails: "8.0"
     services:


### PR DESCRIPTION
Closes #290. Fleet-wide Blacksmith cost cut — tracker: https://github.com/developerz-ai/infrastructure/issues/681

## What

Trims the `test` job matrix in `.github/workflows/test.yml` from **7 legs** (Ruby 3.2/3.3/3.4 × Rails 7.2/8.0, plus the `4.0/8.0` include) to **3**, expressed as a pure `include`:

| Leg | Status |
|-----|--------|
| `test (3.4, 7.2)` | ✅ kept — **required context** |
| `test (4.0, 8.0)` | ✅ kept — **required context** |
| `test (3.3, 8.0)` | ✅ kept — one non-edge middle combo for coverage |
| `test (3.2, 7.2)` | ❌ dropped |
| `test (3.2, 8.0)` | ❌ dropped |
| `test (3.3, 7.2)` | ❌ dropped |
| `test (3.4, 8.0)` | ❌ dropped |

## Why the required contexts are safe

`main` branch protection has `strict: true` and gates merge on **exactly** these two context names:

```
required_status_checks.contexts = ["test (3.4, 7.2)", "test (4.0, 8.0)"]
```

They are preserved **byte-identical**:
- The job has **no explicit `name:`**, so GitHub's default matrix naming keeps emitting `test (<ruby>, <rails>)`.
- The existing `4.0/8.0` include leg already rendered as `test (4.0, 8.0)` — proof that include entries render ruby-first — so moving `3.4/7.2` into an include entry does not change its rendered name.
- Verified locally: the matrix expands to exactly `test (3.3, 8.0)`, `test (3.4, 7.2)`, `test (4.0, 8.0)` (3 legs, both required names present byte-for-byte).

**Branch protection is untouched in this PR** — the low-risk path called out in #290. `parity`, `coverage`, and `frontend` jobs are untouched, and no gate/coverage threshold is weakened.

## Notes for review

- Adding a leg later is a one-line `include` entry.
- If a leg name ever needs to change, the protection `contexts` must move in lockstep.
- `parity`, `coverage`, `frontend` jobs unchanged.

---

🤖 **Authored by the developerz.ai fleet agent** (bot always discloses). **HUMAN MERGE — @Din**, per #290 (HITL). Please do not auto-merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD test matrix configuration to optimize tested dependency combinations for better coverage validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->