### PR TITLE
fix: Redis resilience — pool retry, sizing, fork-safety

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,16 @@ group :development, :test do
   gem "rake", ">= 13.0"
   gem "minitest", ">= 5.20"
   gem "minitest-parallel_fork"
-  gem "simplecov", require: false
-  gem "simplecov-cobertura", require: false
+  # Pin to the 0.x line. SimpleCov 1.0 rewrote subprocess handling: the default
+  # `at_fork` proc now ignores the name argument and labels every child
+  # `(subprocess: #{subprocess_serial})`. Our parallel_fork coverage merge
+  # (test/test_helper.rb) passes a per-worker name so each worker writes a
+  # distinct resultset; under 1.0 the serial stays 0 for all workers (its only
+  # increment lives in the off-by-default Process._fork hook), so they collide
+  # on one key, clobber each other, and the merged report collapses far below
+  # the 90% gate. cobertura 4.0 requires simplecov ~> 1.0, so it pins with it.
+  gem "simplecov", "~> 0.22", require: false
+  gem "simplecov-cobertura", "~> 3.2", require: false
   gem "rubocop", require: false
   gem "rubocop-minitest", require: false
   gem "rubocop-rake", require: false

--- a/docs/target/sidekiq-free.md
+++ b/docs/target/sidekiq-free.md
@@ -314,8 +314,7 @@ class Sidekiq::Config
   # redis
   def redis=(hash)                  # merge into @redis_config
   def reap_idle_redis_connections(timeout = 60)
-  def redis_pool
-  def local_redis_pool              # internal/housekeeping pool size=10
+  def redis_pool                    # default_capsule's main pool
   def new_redis_pool(size, name)    # via Sidekiq::RedisConnection.create
   def redis_info                    # parses INFO command
   def redis { |conn| ... }          # yield connection with READONLY/NOREPLICAS/UNBLOCKED retry
@@ -371,9 +370,10 @@ class Sidekiq::Capsule
 
   def client_middleware { |chain| } # copy_for(self)
   def server_middleware { |chain| }
-  def redis_pool
-  def local_redis_pool              # size = @concurrency
+  def redis_pool                    # main pool: max(@concurrency + 5, 10)
+  def fetch_redis_pool              # blocking-BLMOVE fetch pool, size = @concurrency
   def redis { |conn| ... }
+  def fetch_redis { |conn| ... }    # checkout from the fetch pool
   def lookup(name)
   def logger
 end

--- a/lib/wurk/capsule.rb
+++ b/lib/wurk/capsule.rb
@@ -197,13 +197,7 @@ module Wurk
     end
 
     def build_pool(size:, name:)
-      cfg = @config.redis_config
-      RedisPool.new(
-        size: size,
-        url: cfg[:url] || RedisPool::DEFAULT_URL,
-        timeout: cfg[:timeout] || RedisPool::DEFAULT_TIMEOUT,
-        name: name
-      )
+      @config.new_redis_pool(size, name)
     end
   end
 end

--- a/lib/wurk/capsule.rb
+++ b/lib/wurk/capsule.rb
@@ -25,7 +25,7 @@ module Wurk
       @weights = { 'default' => 0 }
       @fetcher = nil
       @redis_pool = nil
-      @local_redis_pool = nil
+      @fetch_redis_pool = nil
       @client_chain = nil
       @server_chain = nil
     end
@@ -65,7 +65,7 @@ module Wurk
     def prepare!
       @fetcher ||= build_fetcher
       redis_pool
-      local_redis_pool
+      fetch_redis_pool
       client_middleware
       server_middleware
       self
@@ -86,20 +86,27 @@ module Wurk
       chain
     end
 
-    # Pool size = concurrency + POOL_OVERHEAD. Every processor thread can
-    # be parked in a blocking BLMOVE (reliable fetch), holding its slot
-    # for ~3s. POOL_OVERHEAD reserves connections for the Launcher's
-    # heartbeat thread + the Scheduled::Poller so they can never be
-    # starved by busy fetchers. Without this, concurrency=1 deadlocks
-    # immediately (worker holds the only slot, heartbeat times out).
-    POOL_OVERHEAD = 2
+    # Headroom above `concurrency` for the main pool; the whole pool is then
+    # floored at MIN_POOL_SIZE. Blocking BLMOVE fetch has its own pool
+    # (#fetch_redis_pool), so the main pool serves only the background loops —
+    # heartbeat, scheduled poller, leader election, cron, the two metrics
+    # rollups, reaper, history, health probe — plus the host's own job-code
+    # checkouts. `concurrency + 5` (floor 10) gives each an unstarvable slot;
+    # the old `concurrency + 2` starved them once fetch also drew from here —
+    # the #101 `0/N` pool-exhaustion incident. Override via `config.redis[:size]`.
+    POOL_HEADROOM = 5
+    MIN_POOL_SIZE = 10
 
     def redis_pool
-      @redis_pool ||= build_pool(size: @concurrency + POOL_OVERHEAD, name: "#{@name}-main")
+      @redis_pool ||= build_pool(size: main_pool_size, name: "#{@name}-main")
     end
 
-    def local_redis_pool
-      @local_redis_pool ||= build_pool(size: @concurrency, name: "#{@name}-local")
+    # Dedicated pool for the reliable fetcher's blocking BLMOVE: one slot per
+    # processor thread (`concurrency`), since at most that many threads park in
+    # fetch at once. Keeping fetch off the main pool is what lets an idle worker
+    # hold zero main-pool connections again.
+    def fetch_redis_pool
+      @fetch_redis_pool ||= build_pool(size: @concurrency, name: "#{@name}-fetch")
     end
 
     # Disconnect and drop cached pools. Called by Wurk::Swarm just before
@@ -109,12 +116,18 @@ module Wurk
     def reset_redis_pools!
       @redis_pool&.disconnect!
       @redis_pool = nil
-      @local_redis_pool&.disconnect!
-      @local_redis_pool = nil
+      @fetch_redis_pool&.disconnect!
+      @fetch_redis_pool = nil
     end
 
     def redis(&)
       redis_pool.with(&)
+    end
+
+    # Checkout from the dedicated fetch pool. Only the reliable fetcher's
+    # blocking BLMOVE uses this, so a parked fetch never holds a main-pool slot.
+    def fetch_redis(&)
+      fetch_redis_pool.with(&)
     end
 
     def lookup(name)
@@ -194,6 +207,12 @@ module Wurk
       return parsed.map(&:first) if %i[strict random].include?(mode)
 
       parsed.flat_map { |q, w| [q] * w }
+    end
+
+    # `config.redis = { size: N }` pins the main pool at N; otherwise
+    # `concurrency + POOL_HEADROOM`, floored at MIN_POOL_SIZE.
+    def main_pool_size
+      @config.redis_config[:size] || [@concurrency + POOL_HEADROOM, MIN_POOL_SIZE].max
     end
 
     def build_pool(size:, name:)

--- a/lib/wurk/client/buffered.rb
+++ b/lib/wurk/client/buffered.rb
@@ -144,8 +144,9 @@ module Wurk
         public
 
         # Drain payloads through `raw_push` on the given client. Stops on
-        # the first ConnectionError, preserving order at the head of the
-        # buffer so the next push retries the same payload. Emits statsd
+        # the first transient failure (ConnectionError past the pool's own
+        # retries, or a starved checkout), preserving order at the head of
+        # the buffer so the next push retries the same payload. Emits statsd
         # `jobs.recovered.push` per drained payload.
         def drain!(client)
           drained = 0
@@ -206,14 +207,14 @@ module Wurk
           buffer_mutex.synchronize { buffer.shift }
         end
 
-        # Drain marks the thread so our prepended raw_push re-raises
-        # ConnectionError back here instead of swallowing it into the buffer
+        # Drain marks the thread so our prepended raw_push re-raises the
+        # transient error back here instead of swallowing it into the buffer
         # (which would spin forever).
         def attempt_replay(client, payload)
           Thread.current[DRAINING_KEY] = true
           client.send(:raw_push, [payload])
           true
-        rescue RedisClient::ConnectionError
+        rescue RedisClient::ConnectionError, ConnectionPool::TimeoutError
           false
         ensure
           Thread.current[DRAINING_KEY] = false
@@ -222,7 +223,7 @@ module Wurk
 
       # Background drain thread. Wakes every `interval` seconds and tries
       # `Buffered.drain!` against a fresh Wurk::Client. drain! already
-      # short-circuits on the first ConnectionError, so a still-down Redis
+      # short-circuits on the first transient failure, so a still-down Redis
       # just leaves the buffer alone for this tick — no exponential
       # backoff or explicit "reconnect detection" needed; the inner
       # connection retry already lives inside `client.raw_push`.
@@ -292,7 +293,9 @@ module Wurk
       end
 
       # Wraps Wurk::Client. push / push_bulk drain the buffer first;
-      # raw_push catches ConnectionError and buffers non-batched payloads.
+      # raw_push catches transient failures — RedisClient::ConnectionError
+      # past RedisPool's own retries, or a starved checkout
+      # (ConnectionPool::TimeoutError) — and buffers non-batched payloads.
       module InstanceMethods
         def push(item)
           Buffered.drain!(self)
@@ -308,7 +311,7 @@ module Wurk
 
         def raw_push(payloads)
           super
-        rescue RedisClient::ConnectionError
+        rescue RedisClient::ConnectionError, ConnectionPool::TimeoutError
           raise if Thread.current[Buffered::DRAINING_KEY]
 
           bidless, batched = payloads.partition { |p| !p['bid'] }

--- a/lib/wurk/component.rb
+++ b/lib/wurk/component.rb
@@ -22,6 +22,9 @@ module Wurk
 
     attr_reader :config
 
+    # `leader?` cache TTL — see the method doc below.
+    LEADER_CACHE_TTL_MS = 5_000
+
     # --- clocks ---------------------------------------------------------
 
     def real_ms
