### PR TITLE
fix: shutdown/requeue safety — no double-execution on timeout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Skip step 3 → leaked sockets in children. Skip step 5 → children corrupt eac
 | Signal | Target | Effect |
 |---|---|---|
 | SIGTERM / SIGINT | parent | Graceful drain. Relayed to children; in-flight finishes to `shutdown_timeout`; exit |
-| SIGTSTP | parent | Pause fetch globally; in-flight continues; SIGCONT resumes |
+| SIGTSTP | parent | Quiet globally: relayed to children, each stops fetching; in-flight continues. One-way (matches Sidekiq TSTP, spec §21.3) — no resume; TERM to shut down |
 | SIGUSR1 | parent | Rolling restart: fork replacement → wait for heartbeat → SIGTERM old slot → next |
 | SIGUSR2 | child | Reopen log files (logrotate) |
 | SIGKILL | any | Safe — private-list entries stay in Redis and are reclaimed on next boot |

--- a/docs/idea/04-signals.md
+++ b/docs/idea/04-signals.md
@@ -6,7 +6,7 @@
 |---|---|---|
 | SIGTERM | parent | Graceful drain. Parent relays to all children. Each child stops fetching, lets in-flight jobs finish up to the shutdown timeout, then exits. Parent waits for all children, then exits |
 | SIGINT | parent | Same as SIGTERM (Ctrl-C in standalone) |
-| SIGTSTP | parent | Pause fetching globally. In-flight jobs continue. Resume via SIGCONT |
+| SIGTSTP | parent | Quiet globally: relayed to children, each stops fetching new jobs. In-flight jobs continue. One-way — no resume signal (matches Sidekiq TSTP); send SIGTERM to shut down |
 | SIGUSR1 | parent | Rolling restart. Forks a replacement child before terminating the old one — zero dropped jobs even for long-running work |
 | SIGUSR2 | child | Reopen log files (logrotate-friendly) |
 | SIGKILL | any | Hard stop. Jobs already moved into the per-process private list survive in Redis and are reclaimed on next boot |

--- a/lib/wurk/fetcher.rb
+++ b/lib/wurk/fetcher.rb
@@ -7,5 +7,10 @@ module Wurk
   class Fetcher
     def retrieve_work; end
     def bulk_requeue(in_progress); end
+
+    # Quiet hook: Manager#quiet calls this so retrieve_work can short-circuit
+    # and stop pulling new work the instant a process is quieted. No-op in the
+    # abstract base; Reliable flips its drain flag.
+    def terminate; end
   end
 end

--- a/lib/wurk/fetcher/reliable.rb
+++ b/lib/wurk/fetcher/reliable.rb
@@ -3,6 +3,7 @@
 require 'socket'
 require_relative '../component'
 require_relative '../keys'
+require_relative '../lua'
 require_relative '../fetcher'
 
 module Wurk
@@ -79,19 +80,20 @@ module Wurk
       end
 
       # Called on shutdown for jobs the Processor couldn't finish in time.
-      # One pipelined RPUSH per public queue (head insert) so on next boot
-      # they're picked again ahead of fresh enqueues.
+      # Atomically moves each still-private UoW back to its public queue via
+      # the RELIABLE_REQUEUE Lua (LREM-guarded RPUSH): the job leaves the
+      # per-process private list and reappears on the public queue in one hop,
+      # so it's visible immediately after a deploy instead of waiting for the
+      # next boot's reaper. The guard makes the move idempotent against the
+      # cross-thread `job`-read race in Manager#hard_shutdown — a Processor
+      # that ACKed in that window is a no-op (LREM misses, RPUSH skipped), so a
+      # finished job is never resurrected. Sidekiq Pro super_fetch §3 retains
+      # in-flight in the private list until the next boot; we prefer the
+      # immediate move so a rolling deploy recovers work without a restart.
       def bulk_requeue(in_progress)
         return if in_progress.nil? || in_progress.empty?
 
-        grouped = in_progress.group_by(&:queue)
-        config.redis do |conn|
-          conn.pipelined do |pipe|
-            grouped.each do |public_q, uows|
-              pipe.call('RPUSH', public_q, *uows.map(&:job))
-            end
-          end
-        end
+        config.redis { |conn| requeue_pipelined(conn, in_progress) }
       end
 
       # Prefixed queue keys (`queue:<name>`) in fetch order. Strict mode
@@ -112,6 +114,29 @@ module Wurk
       end
 
       private
+
+      # One pipelined RELIABLE_REQUEUE EVALSHA per UoW. Mirrors
+      # Client#push_batched_pipelined: a pipelined EVALSHA surfaces NOSCRIPT
+      # only at finalize (never to eval_cached's inline rescue). Every command
+      # here is the same script, so a flushed cache fails all of them and
+      # applies none — recover by reloading once and replaying the whole
+      # pipeline via source-embedded EVAL.
+      def requeue_pipelined(conn, in_progress, eval_method: :eval_cached)
+        conn.pipelined do |pipe|
+          in_progress.each do |uow|
+            Wurk::Lua::Loader.public_send(
+              eval_method, pipe, :reliable_requeue,
+              keys: [self.class.private_queue_name(uow.queue), uow.queue],
+              argv: [uow.job]
+            )
+          end
+        end
+      rescue RedisClient::CommandError => e
+        raise unless e.message.to_s.start_with?('NOSCRIPT')
+
+        Wurk::Lua::Loader.script_load_all(conn)
+        requeue_pipelined(conn, in_progress, eval_method: :eval_with_source)
+      end
 
       # SMEMBERS of the `paused` SET. One round-trip per fetch pass; the
       # set is tiny in practice (one entry per paused queue) so the cost

