### PR TITLE
docs(readme): add Tesote AI fleet-wiring note

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,4 @@ is the same basis the Supreme Court upheld for Google's reuse of the Java API in
 *Google v. Oracle* (2021). "Sidekiq" is a trademark of Contributed Systems, LLC;
 Wurk is independent and not affiliated with or endorsed by them. Full reasoning:
 **[docs/clean-room.md](https://github.com/developerz-ai/wurk/blob/main/docs/clean-room.md)**.
+This repository is dispatchable from the Tesote AI engineering Spaces via the developerz.ai fleet MCP.


### PR DESCRIPTION
Adds a single one-line note to the end of `README.md` confirming this repo is dispatchable from the Tesote AI engineering Spaces via the developerz.ai fleet MCP.

This is an end-to-end fleet-wiring smoke test dispatched from the Tesote AI GG-Coin engineering Space.

## Changes
- Append exactly one line to `README.md`. Nothing else modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)