@@ -71,20 +74,25 @@ module Wurk
     # --- cluster leadership --------------------------------------------
 
     # True iff this process currently holds the cluster `dear-leader` lock.
-    # Per spec, the check is performed at call time (Wurk does not cache);
-    # callers must not poll faster than the 60s follower cadence. Returns
-    # false unconditionally when `WURK_LEADER=false` (or `SIDEKIQ_LEADER=false`)
-    # is set on the process (opt-out hot-standby). Any Redis error is swallowed →
-    # false, so a transient partition can't propagate as an exception into user
-    # code.
+    # Cached per Component instance for `LEADER_CACHE_TTL_MS` (~5s): cron and
+    # the metrics rollups call this every tick, and an uncached GET would
+    # double their Redis traffic at short intervals for no benefit — the
+    # lock's own renewal cadence (60s+, spec §6.1) easily tolerates a
+    # few-second-stale read. Returns false unconditionally when
+    # `WURK_LEADER=false` (or `SIDEKIQ_LEADER=false`) is set on the process
+    # (opt-out hot-standby). Any Redis error is swallowed → false, so a
+    # transient partition can't propagate as an exception into user code.
     #
     # Spec: docs/target/sidekiq-ent.md §6.1.
     def leader?
       return false if Wurk::Leader.opted_out?
 
-      redis { |c| c.call('GET', Wurk::Leader::DEFAULT_KEY) } == identity
-    rescue StandardError
-      false
+      now = mono_ms
+      if @leader_checked_at.nil? || (now - @leader_checked_at) >= LEADER_CACHE_TTL_MS
+        @leader_checked_at = now
+        @leader_cached = fetch_leader?
+      end
+      @leader_cached
     end
 
     # --- thread boundaries ---------------------------------------------
@@ -126,6 +134,12 @@ module Wurk
     end
 
     private
+
+    def fetch_leader?
+      redis { |c| c.call('GET', Wurk::Leader::DEFAULT_KEY) } == identity
+    rescue StandardError
+      false
+    end
 
     def run_lifecycle_hook(hook, event, reraise)
       hook.call

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -495,13 +495,11 @@ module Wurk
       logger
     end
 
+    # `size`/`name` are pool-structural (the caller owns them); every other
+    # key the host set via `config.redis = {...}` — url, the split timeouts,
+    # reconnect_attempts, driver, … — flows through to RedisPool verbatim.
     def build_redis_pool(size:, name:)
-      RedisPool.new(
-        size: size,
-        url: @redis_config[:url] || RedisPool::DEFAULT_URL,
-        timeout: @redis_config[:timeout] || RedisPool::DEFAULT_TIMEOUT,
-        name: name
-      )
+      RedisPool.new(size: size, name: name, **@redis_config.except(:size, :name))
     end
   end
 end

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -177,17 +177,11 @@ module Wurk
       default_capsule.redis_pool
     end
 
-    def local_redis_pool
-      @local_redis_pool ||= build_redis_pool(size: 10, name: 'internal')
-    end
-
-    # Disconnect and drop every cached pool — the per-capsule mains plus
-    # the config-level internal pool. Used by Wurk::Swarm so the parent
-    # never leaks sockets into forks and each child can build fresh ones.
+    # Disconnect and drop every capsule's cached pools (main + fetch). Used by
+    # Wurk::Swarm so the parent never leaks sockets into forks and each child
+    # can build fresh ones.
     def reset_redis_pools!
       @capsules.each_value(&:reset_redis_pools!)
-      @local_redis_pool&.disconnect!
-      @local_redis_pool = nil
     end
 
     def new_redis_pool(size, name = 'custom')

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -43,13 +43,21 @@ module Wurk
       reloader: proc { |&b| b.call },
       backtrace_cleaner: ->(bt) { bt },
       logged_job_attributes: %w[bid tags],
-      redis_idle_timeout: nil
+      redis_idle_timeout: nil,
+      redis_error_handlers: []
     }.freeze
 
     # :fork fires only inside swarm children, after fork + internal AR/Redis
     # reconnect — apps reopen sockets / non-fork-safe libs there (Ent §7.4).
     LIFECYCLE_EVENTS = %i[startup fork quiet shutdown exit heartbeat beat leader].freeze
     DEFAULT_THREAD_PRIORITY = -1
+
+    # Redis client / pool errors that the pool wrapper already retried before
+    # re-raising. Logged one level up (WARN, not INFO) so a transient blip
+    # surfaces in ops dashboards without drowning steady-state noise (#101).
+    # RedisClient + ConnectionPool are always loaded before this file (capsule
+    # → redis_pool requires both), so referencing them here is safe.
+    REDIS_ERROR_CLASSES = [RedisClient::Error, ConnectionPool::TimeoutError].freeze
 
     # Default error handler. Wraps the report in the thread-local
     # Wurk::Context so logger formatters/JSON layouts can pick up jid/bid/tags.
@@ -62,7 +70,8 @@ module Wurk
       Wurk::Context.with(safe_ctx) do
         dev = $DEBUG || ENV['WURK_DEBUG'] || cfg.logger.debug?
         msg = dev ? ex.full_message : ex.detailed_message
-        cfg.logger.info { msg }
+        level = REDIS_ERROR_CLASSES.any? { |k| ex.is_a?(k) } ? :warn : :info
+        cfg.logger.public_send(level) { msg }
       end
     end
 
@@ -208,6 +217,19 @@ module Wurk
 
     def death_handlers
       @options[:death_handlers]
+    end
+
+    # Telemetry hook fired by RedisPool on every transient-error retry and
+    # final give-up. The block receives one Hash: { error:, attempt:, retried:,
+    # pool: }. Opt-in — pools stay silent until a handler is registered.
+    def on_redis_error(&block)
+      raise ArgumentError, 'block required for on_redis_error' unless block
+
+      @options[:redis_error_handlers] << block
+    end
+
+    def redis_error_handlers
+      @options[:redis_error_handlers]
     end
 
     def average_scheduled_poll_interval=(interval)
@@ -498,8 +520,21 @@ module Wurk
     # `size`/`name` are pool-structural (the caller owns them); every other
     # key the host set via `config.redis = {...}` — url, the split timeouts,
     # reconnect_attempts, driver, … — flows through to RedisPool verbatim.
+    # Every pool built here is wired to the redis-error telemetry dispatcher.
     def build_redis_pool(size:, name:)
-      RedisPool.new(size: size, name: name, **@redis_config.except(:size, :name))
+      RedisPool.new(size: size, name: name, on_error: method(:dispatch_redis_error),
+                    **@redis_config.except(:size, :name))
+    end
+
+    # Fan a RedisPool retry/give-up event out to the registered handlers. A
+    # raising handler is logged and skipped so one bad hook can't break the
+    # pool's retry path (mirrors #handle_exception).
+    def dispatch_redis_error(info)
+      redis_error_handlers.each do |handler|
+        handler.call(info)
+      rescue StandardError => e
+        logger.error("redis_error_handler raised: #{e.class}: #{e.message}")
+      end
     end
   end
 end

--- a/lib/wurk/fetcher/reliable.rb
+++ b/lib/wurk/fetcher/reliable.rb
@@ -130,9 +130,12 @@ module Wurk
       def blmove(public_q)
         priv = self.class.private_queue_name(public_q)
         timeout = poll_interval
-        # Extend the socket read-timeout past BLMOVE's own timeout so the
-        # default 1s pool timeout doesn't fire before BLMOVE returns.
-        job = config.redis do |conn|
+        # Dedicated fetch pool, not the main one: a parked BLMOVE holds its slot
+        # for the whole block window, so routing it here keeps idle fetchers from
+        # starving the main pool's background loops (#101). Extend the socket
+        # read-timeout one second past BLMOVE's own server-side timeout so the
+        # connection's read timeout can't fire while BLMOVE is legitimately blocked.
+        job = config.fetch_redis do |conn|
           conn.blocking_call(timeout + 1, 'BLMOVE', public_q, priv, 'RIGHT', 'LEFT', timeout)
         end
         job ? UnitOfWork.new(queue: public_q, job: job, config: config) : nil

--- a/lib/wurk/limiter.rb
+++ b/lib/wurk/limiter.rb
@@ -97,9 +97,8 @@ module Wurk
                   when Hash
                     Wurk::RedisPool.new(
                       size: @redis[:size] || 10,
-                      url: @redis[:url] || Wurk::RedisPool::DEFAULT_URL,
-                      timeout: @redis[:timeout] || Wurk::RedisPool::DEFAULT_TIMEOUT,
-                      name: 'limiter'
+                      name: 'limiter',
+                      **@redis.except(:size, :name)
                     )
                   else
                     raise ArgumentError, "Limiter.config.redis must be Hash or RedisPool, got #{@redis.class}"

--- a/lib/wurk/lua/loader.rb
+++ b/lib/wurk/lua/loader.rb
@@ -14,12 +14,18 @@ module Wurk
       NOSCRIPT_PREFIX = 'NOSCRIPT'
 
       class << self
-        # Eagerly upload every registered script to the given connection.
-        # Idempotent on the Redis side: `SCRIPT LOAD` of the same source
-        # returns the same SHA regardless of how often it's called.
-        # Manager calls this once per child after the post-fork reconnect.
+        # Eagerly upload every registered script to the given connection in a
+        # single pipelined round-trip (all SCRIPT LOADs, one RTT — not one per
+        # script). Idempotent on the Redis side: `SCRIPT LOAD` of the same source
+        # returns the same SHA no matter how often it runs. ChildBoot calls this
+        # once per child right after the post-fork reconnect so the first real
+        # EVALSHA hits a warm cache instead of paying a NOSCRIPT reload. Transient
+        # connection errors are the pool wrapper's job (Wurk::RedisPool#with);
+        # this only ships the loads.
         def script_load_all(redis)