--- a/lib/wurk/fetcher/reliable.rb
+++ b/lib/wurk/fetcher/reliable.rb
@@ -109,6 +109,11 @@ module Wurk
         names.map { |q| "#{Keys::QUEUE_PREFIX}#{q}" }
       end
 
+      # Quiet hook (Manager#quiet). Flips the drain flag so retrieve_work
+      # short-circuits: once quieted, no processor can pull a fresh UoW, even
+      # one sitting in the between-jobs window (Processor#run only re-checks its
+      # own @done between iterations). Quiet is one-way — matches Sidekiq TSTP
+      # (spec §21.3), there is no un-terminate.
       def terminate
         @done = true
       end

--- a/lib/wurk/lua.rb
+++ b/lib/wurk/lua.rb
@@ -56,6 +56,26 @@ module Wurk
       return #jobs
     LUA
 
+    # Reliable fetch (Pro super_fetch §3) shutdown requeue: atomically move
+    # one in-flight job from a per-process private list back to its public
+    # queue. The LREM guard is the whole point — RPUSH runs only when the job
+    # was still in the private list (LREM removed exactly 1). A job the
+    # Processor ACKed in the window between hard_shutdown's cross-thread `job`
+    # read and this move (LREM removes 0) is NOT re-pushed, so the job lands in
+    # exactly one place and can't double-execute. RPUSH (public tail) not LPUSH
+    # so the reclaimed job is fetched next — LMOVE pops the tail — ahead of
+    # fresh LPUSH'd enqueues.
+    # KEYS = [private_list, public_queue]
+    # ARGV = [job_json]
+    # Returns 1 when the job was moved, 0 when it was already acked.
+    RELIABLE_REQUEUE = <<~LUA
+      if redis.call("lrem", KEYS[1], 1, ARGV[1]) == 1 then
+        redis.call("rpush", KEYS[2], ARGV[1])
+        return 1
+      end
+      return 0
+    LUA
+
     # Pro Batch: register a job into a batch and push it to its queue
     # atomically. Keeps total/pending in sync with the jids set.
     #
@@ -259,6 +279,7 @@ module Wurk
       zpopbyscore: ZPOPBYSCORE,
       bulk_push: BULK_PUSH,
       reliable_schedule_promote: RELIABLE_SCHEDULE_PROMOTE,
+      reliable_requeue: RELIABLE_REQUEUE,
       batch_push: BATCH_PUSH,
       batch_ack_success: BATCH_ACK_SUCCESS,
       batch_ack_failed: BATCH_ACK_FAILED,

--- a/lib/wurk/manager.rb
+++ b/lib/wurk/manager.rb
@@ -87,10 +87,13 @@ module Wurk
       end
     end
 
-    # Reached when the deadline expired with workers still busy. We must
-    # push their in-flight UoWs back to the public queues BEFORE raising
-    # Wurk::Shutdown into the threads — losing a job is worse than running
-    # it twice (Sidekiq's at-least-once contract).
+    # Reached when the deadline expired with workers still busy. Atomically
+    # move their in-flight UoWs private→public (Reliable#bulk_requeue) BEFORE
+    # raising Wurk::Shutdown into the threads, so a job killed mid-perform is
+    # re-run once (Sidekiq's at-least-once contract). `job` is read off another
+    # thread, so a Processor can ACK between this map and the requeue — but
+    # bulk_requeue's LREM guard skips the RPUSH on a miss, so a job that
+    # finished in that window is not resurrected onto the public queue.
     def hard_shutdown # rubocop:disable Metrics/AbcSize
       cleanup = nil
       @plock.synchronize do

--- a/lib/wurk/manager.rb
+++ b/lib/wurk/manager.rb
@@ -48,6 +48,13 @@ module Wurk
         @done = true
         @workers.dup
       end
+      # Halt fetching for the whole capsule up front: the shared fetcher's drain
+      # flag makes retrieve_work return nil immediately, so a processor can't pull
+      # a fresh job between quiet and its own terminate taking effect. Safe-nav
+      # covers a quiet that lands before Capsule#prepare! materializes the fetcher
+      # (e.g. a signal-driven quiet on a partially-booted launcher) — nothing is
+      # fetching yet, so there is nothing to halt.
+      capsule.fetcher&.terminate
       logger.info { "Terminating quiet threads for #{capsule.name} capsule" }
       snapshot.each(&:terminate)
     end

--- a/lib/wurk/manager.rb
+++ b/lib/wurk/manager.rb
@@ -38,15 +38,18 @@ module Wurk
     end
 
     def start
-      @workers.each(&:start)
+      workers_snapshot.each(&:start)
     end
 
     def quiet
       return if @done
 
