### PR TITLE
chore(gitignore): ignore codegraph index (.codegraph/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ vendor/assets/dashboard/*
 # checkouts and per-harness lockfiles they produce are not.
 test/ecosystem/.checkouts/
 test/ecosystem/*/Gemfile.lock
+
+# CodeGraph index — local per-machine SQLite DB (.codegraph/); never committed
+.codegraph/


### PR DESCRIPTION
## What
Adds `.codegraph/` to `.gitignore`.

## Why
`codegraph init` (per the developerz.ai codegraph standard) builds a **local per-machine** SQLite knowledge graph at `.codegraph/codegraph.db` (+ daemon lock/socket). The [codegraph docs](https://github.com/colbymchenry/codegraph) are explicit: the index is **100% local** and **OS-specific** — *"the background-server lock and the SQLite index are tied to the OS that wrote them"* — so it must never be committed. This entry keeps the binary DB out of git while leaving the index on the machine where coding agents (Claude Code / Cursor / Codex) consume it via the `.mcp.json` `codegraph` server.

No code change — `.gitignore` only. Pairs with the `codegraph` entry in `.mcp.json` already on `main`.

## Verify
`.gitignore`-only diff → no compiled/test surface. Confirmed `git check-ignore .codegraph/` now matches; `git status` shows only `.gitignore` modified.