-          SCRIPTS.each_value { |src| redis.call('SCRIPT', 'LOAD', src) }
+          redis.pipelined do |pipe|
+            SCRIPTS.each_value { |src| pipe.call('SCRIPT', 'LOAD', src) }
+          end
         end
 
         # @param redis [RedisClient] a single connection (not a pool)

--- a/lib/wurk/redis_connection.rb
+++ b/lib/wurk/redis_connection.rb
@@ -10,21 +10,18 @@ module Wurk
   # (connection_pool-backed, redis-client adapter), which is `.with`-compatible
   # with everything that expects a Sidekiq pool.
   #
-  # Accepts Sidekiq's option keys (`url`, `size`, `pool_timeout`, `name`),
-  # string- or symbol-keyed. Anything omitted falls back to RedisPool's defaults
-  # (URL = ENV["REDIS_URL"] or redis://localhost:6379/0).
+  # Accepts Sidekiq's option keys (`url`, `size`, `pool_timeout`, `name`) plus
+  # the socket knobs (`connect_timeout`/`read_timeout`/`write_timeout`/
+  # `reconnect_attempts`/`driver`), string- or symbol-keyed. Anything omitted
+  # falls back to RedisPool's defaults (URL = ENV["REDIS_URL"] or
+  # redis://localhost:6379/0).
   module RedisConnection
     # Housekeeping/standalone default; per-capsule pools size to concurrency.
     DEFAULT_POOL_SIZE = 10
 
     def self.create(options = {})
       opts = options.transform_keys(&:to_sym)
-      RedisPool.new(
-        size: opts[:size] || DEFAULT_POOL_SIZE,
-        url: opts[:url] || RedisPool::DEFAULT_URL,
-        timeout: opts[:pool_timeout] || RedisPool::DEFAULT_TIMEOUT,
-        name: opts[:name] || RedisPool::DEFAULT_NAME
-      )
+      RedisPool.new(size: opts.delete(:size) || DEFAULT_POOL_SIZE, **opts)
     end
   end
 end

--- a/lib/wurk/redis_pool.rb
+++ b/lib/wurk/redis_pool.rb
@@ -9,8 +9,17 @@ module Wurk
   # across forks: the parent closes the pool before fork, each child opens a
   # fresh one (see docs/idea/03-process-model.md, steps 3 and 5).
   #
-  # Retry policy on conn-level errors: close + retry once for messages
-  # prefixed READONLY / NOREPLICAS / UNBLOCKED. Spec: docs/target/sidekiq-free.md §26.
+  # #with absorbs transient Redis failures (production incident #101):
+  #   * READONLY / NOREPLICAS / UNBLOCKED — a failover happened; close and retry
+  #     once immediately so redis-client redials the new primary (spec §26).
+  #   * ConnectionError (incl. CannotConnect / Read- / WriteTimeout) — a blip;
+  #     close and retry with exponential backoff up to CONN_MAX_ATTEMPTS, then
+  #     raise. At-least-once tolerates the rare duplicate and JobRetry re-runs
+  #     the job anyway, so retrying at the pool layer is strictly better.
+  #   * ConnectionPool::TimeoutError — checkout starved; retry once after a
+  #     short jittered pause, then raise (sizing is the fix, not queuing).
+  # Every retry and final give-up is reported through the injected `on_error`
+  # telemetry hook (Wurk::Configuration#on_redis_error).
   class RedisPool
     DEFAULT_URL  = ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')
     DEFAULT_NAME = 'default'
@@ -28,39 +37,58 @@ module Wurk
     DEFAULT_WRITE_TIMEOUT      = 2.5
     DEFAULT_RECONNECT_ATTEMPTS = 1
 
-    # Server-side messages where Sidekiq (and therefore Wurk) closes the
-    # connection and retries the block exactly once. Any other RedisClient::Error
-    # propagates immediately.
+    # Server-side messages where the connection is closed and the block retried
+    # exactly once. READONLY is itself a RedisClient::ConnectionError subclass,
+    # so this message match must be tested BEFORE the generic ConnectionError
+    # backoff below (otherwise a failover would sleep instead of redialing).
     RETRYABLE_MSG = /\A(READONLY|NOREPLICAS|UNBLOCKED)/
+
+    # ConnectionError backoff: CONN_MAX_ATTEMPTS total tries, sleeping
+    # (BASE * 2**attempt) + rand*JITTER before each retry. The 1.0s + 2.0s pair
+    # rides out a sub-4s blip; the jitter de-syncs a fleet reconnecting at once.
+    CONN_MAX_ATTEMPTS   = 3
+    CONN_BACKOFF_BASE   = 0.5
+    CONN_BACKOFF_JITTER = 0.25
+
+    # Checkout-timeout retry: one retry after a jittered pause in
+    # [POOL_RETRY_MIN, POOL_RETRY_MIN + POOL_RETRY_SPREAD). No loop — sustained
+    # checkout starvation is a sizing bug, not something to queue behind.
+    POOL_RETRY_MIN    = 0.1
+    POOL_RETRY_SPREAD = 0.2
 
     attr_reader :size, :url, :name, :pool_timeout, :client_config
 
     # Takes the standard Sidekiq `config.redis` hash: `pool_timeout` tunes the
     # ConnectionPool checkout; `connect_timeout`/`read_timeout`/`write_timeout`/
     # `reconnect_attempts` plus any other key (driver, ssl_params, …) forward
-    # verbatim to RedisClient.config.
-    def initialize(size:, name: DEFAULT_NAME, **options)
+    # verbatim to RedisClient.config. `on_error` is an optional callable fired
+    # per retry / final give-up with { error:, attempt:, retried:, pool: }.
+    def initialize(size:, name: DEFAULT_NAME, on_error: nil, **options)
       @size          = size
       @name          = name
+      @on_error      = on_error
       @pool_timeout  = options.fetch(:pool_timeout, DEFAULT_POOL_TIMEOUT)
       @client_config = build_client_config(options)
       @url           = @client_config[:url]
       @pool          = ConnectionPool.new(size: size, timeout: @pool_timeout) { build_client }
     end
 
-    def with
-      @pool.with do |conn|
-        attempts = 0
-        begin
-          yield conn
-        rescue RedisClient::Error => e
-          raise unless RETRYABLE_MSG.match?(e.message.to_s)
-          raise if attempts >= 1
-
-          attempts += 1
-          safe_close(conn)
-          retry
+    # Checkout a connection and run the block. ConnectionPool::TimeoutError is
+    # raised by @pool.with *before* the block runs, so it is caught out here
+    # (the in-block #run rescue never sees it) — one retry, then raise.
+    def with(&block)
+      checkout_retried = false
+      begin
+        @pool.with { |conn| run(conn, &block) }
+      rescue ConnectionPool::TimeoutError => e
+        if checkout_retried
+          notify_error(e, attempt: 2, retried: false)
+          raise
         end
+        checkout_retried = true
+        notify_error(e, attempt: 1, retried: true)
+        sleep(checkout_delay)
+        retry
       end
     end
 
@@ -68,8 +96,18 @@ module Wurk
       @pool.shutdown { |conn| safe_close(conn) }
     end
 
+    # Redis INFO parsed to a Hash, with this pool's own `size` / `available`
+    # slot counts merged in — one call gives a heartbeat both Redis health and
+    # local pool saturation. (Real Redis INFO has no `size`/`available` field.)
     def info
       with { |conn| parse_info(conn.call('INFO')) }
+        .merge('size' => @size, 'available' => available)
+    end
+
+    # Free (unchecked-out) slots right now. Local and cheap — no Redis round
+    # trip — so a monitor can poll it without perturbing the pool.
+    def available
+      @pool.available
     end
 
     private
@@ -98,6 +136,58 @@ module Wurk
       conn.close
     rescue StandardError
       nil
+    end
+
+    # Runs the block on the checked-out `conn`, retrying transient RedisClient
+    # errors in place: the same slot is reused across retries (redis-client
+    # redials a closed socket lazily), so a busy fetcher can't leak checkouts.
+    def run(conn)
+      attempts = 0
+      begin
+        attempts += 1
+        yield conn
+      rescue RedisClient::Error => e
+        plan = retry_plan(e, attempts)
+        raise if plan == :propagate
+
+        notify_error(e, attempt: attempts, retried: plan != :exhausted)
+        raise if plan == :exhausted
+
+        safe_close(conn)
+        sleep(backoff_delay(attempts)) if plan == :backoff
+        retry
+      end
+    end
+
+    # Pure classification of a RedisClient error against the attempt count:
+    #   :failover  → close + immediate retry (a primary swap)
+    #   :backoff   → close + sleep + retry (a connection blip)
+    #   :exhausted → ConnectionError past the cap; report and give up
+    #   :propagate → not transient (or a spent failover); raise as-is
+    def retry_plan(err, attempts)
+      if RETRYABLE_MSG.match?(err.message.to_s)
+        attempts > 1 ? :propagate : :failover
+      elsif err.is_a?(RedisClient::ConnectionError)
+        attempts >= CONN_MAX_ATTEMPTS ? :exhausted : :backoff
+      else
+        :propagate
+      end
+    end
+
+    def notify_error(error, attempt:, retried:)
+      return if @on_error.nil?
+
+      @on_error.call({ error:, attempt:, retried:, pool: @name })
+    rescue StandardError
+      nil
+    end
+
+    def backoff_delay(attempt)
+      (CONN_BACKOFF_BASE * (2**attempt)) + (rand * CONN_BACKOFF_JITTER)
+    end
+
+    def checkout_delay
+      POOL_RETRY_MIN + (rand * POOL_RETRY_SPREAD)
     end
 
     def parse_info(raw)

--- a/lib/wurk/redis_pool.rb
+++ b/lib/wurk/redis_pool.rb
@@ -12,23 +12,40 @@ module Wurk
   # Retry policy on conn-level errors: close + retry once for messages
   # prefixed READONLY / NOREPLICAS / UNBLOCKED. Spec: docs/target/sidekiq-free.md §26.
   class RedisPool
