### PR TITLE
chore(policy): enable auto-merge + dependency-PR lane dogfood (dz#789)

### DIFF
--- a/.maintainer.yml
+++ b/.maintainer.yml
@@ -3,9 +3,12 @@
 #
 # Dogfood pass with coding handoff live. The bot triages (qualifies, labels,
 # asks reporters for repro) and, once a task is ready, dispatches coding to the
-# fleet over the webhook handoff. Auto-merge stays off, and we defer to other
-# bots (coderabbit/copilot/dependabot) before acting on PRs. Everything not set
-# here uses the schema defaults.
+# fleet over the webhook handoff. Auto-merge is ON (dz#789 dependency-PR lane
+# dogfood): green routine PRs — including Dependabot minors — merge on CI +
+# gates; majors still stop on ask_before_acting (major_dep_bump). We still wait
+# for reviewer bots (coderabbit/copilot) to settle before acting. Everything
+# not set here uses the schema defaults (release: release-please, so merged
+# waves cut a batched release).
 version: 1
 
 tone:
@@ -22,8 +25,8 @@ handoff:
   ask_reporter_first: false
 
 pr:
-  wait_for_other_bots: [coderabbit, copilot, dependabot]
-  auto_merge: false
+  wait_for_other_bots: [coderabbit, copilot]
+  auto_merge: true
 
 escalate:
   always: [security, license, cla]


### PR DESCRIPTION
Dogfood flip for developerz-ai/developerz.ai#789 (dependency-bot PRs as maintainer tasks + merged-PR → release trigger).

- `pr.auto_merge: true` — green routine PRs (Dependabot minors included) merge on CI + machine gates; the 4 open major bumps still stop on `ask_before_acting: major_dep_bump`.
- `wait_for_other_bots: [coderabbit, copilot]` — dependabot dropped: under the new lane a dependency-bot *author* is the work item (it never reviews); reviewer bots keep the settle rule.
- `release` stays on schema default (`release-please`) so a merged bump wave cuts one batched release.

Validated against the live schema (`parseYaml` → ok). **Hold merge until the dz#792/#796 images roll out** — flipping early changes wurk behavior on the old build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated pull request handling for eligible routine changes.
  * Routine pull requests can now be automatically merged after required checks pass.
  * Major updates continue to require manual approval.
  * Adjusted the set of automated review checks required before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->