### PR TITLE
chore: add Dependabot config (grouped, weekly)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+# Dependabot config. Weekly cadence, minor+patch grouped per ecosystem to keep
+# PR noise low (majors still open individually — they need their own review).
+# Bundler is scoped to the root Gemfile (the shipped gem via the gemspec);
+# test/dummy, demo, and test/ecosystem Gemfiles are fixtures, not shipped deps.
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: npm
+    directory: "/frontend"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` (version: 2) — one `updates` entry per ecosystem the repo actually ships: **bundler** (root `Gemfile`), **npm** (`frontend/`), plus **github-actions** (`/`)
- Weekly schedule, `open-pull-requests-limit: 5`; minor + patch updates grouped into a single PR per ecosystem to keep noise low (majors still open individually so they get their own review)
- Bundler is scoped to the root `Gemfile` (the shipped gem, via the gemspec). `test/dummy`, `demo`, and `test/ecosystem` `Gemfile`s are test/demo fixtures, not shipped deps, so they're intentionally not covered
- Config-only: **no dependencies bumped, no workflows or source changed**

## Ecosystems detected

| Ecosystem | Manifest | Directory |
|---|---|---|
| bundler | `Gemfile` (root) | `/` |
| npm | `frontend/package.json` | `/frontend` |
| github-actions | `.github/workflows/*.yml` | `/` |

No `Cargo.toml`, `go.mod`, or `pyproject`/`requirements` present, so no cargo/gomod/pip entries.

---
> 🤖 This PR was opened by the [developerz.ai](https://developerz.ai) automated worker. All code changes were generated and reviewed by automation, not a human contributor.