-    DEFAULT_URL     = ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')
-    DEFAULT_TIMEOUT = 1.0
-    DEFAULT_NAME    = 'default'
+    DEFAULT_URL  = ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')
+    DEFAULT_NAME = 'default'
+
+    # ConnectionPool checkout wait — how long #with blocks for a free slot.
+    DEFAULT_POOL_TIMEOUT = 1.0
+
+    # Socket-level timeouts handed to RedisClient, split apart from the checkout
+    # wait above. read/write are deliberately wider than connect so a briefly-
+    # slow-but-alive Redis (RDB fork pause, a large BLMOVE payload) doesn't
+    # spuriously ReadTimeout — the production incident (#101) the single
+    # dual-use timeout caused. reconnect_attempts re-dials a dropped socket once.
+    DEFAULT_CONNECT_TIMEOUT    = 1.0
+    DEFAULT_READ_TIMEOUT       = 2.5
+    DEFAULT_WRITE_TIMEOUT      = 2.5
+    DEFAULT_RECONNECT_ATTEMPTS = 1
 
     # Server-side messages where Sidekiq (and therefore Wurk) closes the
     # connection and retries the block exactly once. Any other RedisClient::Error
     # propagates immediately.
     RETRYABLE_MSG = /\A(READONLY|NOREPLICAS|UNBLOCKED)/
 
-    attr_reader :size, :url, :timeout, :name
+    attr_reader :size, :url, :name, :pool_timeout, :client_config
 
-    def initialize(size:, url: DEFAULT_URL, timeout: DEFAULT_TIMEOUT, name: DEFAULT_NAME)
-      @size    = size
-      @url     = url
-      @timeout = timeout
-      @name    = name
-      @pool    = ConnectionPool.new(size: size, timeout: timeout) { build_client }
+    # Takes the standard Sidekiq `config.redis` hash: `pool_timeout` tunes the
+    # ConnectionPool checkout; `connect_timeout`/`read_timeout`/`write_timeout`/
+    # `reconnect_attempts` plus any other key (driver, ssl_params, …) forward
+    # verbatim to RedisClient.config.
+    def initialize(size:, name: DEFAULT_NAME, **options)
+      @size          = size
+      @name          = name
+      @pool_timeout  = options.fetch(:pool_timeout, DEFAULT_POOL_TIMEOUT)
+      @client_config = build_client_config(options)
+      @url           = @client_config[:url]
+      @pool          = ConnectionPool.new(size: size, timeout: @pool_timeout) { build_client }
     end
 
     def with
@@ -57,11 +74,24 @@ module Wurk
 
     private
 
+    # Socket config forwarded to RedisClient.config. Host-supplied keys win over
+    # the defaults; `pool_timeout` is dropped (it's a pool concern, not a socket
+    # one) and unknown keys pass straight through.
+    def build_client_config(options)
+      {
+        url: DEFAULT_URL,
+        connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+        read_timeout: DEFAULT_READ_TIMEOUT,
+        write_timeout: DEFAULT_WRITE_TIMEOUT,
+        reconnect_attempts: DEFAULT_RECONNECT_ATTEMPTS
+      }.merge(options.except(:pool_timeout)).freeze
+    end
+
     # Wrapped in the CompatClient decorator so `Sidekiq.redis { |c| c.smembers }`
     # method-style commands work like Sidekiq 7+ (#204). Wurk's own code paths
     # use #call, which the decorator forwards.
     def build_client
-      RedisClientAdapter::CompatClient.new(RedisClient.config(url: @url, timeout: @timeout).new_client)
+      RedisClientAdapter::CompatClient.new(RedisClient.config(**@client_config).new_client)
     end
 
     def safe_close(conn)

--- a/lib/wurk/scheduled.rb
+++ b/lib/wurk/scheduled.rb
@@ -39,9 +39,7 @@ module Wurk
       # client. `now` is captured once per set so a slow loop on one ZSET
       # can't keep grabbing newly-scheduled jobs from a moving window.
       def enqueue_jobs(sorted_sets = SETS)
-        @config.redis do |conn|
-          sorted_sets.each { |sset| drain_set(conn, sset) }
-        end
+        sorted_sets.each { |sset| drain_set(sset) }
       end
 
       def terminate
@@ -50,12 +48,16 @@ module Wurk
 
       private
 
-      def drain_set(conn, sset)
+      # Pop under one checkout (the pooled EVALSHA loop), push outside it —
+      # `@client.push` checks out its own connection, so nesting it inside
+      # `@config.redis` would hold two checkouts from the same pool at once
+      # per job, halving effective pool concurrency under load.
+      def drain_set(sset)
         now = real_time.to_s
         loop do
           break if @done
 
-          jobstr = Wurk::Lua::Loader.eval_cached(conn, :zpopbyscore, keys: [sset], argv: [now])
+          jobstr = @config.redis { |conn| Wurk::Lua::Loader.eval_cached(conn, :zpopbyscore, keys: [sset], argv: [now]) }
           break unless jobstr
 
           @client.push(Wurk.load_json(jobstr))

--- a/lib/wurk/swarm/child_boot.rb
+++ b/lib/wurk/swarm/child_boot.rb
@@ -3,6 +3,7 @@
 require_relative '../component'
 require_relative '../launcher'
 require_relative '../fetcher/reliable'
+require_relative '../lua'
 
 module Wurk
   class Swarm
@@ -72,12 +73,35 @@ module Wurk
 
       def reconnect_after_fork
         @config.reset_redis_pools!
+        validate_redis!
+        reconnect_active_record
+      end
+
+      # Prove the child's fresh Redis socket reaches a live server before it
+      # starts fetching: one PING through RedisPool#with, which owns the
+      # retry+backoff (production incident #101), so a transient blip during
+      # boot rides out instead of racing straight into a dead pool. A PING that
+      # still fails past the wrapper's retries propagates and crashes the child
+      # (the swarm respawns it) rather than booting a worker that can't reach
+      # Redis. The same checkout eagerly primes every Lua script in one
+      # pipelined round-trip so the first EVALSHA hits a warm cache.
+      def validate_redis!
+        @config.redis_pool.with do |conn|
+          conn.call('PING')
+          Wurk::Lua::Loader.script_load_all(conn)
+        end
+      end
+
+      # AR reconnect is best-effort — a Redis-only worker with no database still
+      # runs — but the silent `rescue nil` here hid a real misconfiguration
+      # during the #101 audit, so warn loudly instead of swallowing.
+      def reconnect_active_record
         return unless defined?(::ActiveRecord::Base)
 
-        begin
-          ::ActiveRecord::Base.establish_connection
-        rescue StandardError
-          nil
+        ::ActiveRecord::Base.establish_connection
+      rescue StandardError => e
+        @config.logger.warn do
+          "swarm child ##{@index} (#{::Process.pid}) ActiveRecord reconnect failed: #{e.class}: #{e.message}"
         end
       end
 

--- a/test/integration/liveness_probe_test.rb
+++ b/test/integration/liveness_probe_test.rb
@@ -29,7 +29,7 @@ class LivenessProbeTest < Wurk::Test::UnitCase
     # otherwise Heartbeat#beat! and the health server's Redis ping hit
     # FrozenError on first call. Mirrors Swarm::ChildBoot#apply_slot_to_config.
     cap.redis_pool
-    cap.local_redis_pool
+    cap.fetch_redis_pool
     cap.client_middleware
     cap.server_middleware
     # Bind on 127.0.0.1:0 so each test gets a unique OS-assigned port.

