### PR TITLE
chore(mcp): add codegraph MCP server config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "codegraph": {
+      "type": "stdio",
+      "command": "codegraph",
+      "args": ["serve", "--mcp"]
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds a repo-root `.mcp.json` wiring **codegraph** ([github.com/colbymchenry/codegraph](https://github.com/colbymchenry/codegraph)) so coding agents (Claude Code, Cursor, Codex) get the structural knowledge-graph tools. Standardized across developerz.ai-operated repos per [developerz.ai/docs/standards/mcp-codegraph-audit.md](https://github.com/developerz-ai/developerz.ai/blob/main/docs/standards/mcp-codegraph-audit.md).

This repo had **no** `.mcp.json`; the new file contains only the codegraph entry:

```jsonc
{
  "mcpServers": {
    "codegraph": { "type": "stdio", "command": "codegraph", "args": ["serve", "--mcp"] }
  }
}
```

The entry is mirrored from the codegraph README's **Manual Setup** section (not invented).

## Scope

Config-only. **No `codegraph init` / `.codegraph/` index build** here — that's a deferred per-repo, machine-local follow-up (the index is never committed).

## Notes

- Assumes the `codegraph` binary is on `$PATH` (install: `curl -fsSL https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh | sh` or `npm i -g @colbymchenry/codegraph`).
- Static JSON config file — inert to the Ruby spec suite and `rubocop` (Ruby-only linter). Confirmed it is **not** swept into the published gem: `wurk.gemspec`'s `spec.files` is an explicit allowlist (`lib/**`, `app/**`, `config/**`, `exe/*`, `vendor/assets/dashboard/**`, `README.md`, `LICENSE`) that does not match a root `.mcp.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)