-      @done = true
+      snapshot = @plock.synchronize do
+        @done = true
+        @workers.dup
+      end
       logger.info { "Terminating quiet threads for #{capsule.name} capsule" }
-      @workers.each(&:terminate)
+      snapshot.each(&:terminate)
     end
 
     # Graceful shutdown: quiet first, then poll for workers to clear.
@@ -57,11 +60,11 @@ module Wurk
       # Lifecycle hooks (e.g. :quiet) can be async; give them a tick to settle
       # before we start polling. Matches Sidekiq's PAUSE_TIME behavior.
       sleep PAUSE_TIME
-      return if @workers.empty?
+      return if workers_empty?
 
       logger.info { 'Pausing to allow jobs to finish...' }
-      wait_for(deadline) { @workers.empty? }
-      return if @workers.empty?
+      wait_for(deadline) { workers_empty? }
+      return if workers_empty?
 
       hard_shutdown
     ensure
@@ -75,16 +78,27 @@ module Wurk
     # Processor#run callback: invoked when a Processor thread exits, whether
     # cleanly or via raised exception. Removes the dead processor from the
     # pool and (unless we're already stopping) spawns a replacement so the
-    # capsule's concurrency stays constant.
+    # capsule's concurrency stays constant. If the replacement itself can't be
+    # spawned, crash the child (the swarm respawns it) rather than silently
+    # dropping concurrency. Snapshot under @plock; start the replacement — a
+    # side effect — outside the lock.
     def processor_result(processor, _reason = nil)
-      @plock.synchronize do
+      replacement = @plock.synchronize do
         @workers.delete(processor)
         unless @done
           p = Processor.new(@capsule, &method(:processor_result))
           @workers << p
-          p.start
+          p
         end
       end
+      replacement&.start
+    rescue StandardError => e
+      # Replacement spawn failed (e.g. ThreadError at the OS thread limit).
+      # Silently running one Processor short for the life of the process is
+      # invisible degradation; instead report and crash the child on the main
+      # thread so the swarm respawns it at full concurrency (plan 02 §6).
+      @capsule.config.handle_exception(e, { context: 'Manager could not replace a dead Processor' })
+      main_thread.raise(e)
     end
 
     # Reached when the deadline expired with workers still busy. Atomically
@@ -95,10 +109,7 @@ module Wurk
     # bulk_requeue's LREM guard skips the RPUSH on a miss, so a job that
     # finished in that window is not resurrected onto the public queue.
     def hard_shutdown # rubocop:disable Metrics/AbcSize
-      cleanup = nil
-      @plock.synchronize do
-        cleanup = @workers.dup
-      end
+      cleanup = workers_snapshot
 
       if cleanup.any?
         jobs = cleanup.map(&:job).compact
@@ -114,10 +125,27 @@ module Wurk
       # The caller typically `exit`s immediately after we return; give
       # threads a brief window to run their `ensure` blocks.
       deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + 3
-      wait_for(deadline) { @workers.empty? }
+      wait_for(deadline) { workers_empty? }
     end
 
     private
+
+    # The @workers Set is mutated from Processor threads (processor_result)
+    # while the lifecycle methods read/iterate it from the manager thread.
+    # Snapshot under @plock, then act on the copy outside the lock.
+    def workers_snapshot
+      @plock.synchronize { @workers.dup }
+    end
+
+    def workers_empty?
+      @plock.synchronize { @workers.empty? }
+    end
+
+    # Seam over Thread.main: lets processor_result's replacement-failure crash
+    # be unit-tested against a controlled thread instead of the live runner.
+    def main_thread
+      Thread.main
+    end
 
     # Polls `condblock` until it returns true or the monotonic deadline
     # passes. The PAUSE_TIME floor stops us from spinning when only a few

--- a/lib/wurk/swarm.rb
+++ b/lib/wurk/swarm.rb
@@ -22,8 +22,7 @@ module Wurk
   #
   # Signals (see docs/idea/04-signals.md):
   #   TERM/INT  → `shutdown`           (graceful drain)
-  #   TSTP      → relay TSTP           (pause fetch)
-  #   CONT      → relay CONT           (resume fetch)
+  #   TSTP      → relay TSTP           (quiet — stop fetching; one-way, no resume)
   #   USR1      → `rolling_restart`    (zero-downtime cycle)
   class Swarm
     include Component
@@ -132,7 +131,7 @@ module Wurk
 
     def install_signal_handlers
       { 'TERM' => :term, 'INT' => :term, 'TSTP' => :tstp,
-        'CONT' => :cont, 'USR1' => :usr1 }.each do |sig, sym|
+        'USR1' => :usr1 }.each do |sig, sym|
         ::Signal.trap(sig) { @signal_queue << sym }
       end
     end
@@ -145,7 +144,6 @@ module Wurk
         case sym
         when :term then shutdown
         when :tstp then relay_signal('TSTP')
-        when :cont then relay_signal('CONT')
         when :usr1 then rolling_restart
         end
       end

--- a/lib/wurk/swarm/child_boot.rb
+++ b/lib/wurk/swarm/child_boot.rb
@@ -65,10 +65,10 @@ module Wurk
         wait_loop(launcher)
       end
 