--- a/test/integration/redis_outage_recovery_test.rb
+++ b/test/integration/redis_outage_recovery_test.rb
@@ -1,0 +1,274 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'socket'
+require 'uri'
+
+# Top-level (not nested) so Processor#build_instance's `Object.const_get`
+# resolves it the same way every other sentinel worker in this suite does.
+# Records its own execution directly against real Redis (bypassing the
+# BlipProxy entirely) so the recording itself can never be affected by the
+# very outage the test is injecting.
+class RedisOutageRecoverySentinelWorker
+  include Wurk::Job
+
+  def perform(redis_url, exec_key)
+    client = RedisClient.config(url: redis_url).new_client
+    client.call('RPUSH', exec_key, jid)
+  ensure
+    client&.close
+  end
+end
+
+# Production incident #101 DoD: a transient Redis blip must self-heal through
+# RedisPool's retry+backoff (Wurk::RedisPool#run) with zero job failures and
+# zero duplicate executions, with no process restart, and the main pool must
+# sit fully available again once fetching goes idle (the dedicated fetch pool
+# is what makes that last part possible — see Capsule#fetch_redis_pool).
+#
+# No mock: every job push, fetch, ack and assertion round-trips through a
+# real Redis server (Wurk::Test.redis_url). The "blip" is a real TCP outage
+# injected by BlipProxy, a transparent relay this test sits the pool's Redis
+# connection behind — CLIENT PAUSE / DEBUG SLEEP would work too, but freeze
+# the *entire* shared instance for the whole poll timeout (see the
+# ClientOutageTest / LivenessProbeTest comments: minitest-parallel_fork runs
+# every test class against the *same* Redis process, just different logical
+# DBs, so a global pause races every sibling test). The proxy confines the
+# blip to this test's own connections.
+class RedisOutageRecoveryTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  JOB_COUNT      = 6
+  CONCURRENCY    = 3
+  BLIP_SECONDS   = 2.5 # within CONN_MAX_ATTEMPTS' backoff budget (~3.2s worst case)
+  POLL_TIMEOUT   = 20.0
+  POLL_INTERVAL  = 0.1
+
+  def setup
+    super
+    @ns = "outage-#{::Process.pid}-#{object_id}"
+    @queue_name = "#{@ns}-q"
+    @exec_key = "#{@ns}-exec"
+    @observer = RedisClient.config(url: Wurk::Test.redis_url).new_client
+    @proxy = BlipProxy.new(Wurk::Test.redis_url)
+    @config = build_config
+    @capsule = build_capsule
+    @manager = Wurk::Manager.new(@capsule)
+  end
+
+  def teardown
+    stop_manager
+    @proxy&.stop!
+    cleanup_keys
+    @config&.reset_redis_pools!
+    @observer&.close
+  ensure
+    super
+  end
+
+  # rubocop:disable Metrics/AbcSize, Minitest/MultipleAssertions
+  def test_blip_self_heals_with_no_failures_no_duplicates_and_idle_holds_no_main_pool_conns
+    jids = enqueue_jobs(JOB_COUNT)
+    @manager.start
+
+    assert wait_until? { executed_count >= 1 }, 'no job executed before the blip — pipeline never started'
+
+    @proxy.blip!(BLIP_SECONDS)
+
+    assert wait_until?(timeout: POLL_TIMEOUT) { executed_count == JOB_COUNT },
+           "expected #{JOB_COUNT} executions after the blip, saw #{executed_count} within #{POLL_TIMEOUT}s"
+
+    executed = @observer.call('LRANGE', @exec_key, 0, -1)
+
+    assert_equal JOB_COUNT, executed.size, 'a job was lost across the blip'
+    assert_equal JOB_COUNT, executed.uniq.size, 'a job ran more than once across the blip'
+    assert_equal jids.sort, executed.sort, 'executed jids must exactly match the enqueued jids'
+
+    assert_equal 0, @observer.call('ZCARD', Wurk::Keys::RETRY).to_i, 'no job should have failed into the retry set'
+    assert_equal 0, @observer.call('ZCARD', Wurk::Keys::DEAD).to_i, 'no job should have failed into the dead set'
+    assert_equal 0, @observer.call('LLEN', "queue:#{@queue_name}").to_i, 'public queue must fully drain'
+    assert_equal 0, @observer.call('LLEN', private_queue_key).to_i, 'private list must fully drain (every job acked)'
+
+    refute_predicate @manager, :stopped?, 'the manager must self-heal in place — no restart'
+
+    quiesce!
+
+    assert_equal @capsule.redis_pool.size, @capsule.redis_pool.available,
+                 'idle worker must hold zero main-pool connections once fetching goes idle'
+    assert_equal @capsule.fetch_redis_pool.size, @capsule.fetch_redis_pool.available,
+                 'idle worker must hold zero fetch-pool connections once fetching goes idle'
+  end
+  # rubocop:enable Metrics/AbcSize, Minitest/MultipleAssertions
+
+  private
+
+  def build_config
+    config = Wurk::Configuration.new
+    config.logger = ::Logger.new(IO::NULL)
+    config.redis = { url: @proxy.url }
+    config[:fetch_poll_interval] = 0.2
+    config
+  end
+
+  def build_capsule
+    cap = @config.default_capsule
+    cap.queues = [@queue_name]
+    cap.concurrency = CONCURRENCY
+    cap.prepare!
+  end
+
+  def stop_manager
+    return unless @manager
+
+    workers = @manager.workers.dup
+    @manager.quiet
+    workers.each(&:kill)
+  end
+
+  def enqueue_jobs(count)
+    client = Wurk::Client.new(pool: @capsule.redis_pool, config: @config)
+    count.times.map do
+      client.push('class' => RedisOutageRecoverySentinelWorker.name,
+                  'args' => [Wurk::Test.redis_url, @exec_key],
+                  'queue' => @queue_name)
+    end
+  end
+
+  def executed_count
+    @observer.call('LLEN', @exec_key).to_i
+  end
+
+  # Stops fetching (Manager#quiet, no replacement processors spawned) and
+  # blocks until every processor thread has actually exited its run loop —
+  # not just requested to — so the pool-availability assertion below can't
+  # race a thread that's mid-checkout.
+  def quiesce!
+    workers = @manager.workers.dup
+    @manager.quiet
+    workers.each { |w| w.thread&.join(5) }
+  end
+
+  def private_queue_key
+    Wurk::Fetcher::Reliable.private_queue_name("queue:#{@queue_name}")
+  end
+
+  def wait_until?(timeout: 5.0)
+    deadline = monotonic_now + timeout
+    while monotonic_now < deadline
+      return true if yield
+
+      sleep POLL_INTERVAL
+    end
+    false
+  end
+
+  def monotonic_now
+    ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+  end
+
+  def cleanup_keys
+    return unless @observer
+
+    @observer.call('DEL', @exec_key, "queue:#{@queue_name}", private_queue_key)
+    @observer.call('SREM', 'queues', @queue_name)
+  rescue StandardError
+    nil
+  end
+
+  # Transparent TCP relay sitting in front of the real (shared) test Redis
+  # instance. `blip!` drops every currently-relayed byte stream and refuses
+  # new connections for the given window, then restores plain pass-through —
+  # a real network blip confined to whichever pool points at this proxy's
+  # `#url`, so sibling parallel test workers on the same shared Redis process
+  # are never disturbed.
+  class BlipProxy
+    def initialize(upstream_url)
+      uri = URI.parse(upstream_url)
+      @upstream_host = uri.host
+      @upstream_port = uri.port
+      @db = uri.path.delete_prefix('/')
+      @server = TCPServer.new('127.0.0.1', 0)
+      @port = @server.addr(false)[1]
+      @outage = false
+      @mutex = ::Mutex.new
+      @sockets = []
+      @accept_thread = Thread.new { accept_loop }
+    end
+
+    def url
+      "redis://127.0.0.1:#{@port}/#{@db}"
+    end
+
+    def blip!(seconds)
+      @mutex.synchronize do
+        @outage = true
+        drop_tracked_sockets
+      end
+      sleep seconds
+      @mutex.synchronize { @outage = false }
+    end
+
+    def stop!
+      @accept_thread.kill
+      @accept_thread.join(1)
+      @server.close
+    rescue IOError, Errno::EBADF
+      nil
+    ensure
+      @mutex.synchronize { drop_tracked_sockets }
+    end
+
+    private
+
+    def accept_loop
+      loop do
+        client = @server.accept
+        if outage?
+          close_quietly(client)
+          next
+        end
+        relay(client)
+      end
+    rescue IOError, Errno::EBADF
+      nil
+    end
+
+    def outage?
+      @mutex.synchronize { @outage }
+    end
+
+    def relay(client)
+      upstream = TCPSocket.new(@upstream_host, @upstream_port)
+      @mutex.synchronize { @sockets.push(client, upstream) }
+      pump(client, upstream)
+      pump(upstream, client)
+    end
+
+    def pump(from, dest)
+      Thread.new do
+        IO.copy_stream(from, dest)
+      rescue StandardError
+        nil
+      ensure
+        untrack(from)
+        untrack(dest)
+      end
+    end
+
+    def untrack(sock)
+      @mutex.synchronize { @sockets.delete(sock) }
+      close_quietly(sock)
+    end
+
+    def drop_tracked_sockets
+      @sockets.each { |s| close_quietly(s) }
+      @sockets.clear
+    end
+
+    def close_quietly(sock)
+      sock.close
+    rescue StandardError
+      nil
+    end
+  end
+end

--- a/test/unit/capsule_test.rb
+++ b/test/unit/capsule_test.rb
@@ -12,7 +12,7 @@ class CapsuleTest < Wurk::Test::UnitCase
 
   def teardown
     @capsule.instance_variable_get(:@redis_pool)&.disconnect!
-    @capsule.instance_variable_get(:@local_redis_pool)&.disconnect!
+    @capsule.instance_variable_get(:@fetch_redis_pool)&.disconnect!
   rescue ConnectionPool::PoolShuttingDownError
     # already torn down
   ensure
@@ -133,7 +133,7 @@ class CapsuleTest < Wurk::Test::UnitCase
     @capsule.prepare!
 
     refute_nil @capsule.instance_variable_get(:@redis_pool)
-    refute_nil @capsule.instance_variable_get(:@local_redis_pool)
+    refute_nil @capsule.instance_variable_get(:@fetch_redis_pool)
   end
 
   def test_queue_specs_round_trips_weighted_queues
@@ -281,27 +281,43 @@ class CapsuleTest < Wurk::Test::UnitCase
 
   # --- redis pools -------------------------------------------------------
 
-  def test_redis_pool_size_is_concurrency_plus_overhead
+  # Main pool = concurrency + POOL_HEADROOM once past the MIN_POOL_SIZE floor.
+  # Blocking fetch draws from the separate fetch pool, so this pool only serves
+  # the background loops + job-code checkouts.
+  def test_redis_pool_size_is_concurrency_plus_headroom
     @capsule.concurrency = 7
 
-    # Heartbeat thread + scheduled poller each need an unstarvable slot
-    # while every worker thread can be parked in BLMOVE — see the
-    # POOL_OVERHEAD comment in Wurk::Capsule.
-    assert_equal 7 + Wurk::Capsule::POOL_OVERHEAD, @capsule.redis_pool.size
+    assert_equal 7 + Wurk::Capsule::POOL_HEADROOM, @capsule.redis_pool.size
+  end
+
+  def test_redis_pool_size_is_floored_at_minimum
+    @capsule.concurrency = 1
+
+    assert_equal Wurk::Capsule::MIN_POOL_SIZE, @capsule.redis_pool.size
+  end
+
+  # config.redis = { size: N } pins the main pool at N, overriding the formula.
+  def test_redis_pool_size_honors_config_size_override
+    @config.redis = { size: 42 }
+    cap = Wurk::Capsule.new('override', @config)
+
+    assert_equal 42, cap.redis_pool.size
+  ensure
+    cap&.redis_pool&.disconnect!
   end
 
   def test_redis_pool_is_memoized
     assert_same @capsule.redis_pool, @capsule.redis_pool
   end
 
-  def test_local_redis_pool_size_matches_concurrency
+  def test_fetch_redis_pool_size_matches_concurrency
     @capsule.concurrency = 4
 
-    assert_equal 4, @capsule.local_redis_pool.size
+    assert_equal 4, @capsule.fetch_redis_pool.size
   end
 
-  def test_redis_pool_and_local_pool_are_distinct
-    refute_same @capsule.redis_pool, @capsule.local_redis_pool
+  def test_redis_pool_and_fetch_pool_are_distinct
+    refute_same @capsule.redis_pool, @capsule.fetch_redis_pool
   end
 
   def test_redis_pool_url_from_config
@@ -315,12 +331,12 @@ class CapsuleTest < Wurk::Test::UnitCase
 
   def test_reset_redis_pools_drops_cached_pools
     pool = @capsule.redis_pool
-    local = @capsule.local_redis_pool
+    fetch = @capsule.fetch_redis_pool
 
     @capsule.reset_redis_pools!
 
     refute_same pool, @capsule.redis_pool, 'main pool should be rebuilt after reset'
-    refute_same local, @capsule.local_redis_pool, 'local pool should be rebuilt after reset'
+    refute_same fetch, @capsule.fetch_redis_pool, 'fetch pool should be rebuilt after reset'
   end
 
   def test_reset_redis_pools_is_safe_when_pools_were_never_built

--- a/test/unit/child_boot_test.rb
+++ b/test/unit/child_boot_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# ChildBoot#reconnect_after_fork runs inside forked swarm children; the real
+# fork path is proven end-to-end by swarm_boot_test. Here we drive its Redis
+# side in-process (no fork) against real Redis so the post-fork PING + eager
+# pipelined script-load logic is exercised directly. `send` reaches the private
+# reconnect because there is no public entry that runs it without the launcher.
+class ChildBootTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @config = Wurk::Configuration.new
+    @config.logger = ::Logger.new(IO::NULL)
+    @config.redis = { url: Wurk::Test.redis_url }
+    @boot = Wurk::Swarm::ChildBoot.new(@config, nil, 0)
+  end
+
+  def teardown
+    @config&.reset_redis_pools!
+  ensure
+    super
+  end
+
+  # PINGs, primes every Lua script, and (with ActiveRecord absent in unit env)
+  # returns cleanly. A live-cache SCRIPT FLUSH would race peer workers that
+  # share the global script cache, so we assert the end state: all SHAs present.
+  def test_reconnect_after_fork_primes_every_lua_script
+    @boot.send(:reconnect_after_fork)
+
+    shas    = Wurk::Lua::SHAS.values
+    present = @config.redis { |c| c.call('SCRIPT', 'EXISTS', *shas) }
+
+    assert(present.all? { |v| v == 1 }, "post-fork boot must leave every script cached, got #{present.inspect}")
+  end
+
+  def test_validate_redis_pings_then_pipelines_every_script_load
+    result = @boot.send(:validate_redis!)
+
+    # #with returns the block value; script_load_all is the last expression, so
+    # its one-SHA-per-script pipeline result proves both the PING (which would
+    # have raised first) and the eager load ran on the same checkout.
+    assert_equal Wurk::Lua::SCRIPTS.size, result.size
+  end
+end

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -276,24 +276,6 @@ class ConfigurationTest < Wurk::Test::UnitCase
     pool&.disconnect!
   end
 
-  def test_local_redis_pool_is_size_10
-    assert_equal 10, @config.local_redis_pool.size
-  ensure
-    @config.local_redis_pool&.disconnect!
-  end
-
-  def test_reset_redis_pools_resets_capsules_and_local_pool
-    cap_pool = @config.default_capsule.redis_pool
-    local_pool = @config.local_redis_pool
-
-    @config.reset_redis_pools!
-
-    refute_same cap_pool, @config.default_capsule.redis_pool
-    refute_same local_pool, @config.local_redis_pool
-  ensure
-    @config.reset_redis_pools!
-  end
-
   def test_reset_redis_pools_calls_through_to_every_capsule
     extra = @config.capsule('extra') { |c| c.concurrency = 1 }
     main_pool = @config.default_capsule.redis_pool

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -266,6 +266,16 @@ class ConfigurationTest < Wurk::Test::UnitCase
     assert_same @config.default_capsule.redis_pool, @config.redis_pool
   end
 
+  def test_redis_config_passes_socket_timeouts_through_to_pool
+    @config.redis = { url: Wurk::Test.redis_url, read_timeout: 5.0, reconnect_attempts: 2 }
+    pool = @config.new_redis_pool(3, 'passthrough')
+
+    assert_equal({ read_timeout: 5.0, reconnect_attempts: 2 },
+                 pool.client_config.slice(:read_timeout, :reconnect_attempts))
+  ensure
+    pool&.disconnect!
+  end
+
   def test_local_redis_pool_is_size_10
     assert_equal 10, @config.local_redis_pool.size
   ensure

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -413,6 +413,37 @@ class ConfigurationTest < Wurk::Test::UnitCase
     refute_match(/backtrace_marker/, io.string)
   end
 
+  def test_default_error_handler_logs_redis_errors_at_warn
+    io = StringIO.new
+    @config.logger = ::Logger.new(io)
+    @config.logger.level = ::Logger::INFO
+
+    Wurk::Configuration::ERROR_HANDLER.call(RedisClient::ConnectionError.new('down'), {}, @config)
+
+    assert_match(/WARN/, io.string)
+    assert_match(/down/, io.string)
+  end
+
+  def test_default_error_handler_logs_pool_timeouts_at_warn
+    io = StringIO.new
+    @config.logger = ::Logger.new(io)
+
+    Wurk::Configuration::ERROR_HANDLER.call(ConnectionPool::TimeoutError.new('waited'), {}, @config)
+
+    assert_match(/WARN/, io.string)
+  end
+
+  def test_default_error_handler_logs_non_redis_errors_at_info
+    io = StringIO.new
+    @config.logger = ::Logger.new(io)
+    @config.logger.level = ::Logger::INFO
+
+    Wurk::Configuration::ERROR_HANDLER.call(StandardError.new('plain'), {}, @config)
+
+    assert_match(/INFO/, io.string)
+    assert_match(/plain/, io.string)
+  end
+
   def test_default_error_handler_wraps_ctx_in_wurk_context
     seen = nil
     capturing = Class.new(::Logger) do
@@ -435,6 +466,59 @@ class ConfigurationTest < Wurk::Test::UnitCase
     @config.death_handlers << handler
 
     assert_includes @config.death_handlers, handler
+  end
+
+  # --- redis-error telemetry (#101) --------------------------------------
+
+  def test_redis_error_handlers_default_empty
+    assert_empty @config.redis_error_handlers
+  end
+
+  def test_on_redis_error_registers_a_handler
+    block = ->(_info) {}
+    @config.on_redis_error(&block)
+
+    assert_includes @config.redis_error_handlers, block
+  end
+
+  def test_on_redis_error_requires_a_block
+    assert_raises(ArgumentError) { @config.on_redis_error }
+  end
+
+  def test_redis_error_handlers_not_shared_between_instances
+    @config.on_redis_error { :noop }
+
+    assert_empty Wurk::Configuration.new.redis_error_handlers
+  end
+
+  def test_dispatch_redis_error_invokes_handlers_with_payload
+    seen = []
+    @config.on_redis_error { |info| seen << info }
+    payload = { error: RuntimeError.new('x'), attempt: 2, retried: false, pool: 'p' }
+
+    @config.send(:dispatch_redis_error, payload)
+
+    assert_equal [payload], seen
+  end
+
+  def test_dispatch_redis_error_swallows_and_logs_handler_errors
+    io = StringIO.new
+    @config.logger = ::Logger.new(io)
+    @config.on_redis_error { raise 'handler boom' }
+
+    @config.send(:dispatch_redis_error, { error: 'e', attempt: 1, retried: true, pool: 'p' })
+
+    assert_match(/redis_error_handler raised/, io.string)
+    assert_match(/handler boom/, io.string)
+  end
+
+  def test_built_pools_are_wired_to_the_redis_error_dispatcher
+    @config.redis = { url: Wurk::Test.redis_url }
+    pool = @config.new_redis_pool(1, 'wired')
+
+    assert pool.instance_variable_get(:@on_error), 'pool must receive an on_error dispatcher'
+  ensure
+    pool&.disconnect!
   end
 
   # --- health_check ------------------------------------------------------

--- a/test/unit/fetcher_reliable_test.rb
+++ b/test/unit/fetcher_reliable_test.rb
@@ -192,11 +192,25 @@ class FetcherReliableTest < Wurk::Test::UnitCase
     assert_equal [1.25, 'BLMOVE', @public_queue, private_queue, 'RIGHT', 'LEFT', 0.25], args
   end
 
+  # blmove must draw from the dedicated fetch pool, never the main pool, so a
+  # parked BLMOVE can't starve the background loops that share the main pool (#101).
+  def test_blmove_checks_out_from_the_fetch_pool_not_the_main_pool
+    used = nil
+    conn = Object.new
+    conn.define_singleton_method(:blocking_call) { |*_| nil }
+    @capsule.define_singleton_method(:fetch_redis) { |&blk| used = :fetch; blk.call(conn) }
+    @capsule.define_singleton_method(:redis) { |&blk| used = :main; blk.call(conn) }
+
+    @fetcher.send(:blmove, @public_queue)
+
+    assert_equal :fetch, used
+  end
+
   private
 
-  # Stub the capsule's Redis so blmove's BLMOVE timeout args can be captured
-  # without actually blocking on a real empty queue. Returns the array the
-  # recorded `blocking_call` writes its arguments into.
+  # Stub the capsule's fetch pool so blmove's BLMOVE timeout args can be
+  # captured without actually blocking on a real empty queue. Returns the array
+  # the recorded `blocking_call` writes its arguments into.
   def captured_blmove_args
     box = []
     conn = Object.new