-      # Parent installed traps for TERM/INT/TSTP/CONT/USR1 — the child
-      # needs its own behavior, not the parent's.
+      # Parent installed traps for TERM/INT/TSTP/USR1 — the child needs its own
+      # behavior, not the parent's. USR2 too: the child owns log-reopen.
       def reset_inherited_signals
-        %w[TERM INT TSTP CONT USR1 USR2].each { |s| ::Signal.trap(s, 'DEFAULT') }
+        %w[TERM INT TSTP USR1 USR2].each { |s| ::Signal.trap(s, 'DEFAULT') }
       end
 
       def reconnect_after_fork

--- a/test/integration/graceful_shutdown_test.rb
+++ b/test/integration/graceful_shutdown_test.rb
@@ -23,6 +23,26 @@ class GracefulShutdownSentinelWorker
   end
 end
 
+# Top-level for the same fork/Marshal reason as the sentinel above. Increments
+# a shared counter every time perform is *invoked*, whether or not the run
+# completes — the assertion that matters is how many times this fires across
+# a hard-killed attempt plus a post-reboot retry, not just whether it
+# eventually finishes.
+class TimeoutRequeueSentinelWorker
+  include Wurk::Job
+
+  def perform(redis_url, attempt_key, done_key, sleep_seconds)
+    client = RedisClient.config(url: redis_url).new_client
+    client.call('INCR', attempt_key)
+    client.call('EXPIRE', attempt_key, 60)
+    sleep sleep_seconds
+    client.call('SET', done_key, ::Process.pid.to_s)
+    client.call('EXPIRE', done_key, 60)
+  ensure
+    client&.close
+  end
+end
+
 # Real fork, real signal, real Redis. Boot a swarm in a subprocess with
 # install_signals: true, enqueue an in-flight job, SIGTERM the parent,
 # assert the job finishes within shutdown_timeout.
@@ -38,12 +58,24 @@ class GracefulShutdownTest < Wurk::Test::UnitCase
   POLL_INTERVAL = 0.1
   SHUTDOWN_TIMEOUT = 15
 
+  # Second scenario: a job whose sleep outlasts a short shutdown_timeout, so
+  # hard_shutdown fires for real. Job sleep must clear FAST_DRAIN_TIMEOUT by a
+  # wide margin so the kill is deterministic; swarm-level timeouts must clear
+  # the worst-case drain time (quiet settle + poll-to-deadline + hard_shutdown's
+  # own 3s grace window) with room to spare.
+  FAST_DRAIN_TIMEOUT = 2
+  FAST_SWARM_TIMEOUT = 12
+  TIMEOUT_JOB_SLEEP_SECONDS = 6
+  REBOOT_DRAIN_TIMEOUT = 15
+  REBOOT_SWARM_TIMEOUT = 20
+
   def setup
     super
     @ns = "gshut-#{::Process.pid}-#{object_id}"
     @queue_name = "#{@ns}-q"
     @started_key = "#{@ns}-started"
     @done_key = "#{@ns}-done"
+    @attempt_key = "#{@ns}-attempts"
     @observer = RedisClient.config(url: Wurk::Test.redis_url).new_client
   end
 
@@ -73,10 +105,55 @@ class GracefulShutdownTest < Wurk::Test::UnitCase
     end
   end
 
+  # The bug this closes: before the LREM-guarded bulk_requeue (fetcher/reliable.rb),
+  # a job still in-flight when shutdown_timeout elapsed could end up duplicated
+  # across the private and public lists, so a reboot could execute it a second
+  # time *concurrently* with the about-to-be-killed original. Proves the fix
+  # end to end: a job that sleeps past a short shutdown_timeout gets hard-killed
+  # and requeued exactly once (private list empty, public queue holds one copy),
+  # and a reboot that picks it back up runs it exactly once more — not twice.
+  def test_job_killed_past_shutdown_timeout_is_requeued_and_runs_exactly_once_more # rubocop:disable Minitest/MultipleAssertions,Metrics/AbcSize
+    push_timeout_job(sleep_seconds: TIMEOUT_JOB_SLEEP_SECONDS)
+
+    first_pid = fork_swarm_supervisor(config_timeout: FAST_DRAIN_TIMEOUT, swarm_timeout: FAST_SWARM_TIMEOUT)
+    begin
+      assert wait_for_key(@attempt_key), 'job never started within poll timeout'
+
+      ::Process.kill('TERM', first_pid)
+
+      assert wait_for_pid_exit(first_pid, timeout: FAST_SWARM_TIMEOUT + 5),
+             "supervisor pid #{first_pid} did not exit within its shutdown window"
+    ensure
+      reap_supervisor(first_pid)
+    end
+
+    refute @observer.call('GET', @done_key), 'job must not have completed before the hard kill'
+    assert_equal '1', @observer.call('GET', @attempt_key), 'exactly one attempt before the timeout kill'
+    assert_empty private_list_keys, 'bulk_requeue must leave no residual private-list entries'
+    assert_equal 1, @observer.call('LLEN', public_queue_key), 'timed-out job must be requeued to the public queue'
+
+    second_pid = fork_swarm_supervisor(config_timeout: REBOOT_DRAIN_TIMEOUT, swarm_timeout: REBOOT_SWARM_TIMEOUT)
+    begin
+      assert wait_for_key(@done_key), 'requeued job never completed after reboot'
+
+      ::Process.kill('TERM', second_pid)
+
+      assert wait_for_pid_exit(second_pid, timeout: REBOOT_SWARM_TIMEOUT + 5),
+             "supervisor pid #{second_pid} did not exit within its shutdown window"
+    ensure
+      reap_supervisor(second_pid)
+    end
+
+    assert_equal '2', @observer.call('GET', @attempt_key),
+                 'the reboot must run the requeued job exactly once more, not twice'
+    assert_equal 0, @observer.call('LLEN', public_queue_key), 'completed job must not remain on the public queue'
+    assert_empty private_list_keys, 'ack after completion must leave no residual private-list entries'
+  end
+
   private
 
   def push_job(sleep_seconds:)