@@ -204,7 +218,7 @@ class FetcherReliableTest < Wurk::Test::UnitCase
       box.replace(a)
       nil
     end
-    @capsule.define_singleton_method(:redis) { |&blk| blk.call(conn) }
+    @capsule.define_singleton_method(:fetch_redis) { |&blk| blk.call(conn) }
     box
   end
 

--- a/test/unit/lua_loader_test.rb
+++ b/test/unit/lua_loader_test.rb
@@ -5,7 +5,6 @@ require_relative '../test_helper'
 class LuaLoaderTest < Wurk::Test::UnitCase
   parallelize_me!
 
-
   def setup
     super
     @pool = Wurk::RedisPool.new(size: 1, url: Wurk::Test.redis_url, timeout: 2, name: 'loader-test')
@@ -36,6 +35,19 @@ class LuaLoaderTest < Wurk::Test::UnitCase
 
       assert(present.all? { |v| v == 1 }, "all SHAs must be cached after script_load_all, got #{present.inspect}")
     end
+  end
+
+  # The eager post-fork load must cost one round-trip, not one per script —
+  # a regression to N separate SCRIPT LOADs would re-open the boot-latency
+  # hole the #101 fix closed.
+  def test_script_load_all_batches_into_a_single_pipeline
+    conn = FakePipelineConn.new
+    Wurk::Lua::Loader.script_load_all(conn)
+
+    assert_equal 1, conn.pipeline_count, 'script_load_all must batch into exactly one pipeline'
+    assert_equal Wurk::Lua::SCRIPTS.size, conn.loaded.size, 'every registered script must be loaded'
+    assert(conn.loaded.all? { |cmd| cmd.first(2) == %w[SCRIPT LOAD] },
+           "expected only SCRIPT LOADs, got #{conn.loaded.inspect}")
   end
 
   # --- eval_cached happy path ----------------------------------------
@@ -137,6 +149,28 @@ class LuaLoaderTest < Wurk::Test::UnitCase
       { commands: ['EVAL'], source: Wurk::Lua::SCRIPTS[:zpopbyscore] },
       { commands: conn.command_log, source: conn.last_script_source }
     )
+  end
+
+  # Stand-in connection that records the pipelined SCRIPT LOADs so the test
+  # can assert script_load_all uses one pipeline (not a call-per-script loop).
+  class FakePipelineConn
+    attr_reader :pipeline_count, :loaded
+
+    def initialize
+      @pipeline_count = 0
+      @loaded = []
+    end
+
+    def pipelined
+      @pipeline_count += 1
+      yield Pipe.new(@loaded)
+      []
+    end
+
+    class Pipe
+      def initialize(sink) = @sink = sink
+      def call(*args) = @sink << args
+    end
   end
 
   # Stand-in connection that simulates Redis returning NOSCRIPT on the

--- a/test/unit/redis_pool_test.rb
+++ b/test/unit/redis_pool_test.rb
@@ -5,7 +5,6 @@ require_relative '../test_helper'
 class RedisPoolTest < Wurk::Test::UnitCase
   parallelize_me!
 
-
   def teardown
     @pool&.disconnect!
   rescue ConnectionPool::PoolShuttingDownError
@@ -21,14 +20,14 @@ class RedisPoolTest < Wurk::Test::UnitCase
 
     assert_instance_of Wurk::RedisPool, @pool
     assert_equal 3, @pool.size
-    assert_equal 'PONG', @pool.with { |c| c.call('PING') }
+    assert_equal('PONG', @pool.with { |c| c.call('PING') })
   end
 
   def test_redis_connection_create_accepts_string_keys
     @pool = Wurk::RedisConnection.create('url' => Wurk::Test.redis_url, 'size' => 2, 'pool_timeout' => 3)
 
     assert_equal 2, @pool.size
-    assert_equal 3, @pool.timeout
+    assert_equal 3, @pool.pool_timeout
   end
 
   def test_redis_connection_create_defaults_size_when_omitted
@@ -40,16 +39,16 @@ class RedisPoolTest < Wurk::Test::UnitCase
   # --- happy path (real Redis) ---
 
   def test_initialize_stores_size
-    @pool = Wurk::RedisPool.new(size: 4, url: Wurk::Test.redis_url, timeout: 2, name: 'primary')
+    @pool = Wurk::RedisPool.new(size: 4, url: Wurk::Test.redis_url, pool_timeout: 2, name: 'primary')
 
     assert_equal 4, @pool.size
   end
 
   def test_initialize_stores_url_timeout_and_name
-    @pool = Wurk::RedisPool.new(size: 1, url: Wurk::Test.redis_url, timeout: 2, name: 'primary')
+    @pool = Wurk::RedisPool.new(size: 1, url: Wurk::Test.redis_url, pool_timeout: 2, name: 'primary')
 
     assert_equal Wurk::Test.redis_url, @pool.url
-    assert_equal 2, @pool.timeout
+    assert_equal 2, @pool.pool_timeout
     assert_equal 'primary', @pool.name
   end
 
@@ -57,8 +56,54 @@ class RedisPoolTest < Wurk::Test::UnitCase
     @pool = Wurk::RedisPool.new(size: 1)
 
     assert_equal Wurk::RedisPool::DEFAULT_URL, @pool.url
-    assert_equal Wurk::RedisPool::DEFAULT_TIMEOUT, @pool.timeout
+    assert_equal Wurk::RedisPool::DEFAULT_POOL_TIMEOUT, @pool.pool_timeout
     assert_equal Wurk::RedisPool::DEFAULT_NAME, @pool.name
+  end
+
+  # --- split checkout vs socket timeouts (#101) ---
+
+  SOCKET_KEYS = %i[connect_timeout read_timeout write_timeout reconnect_attempts].freeze
+
+  def test_socket_timeouts_default_to_documented_split
+    @pool = build_pool
+    expected = {
+      connect_timeout: Wurk::RedisPool::DEFAULT_CONNECT_TIMEOUT,
+      read_timeout: Wurk::RedisPool::DEFAULT_READ_TIMEOUT,
+      write_timeout: Wurk::RedisPool::DEFAULT_WRITE_TIMEOUT,
+      reconnect_attempts: Wurk::RedisPool::DEFAULT_RECONNECT_ATTEMPTS
+    }
+
+    assert_equal expected, @pool.client_config.slice(*SOCKET_KEYS)
+  end
+
+  def test_read_write_defaults_are_wider_than_connect_and_checkout
+    assert_operator Wurk::RedisPool::DEFAULT_READ_TIMEOUT, :>, Wurk::RedisPool::DEFAULT_CONNECT_TIMEOUT
+    assert_operator Wurk::RedisPool::DEFAULT_WRITE_TIMEOUT, :>, Wurk::RedisPool::DEFAULT_POOL_TIMEOUT
+  end
+
+  def test_split_timeouts_are_configured_independently
+    @pool = Wurk::RedisPool.new(
+      size: 1, url: Wurk::Test.redis_url, name: 'split',
+      pool_timeout: 0.5, connect_timeout: 0.7, read_timeout: 5.0, write_timeout: 3.0, reconnect_attempts: 2
+    )
+
+    assert_in_delta 0.5, @pool.pool_timeout
+    assert_equal({ connect_timeout: 0.7, read_timeout: 5.0, write_timeout: 3.0, reconnect_attempts: 2 },
+                 @pool.client_config.slice(*SOCKET_KEYS))
+  end
+
+  def test_pool_timeout_is_not_forwarded_to_the_client_config
+    @pool = build_pool(pool_timeout: 0.25)
+
+    assert_in_delta 0.25, @pool.pool_timeout
+    refute @pool.client_config.key?(:pool_timeout), 'pool_timeout is a checkout knob, not a socket one'
+  end
+
+  def test_forwards_unknown_keys_to_redis_client_verbatim
+    @pool = Wurk::RedisPool.new(size: 1, url: Wurk::Test.redis_url, name: 'drv', driver: :ruby)
+
+    assert_equal :ruby, @pool.client_config[:driver]
+    assert_equal('PONG', @pool.with { |c| c.call('PING') })
   end
 
   def test_with_yields_a_usable_redis_connection
@@ -168,12 +213,12 @@ class RedisPoolTest < Wurk::Test::UnitCase
 
   private
 
-  def build_pool(size: 1, timeout: 1, name: 'test')
-    Wurk::RedisPool.new(size: size, url: Wurk::Test.redis_url, timeout: timeout, name: name)
+  def build_pool(size: 1, pool_timeout: 1, name: 'test')
+    Wurk::RedisPool.new(size: size, url: Wurk::Test.redis_url, pool_timeout: pool_timeout, name: name)
   end
 
   def pool_wrapping(conn)
-    pool = Wurk::RedisPool.new(size: 1, url: Wurk::Test.redis_url, timeout: 1, name: 'fake')
+    pool = Wurk::RedisPool.new(size: 1, url: Wurk::Test.redis_url, pool_timeout: 1, name: 'fake')
     pool.instance_variable_set(:@pool, FakePool.new(conn))
     pool
   end

--- a/test/unit/redis_pool_test.rb
+++ b/test/unit/redis_pool_test.rb
@@ -179,12 +179,127 @@ class RedisPoolTest < Wurk::Test::UnitCase
     assert_equal 0, conn.closes
   end
 
-  def test_does_not_retry_connection_errors_without_retryable_message
+  # --- connection-error backoff (#101) ---
+
+  def test_retries_connection_error_with_backoff_then_succeeds
     conn = FlakyConn.new(kind: :timeout, raises: 1)
     pool = pool_wrapping(conn)
-    assert_raises(RedisClient::ConnectionError) { pool.with(&:exec) }
-    assert_equal 1, conn.calls
-    assert_equal 0, conn.closes
+
+    no_sleep(pool) { assert_equal(:ok, pool.with(&:exec)) }
+    assert_equal 2, conn.calls
+    assert_equal 1, conn.closes, 'connection is closed before the backoff retry'
+  end
+
+  def test_retries_cannot_connect_error
+    conn = FlakyConn.new(kind: :cannot_connect, raises: 1)
+    pool = pool_wrapping(conn)
+
+    no_sleep(pool) { assert_equal(:ok, pool.with(&:exec)) }
+    assert_equal 2, conn.calls
+  end
+
+  def test_connection_error_retries_to_the_cap_then_raises
+    conn = FlakyConn.new(kind: :timeout, raises: 99)
+    pool = pool_wrapping(conn)
+
+    no_sleep(pool) { assert_raises(RedisClient::ConnectionError) { pool.with(&:exec) } }
+    assert_equal Wurk::RedisPool::CONN_MAX_ATTEMPTS, conn.calls
+    assert_equal Wurk::RedisPool::CONN_MAX_ATTEMPTS - 1, conn.closes
+  end
+
+  # --- telemetry hook ---
+
+  def test_notifies_on_each_retry_and_the_final_give_up
+    events = []
+    conn = FlakyConn.new(kind: :timeout, raises: 99)
+    pool = pool_wrapping(conn, on_error: ->(info) { events << info })
+
+    no_sleep(pool) { assert_raises(RedisClient::ConnectionError) { pool.with(&:exec) } }
+
+    summary = events.map { |e| [e[:attempt], e[:retried], e[:pool], e[:error].class] }
+
+    assert_equal([[1, true, 'fake', RedisClient::ConnectionError],
+                  [2, true, 'fake', RedisClient::ConnectionError],
+                  [3, false, 'fake', RedisClient::ConnectionError]], summary)
+  end
+
+  def test_notifies_on_failover_retry
+    events = []
+    conn = FlakyConn.new(kind: :readonly, raises: 1)
+    pool = pool_wrapping(conn, on_error: ->(info) { events << info })
+
+    assert_equal(:ok, pool.with(&:exec))
+    assert_equal([{ attempt: 1, retried: true }], events.map { |e| e.slice(:attempt, :retried) })
+  end
+
+  def test_does_not_notify_on_non_transient_errors
+    events = []
+    conn = FlakyConn.new(kind: :other, raises: 1)
+    pool = pool_wrapping(conn, on_error: ->(info) { events << info })
+
+    assert_raises(RedisClient::CommandError) { pool.with(&:exec) }
+    assert_empty events
+  end
+
+  def test_a_raising_telemetry_hook_never_breaks_the_retry_path
+    conn = FlakyConn.new(kind: :timeout, raises: 1)
+    pool = pool_wrapping(conn, on_error: ->(_info) { raise 'telemetry boom' })
+
+    no_sleep(pool) { assert_equal(:ok, pool.with(&:exec)) }
+  end
+
+  # --- pool checkout-timeout retry ---
+
+  def test_retries_checkout_timeout_once_then_succeeds
+    fake = FlakyCheckoutPool.new(FlakyConn.new(kind: :readonly, raises: 0), timeouts: 1)
+    pool = pool_over(fake)
+
+    no_checkout_sleep(pool) { assert_equal(:ok, pool.with(&:exec)) }
+    assert_equal 2, fake.calls, 'one retry → two checkout attempts'
+  end
+
+  def test_checkout_timeout_retries_exactly_once_then_raises
+    events = []
+    fake = FlakyCheckoutPool.new(FlakyConn.new(kind: :readonly, raises: 0), timeouts: 99)
+    pool = pool_over(fake, on_error: ->(info) { events << info })
+
+    no_checkout_sleep(pool) { assert_raises(ConnectionPool::TimeoutError) { pool.with { :never } } }
+    assert_equal 2, fake.calls, 'no loop: one retry only'
+    assert_equal([true, false], events.map { |e| e[:retried] })
+  end
+
+  # --- backoff timing formulas ---
+
+  def test_backoff_delay_grows_exponentially_within_jitter
+    pool = build_pool
+
+    assert_includes(1.0...1.25, pool.send(:backoff_delay, 1))
+    assert_includes(2.0...2.25, pool.send(:backoff_delay, 2))
+  end
+
+  def test_checkout_delay_within_documented_window
+    pool = build_pool
+
+    assert_includes(0.1...0.3, pool.send(:checkout_delay))
+  end
+
+  # --- pool stats for heartbeat ---
+
+  def test_available_reports_free_slots
+    @pool = build_pool(size: 3)
+
+    assert_equal 3, @pool.available
+    @pool.with { assert_equal 2, @pool.available }
+    assert_equal 3, @pool.available
+  end
+
+  def test_info_exposes_pool_stats
+    @pool = build_pool(size: 2)
+    info = @pool.info
+
+    assert_equal 2, info['size']
+    assert_equal 2, info['available']
+    assert info.key?('redis_version'), 'still carries Redis INFO'
   end
 
   def test_reraises_after_a_single_retry
@@ -217,10 +332,30 @@ class RedisPoolTest < Wurk::Test::UnitCase
     Wurk::RedisPool.new(size: size, url: Wurk::Test.redis_url, pool_timeout: pool_timeout, name: name)
   end
 
-  def pool_wrapping(conn)
-    pool = Wurk::RedisPool.new(size: 1, url: Wurk::Test.redis_url, pool_timeout: 1, name: 'fake')
-    pool.instance_variable_set(:@pool, FakePool.new(conn))
+  def pool_wrapping(conn, on_error: nil)
+    pool_over(FakePool.new(conn), on_error: on_error)
+  end
+
+  # Swap in a fake @pool so retry tests never open a real socket → deterministic
+  # and fast. A real socket is still built (and immediately shadowed) so
+  # client_config etc. stay populated.
+  def pool_over(fake_pool, on_error: nil)
+    pool = Wurk::RedisPool.new(size: 1, url: Wurk::Test.redis_url, pool_timeout: 1, name: 'fake', on_error: on_error)
+    pool.instance_variable_set(:@pool, fake_pool)
     pool
+  end
+
+  # Neutralize the retry sleeps so tests stay instant. Minitest 6 dropped
+  # minitest/mock, so shadow the (private) delay methods on the throwaway pool
+  # instance directly — no restore needed, the instance dies with the test.
+  def no_sleep(pool)
+    pool.define_singleton_method(:backoff_delay) { |_attempt| 0 }
+    yield
+  end
+
+  def no_checkout_sleep(pool)
+    pool.define_singleton_method(:checkout_delay) { 0 }
+    yield
   end
 
   # Stand-in for a ConnectionPool that always yields the same fake conn.
@@ -239,6 +374,27 @@ class RedisPoolTest < Wurk::Test::UnitCase
     end
   end
 
+  # Raises ConnectionPool::TimeoutError on the first `timeouts` checkouts, then
+  # yields the conn — exercises the out-of-block checkout-timeout retry.
+  class FlakyCheckoutPool
+    attr_reader :calls
+
+    def initialize(conn, timeouts:)
+      @conn = conn
+      @timeouts = timeouts
+      @calls = 0
+    end
+
+    def with
+      @calls += 1
+      raise ConnectionPool::TimeoutError, 'Waited 1 sec' if @calls <= @timeouts
+
+      yield @conn
+    end
+
+    def shutdown(&); end
+  end
+
   class FlakyConn
     ERRORS = {
       readonly: [RedisClient::ReadOnlyError, "READONLY You can't write against a read only replica."],
@@ -246,7 +402,8 @@ class RedisPoolTest < Wurk::Test::UnitCase
       unblocked: [RedisClient::CommandError,
                   'UNBLOCKED force unblock from blocking operation, instance state changed (master -> replica?)'],
       other: [RedisClient::CommandError, 'ERR wrong number of arguments'],
-      timeout: [RedisClient::ConnectionError, 'Connection timed out']
+      timeout: [RedisClient::ConnectionError, 'Connection timed out'],
+      cannot_connect: [RedisClient::CannotConnectError, 'Errno::ECONNREFUSED']
     }.freeze
 
     attr_reader :calls, :closes


### PR DESCRIPTION
## Summary
- Closes out production incident #101: split checkout/socket timeouts with Sidekiq-compat `config.redis` pass-through, bounded retry+backoff for connection blips, one-shot checkout-timeout retry, and a `:redis_error` telemetry hook (all landed in prior commits on this branch).
- Right-sizes the main pool (`concurrency+5`, floor 10) and gives the reliable fetcher its own dedicated BLMOVE pool so an idle worker holds zero main-pool connections; post-fork PING validation + eager pipelined Lua script load; broadened buffered-client rescue, un-nested scheduler checkout, cached `leader?`.
- **This commit**: `test/integration/redis_outage_recovery_test.rb` — real Redis, no mock, proves the whole thing end-to-end: a 2.5s network blip (injected via a private TCP proxy so sibling parallel tests are never disturbed) self-heals with zero job failures/duplicates, no process restart, and the main pool sits fully available once fetching goes idle.

## Test plan
- [x] `bin/rake test TEST=test/unit/redis_pool_test.rb` — 36 runs, 0 failures
- [x] `bin/rake test TEST=test/integration/redis_outage_recovery_test.rb` — passes, stable across repeated runs
- [x] `bin/rake test:parity` — 23 runs, 0 failures
- [x] `bin/rake bench` — enqueue/fetch+execute/bulk/swarm-boot/memory all ran clean (no code changed in this commit, test-only)
- [x] `COVERAGE=1 bin/rake test` — line 96.51%, branch 90.31% (gate ≥90/90)
- [x] `bundle exec rubocop test/integration/redis_outage_recovery_test.rb` — clean

Note: `bin/rake test` has 2 pre-existing failures in `CronTest#test_dst_fall_back_*` unrelated to this change (reproduces identically on a clean checkout of this branch with no files touched, independent of `TZ`) — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)