-    config = build_config
+    config = build_config(SHUTDOWN_TIMEOUT)
     client = Wurk::Client.new(pool: capsule_pool(config), config: config)
     client.push('class' => GracefulShutdownSentinelWorker.name,
                 'args' => [Wurk::Test.redis_url, @started_key, @done_key, sleep_seconds],
@@ -85,10 +162,20 @@ class GracefulShutdownTest < Wurk::Test::UnitCase
     config&.reset_redis_pools!
   end
 
-  def build_config
+  def push_timeout_job(sleep_seconds:)
+    config = build_config(SHUTDOWN_TIMEOUT)
+    client = Wurk::Client.new(pool: capsule_pool(config), config: config)
+    client.push('class' => TimeoutRequeueSentinelWorker.name,
+                'args' => [Wurk::Test.redis_url, @attempt_key, @done_key, sleep_seconds],
+                'queue' => @queue_name)
+  ensure
+    config&.reset_redis_pools!
+  end
+
+  def build_config(timeout)
     config = Wurk::Configuration.new
     config.logger = ::Logger.new(IO::NULL)
-    config[:timeout] = SHUTDOWN_TIMEOUT
+    config[:timeout] = timeout
     config
   end
 
@@ -100,13 +187,13 @@ class GracefulShutdownTest < Wurk::Test::UnitCase
 
   # Boots the swarm inside a subprocess so SIGTERM exercises the real
   # signal handler. install_signals: true is what we want to test.
-  def fork_swarm_supervisor(count:)
+  def fork_swarm_supervisor(count: 1, config_timeout: SHUTDOWN_TIMEOUT, swarm_timeout: SHUTDOWN_TIMEOUT)
     ::Process.fork do
       $stdout.reopen(IO::NULL)
       $stderr.reopen(IO::NULL)
-      config = build_config
+      config = build_config(config_timeout)
       topology = Wurk::Topology.flat(count: count, queues: [@queue_name], concurrency: 1)
-      swarm = Wurk::Swarm.new(topology: topology, config: config, shutdown_timeout: SHUTDOWN_TIMEOUT)
+      swarm = Wurk::Swarm.new(topology: topology, config: config, shutdown_timeout: swarm_timeout)
       swarm.boot(install_signals: true)
       swarm.supervise
       exit 0
@@ -156,15 +243,30 @@ class GracefulShutdownTest < Wurk::Test::UnitCase
   def cleanup_observer_keys
     return unless @observer
 
-    @observer.call('DEL', @started_key, @done_key, "queue:#{@queue_name}")
-    cursor = '0'
-    loop do
-      cursor, keys = @observer.call('SCAN', cursor, 'MATCH', "queue:#{@queue_name}|*", 'COUNT', 100)
-      @observer.call('DEL', *keys) unless keys.empty?
-      break if cursor == '0'
-    end
+    @observer.call('DEL', @started_key, @done_key, @attempt_key, public_queue_key)
+    private_list_keys.each { |k| @observer.call('DEL', k) }
   rescue StandardError
     nil
+  end
+
+  def public_queue_key
+    "#{Wurk::Keys::QUEUE_PREFIX}#{@queue_name}"
+  end
+
+  # Private lists are named `<public_queue>|<host>|<pid>|<idx>` (Reliable
+  # .private_queue_name) — the pid belongs to the forked swarm child, which the
+  # test never learns directly, so SCAN by prefix instead. Redis deletes a list
+  # key outright once its last element is LREM'd/ACK'd, so "no matching keys"
+  # is equivalent to "every private list is empty".
+  def private_list_keys
+    keys = []
+    cursor = '0'
+    loop do
+      cursor, batch = @observer.call('SCAN', cursor, 'MATCH', "#{public_queue_key}|*", 'COUNT', 100)
+      keys.concat(batch)
+      break if cursor == '0'
+    end
+    keys
   end
 
   def monotonic_now

--- a/test/unit/fetcher_reliable_test.rb
+++ b/test/unit/fetcher_reliable_test.rb
@@ -96,11 +96,43 @@ class FetcherReliableTest < Wurk::Test::UnitCase
     assert_equal payload, lindex(@public_queue, 0)
   end
 
-  # --- bulk_requeue --------------------------------------------------
+  # --- bulk_requeue (atomic private→public move) ---------------------
 
-  def test_bulk_requeue_rpushes_grouped_by_queue
+  # The reliable-fetch recovery path: a job still in the private list at
+  # shutdown is LREM'd out and RPUSH'd to its public queue in one atomic hop,
+  # so it lands in exactly one place — no private+public double copy that
+  # would double-execute (once from the RPUSH, once from the boot reaper).
+  def test_bulk_requeue_moves_job_from_private_to_public
+    payload = enqueue('bq1')
+    uow = @fetcher.retrieve_work
+
+    @fetcher.bulk_requeue([uow])
+
+    assert_equal 0, llen(private_queue), 'LREM must clear the private copy'
+    assert_equal [payload], lrange(@public_queue)
+  end
+
+  # hard_shutdown reads `job` off another thread, so a Processor can ACK
+  # (LREM the private copy) between that read and the requeue. The LREM guard
+  # then removes nothing and skips the RPUSH — a job that already finished is
+  # not resurrected onto the public queue.
+  def test_bulk_requeue_skips_rpush_when_job_already_acked
+    enqueue('bq-acked')
+    uow = @fetcher.retrieve_work
+    uow.acknowledge
+
+    @fetcher.bulk_requeue([uow])
+
+    assert_equal 0, llen(private_queue)
+    assert_equal 0, llen(@public_queue), 'acked job must not be re-pushed'
+  end
+
+  def test_bulk_requeue_moves_each_uow_to_its_own_queue
     other_queue_name   = "#{@queue_name}-other"
     other_public_queue = "#{Wurk::Keys::QUEUE_PREFIX}#{other_queue_name}"
+    other_private      = Wurk::Fetcher::Reliable.private_queue_name(other_public_queue)
+    seed_private(private_queue, 'j1', 'j2')
+    seed_private(other_private, 'k1')
     uows = [
       uow_for(@public_queue, 'j1'),
       uow_for(@public_queue, 'j2'),
@@ -112,7 +144,7 @@ class FetcherReliableTest < Wurk::Test::UnitCase
     assert_equal %w[j1 j2], lrange(@public_queue)
     assert_equal %w[k1], lrange(other_public_queue)
   ensure
-    @pool.with { |c| c.call('DEL', other_public_queue) } if other_public_queue
+    @pool.with { |c| c.call('DEL', other_public_queue, other_private) } if other_public_queue
   end
 
   def test_bulk_requeue_noop_on_nil
@@ -121,6 +153,30 @@ class FetcherReliableTest < Wurk::Test::UnitCase
 
   def test_bulk_requeue_noop_on_empty
     assert_nil @fetcher.bulk_requeue([])
+  end
+
+  # NOSCRIPT recovery (rescue branch): a pipelined EVALSHA surfaces NOSCRIPT
+  # only at finalize, so requeue_pipelined reloads all scripts and replays via
+  # source-embedded EVAL. SCRIPT FLUSH forces that path; the move must still land.
+  def test_bulk_requeue_reloads_lua_after_script_flush
+    payload = enqueue('bq-flush')
+    uow = @fetcher.retrieve_work
+    @pool.with { |c| c.call('SCRIPT', 'FLUSH') }
+
+    @fetcher.bulk_requeue([uow])
+
+    assert_equal [payload], lrange(@public_queue),
+                 'NOSCRIPT must trigger script_load_all + EVAL-source retry, then move the job'
+  end
+
+  # Re-raise branch: a string at the private-list key makes the RELIABLE_REQUEUE
+  # Lua's LREM raise WRONGTYPE — a CommandError that is *not* NOSCRIPT, so it
+  # must propagate rather than trigger the script-reload retry.
+  def test_bulk_requeue_reraises_non_noscript_command_error
+    @pool.with { |c| c.call('SET', private_queue, 'not-a-list') }
+    uow = uow_for(@public_queue, 'x1')
+
+    assert_raises(RedisClient::CommandError) { @fetcher.bulk_requeue([uow]) }
   end
 
   # --- queues_cmd ----------------------------------------------------
@@ -229,6 +285,12 @@ class FetcherReliableTest < Wurk::Test::UnitCase
   def enqueue(payload)
     @pool.with { |c| c.call('LPUSH', @public_queue, payload) }
     payload
+  end
+
+  # Place payloads into a private list exactly as a real fetch's LMOVE would,
+  # so bulk_requeue's LREM guard has a copy to remove.
+  def seed_private(key, *payloads)
+    @pool.with { |c| c.call('RPUSH', key, *payloads) }
   end
 
   def llen(key)

--- a/test/unit/fetcher_test.rb
+++ b/test/unit/fetcher_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# The abstract Wurk::Fetcher base class defines the drop-in fetcher contract
+# (retrieve_work / bulk_requeue / terminate) as safe no-ops. A custom
+# config[:fetch_class] that subclasses it inherits these, so Manager#quiet can
+# call terminate and Manager#hard_shutdown can call bulk_requeue unconditionally.
+class FetcherTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @fetcher = Wurk::Fetcher.new
+  end
+
+  def test_retrieve_work_defaults_to_nil
+    assert_nil @fetcher.retrieve_work
+  end
+
+  def test_bulk_requeue_defaults_to_noop
+    assert_nil @fetcher.bulk_requeue([:anything])
+  end
+
+  def test_terminate_defaults_to_noop
+    # Quiet hook: a subclass without its own terminate must not raise when quieted.
+    assert_nil @fetcher.terminate
+  end
+end

--- a/test/unit/lua_test.rb
+++ b/test/unit/lua_test.rb
@@ -31,7 +31,7 @@ class LuaTest < Wurk::Test::UnitCase
 
   def test_scripts_registry_holds_expected_keys
     assert_equal(
-      %i[zpopbyscore bulk_push reliable_schedule_promote
+      %i[zpopbyscore bulk_push reliable_schedule_promote reliable_requeue
          batch_push batch_ack_success batch_ack_failed batch_ack_complete batch_invalidate
          batch_append_callback
          fast_delete_job fast_delete_by_class release_if_owner

--- a/test/unit/manager_test.rb
+++ b/test/unit/manager_test.rb
@@ -126,6 +126,44 @@ class ManagerTest < Wurk::Test::UnitCase
     assert_nil @capsule.fetcher.retrieve_work
   end
 
+  # `quiet` (manager thread) and `processor_result` (replace-on-die, called from
+  # each dying Processor's own thread) both read/mutate @workers. Whichever wins
+  # the @plock race is a legitimate outcome — quiet-then-churn skips the
+  # replacement (test_processor_result_does_not_replace_after_quiet), churn-then-quiet
+  # spawns one first — but neither ordering may raise or corrupt @workers. Looped
+  # under this file's parallelize_me! to shake out ordering-dependent bugs.
+  def test_quiet_races_processor_churn_without_exceptions_or_leaks # rubocop:disable Metrics/AbcSize
+    25.times do
+      mgr = Wurk::Manager.new(@capsule)
+      silence_processors(mgr)
+      victims = mgr.workers.to_a
+      errors = Queue.new
+
+      with_processor_new(fake_processor) do
+        threads = victims.map do |victim|
+          Thread.new do
+            mgr.processor_result(victim)
+          rescue StandardError => e
+            errors << e
+          end
+        end
+        threads << Thread.new do
+          mgr.quiet
+        rescue StandardError => e
+          errors << e
+        end
+        threads.each(&:join)
+      end
+
+      collected = []
+      collected << errors.pop until errors.empty?
+
+      assert_empty collected, 'concurrent quiet + processor_result churn must not raise'
+      assert_predicate mgr, :stopped?
+      assert_operator mgr.workers.size, :<=, @capsule.concurrency, 'no duplicate/leaked worker entries from the race'
+    end
+  end
+
   # --- processor_result ------------------------------------------------
 
   def test_processor_result_removes_processor_and_spawns_replacement # rubocop:disable Minitest/MultipleAssertions
@@ -316,12 +354,16 @@ class ManagerTest < Wurk::Test::UnitCase
   end
 
   # Stand-in for a Processor that satisfies the Manager's interface without
-  # spawning a real thread. Records #start so tests can assert wiring.
+  # spawning a real thread. Records #start so tests can assert wiring. Also
+  # answers #terminate as a no-op — a churn race can hand this replacement to
+  # `quiet`'s snapshot before it's ever started, and quiet always terminates
+  # every worker it captures.
   def fake_processor
     Object.new.tap do |p|
       started = [false]
-      p.define_singleton_method(:start)    { started[0] = true }
-      p.define_singleton_method(:started?) { started[0] }
+      p.define_singleton_method(:start)     { started[0] = true }
+      p.define_singleton_method(:started?)  { started[0] }
+      p.define_singleton_method(:terminate) { nil }
     end
   end
 

--- a/test/unit/manager_test.rb
+++ b/test/unit/manager_test.rb
@@ -114,6 +114,18 @@ class ManagerTest < Wurk::Test::UnitCase
     assert_equal mgr.workers.size, calls
   end
 
+  def test_quiet_terminates_the_capsule_fetcher
+    mgr = Wurk::Manager.new(@capsule)
+    silence_processors(mgr)
+    @pool.with { |c| c.call('RPUSH', @public_queue, '{"jid":"halt"}') }
+
+    mgr.quiet
+
+    # Drained fetcher short-circuits retrieve_work even with a job waiting, so a
+    # processor can't pull fresh work between quiet and its own terminate.
+    assert_nil @capsule.fetcher.retrieve_work
+  end
+
   # --- processor_result ------------------------------------------------
 
   def test_processor_result_removes_processor_and_spawns_replacement # rubocop:disable Minitest/MultipleAssertions

--- a/test/unit/manager_test.rb
+++ b/test/unit/manager_test.rb
@@ -74,6 +74,22 @@ class ManagerTest < Wurk::Test::UnitCase
     assert_equal mgr.workers.to_a, started
   end
 
+  # start iterates a @plock snapshot, not the live Set, so a Processor that
+  # dies (mutating @workers via processor_result) while its siblings are still
+  # being started can't trigger "can't add a new key into hash during
+  # iteration". Deterministic stand-in for real replace-on-die churn.
+  def test_start_iterates_a_snapshot_so_mid_iteration_churn_is_safe
+    mgr = Wurk::Manager.new(@capsule)
+    workers = mgr.workers.to_a
+    workers.each { |w| w.define_singleton_method(:start) { nil } }
+    victim = workers.last
+    workers.first.define_singleton_method(:start) { mgr.processor_result(victim) }
+
+    with_processor_new(fake_processor) { mgr.start }
+
+    refute_includes mgr.workers, victim
+  end
+
   # --- quiet -----------------------------------------------------------
 
   def test_quiet_flips_stopped_and_terminates_each_processor
@@ -135,6 +151,51 @@ class ManagerTest < Wurk::Test::UnitCase
     mgr.processor_result(victim, RuntimeError.new('boom'))
 
     refute_includes mgr.workers, victim
+  end
+
+  # A replacement that can't be spawned (Processor.new raising) must escalate
+  # to a visible crash on the main thread — not silently drop concurrency.
+  def test_processor_result_crashes_child_when_replacement_cannot_spawn # rubocop:disable Minitest/MultipleAssertions,Metrics/AbcSize
+    mgr = Wurk::Manager.new(@capsule)
+    silence_processors(mgr)
+    victim = mgr.workers.first
+    target, crashes = crash_target
+    mgr.define_singleton_method(:main_thread) { target }
+    reported = capture_error_handler
+
+    boom = ThreadError.new('cannot create thread')
+    with_processor_new_raising(boom) { mgr.processor_result(victim) }
+
+    assert_same boom, crashes.pop, 'must escalate to a crash on the main thread'
+    assert_equal [boom], reported.map(&:first), 'must report via handle_exception'
+    refute_includes mgr.workers, victim
+    assert_equal 2, mgr.workers.size, 'no silent replacement on failure'
+  ensure
+    target&.kill
+  end
+
+  # Same escalation when the replacement is built but its thread won't start.
+  def test_processor_result_crashes_child_when_replacement_start_raises # rubocop:disable Metrics/AbcSize
+    mgr = Wurk::Manager.new(@capsule)
+    silence_processors(mgr)
+    victim = mgr.workers.first
+    target, crashes = crash_target
+    mgr.define_singleton_method(:main_thread) { target }
+
+    boom = ThreadError.new('start failed')
+    exploding = Object.new.tap { |p| p.define_singleton_method(:start) { raise boom } }
+    with_processor_new(exploding) { mgr.processor_result(victim) }
+
+    assert_same boom, crashes.pop
+    refute_includes mgr.workers, victim
+  ensure
+    target&.kill
+  end
+
+  def test_main_thread_seam_targets_the_process_main_thread
+    mgr = Wurk::Manager.new(@capsule)
+
+    assert_same Thread.main, mgr.send(:main_thread)
   end
 
   # --- stop / hard_shutdown -------------------------------------------
@@ -268,5 +329,38 @@ class ManagerTest < Wurk::Test::UnitCase
     yield
   ensure
     sc.define_method(:new) { |*a, &b| original.call(*a, &b) }
+  end
+
+  # Same stub, but `Wurk::Processor.new` raises — simulates OS thread/memory
+  # exhaustion during replace-on-die.
+  def with_processor_new_raising(error)
+    sc = Wurk::Processor.singleton_class
+    original = Wurk::Processor.method(:new)
+    sc.define_method(:new) { |*_args, &_blk| raise error }
+    yield
+  ensure
+    sc.define_method(:new) { |*a, &b| original.call(*a, &b) }
+  end
+
+  # A parked thread standing in for the process main thread, so a crash
+  # escalation (`main_thread.raise`) can be observed instead of taking down
+  # the test runner. Returns [thread, queue-of-caught-exceptions].
+  def crash_target
+    caught = Queue.new
+    t = Thread.new do
+      Thread.current.report_on_exception = false
+      sleep 5
+    rescue StandardError => e
+      caught << e
+    end
+    Thread.pass until t.status == 'sleep'
+    [t, caught]
+  end
+
+  # Register a recording error handler and return the array it appends to.
+  def capture_error_handler
+    seen = []
+    @config.error_handlers << ->(ex, ctx, _cfg) { seen << [ex, ctx] }
+    seen
   end
 end


### PR DESCRIPTION
## Summary
- Atomic private→public `bulk_requeue` (LREM-guarded RPUSH) so a job in-flight past `shutdown_timeout` lands in exactly one place — closes the race where a timed-out job could be duplicated across the private/public lists and executed twice.
- Manager `@plock` discipline around `@workers` (start/quiet/processor_result/hard_shutdown) + crash-visible processor replacement on spawn failure.
- Quiet halts fetching immediately via the shared fetcher's drain flag; dropped the dead TSTP/CONT resume claim (TSTP is one-way per spec §21.3).
- This PR's final task: end-to-end integration proof — a job sleeping past a short `shutdown_timeout` is hard-killed, requeued exactly once (private list empty, public queue holds one copy), and a reboot runs it exactly once more (never twice). Plus a unit stress test for concurrent `quiet` + `processor_result` churn under `@plock`.

## Test plan
- [x] `bin/rake test TEST=test/integration/graceful_shutdown_test.rb`
- [x] `bin/rake test TEST=test/unit/manager_test.rb`
- [x] `bin/rake test:parity`
- [x] `bin/rake test` (full suite; 2 pre-existing/unrelated `CronTest` DST failures reproduce identically on `main`, not touched by this branch)
- [x] `bundle exec rubocop` on changed files

Co-Authored-By: Claude <noreply@anthropic.com>