### PR TITLE
fix(swarm): supervision hardening — backoff, restart, orphan guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,25 @@ Plus Wurk extras: a worker topology DSL, a Kubernetes liveness/readiness listene
 
 JRuby, TruffleRuby, and Windows fall back to threads-only mode (no fork) — behaviorally equivalent to stock Sidekiq.
 
+## Running the workers
+
+Under Rails the engine **auto-starts** the swarm on boot — a plain `rails server` already forks workers and fetches. Set `WURK_DISABLED=1` on any process that shouldn't (e.g. the web tier when you run workers on their own dyno).
+
+**One exception — preforking web servers.** A clustered Puma, Unicorn, or Passenger forks its own web workers, so Wurk **refuses** to also fork the swarm there — it would multiply the swarm by the web-worker count, or entangle its supervisor with the server's own fork/signal handling — and logs how to proceed. Either run the swarm as its own process (recommended):
+
+```bash
+bundle exec wurkswarm   # forked swarm, real parallelism
+```
+
+…or run it inside the web process as threads only, no fork (like Sidekiq embedded):
+
+```ruby
+# config/application.rb  (here, not an initializer — server mode is decided before initializers load)
+config.wurk.embed_in_web = true
+```
+
+Single-mode Puma (the `rails server` default) isn't preforking, so auto-start is unaffected. Full details, flags, and the standalone runners: **[Starting the worker](https://github.com/developerz-ai/wurk/blob/main/docs/running.md)**.
+
 ## The dashboard
 
 Mount the engine wherever you like:

--- a/docs/idea/04-signals.md
+++ b/docs/idea/04-signals.md
@@ -21,6 +21,15 @@ Anything still sitting in the per-process private list at the moment of exit is 
 
 Reliable fetch atomically moves a job ID from the main queue into a per-process private list. The job ID is in two lists for the duration of the work, then removed from the private list on success. If the process disappears (SIGKILL, OOM, hardware failure), the job ID stays in the private list. A janitor — or simply the next boot of a process with the same hostname/PID lineage — moves it back. No job is lost.
 
+## Orphan protection (SIGKILL'd supervisor)
+
+If the supervisor itself is SIGKILLed (or OOM-killed, or crashes), its children would otherwise keep fetching with no parent — and the next redeploy that boots a fresh supervisor would then run doubled concurrency against the same queues. Each child arms two independent mechanisms so it self-terminates the moment it is orphaned, both routed through its own SIGTERM handler (an ordinary graceful drain, not a hard kill):
+
+- **Linux:** `PR_SET_PDEATHSIG=SIGTERM`, set right after fork so the kernel delivers SIGTERM the instant the parent dies (zero latency). The fork race — the parent dying in the window before the syscall lands — is closed by the watchdog's first check.
+- **Every platform:** a watchdog thread compares `getppid` (against the parent PID captured *before* the fork, so it's never fooled by the reparent PID) every 5 seconds; a mismatch means the parent is gone. This is the sole mechanism on non-fork/non-Linux platforms and a backstop elsewhere.
+
+A cleanly-shutting-down supervisor drains its children the normal way (SIGTERM relay) long before either mechanism trips, so orphan protection only fires on an *unclean* supervisor death.
+
 ## Rolling restart semantics
 
 Triggered by SIGUSR1 to the parent. The parent walks its child list one at a time:

--- a/docs/running.md
+++ b/docs/running.md
@@ -43,7 +43,7 @@ from one of them is unsafe two ways:
 
 So Wurk **refuses** to fork there and logs an actionable notice instead:
 
-```
+```text
 wurk: preforking web server detected (Puma cluster / Unicorn / Passenger).
 Refusing to fork the worker swarm from a process that forks its own workers.
 ...

--- a/docs/running.md
+++ b/docs/running.md
@@ -29,6 +29,51 @@ If you'd rather run the worker as its own process even under Rails, disable the
 auto-fork as above and use one of the standalone runners below pointed at your
 app directory.
 
+### Under a preforking web server (Puma cluster, Unicorn, Passenger)
+
+Auto-fork is only safe from a process that **won't fork itself.** A clustered
+Puma, Unicorn, or Passenger already forks its own web workers. Forking the swarm
+from one of them is unsafe two ways:
+
+- **No app preloading** — every web worker re-runs the railtie hook and forks
+  its own full swarm, multiplying your worker count by the web concurrency.
+- **With app preloading** — the swarm boots in the server master, and its
+  supervisor thread ends up tangled with the server's own fork and signal
+  handling.
+
+So Wurk **refuses** to fork there and logs an actionable notice instead:
+
+```
+wurk: preforking web server detected (Puma cluster / Unicorn / Passenger).
+Refusing to fork the worker swarm from a process that forks its own workers.
+...
+```
+
+Pick one:
+
+- **Run the swarm as its own process — recommended.** `bundle exec wurkswarm`
+  (or `wurk`) on its own dyno/unit, the standard production topology. Set
+  `WURK_DISABLED=1` on the web process to silence the notice.
+- **Run workers inside the web process — threads only, no fork.** Opt into
+  embedded mode (the same model as Sidekiq embedded — worker threads share the
+  web process, no swarm):
+
+  ```ruby
+  # config/application.rb
+  config.wurk.embed_in_web = true
+  ```
+
+  Set this in `config/application.rb`, **not** an initializer — server mode is
+  decided before `config/initializers/*` load, so a later flag would arrive too
+  late and your `Sidekiq.configure_server` blocks would be skipped.
+
+Single-mode Puma (`workers 0`, the `rails server` default) is threaded, not
+preforking, so auto-fork stays on there — nothing to change for local dev.
+
+Detection is best-effort: a cluster it misses falls back to the normal fork path,
+and an over-eager match is always escapable via `embed_in_web`, `WURK_DISABLED=1`,
+or simply running `wurkswarm` separately.
+
 ---
 
 ## The two runners

--- a/lib/wurk/cli.rb
+++ b/lib/wurk/cli.rb
@@ -45,7 +45,11 @@ module Wurk
         cli.launcher.quiet
       end,
       'TTIN' => BACKTRACE_DUMPER,
-      'INFO' => BACKTRACE_DUMPER
+      'INFO' => BACKTRACE_DUMPER,
+      'USR2' => lambda do |cli|
+        cli.logger.info 'Received USR2, reopening logs'
+        cli.reopen_logs
+      end
     }.freeze
 
     # Table-driven so adding a flag doesn't grow `define_value_flags`'s ABC
@@ -189,7 +193,14 @@ module Wurk
     end
 
     def signal_names
-      %w[INT TERM TSTP TTIN INFO]
+      %w[INT TERM TSTP TTIN INFO USR2]
+    end
+
+    def reopen_logs
+      log = logger
+      log.reopen if log.respond_to?(:reopen)
+    rescue StandardError
+      nil
     end
 
     def validate_redis!

--- a/lib/wurk/cli.rb
+++ b/lib/wurk/cli.rb
@@ -48,7 +48,8 @@ module Wurk
       'INFO' => BACKTRACE_DUMPER,
       'USR2' => lambda do |cli|
         cli.logger.info 'Received USR2, reopening logs'
-        cli.reopen_logs
+        # reopen_logs is private — an explicit receiver needs __send__.
+        cli.__send__(:reopen_logs)
       end
     }.freeze
 

--- a/lib/wurk/health.rb
+++ b/lib/wurk/health.rb
@@ -28,40 +28,36 @@ module Wurk
     # start/stop; safe to call from Launcher#run / Launcher#stop.
     class Server
       ACCEPT_TIMEOUT = 0.2
+      # How often a non-owner child re-attempts the shared port. Short enough
+      # that probes come back quickly after the owner dies, long enough not to
+      # spin. See #start_retry_loop.
+      RETRY_INTERVAL = 5
 
       attr_reader :port, :bind
 
-      def initialize(launcher, port: DEFAULT_PORT, bind: DEFAULT_BIND, ready_window: DEFAULT_READY_WINDOW)
-        @launcher     = launcher
-        @config       = launcher.instance_variable_get(:@config)
-        @port         = port
-        @bind         = bind
-        @ready_window = ready_window
-        @server       = nil
-        @thread       = nil
-        @done         = false
+      def initialize(launcher, port: DEFAULT_PORT, bind: DEFAULT_BIND,
+                     ready_window: DEFAULT_READY_WINDOW, retry_interval: RETRY_INTERVAL)
+        @launcher       = launcher
+        @config         = launcher.instance_variable_get(:@config)
+        @port           = port
+        @bind           = bind
+        @ready_window   = ready_window
+        @retry_interval = retry_interval
+        @server         = nil
+        @thread         = nil
+        @retry_thread   = nil
+        @done           = false
       end
 
       def start
-        @server = ::TCPServer.new(@bind, @port)
-        # Capture the OS-assigned port when caller passed 0 (test pattern,
-        # also lets the kernel pick a free port at boot).
-        @port = @server.addr[1]
         @done = false
-        @thread = ::Thread.new { run }
-        @thread.name = 'wurk-health'
-        self
-      rescue ::Errno::EADDRINUSE => e
-        # Swarm children all try to bind the same port — only the first wins.
-        # Don't crash the worker; just log and skip.
-        logger&.warn { "Wurk::Health: port #{@port} in use; health server NOT started (#{e.message})" }
-        @server = nil
-        @thread = nil
+        bind_and_serve || start_retry_loop
         self
       end
 
       def stop
         @done = true
+        stop_retry_loop
         srv = @server
         @server = nil
         srv&.close
@@ -73,7 +69,58 @@ module Wurk
         @thread&.alive? == true
       end
 
+      # True while a non-owner child is still polling to take the shared port
+      # over (see #start_retry_loop). Distinct from #running?, which reports the
+      # accept thread specifically.
+      def retrying?
+        @retry_thread&.alive? == true
+      end
+
       private
+
+      # One bind attempt. On success spins the accept thread and returns true.
+      # On EADDRINUSE — a sibling swarm child already owns the shared port —
+      # returns false so the caller schedules a retry.
+      def bind_and_serve
+        @server = ::TCPServer.new(@bind, @port)
+        # Capture the OS-assigned port when caller passed 0 (test pattern,
+        # also lets the kernel pick a free port at boot).
+        @port = @server.addr[1]
+        @thread = ::Thread.new { run }
+        @thread.name = 'wurk-health'
+        true
+      rescue ::Errno::EADDRINUSE
+        @server = nil
+        @thread = nil
+        false
+      end
+
+      # Non-owner children poll the shared port instead of giving up. A single
+      # bind-at-boot went dark to k8s the moment the owning child died —
+      # nothing rebound until the pod restarted. Now a survivor takes the port
+      # over within RETRY_INTERVAL of the owner's exit, so liveness/readiness
+      # ride out ordinary child churn (crash-respawn, rolling restart, recycle).
+      def start_retry_loop
+        logger&.warn do
+          "Wurk::Health: port #{@port} in use; polling every #{@retry_interval}s to take it over"
+        end
+        @retry_thread = ::Thread.new do
+          ::Thread.current.name = 'wurk-health-retry'
+          ::Thread.current.report_on_exception = false
+          sleep @retry_interval until @done || bind_and_serve
+        end
+      end
+
+      def stop_retry_loop
+        thread = @retry_thread
+        @retry_thread = nil
+        return unless thread
+
+        thread.wakeup if thread.alive?
+        thread.join(@retry_interval + 1)
+      rescue ThreadError
+        nil
+      end
 
       def run
         until @done

--- a/lib/wurk/health.rb
+++ b/lib/wurk/health.rb
@@ -50,6 +50,11 @@ module Wurk
       end
 
       def start
+        # Idempotent (see class doc): a second start on a live instance would
+        # re-bind the same port, hit EADDRINUSE, and null out @server/@thread —
+        # leaking the original listener so stop could never close it.
+        return self if running? || retrying?
+
         @done = false
         bind_and_serve || start_retry_loop
         self

--- a/lib/wurk/launcher.rb
+++ b/lib/wurk/launcher.rb
@@ -65,6 +65,7 @@ module Wurk
       @started_at = nil
       @heartbeat = nil
       @heartbeat_thread = nil
+      @boot_reclaim_thread = nil
       @health_server = build_health_server
     end
 
@@ -94,7 +95,9 @@ module Wurk
       @history&.start
       @managers.each(&:start)
       @reaper.start
-      boot_reclaim
+      # Run on a background thread so /ready probe isn't delayed by a large
+      # orphan sweep (reaper.reclaim! is atomic, but can scan many entries).
+      @boot_reclaim_thread = safe_thread('boot-reclaim', &method(:boot_reclaim))
       @health_server&.start
     end
 

--- a/lib/wurk/rails_boot.rb
+++ b/lib/wurk/rails_boot.rb
@@ -104,10 +104,16 @@ module Wurk
 
     def boot_swarm
       swarm = Wurk::Swarm.new(topology: Wurk.configuration.topology)
-      swarm.boot
-      # Embedded in the Rails process: supervise must run somewhere or queued
-      # signals never drain, crashed children never respawn, and memory checks
-      # never fire. A background thread keeps the host's main thread free.
+      # Co-hosted in the web process (e.g. Puma single mode): the host owns the
+      # process-wide TERM/INT traps. Installing the swarm's own would hijack
+      # them — a deploy TERM would drain the swarm but never stop the HTTP
+      # server. Let the host keep signal ownership and drain the swarm on its
+      # graceful exit (same contract as boot_embedded).
+      swarm.boot(install_signals: false)
+      at_exit { swarm.shutdown }
+      # supervise must still run somewhere or crashed children never respawn and
+      # memory checks never fire. A background thread keeps the host's main
+      # thread free to serve HTTP.
       Thread.new do
         swarm.supervise
       rescue StandardError => e

--- a/lib/wurk/rails_boot.rb
+++ b/lib/wurk/rails_boot.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+module Wurk
+  # Coordinates how Wurk boots inside a Rails host: whether this process should
+  # boot at all, whether it may fork the swarm, and the boot itself. The Railtie
+  # owns only the Rails hooks (config namespace + server_mode initializer +
+  # after_initialize) and delegates every decision and side effect here, so the
+  # boot policy stays pure and unit-testable without the Railtie DSL.
+  # See docs/idea/03-process-model.md for the exact ordering.
+  module RailsBoot
+    module_function
+
+    # Invoked from the `wurk.server_mode` initializer, before config/initializers
+    # load. This Rails process forks the workers, so it IS the server. Enter
+    # server mode now — otherwise the app's `Sidekiq.configure_server` blocks
+    # gate on `config.server?` (still false) and are silently dropped. A process
+    # that won't run workers (skip_boot?, or one that refuses to boot under a
+    # preforking web server) is not a server.
+    def enter_server_mode_if_serving(app = ::Rails.application)
+      return if skip_boot?
+      return if boot_action(app) == :refuse
+
+      Wurk.enter_server_mode
+    end
+
+    # Invoked from after_initialize, once the host app has fully initialized.
+    def boot(app = ::Rails.application)
+      return if skip_boot?
+
+      case boot_action(app)
+      when :fork   then boot_swarm
+      when :embed  then boot_embedded
+      when :refuse then refuse_preforking_boot
+      end
+    end
+
+    # A process that won't run workers isn't a server: skip both server mode
+    # and the swarm boot. Console mode is detected reliably here — the console
+    # command file defines ::Rails::Console before initializers run.
+    def skip_boot?
+      ENV['WURK_DISABLED'] == '1' ||
+        building? ||
+        defined?(::Rails::Console) ||
+        ::Rails.env.test?
+    end
+
+    # What boot should do once skip_boot? is false. Pure — reads env / loaded
+    # constants / host config, no side effects — so the boot decision is
+    # unit-testable without forking:
+    #   :fork   — safe to fork the swarm in the background (the default).
+    #   :refuse — a preforking web server owns process forking here; don't.
+    #   :embed  — host opted into in-process threads-only via embed_in_web.
+    def boot_action(app = ::Rails.application)
+      return :fork unless preforking_web_server?
+
+      embed_in_web?(app) ? :embed : :refuse
+    end
+
+    # Preforking / clustered web servers (Puma cluster, Unicorn, Passenger)
+    # fork their own worker processes. Forking the swarm from `after_initialize`
+    # in one of them is the highest-risk boot path: without app preloading every
+    # server-worker re-runs the hook and forks its own full swarm (N×
+    # oversubscription); with preloading the swarm supervisor ends up entangled
+    # with the server's own fork/signal supervision. Detect the common three.
+    def preforking_web_server?
+      return true if defined?(::PhusionPassenger)
+      return true if defined?(::Unicorn)
+
+      puma_cluster?
+    end
+
+    # Puma only preforks in cluster mode (workers > 0); single mode is threaded
+    # and safe to co-host the swarm. Best-effort: a missed cluster falls through
+    # to the historical fork path; an over-eager match is escapable via
+    # embed_in_web / WURK_DISABLED / running the swarm as its own process.
+    def puma_cluster?
+      return false unless defined?(::Puma)
+
+      count = puma_worker_count
+      count.is_a?(Integer) && count.positive?
+    end
+
+    # Worker count from Puma's parsed CLI config when the server booted it, else
+    # from WEB_CONCURRENCY (the near-universal convention for Puma workers).
+    # Guarded — the accessor and options shape vary across Puma versions.
+    def puma_worker_count
+      cfg = ::Puma.cli_config if ::Puma.respond_to?(:cli_config)
+      workers = cfg&.options&.[](:workers)
+      return workers.to_i if workers
+
+      ENV['WEB_CONCURRENCY']&.to_i
+    rescue StandardError
+      nil
+    end
+
+    # Host opt-in (config/application.rb): run workers as in-process threads
+    # instead of forking, like Sidekiq embedded. Set it in application.rb, not
+    # an initializer — server mode is decided before initializers load.
+    def embed_in_web?(app = ::Rails.application)
+      app.config.wurk&.embed_in_web == true
+    rescue StandardError
+      false
+    end
+
+    def boot_swarm
+      swarm = Wurk::Swarm.new(topology: Wurk.configuration.topology)
+      swarm.boot
+      # Embedded in the Rails process: supervise must run somewhere or queued
+      # signals never drain, crashed children never respawn, and memory checks
+      # never fire. A background thread keeps the host's main thread free.
+      Thread.new do
+        swarm.supervise
+      rescue StandardError => e
+        logger.error { "wurk supervisor thread died: #{e.class}: #{e.message}" }
+      end
+    end
+
+    # Sidekiq-embedded parity: a threads-only worker inside the web process, no
+    # fork. Redis validation failure keeps the host serving HTTP (log + carry
+    # on). at_exit drains on the graceful shutdown the web server runs on TERM.
+    def boot_embedded
+      instance = Wurk::Embedded.new(Wurk.configuration)
+      instance.run
+      at_exit { instance.stop }
+      logger.info { 'wurk: running embedded in the web process (config.wurk.embed_in_web) — threads only, no fork' }
+      instance
+    rescue StandardError => e
+      logger.error { "wurk: embedded boot failed: #{e.class}: #{e.message}" }
+      nil
+    end
+
+    def refuse_preforking_boot
+      logger.warn { <<~MSG }
+        wurk: preforking web server detected (Puma cluster / Unicorn / Passenger).
+        Refusing to fork the worker swarm from a process that forks its own workers.
+        Run the swarm as its own process instead:
+
+            bundle exec wurkswarm    # forked swarm, real parallelism
+            bundle exec wurk         # single process, thread pool
+
+        Or run workers inside this web process (threads only, no fork):
+
+            # config/application.rb
+            config.wurk.embed_in_web = true
+
+        Already running workers elsewhere? Set WURK_DISABLED=1 here to silence this.
+      MSG
+    end
+
+    def logger
+      Wurk.configuration.logger
+    end
+
+    # A build/precompile step must never fork the swarm (#247). The default
+    # Rails Dockerfile runs `SECRET_KEY_BASE_DUMMY=1 ./bin/rails
+    # assets:precompile`; that loads `:environment` → fires after_initialize,
+    # but there's no Redis during `docker build`, so a fork would hang/fail the
+    # build. Same for other env-loading rake tasks (db:prepare, db:migrate).
+    # The real server path is unaffected: `rails server` / `puma` boot through
+    # Rails::Command, not Rake, and don't set the dummy secret.
+    def building?
+      return true if ENV.key?('SECRET_KEY_BASE_DUMMY')
+
+      defined?(::Rake) && ::Rake.application.top_level_tasks.any?
+    rescue StandardError
+      false
+    end
+  end
+end

--- a/lib/wurk/railtie.rb
+++ b/lib/wurk/railtie.rb
@@ -1,34 +1,39 @@
 # frozen_string_literal: true
 
 require 'rails/railtie'
+require 'active_support/ordered_options'
 
 module Wurk
   # Boot the swarm after the host app has fully initialized.
   # Skip when: WURK_DISABLED=1, Rails console mode, or Rails test env.
   # See docs/idea/03-process-model.md for the exact ordering.
   class Railtie < ::Rails::Railtie
+    # Host-facing config namespace. Pre-created so a host can write
+    # `config.wurk.embed_in_web = true` in config/application.rb without a
+    # NoMethodError — the setter needs the OrderedOptions to already exist.
+    # Shared with the application config via Rails' Railtie::Configuration
+    # @@options, so `Rails.application.config.wurk` reads back the same object.
+    config.wurk = ::ActiveSupport::OrderedOptions.new
+
     # This Rails process forks the workers, so it IS the server. Enter server
     # mode BEFORE config/initializers load — otherwise the app's
     # `Sidekiq.configure_server` blocks gate on `config.server?` (still false)
-    # and are silently dropped. Gated identically to the swarm boot: a process
-    # that won't run workers (disabled / console / test) is not a server.
-    initializer 'wurk.server_mode', before: :load_config_initializers do
-      Wurk.enter_server_mode unless Wurk::Railtie.skip_boot?
-    end
-
-    config.after_initialize do |_app|
+    # and are silently dropped. A process that won't run workers (disabled /
+    # console / test, or one that refuses to boot under a preforking web
+    # server) is not a server.
+    initializer 'wurk.server_mode', before: :load_config_initializers do |app|
       next if Wurk::Railtie.skip_boot?
 
-      swarm = Wurk::Swarm.new(topology: Wurk.configuration.topology)
-      swarm.boot
-      # Embedded mode keeps the Rails process serving HTTP; supervise must
-      # run somewhere or signal_queue never drains, crashed children never
-      # respawn, and memory pressure checks never fire. Background thread
-      # leaves the host's main thread free for Rails.
-      Thread.new do
-        swarm.supervise
-      rescue StandardError => e
-        Wurk.configuration.logger.error { "wurk supervisor thread died: #{e.class}: #{e.message}" }
+      Wurk.enter_server_mode unless Wurk::Railtie.boot_action(app) == :refuse
+    end
+
+    config.after_initialize do |app|
+      next if Wurk::Railtie.skip_boot?
+
+      case Wurk::Railtie.boot_action(app)
+      when :fork   then Wurk::Railtie.boot_swarm
+      when :embed  then Wurk::Railtie.boot_embedded
+      when :refuse then Wurk::Railtie.refuse_preforking_boot
       end
     end
 
@@ -40,6 +45,113 @@ module Wurk
         building? ||
         defined?(::Rails::Console) ||
         ::Rails.env.test?
+    end
+
+    # What after_initialize should do once skip_boot? is false. Pure — reads
+    # env / loaded constants / host config, no side effects — so the boot
+    # decision is unit-testable without forking:
+    #   :fork   — safe to fork the swarm in the background (the default).
+    #   :refuse — a preforking web server owns process forking here; don't.
+    #   :embed  — host opted into in-process threads-only via embed_in_web.
+    def self.boot_action(app = ::Rails.application)
+      return :fork unless preforking_web_server?
+
+      embed_in_web?(app) ? :embed : :refuse
+    end
+
+    # Preforking / clustered web servers (Puma cluster, Unicorn, Passenger)
+    # fork their own worker processes. Forking the swarm from `after_initialize`
+    # in one of them is the highest-risk boot path: without app preloading every
+    # server-worker re-runs the hook and forks its own full swarm (N×
+    # oversubscription); with preloading the swarm supervisor ends up entangled
+    # with the server's own fork/signal supervision. Detect the common three.
+    def self.preforking_web_server?
+      return true if defined?(::PhusionPassenger)
+      return true if defined?(::Unicorn)
+
+      puma_cluster?
+    end
+
+    # Puma only preforks in cluster mode (workers > 0); single mode is threaded
+    # and safe to co-host the swarm. Best-effort: a missed cluster falls through
+    # to the historical fork path; an over-eager match is escapable via
+    # embed_in_web / WURK_DISABLED / running the swarm as its own process.
+    def self.puma_cluster?
+      return false unless defined?(::Puma)
+
+      count = puma_worker_count
+      count.is_a?(Integer) && count.positive?
+    end
+
+    # Worker count from Puma's parsed CLI config when the server booted it, else
+    # from WEB_CONCURRENCY (the near-universal convention for Puma workers).
+    # Guarded — the accessor and options shape vary across Puma versions.
+    def self.puma_worker_count
+      cfg = ::Puma.cli_config if ::Puma.respond_to?(:cli_config)
+      workers = cfg&.options&.[](:workers)
+      return workers.to_i if workers
+
+      ENV['WEB_CONCURRENCY']&.to_i
+    rescue StandardError
+      nil
+    end
+
+    # Host opt-in (config/application.rb): run workers as in-process threads
+    # instead of forking, like Sidekiq embedded. Set it in application.rb, not
+    # an initializer — server mode is decided before initializers load.
+    def self.embed_in_web?(app = ::Rails.application)
+      app.config.wurk&.embed_in_web == true
+    rescue StandardError
+      false
+    end
+
+    def self.boot_swarm
+      swarm = Wurk::Swarm.new(topology: Wurk.configuration.topology)
+      swarm.boot
+      # Embedded in the Rails process: supervise must run somewhere or the
+      # signal_queue never drains, crashed children never respawn, and memory
+      # checks never fire. A background thread keeps the host's main thread free.
+      Thread.new do
+        swarm.supervise
+      rescue StandardError => e
+        logger.error { "wurk supervisor thread died: #{e.class}: #{e.message}" }
+      end
+    end
+
+    # Sidekiq-embedded parity: a threads-only worker inside the web process, no
+    # fork. Redis validation failure keeps the host serving HTTP (log + carry
+    # on). at_exit drains on the graceful shutdown the web server runs on TERM.
+    def self.boot_embedded
+      instance = Wurk::Embedded.new(Wurk.configuration)
+      instance.run
+      at_exit { instance.stop }
+      logger.info { 'wurk: running embedded in the web process (config.wurk.embed_in_web) — threads only, no fork' }
+      instance
+    rescue StandardError => e
+      logger.error { "wurk: embedded boot failed: #{e.class}: #{e.message}" }
+      nil
+    end
+
+    def self.refuse_preforking_boot
+      logger.warn { <<~MSG }
+        wurk: preforking web server detected (Puma cluster / Unicorn / Passenger).
+        Refusing to fork the worker swarm from a process that forks its own workers.
+        Run the swarm as its own process instead:
+
+            bundle exec wurkswarm    # forked swarm, real parallelism
+            bundle exec wurk         # single process, thread pool
+
+        Or run workers inside this web process (threads only, no fork):
+
+            # config/application.rb
+            config.wurk.embed_in_web = true
+
+        Already running workers elsewhere? Set WURK_DISABLED=1 here to silence this.
+      MSG
+    end
+
+    def self.logger
+      Wurk.configuration.logger
     end
 
     # A build/precompile step must never fork the swarm (#247). The default

--- a/lib/wurk/railtie.rb
+++ b/lib/wurk/railtie.rb
@@ -2,10 +2,13 @@
 
 require 'rails/railtie'
 require 'active_support/ordered_options'
+require_relative 'rails_boot'
 
 module Wurk
-  # Boot the swarm after the host app has fully initialized.
-  # Skip when: WURK_DISABLED=1, Rails console mode, or Rails test env.
+  # Rails integration surface only: register the host-facing `config.wurk`
+  # namespace and wire the two boot hooks to Wurk::RailsBoot. All boot policy
+  # (skip/fork/embed/refuse, prefork detection) and execution lives there — this
+  # class exists solely to invoke the coordinator from the Rails lifecycle.
   # See docs/idea/03-process-model.md for the exact ordering.
   class Railtie < ::Rails::Railtie
     # Host-facing config namespace. Pre-created so a host can write
@@ -15,158 +18,15 @@ module Wurk
     # @@options, so `Rails.application.config.wurk` reads back the same object.
     config.wurk = ::ActiveSupport::OrderedOptions.new
 
-    # This Rails process forks the workers, so it IS the server. Enter server
-    # mode BEFORE config/initializers load — otherwise the app's
+    # Enter server mode BEFORE config/initializers load — otherwise the app's
     # `Sidekiq.configure_server` blocks gate on `config.server?` (still false)
-    # and are silently dropped. A process that won't run workers (disabled /
-    # console / test, or one that refuses to boot under a preforking web
-    # server) is not a server.
+    # and are silently dropped. RailsBoot decides whether this process serves.
     initializer 'wurk.server_mode', before: :load_config_initializers do |app|
-      next if Wurk::Railtie.skip_boot?
-
-      Wurk.enter_server_mode unless Wurk::Railtie.boot_action(app) == :refuse
+      Wurk::RailsBoot.enter_server_mode_if_serving(app)
     end
 
     config.after_initialize do |app|
-      next if Wurk::Railtie.skip_boot?
-
-      case Wurk::Railtie.boot_action(app)
-      when :fork   then Wurk::Railtie.boot_swarm
-      when :embed  then Wurk::Railtie.boot_embedded
-      when :refuse then Wurk::Railtie.refuse_preforking_boot
-      end
-    end
-
-    # A process that won't run workers isn't a server: skip both server mode
-    # and the swarm boot. Console mode is detected reliably here — the console
-    # command file defines ::Rails::Console before initializers run.
-    def self.skip_boot?
-      ENV['WURK_DISABLED'] == '1' ||
-        building? ||
-        defined?(::Rails::Console) ||
-        ::Rails.env.test?
-    end
-
-    # What after_initialize should do once skip_boot? is false. Pure — reads
-    # env / loaded constants / host config, no side effects — so the boot
-    # decision is unit-testable without forking:
-    #   :fork   — safe to fork the swarm in the background (the default).
-    #   :refuse — a preforking web server owns process forking here; don't.
-    #   :embed  — host opted into in-process threads-only via embed_in_web.
-    def self.boot_action(app = ::Rails.application)
-      return :fork unless preforking_web_server?
-
-      embed_in_web?(app) ? :embed : :refuse
-    end
-
-    # Preforking / clustered web servers (Puma cluster, Unicorn, Passenger)
-    # fork their own worker processes. Forking the swarm from `after_initialize`
-    # in one of them is the highest-risk boot path: without app preloading every
-    # server-worker re-runs the hook and forks its own full swarm (N×
-    # oversubscription); with preloading the swarm supervisor ends up entangled
-    # with the server's own fork/signal supervision. Detect the common three.
-    def self.preforking_web_server?
-      return true if defined?(::PhusionPassenger)
-      return true if defined?(::Unicorn)
-
-      puma_cluster?
-    end
-
-    # Puma only preforks in cluster mode (workers > 0); single mode is threaded
-    # and safe to co-host the swarm. Best-effort: a missed cluster falls through
-    # to the historical fork path; an over-eager match is escapable via
-    # embed_in_web / WURK_DISABLED / running the swarm as its own process.
-    def self.puma_cluster?
-      return false unless defined?(::Puma)
-
-      count = puma_worker_count
-      count.is_a?(Integer) && count.positive?
-    end
-
-    # Worker count from Puma's parsed CLI config when the server booted it, else
-    # from WEB_CONCURRENCY (the near-universal convention for Puma workers).
-    # Guarded — the accessor and options shape vary across Puma versions.
-    def self.puma_worker_count
-      cfg = ::Puma.cli_config if ::Puma.respond_to?(:cli_config)
-      workers = cfg&.options&.[](:workers)
-      return workers.to_i if workers
-
-      ENV['WEB_CONCURRENCY']&.to_i
-    rescue StandardError
-      nil
-    end
-
-    # Host opt-in (config/application.rb): run workers as in-process threads
-    # instead of forking, like Sidekiq embedded. Set it in application.rb, not
-    # an initializer — server mode is decided before initializers load.
-    def self.embed_in_web?(app = ::Rails.application)
-      app.config.wurk&.embed_in_web == true
-    rescue StandardError
-      false
-    end
-
-    def self.boot_swarm
-      swarm = Wurk::Swarm.new(topology: Wurk.configuration.topology)
-      swarm.boot
-      # Embedded in the Rails process: supervise must run somewhere or queued
-      # signals never drain, crashed children never respawn, and memory checks
-      # never fire. A background thread keeps the host's main thread free.
-      Thread.new do
-        swarm.supervise
-      rescue StandardError => e
-        logger.error { "wurk supervisor thread died: #{e.class}: #{e.message}" }
-      end
-    end
-
-    # Sidekiq-embedded parity: a threads-only worker inside the web process, no
-    # fork. Redis validation failure keeps the host serving HTTP (log + carry
-    # on). at_exit drains on the graceful shutdown the web server runs on TERM.
-    def self.boot_embedded
-      instance = Wurk::Embedded.new(Wurk.configuration)
-      instance.run
-      at_exit { instance.stop }
-      logger.info { 'wurk: running embedded in the web process (config.wurk.embed_in_web) — threads only, no fork' }
-      instance
-    rescue StandardError => e
-      logger.error { "wurk: embedded boot failed: #{e.class}: #{e.message}" }
-      nil
-    end
-
-    def self.refuse_preforking_boot
-      logger.warn { <<~MSG }
-        wurk: preforking web server detected (Puma cluster / Unicorn / Passenger).
-        Refusing to fork the worker swarm from a process that forks its own workers.
-        Run the swarm as its own process instead:
-
-            bundle exec wurkswarm    # forked swarm, real parallelism
-            bundle exec wurk         # single process, thread pool
-
-        Or run workers inside this web process (threads only, no fork):
-
-            # config/application.rb
-            config.wurk.embed_in_web = true
-
-        Already running workers elsewhere? Set WURK_DISABLED=1 here to silence this.
-      MSG
-    end
-
-    def self.logger
-      Wurk.configuration.logger
-    end
-
-    # A build/precompile step must never fork the swarm (#247). The default
-    # Rails Dockerfile runs `SECRET_KEY_BASE_DUMMY=1 ./bin/rails
-    # assets:precompile`; that loads `:environment` → fires after_initialize,
-    # but there's no Redis during `docker build`, so a fork would hang/fail the
-    # build. Same for other env-loading rake tasks (db:prepare, db:migrate).
-    # The real server path is unaffected: `rails server` / `puma` boot through
-    # Rails::Command, not Rake, and don't set the dummy secret.
-    def self.building?
-      return true if ENV.key?('SECRET_KEY_BASE_DUMMY')
-
-      defined?(::Rake) && ::Rake.application.top_level_tasks.any?
-    rescue StandardError
-      false
+      Wurk::RailsBoot.boot(app)
     end
   end
 end

--- a/lib/wurk/railtie.rb
+++ b/lib/wurk/railtie.rb
@@ -108,9 +108,9 @@ module Wurk
     def self.boot_swarm
       swarm = Wurk::Swarm.new(topology: Wurk.configuration.topology)
       swarm.boot
-      # Embedded in the Rails process: supervise must run somewhere or the
-      # signal_queue never drains, crashed children never respawn, and memory
-      # checks never fire. A background thread keeps the host's main thread free.
+      # Embedded in the Rails process: supervise must run somewhere or queued
+      # signals never drain, crashed children never respawn, and memory checks
+      # never fire. A background thread keeps the host's main thread free.
       Thread.new do
         swarm.supervise
       rescue StandardError => e

--- a/lib/wurk/swarm.rb
+++ b/lib/wurk/swarm.rb
@@ -33,7 +33,7 @@ module Wurk
   #   TERM/INT  → `shutdown`           (graceful drain; aborts any restart)
   #   TSTP      → relay TSTP           (quiet — stop fetching; one-way, no resume)
   #   USR1      → `rolling_restart`    (zero-downtime cycle)
-  class Swarm
+  class Swarm # rubocop:disable Metrics/ClassLength
     include Component
 
     SUPERVISE_TICK = 0.2
@@ -173,11 +173,21 @@ module Wurk
     def install_signal_handlers
       @signal_read, @signal_write = ::IO.pipe
       SWARM_SIGNALS.each_key do |sig|
-        ::Signal.trap(sig) { @signal_write.puts(sig) }
+        ::Signal.trap(sig) { emit_signal(sig) }
       rescue ArgumentError
         # Platform without this signal (e.g. some JRuby builds) — skip it.
         nil
       end
+    end
+
+    # Non-blocking self-pipe write from trap context: a blocking `puts` could
+    # stall signal delivery if the pipe fills. `exception: false` returns
+    # :wait_writable instead of raising when full (drop the coalescible
+    # duplicate); a closed pipe during shutdown is ignored too.
+    def emit_signal(sig)
+      @signal_write.write_nonblock("#{sig}\n", exception: false)
+    rescue ::IOError, ::Errno::EPIPE, ::Errno::EBADF
+      nil
     end
 
     def drain_signals
@@ -247,9 +257,20 @@ module Wurk
       @assignments.each_index do |idx|
         next unless @respawn_backoff.pending?(idx) && @respawn_backoff.ready?(idx)
 
-        @respawn_backoff.consume(idx)
-        spawn_child(@assignments[idx], idx)
+        respawn_slot(idx)
       end
+    end
+
+    # Consume the backoff only after the fork lands. A fork/resource failure
+    # (EAGAIN, ENOMEM) must neither drop the pending respawn nor escape the
+    # supervise loop: on failure we re-arm the backoff and leave the slot
+    # pending so the next due tick retries instead of hot-looping.
+    def respawn_slot(idx)
+      spawn_child(@assignments[idx], idx)
+      @respawn_backoff.consume(idx)
+    rescue StandardError => e
+      delay = @respawn_backoff.fail(idx)
+      logger.warn { "swarm: respawn of slot #{idx} failed (#{e.class}: #{e.message}); retrying in #{delay}s" }
     end
 
     def check_memory_pressure

--- a/lib/wurk/swarm.rb
+++ b/lib/wurk/swarm.rb
@@ -7,6 +7,7 @@ require_relative 'keys'
 require_relative 'swarm/child_boot'
 require_relative 'swarm/backoff'
 require_relative 'swarm/restart'
+require_relative 'swarm/orphan_guard'
 
 module Wurk
   # Parent supervisor. Forks N children per the worker topology, monitors
@@ -41,6 +42,8 @@ module Wurk
     MEMORY_CHECK_INTERVAL = 10
     DEFAULT_SHUTDOWN_TIMEOUT = 25
 
+    SWARM_SIGNALS = { 'TERM' => :term, 'INT' => :term, 'TSTP' => :tstp, 'USR1' => :usr1 }.freeze
+
     attr_reader :topology, :children
 
     def initialize(topology:, config: Wurk.configuration, memory_limit: config.memory_limit_kb,
@@ -53,7 +56,8 @@ module Wurk
       @assignments = []
       @stopping = false
       @last_memory_check = 0
-      @signal_queue = ::Thread::Queue.new
+      @signal_read = nil
+      @signal_write = nil
       @respawn_backoff = Backoff.new(base: RESPAWN_BACKOFF)
       @restart = build_restart
     end
@@ -61,14 +65,20 @@ module Wurk
     # `install_signals:` is false in tests so the integration suite can
     # drive `shutdown` / `rolling_restart` directly without poisoning the
     # test process's signal handlers.
+    #
+    # Traps go in BEFORE fork_children: a TERM landing in the (previously
+    # post-fork) window between fork and trap installation left the parent on
+    # its default disposition — it died instantly and orphaned live, fetching
+    # children. Installed first, the trap queues the TERM and the supervise
+    # loop drains it (relaying to children) even if it arrives mid-boot.
     def boot(install_signals: true)
       raise 'Wurk::Swarm already booted' unless @assignments.empty?
       raise ArgumentError, 'Topology has no slots' if @topology.empty?
 
       @assignments = @topology.assignments.freeze
+      install_signal_handlers if install_signals
       close_parent_sockets
       fork_children
-      install_signal_handlers if install_signals
       @children.keys
     end
 
@@ -144,27 +154,37 @@ module Wurk
       pid
     end
 
+    # Capture the parent PID BEFORE forking and hand it to the child: read
+    # from the parent, it is race-free even if the parent dies the instant
+    # after fork (getppid in the child could already return the reaper). The
+    # child's OrphanGuard compares live getppid against it.
     def fork_child(slot, idx)
+      parent_pid = ::Process.pid
       pid = ::Process.fork
       return pid if pid
 
-      ChildBoot.new(@config, slot, idx).run
+      ChildBoot.new(@config, slot, idx, parent_pid: parent_pid).run
       exit 0 # unreachable; ChildBoot exits explicitly
     end
 
+    # Self-pipe pattern (same as Wurk::CLI): the trap only writes the signal
+    # name to a pipe — no Thread::Queue#push, which takes a mutex a trap can
+    # deadlock against. The supervise loop polls the read end each tick.
     def install_signal_handlers
-      { 'TERM' => :term, 'INT' => :term, 'TSTP' => :tstp,
-        'USR1' => :usr1 }.each do |sig, sym|
-        ::Signal.trap(sig) { @signal_queue << sym }
+      @signal_read, @signal_write = ::IO.pipe
+      SWARM_SIGNALS.each_key do |sig|
+        ::Signal.trap(sig) { @signal_write.puts(sig) }
+      rescue ArgumentError
+        # Platform without this signal (e.g. some JRuby builds) — skip it.
+        nil
       end
     end
 
     def drain_signals
-      until @signal_queue.empty?
-        sym = next_signal_symbol
-        next if sym.nil?
+      return unless @signal_read
 
-        case sym
+      while (sig = read_pending_signal)
+        case SWARM_SIGNALS[sig]
         when :term then shutdown
         when :tstp then relay_signal('TSTP')
         when :usr1 then rolling_restart
@@ -172,10 +192,12 @@ module Wurk
       end
     end
 
-    def next_signal_symbol
-      @signal_queue.pop(true)
-    rescue ThreadError
-      nil
+    # One buffered line per pending signal, non-blocking (wait_readable(0)).
+    # nil once the pipe is drained, ending the loop for this tick.
+    def read_pending_signal
+      return nil unless @signal_read.wait_readable(0)
+
+      @signal_read.gets&.strip
     end
 
     # Reap every exited child this tick (not one), so a fleet-wide death

--- a/lib/wurk/swarm.rb
+++ b/lib/wurk/swarm.rb
@@ -5,11 +5,19 @@ require_relative 'launcher'
 require_relative 'fetcher/reliable'
 require_relative 'keys'
 require_relative 'swarm/child_boot'
+require_relative 'swarm/backoff'
+require_relative 'swarm/restart'
 
 module Wurk
   # Parent supervisor. Forks N children per the worker topology, monitors
-  # PIDs, relays signals, respawns crashed children, handles rolling
-  # restart on SIGUSR1, recycles RSS-bloated children.
+  # PIDs, relays signals, respawns crashed children with per-slot exponential
+  # backoff, handles rolling restart on SIGUSR1, recycles RSS-bloated children.
+  #
+  # The supervise loop never sleeps on behalf of a respawn or a restart: crash
+  # backoff is tracked as per-slot due-times (Swarm::Backoff) and rolling
+  # restart / recycle run as a non-blocking state machine (Swarm::Restart)
+  # advanced one phase per tick. TERM/INT is therefore honored within a tick
+  # regardless of restart or backoff state.
   #
   # Boot ordering (must be exact — see docs/idea/03-process-model.md):
   #   1. Host app boots fully; eager loads done.
@@ -21,7 +29,7 @@ module Wurk
   #   6. Parent calls `supervise` to enter the wait/relay loop.
   #
   # Signals (see docs/idea/04-signals.md):
-  #   TERM/INT  → `shutdown`           (graceful drain)
+  #   TERM/INT  → `shutdown`           (graceful drain; aborts any restart)
   #   TSTP      → relay TSTP           (quiet — stop fetching; one-way, no resume)
   #   USR1      → `rolling_restart`    (zero-downtime cycle)
   class Swarm
@@ -46,6 +54,8 @@ module Wurk
       @stopping = false
       @last_memory_check = 0
       @signal_queue = ::Thread::Queue.new
+      @respawn_backoff = Backoff.new(base: RESPAWN_BACKOFF)
+      @restart = build_restart
     end
 
     # `install_signals:` is false in tests so the integration suite can
@@ -65,7 +75,9 @@ module Wurk
     def supervise
       until done?
         drain_signals
-        reap_one_child
+        reap_children
+        spawn_due_respawns
+        @restart.advance unless @stopping
         check_memory_pressure
         sleep SUPERVISE_TICK
       end
@@ -73,31 +85,35 @@ module Wurk
 
     def shutdown(timeout: @shutdown_timeout)
       @stopping = true
+      @restart.abort
       relay_signal('TERM')
       wait_for_children(timeout)
       hard_kill_stragglers
     end
 
-    # SIGUSR1. For each existing child, fork a replacement, wait for its
-    # first heartbeat, then TERM + drain the old one. Long-running jobs
-    # in the old slot get the full shutdown_timeout while the replacement
-    # is already serving new work.
+    # SIGUSR1: queue every live child for the rolling-restart state machine,
+    # which replaces one slot at a time (spawn replacement → await its
+    # heartbeat → TERM the old child → await its drain) without blocking the
+    # supervise thread, so TERM stays responsive throughout the cycle.
     def rolling_restart
-      @children.dup.each do |old_pid, meta|
-        replacement = fork_child(meta[:slot], meta[:index])
-        @children[replacement] = meta
-        unless wait_for_heartbeat(replacement)
-          logger.warn do
-            "swarm: replacement #{replacement} heartbeat not seen within #{HEARTBEAT_WAIT}s; proceeding anyway"
-          end
-        end
-        safe_kill(old_pid, 'TERM')
-        wait_pid(old_pid, @shutdown_timeout)
-        @children.delete(old_pid)
-      end
+      @restart.enqueue(@children.keys)
     end
 
     private
+
+    def build_restart
+      Restart.new(Restart::Config.new(
+                    spawn: method(:spawn_child),
+                    kill: method(:safe_kill),
+                    heartbeat: method(:heartbeat_seen?),
+                    describe: ->(pid) { @children[pid] },
+                    now: method(:monotonic),
+                    logger: logger,
+                    heartbeat_wait: HEARTBEAT_WAIT,
+                    drain_timeout: @shutdown_timeout,
+                    backoff: Backoff.new(base: RESPAWN_BACKOFF)
+                  ))
+    end
 
     # Step 3.
     def close_parent_sockets
@@ -116,9 +132,16 @@ module Wurk
 
     # Step 4.
     def fork_children
-      @assignments.each_with_index do |slot, idx|
-        @children[fork_child(slot, idx)] = { slot: slot, index: idx }
-      end
+      @assignments.each_index { |idx| spawn_child(@assignments[idx], idx) }
+    end
+
+    # Fork one child for the slot and record its spawn time so crash backoff can
+    # tell a crash-loop (short-lived) from a healthy child that finally died.
+    # Returns the child PID; never returns in the child (ChildBoot exits).
+    def spawn_child(slot, idx)
+      pid = fork_child(slot, idx)
+      @children[pid] = { slot: slot, index: idx, spawned_at: monotonic }
+      pid
     end
 
     def fork_child(slot, idx)
@@ -155,42 +178,78 @@ module Wurk
       nil
     end
 
-    def reap_one_child
-      pid, status = ::Process.wait2(-1, ::Process::WNOHANG)
-      on_child_exit(pid, status) if pid
+    # Reap every exited child this tick (not one), so a fleet-wide death
+    # recovers in parallel rather than one child per SUPERVISE_TICK. ECHILD
+    # (momentarily no children — all crashed and awaiting backoff) is not a stop
+    # condition: the swarm only stops on an explicit TERM/INT.
+    def reap_children
+      loop do
+        pid, status = ::Process.wait2(-1, ::Process::WNOHANG)
+        break unless pid
+
+        on_child_exit(pid, status)
+      end
     rescue Errno::ECHILD
-      @stopping = true
+      nil
     end
 
     def on_child_exit(pid, status)
       meta = @children.delete(pid)
       return unless meta
+      return if @restart.claim_exit(pid)
 
       if @stopping
         logger.info { "swarm: child #{pid} exited (status=#{status.exitstatus})" }
       else
-        logger.warn { "swarm: child #{pid} died (status=#{status.exitstatus}); respawning slot #{meta[:index]}" }
-        sleep RESPAWN_BACKOFF
-        @children[fork_child(meta[:slot], meta[:index])] = meta
+        schedule_respawn(pid, status, meta)
+      end
+    end
+
+    # Arm the slot's backoff instead of sleeping the supervise thread; the next
+    # due tick respawns it. A child that lived past the reset window counts as a
+    # fresh failure (base delay), so only a genuine crash-loop escalates toward
+    # the cap.
+    def schedule_respawn(pid, status, meta)
+      idx = meta[:index]
+      delay = @respawn_backoff.fail(idx, lifetime: monotonic - meta[:spawned_at])
+      logger.warn do
+        "swarm: child #{pid} died (status=#{status.exitstatus}); respawning slot #{idx} in #{delay}s"
+      end
+    end
+
+    # Respawn any slot whose backoff window has elapsed. Runs every tick; a
+    # no-op until a scheduled respawn comes due.
+    def spawn_due_respawns
+      return if @stopping
+
+      @assignments.each_index do |idx|
+        next unless @respawn_backoff.pending?(idx) && @respawn_backoff.ready?(idx)
+
+        @respawn_backoff.consume(idx)
+        spawn_child(@assignments[idx], idx)
       end
     end
 
     def check_memory_pressure
       return unless @memory_limit
 
-      now = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+      now = monotonic
       return if now - @last_memory_check < MEMORY_CHECK_INTERVAL
 
       @last_memory_check = now
       @children.dup.each_key { |pid| recycle_if_bloated(pid) }
     end
 
+    # Route a bloated child through the restart state machine (same path as a
+    # rolling restart) so recycle is graceful — a healthy replacement takes over
+    # before the old child is TERMed — and can't overlap a restart already in
+    # flight on the slot.
     def recycle_if_bloated(pid)
       rss = pid_rss_kb(pid)
       return if rss.nil? || rss < @memory_limit
 
       logger.warn { "swarm: child #{pid} RSS #{rss}KB >= #{@memory_limit}KB; recycling" }
-      safe_kill(pid, 'TERM')
+      @restart.enqueue([pid])
     end
 
     def pid_rss_kb(pid)
@@ -211,22 +270,10 @@ module Wurk
       nil
     end
 
-    def wait_pid(pid, timeout)
-      deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + timeout
-      while ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) < deadline
-        return true if ::Process.wait(pid, ::Process::WNOHANG)
-
-        sleep 0.1
-      end
-      false
-    rescue Errno::ECHILD
-      true
-    end
-
     def wait_for_children(timeout)
-      deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + timeout
-      while ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) < deadline && @children.any?
-        reap_one_child
+      deadline = monotonic + timeout
+      while monotonic < deadline && @children.any?
+        reap_children
         sleep 0.1
       end
     end
@@ -236,19 +283,22 @@ module Wurk
       @children.clear
     end
 
-    # Identity is `<hostname>:<pid>:<nonce>`. PROCESS_NONCE is set when
-    # Component loads in the parent and inherited by every fork — the
-    # parent can compute a child's identity from its PID alone.
-    # Returns true if the heartbeat was observed before the deadline.
-    def wait_for_heartbeat(pid) # rubocop:disable Naming/PredicateMethod
+    # Has the child written its first heartbeat yet? One non-blocking SISMEMBER,
+    # polled by the restart state machine each tick. Identity is
+    # `<hostname>:<pid>:<nonce>`; PROCESS_NONCE is set when Component loads in
+    # the parent and inherited by every fork, so the parent computes a child's
+    # identity from its PID alone. A Redis blip returns false (not seen yet) so a
+    # transient error can't crash the supervisor — the restart deadline still
+    # forces progress.
+    def heartbeat_seen?(pid)
       identity = "#{hostname}:#{pid}:#{Component::PROCESS_NONCE}"
-      deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + HEARTBEAT_WAIT
-      while ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) < deadline
-        return true if @config.redis { |c| c.call('SISMEMBER', Keys::PROCESSES, identity) } == 1
-
-        sleep 0.5
-      end
+      @config.redis { |c| c.call('SISMEMBER', Keys::PROCESSES, identity) } == 1
+    rescue StandardError
       false
+    end
+
+    def monotonic
+      ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
     end
 
     def done?

--- a/lib/wurk/swarm/backoff.rb
+++ b/lib/wurk/swarm/backoff.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Wurk
+  class Swarm
+    # Per-key exponential backoff timer with survival-based reset. Pure
+    # bookkeeping — no sleeping, no I/O — so the supervise thread never blocks
+    # on it: it records a failure, then asks `ready?` each tick and acts only
+    # once the delay has elapsed.
+    #
+    # Delay grows base → 2·base → 4·base … capped at `cap`. A key whose child
+    # survived at least `reset_after` seconds counts as a fresh first failure,
+    # so a slot that ran healthily for a while doesn't inherit an old crash
+    # streak. Keyed by slot index for crash-respawn and (in Swarm::Restart) for
+    # replacement-retry delays.
+    class Backoff
+      BASE = 1.0
+      CAP = 30.0
+      RESET_AFTER = 60.0
+
+      def initialize(base: BASE, cap: CAP, reset_after: RESET_AFTER, clock: nil)
+        @base = base
+        @cap = cap
+        @reset_after = reset_after
+        @clock = clock || -> { ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) }
+        @streak = Hash.new(0)
+        @due_at = {}
+      end
+
+      # Record a failure and schedule the next attempt. `lifetime` is how long
+      # the failed child lived; >= reset_after resets the streak. Returns the
+      # delay applied.
+      def fail(key, lifetime: 0.0)
+        @streak[key] = 0 if lifetime >= @reset_after
+        @streak[key] += 1
+        delay = [@base * (2**(@streak[key] - 1)), @cap].min
+        @due_at[key] = now + delay
+        delay
+      end
+
+      # A retry is scheduled and not yet issued.
+      def pending?(key)
+        @due_at.key?(key)
+      end
+
+      # The scheduled delay has elapsed (or nothing is scheduled).
+      def ready?(key)
+        at = @due_at[key]
+        at.nil? || now >= at
+      end
+
+      # Mark the scheduled retry as issued without resetting the streak, so a
+      # child that crashes straight back escalates toward the cap.
+      def consume(key)
+        @due_at.delete(key)
+      end
+
+      # Forget the key entirely (slot retired or restart succeeded).
+      def clear(key)
+        @streak.delete(key)
+        @due_at.delete(key)
+      end
+
+      private
+
+      def now
+        @clock.call
+      end
+    end
+  end
+end

--- a/lib/wurk/swarm/child_boot.rb
+++ b/lib/wurk/swarm/child_boot.rb
@@ -88,9 +88,11 @@ module Wurk
       # so stray USR1s don't trigger default termination.
       def reset_inherited_signals
         %w[TERM INT TSTP USR2].each { |s| ::Signal.trap(s, 'DEFAULT') }
-        ::Signal.trap('USR1') do
-          @config.logger.debug { 'Received USR1 (rolling restart); no-op in child' }
-        end
+        # A genuine no-op in the child (rolling restart is the parent's job) —
+        # trap it empty so a stray USR1 can't fall through to default
+        # termination. Must NOT log: Logger synchronizes writes and would
+        # deadlock if the trap fired mid-write.
+        ::Signal.trap('USR1') { nil }
       rescue ArgumentError
         nil
       end
@@ -144,11 +146,21 @@ module Wurk
       def install_signal_handlers(launcher)
         @signal_read, @signal_write = ::IO.pipe
         CHILD_SIGNALS.each_key do |sig|
-          ::Signal.trap(sig) { @signal_write.puts(sig) }
+          ::Signal.trap(sig) { emit_signal(sig) }
         rescue ArgumentError
           nil
         end
         @dispatcher = Thread.new { dispatch_signals(launcher) }
+      end
+
+      # Non-blocking self-pipe write from trap context: a blocking `puts` could
+      # stall the TERM drain if the pipe ever filled. `exception: false` returns
+      # :wait_writable instead of raising when full (the queued duplicate
+      # coalesces); a closed pipe during shutdown is ignored too.
+      def emit_signal(sig)
+        @signal_write.write_nonblock("#{sig}\n", exception: false)
+      rescue ::IOError, ::Errno::EPIPE, ::Errno::EBADF
+        nil
       end
 
       # TSTP/USR2 keep looping; TERM/INT run the full launcher.stop

--- a/lib/wurk/swarm/child_boot.rb
+++ b/lib/wurk/swarm/child_boot.rb
@@ -82,10 +82,17 @@ module Wurk
         @watchdog = @orphan_guard.arm
       end
 
-      # Parent installed traps for TERM/INT/TSTP/USR1 — the child needs its own
+      # Parent installed traps for TERM/INT/TSTP — the child needs its own
       # behavior, not the parent's. USR2 too: the child owns log-reopen.
+      # USR1 (rolling restart) is a no-op in the child — trap it with a log
+      # so stray USR1s don't trigger default termination.
       def reset_inherited_signals
-        %w[TERM INT TSTP USR1 USR2].each { |s| ::Signal.trap(s, 'DEFAULT') }
+        %w[TERM INT TSTP USR2].each { |s| ::Signal.trap(s, 'DEFAULT') }
+        ::Signal.trap('USR1') do
+          @config.logger.debug { 'Received USR1 (rolling restart); no-op in child' }
+        end
+      rescue ArgumentError
+        nil
       end
 
       def reconnect_after_fork

--- a/lib/wurk/swarm/child_boot.rb
+++ b/lib/wurk/swarm/child_boot.rb
@@ -4,6 +4,7 @@ require_relative '../component'
 require_relative '../launcher'
 require_relative '../fetcher/reliable'
 require_relative '../lua'
+require_relative 'orphan_guard'
 
 module Wurk
   class Swarm
@@ -22,11 +23,17 @@ module Wurk
 
       CHILD_SIGNALS = { 'TERM' => :term, 'INT' => :term, 'TSTP' => :tstp, 'USR2' => :usr2 }.freeze
 
-      def initialize(config, slot, index)
+      # `parent_pid` is captured by the swarm before it forks (race-free) and
+      # threaded through so OrphanGuard can tell "still supervised" from
+      # "reparented after the supervisor died". Defaults to the live parent for
+      # the non-swarm callers (tests) that construct a ChildBoot directly.
+      def initialize(config, slot, index, parent_pid: ::Process.ppid)
         @config = config
         @slot = slot
         @index = index
-        @signal_queue = ::Thread::Queue.new
+        @parent_pid = parent_pid
+        @signal_read = nil
+        @signal_write = nil
       end
 
       def run
@@ -57,12 +64,22 @@ module Wurk
 
       # Boot the launcher and block until shutdown. wait_loop joins the
       # signal-dispatch thread, so the child can't fall through to `exit 0`
-      # mid-drain.
+      # mid-drain. Orphan protection is armed right AFTER launcher.run — the
+      # TERM handler is in place (so pdeathsig / the watchdog drain gracefully)
+      # and the managers are up (so a self-TERM can't race launcher.run). A
+      # parent that died during boot is still caught immediately: the watchdog's
+      # first getppid check sees the reparent and drains at once.
       def run_launcher
         launcher = Wurk::Launcher.new(@config)
         install_signal_handlers(launcher)
         launcher.run
+        arm_orphan_guard
         wait_loop(launcher)
+      end
+
+      def arm_orphan_guard
+        @orphan_guard = OrphanGuard.new(@parent_pid, logger: @config.logger)
+        @watchdog = @orphan_guard.arm
       end
 
       # Parent installed traps for TERM/INT/TSTP/USR1 — the child needs its own
@@ -114,8 +131,16 @@ module Wurk
         # below — for every entry point, not just the swarm.
       end
 
+      # Self-pipe pattern (same as Wurk::CLI / Wurk::Swarm): the trap only
+      # writes the signal name to a pipe — never Thread::Queue#push, whose
+      # mutex a trap can deadlock against.
       def install_signal_handlers(launcher)
-        CHILD_SIGNALS.each { |sig, sym| ::Signal.trap(sig) { @signal_queue << sym } }
+        @signal_read, @signal_write = ::IO.pipe
+        CHILD_SIGNALS.each_key do |sig|
+          ::Signal.trap(sig) { @signal_write.puts(sig) }
+        rescue ArgumentError
+          nil
+        end
         @dispatcher = Thread.new { dispatch_signals(launcher) }
       end
 
@@ -126,10 +151,14 @@ module Wurk
       # and the main thread would race past the unfinished managers.
       def dispatch_signals(launcher)
         loop do
-          case @signal_queue.pop
+          @signal_read.wait_readable
+          sig = @signal_read.gets&.strip
+          break if sig.nil?
+
+          case CHILD_SIGNALS[sig]
           when :term
             launcher.stop
-            return
+            break
           when :tstp then launcher.quiet
           when :usr2 then reopen_logs
           end

--- a/lib/wurk/swarm/orphan_guard.rb
+++ b/lib/wurk/swarm/orphan_guard.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+module Wurk
+  class Swarm
+    # Orphan protection for a swarm child. A SIGKILL'd (or crashed, or OOM'd)
+    # supervisor leaves its children with no parent — they keep fetching
+    # forever, and the next redeploy that boots a fresh supervisor then runs
+    # doubled concurrency against the same queues. This arms two independent
+    # mechanisms so a child self-terminates the moment it is orphaned:
+    #
+    #   * Linux: PR_SET_PDEATHSIG delivers SIGTERM the instant the forking
+    #     thread dies (kernel-level, zero latency). It is set right after the
+    #     fork; the fork race — the parent can die in the window before the
+    #     syscall lands, so the signal is never queued — is closed by the
+    #     watchdog's immediate getppid check below.
+    #   * Everywhere: a watchdog thread compares getppid against the PID the
+    #     parent captured *before* forking (race-free — never the reaper PID).
+    #     On its first tick, and every `interval` seconds after, a mismatch
+    #     means the parent is gone. This is the only mechanism on non-Linux
+    #     (JRuby, macOS dev) and a backstop for pdeathsig's per-thread caveat.
+    #
+    # Both funnel through the child's own SIGTERM handler (Process.kill self),
+    # so orphan death is an ordinary graceful drain — in-flight jobs finish and
+    # the private list is requeued — not a hard kill.
+    class OrphanGuard
+      WATCHDOG_INTERVAL = 5
+      # <linux/prctl.h>: PR_SET_PDEATHSIG is option 1.
+      PR_SET_PDEATHSIG = 1
+
+      # pdeathsig via libc/prctl is Linux-only. Off elsewhere; the watchdog
+      # thread covers those platforms on its own.
+      def self.pdeathsig_supported?
+        ::RbConfig::CONFIG['host_os'].include?('linux')
+      end
+
+      # `on_orphan` is injectable so unit tests can observe the trip without
+      # actually signalling the test process. Production leaves it nil and
+      # self-TERMs, routing through the child's normal graceful-drain handler.
+      def initialize(parent_pid, logger:, interval: WATCHDOG_INTERVAL,
+                     pdeathsig: pdeathsig_supported?, on_orphan: nil)
+        @parent_pid = parent_pid
+        @logger = logger
+        @interval = interval
+        @pdeathsig = pdeathsig
+        @on_orphan = on_orphan || -> { ::Process.kill('TERM', ::Process.pid) }
+      end
+
+      # Arm both mechanisms. Returns the watchdog thread so the caller can
+      # retain it (otherwise GC could reap it).
+      def arm
+        set_pdeathsig
+        start_watchdog
+      end
+
+      def orphaned?
+        ::Process.ppid != @parent_pid
+      end
+
+      private
+
+      def pdeathsig_supported?
+        self.class.pdeathsig_supported?
+      end
+
+      # `sleep until orphaned?` checks first, so an already-orphaned child
+      # (the pdeathsig fork race) drains on the very first tick with no wait.
+      def start_watchdog
+        ::Thread.new do
+          ::Thread.current.name = 'wurk-orphan-watchdog'
+          ::Thread.current.report_on_exception = false
+          sleep @interval until orphaned?
+          drain
+        end
+      end
+
+      def drain
+        @logger&.warn { "swarm child #{::Process.pid}: parent #{@parent_pid} gone; draining orphan" }
+        @on_orphan.call
+      rescue StandardError => e
+        @logger&.error { "swarm child #{::Process.pid}: orphan drain failed: #{e.class}: #{e.message}" }
+      end
+
+      def set_pdeathsig
+        return unless @pdeathsig
+
+        arm_pdeathsig
+      rescue ::StandardError, ::LoadError => e
+        @logger&.debug { "swarm child #{::Process.pid}: PR_SET_PDEATHSIG unavailable (#{e.class}: #{e.message})" }
+      end
+
+      # prctl(int option, unsigned long arg2, …) — option is int, the rest are
+      # unsigned long. Fiddle opens the already-loaded libc (dlopen nil).
+      def arm_pdeathsig
+        require 'fiddle'
+        libc = ::Fiddle.dlopen(nil)
+        func = ::Fiddle::Function.new(
+          libc['prctl'],
+          [::Fiddle::TYPE_INT, ::Fiddle::TYPE_LONG, ::Fiddle::TYPE_LONG, ::Fiddle::TYPE_LONG, ::Fiddle::TYPE_LONG],
+          ::Fiddle::TYPE_INT
+        )
+        func.call(PR_SET_PDEATHSIG, ::Signal.list.fetch('TERM'), 0, 0, 0)
+      end
+    end
+  end
+end

--- a/lib/wurk/swarm/restart.rb
+++ b/lib/wurk/swarm/restart.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+module Wurk
+  class Swarm
+    # Non-blocking rolling-restart / recycle state machine. One slot is in
+    # flight at a time; `advance` moves it a single phase per supervise tick so
+    # the supervisor never blocks on a restart and keeps honoring TERM:
+    #
+    #   spawn_replacement → await_heartbeat(heartbeat_wait) → term_old
+    #     → await_exit(drain_timeout) → done
+    #
+    # The reaper reports child exits via `claim_exit`, so a replacement that
+    # dies before it heartbeats is seen as dead (not "slow"): the old child is
+    # kept, a per-slot backoff applied, and the slot retried. `abort` drops
+    # everything — the swarm's TERM handler then drains the in-flight
+    # replacement + old as ordinary children.
+    #
+    # Collaborators are injected (Config) so the machine is decoupled from the
+    # swarm's fork/kill/Redis internals and unit-testable against fakes.
+    class Restart
+      Config = Struct.new(:spawn, :kill, :heartbeat, :describe, :now, :logger,
+                          :heartbeat_wait, :drain_timeout, :backoff, keyword_init: true)
+
+      def initialize(config)
+        @spawn = config.spawn            # ->(slot, idx) => replacement pid (registered by the swarm)
+        @kill = config.kill              # ->(pid, sig)
+        @heartbeat = config.heartbeat    # ->(pid) => truthy once the child has beaten
+        @describe = config.describe      # ->(pid) => { slot:, index: } | nil
+        @now = config.now                # -> monotonic seconds
+        @logger = config.logger
+        @heartbeat_wait = config.heartbeat_wait
+        @drain_timeout = config.drain_timeout
+        @backoff = config.backoff
+        @queue = []
+        @current = nil
+      end
+
+      def idle?
+        @current.nil? && @queue.empty?
+      end
+
+      # Queue live child PIDs for restart, skipping any already queued or in
+      # flight so recycle + rolling restart can't double up on one slot.
+      def enqueue(pids)
+        pids.each do |pid|
+          next if in_flight?(pid) || @queue.include?(pid)
+
+          @queue << pid
+        end
+      end
+
+      # Reaper hook. Returns true when `pid` belonged to the in-flight restart
+      # so the swarm skips crash-respawn for it. A replacement is only claimed
+      # while awaiting its heartbeat — once it takes over the slot (await_exit),
+      # its death is an ordinary crash the swarm respawns.
+      def claim_exit(pid) # rubocop:disable Naming/PredicateMethod
+        return false unless @current
+
+        if pid == @current[:old_pid]
+          @current[:old_exited] = true
+          true
+        elsif pid == @current[:replacement] && @current[:phase] == :await_heartbeat
+          @current[:replacement_dead] = true
+          true
+        else
+          false
+        end
+      end
+
+      def advance
+        start_next if @current.nil?
+        return if @current.nil?
+
+        case @current[:phase]
+        when :await_heartbeat then advance_await_heartbeat
+        when :await_exit then advance_await_exit
+        end
+      end
+
+      # TERM/INT: forget queued + in-flight work. The replacement and old child
+      # are ordinary children the swarm's shutdown TERMs and drains.
+      def abort
+        @queue.clear
+        @current = nil
+      end
+
+      private
+
+      def in_flight?(pid)
+        return false unless @current
+
+        pid == @current[:old_pid] || pid == @current[:replacement]
+      end
+
+      def start_next
+        pid = next_ready_pid
+        return unless pid
+
+        meta = @describe.call(pid)
+        replacement = @spawn.call(meta[:slot], meta[:index])
+        @current = { old_pid: pid, index: meta[:index], replacement: replacement,
+                     phase: :await_heartbeat, deadline: now + @heartbeat_wait }
+        @logger.info { "swarm: restarting slot #{meta[:index]} (old #{pid} -> new #{replacement})" }
+      end
+
+      # Head of the queue if its old child still exists and its retry backoff
+      # has elapsed. Drops a stale head whose old child already vanished; leaves
+      # the head queued (returns nil) while a retry backoff is pending, so a
+      # slot whose replacement won't boot doesn't cascade into the next slot.
+      def next_ready_pid
+        pid = @queue.first
+        return nil unless pid
+
+        meta = @describe.call(pid)
+        if meta.nil?
+          @queue.shift
+          return nil
+        end
+        return nil unless @backoff.ready?(meta[:index])
+
+        @queue.shift
+      end
+
+      def advance_await_heartbeat
+        cur = @current
+        return retry_slot if cur[:replacement_dead]
+
+        seen = @heartbeat.call(cur[:replacement])
+        timed_out = now >= cur[:deadline]
+        return unless seen || timed_out
+
+        warn_heartbeat_timeout(cur) if timed_out && !seen
+        @kill.call(cur[:old_pid], 'TERM')
+        cur[:phase] = :await_exit
+        cur[:deadline] = now + @drain_timeout
+      end
+
+      def advance_await_exit
+        cur = @current
+        return finish(cur) if cur[:old_exited]
+        return if now < cur[:deadline]
+
+        # SIGKILL an overrunning old child once, then wait for the reaper to
+        # confirm the exit before finishing — finishing early would let the
+        # later reap look like a fresh crash and spawn a surplus child.
+        return if cur[:killed]
+
+        @kill.call(cur[:old_pid], 'KILL')
+        cur[:killed] = true
+      end
+
+      def finish(cur)
+        @backoff.clear(cur[:index])
+        @current = nil
+      end
+
+      def retry_slot
+        cur = @current
+        delay = @backoff.fail(cur[:index], lifetime: 0.0)
+        @queue.unshift(cur[:old_pid])
+        @logger.warn do
+          "swarm: replacement #{cur[:replacement]} for slot #{cur[:index]} died; " \
+            "keeping #{cur[:old_pid]}, retry in #{delay}s"
+        end
+        @current = nil
+      end
+
+      def warn_heartbeat_timeout(cur)
+        @logger.warn do
+          "swarm: replacement #{cur[:replacement]} heartbeat not seen in #{@heartbeat_wait}s; proceeding to TERM old"
+        end
+      end
+
+      def now
+        @now.call
+      end
+    end
+  end
+end

--- a/lib/wurk/swarm/restart.rb
+++ b/lib/wurk/swarm/restart.rb
@@ -97,10 +97,27 @@ module Wurk
         return unless pid
 
         meta = @describe.call(pid)
-        replacement = @spawn.call(meta[:slot], meta[:index])
+        replacement = spawn_replacement(pid, meta)
+        return unless replacement
+
         @current = { old_pid: pid, index: meta[:index], replacement: replacement,
                      phase: :await_heartbeat, deadline: now + @heartbeat_wait }
         @logger.info { "swarm: restarting slot #{meta[:index]} (old #{pid} -> new #{replacement})" }
+      end
+
+      # Spawn the replacement, requeuing the slot on a fork/resource failure so
+      # the restart work item isn't lost (and the error can't escape the
+      # supervise loop). A per-slot backoff paces the retry — next_ready_pid
+      # leaves the head queued until it elapses.
+      def spawn_replacement(pid, meta)
+        @spawn.call(meta[:slot], meta[:index])
+      rescue StandardError => e
+        delay = @backoff.fail(meta[:index], lifetime: 0.0)
+        @queue.unshift(pid)
+        @logger.warn do
+          "swarm: replacement spawn for slot #{meta[:index]} failed (#{e.class}: #{e.message}); retry in #{delay}s"
+        end
+        nil
       end
 
       # Head of the queue if its old child still exists and its retry backoff

--- a/test/engine/railtie_test.rb
+++ b/test/engine/railtie_test.rb
@@ -2,6 +2,7 @@
 
 require_relative '../engine_test_helper'
 require 'rake' # `::Rake` for the application doubles below
+require 'stringio' # capture the refuse-boot log line
 
 # The railtie owns two boot decisions, both gated by Railtie.skip_boot?:
 #   * entering server mode before config/initializers load (#191), and
@@ -67,7 +68,122 @@ class RailtieTest < Wurk::Test::EngineCase
     end
   end
 
+  # --- preforking web-server guard (Task #11) ---
+  #
+  # Auto-forking the swarm from a process that itself preforks web workers is
+  # the highest-risk boot path (N× oversubscription / entangled supervision).
+  # The railtie detects the common three servers and refuses to fork unless the
+  # host opts into embedded threads-only mode.
+
+  def test_preforking_web_server_is_false_in_a_plain_boot
+    with_env('WEB_CONCURRENCY' => nil) do
+      refute_predicate Wurk::Railtie, :preforking_web_server?,
+                       'a non-clustered boot must keep the swarm-fork path enabled'
+    end
+  end
+
+  def test_unicorn_is_always_preforking
+    with_const(:Unicorn, Module.new) do
+      assert_predicate Wurk::Railtie, :preforking_web_server?
+    end
+  end
+
+  def test_passenger_is_always_preforking
+    with_const(:PhusionPassenger, Module.new) do
+      assert_predicate Wurk::Railtie, :preforking_web_server?
+    end
+  end
+
+  def test_puma_cluster_detected_via_web_concurrency
+    with_puma do
+      with_env('WEB_CONCURRENCY' => '3') do
+        assert_predicate Wurk::Railtie, :preforking_web_server?, 'Puma + WEB_CONCURRENCY>0 is cluster mode'
+      end
+    end
+  end
+
+  def test_puma_single_mode_is_not_preforking
+    with_puma do
+      with_env('WEB_CONCURRENCY' => '0') do
+        refute_predicate Wurk::Railtie, :puma_cluster?, 'WEB_CONCURRENCY=0 is single (threaded) mode'
+      end
+    end
+  end
+
+  def test_boot_action_forks_when_not_preforking
+    with_env('WEB_CONCURRENCY' => nil) do
+      assert_equal :fork, Wurk::Railtie.boot_action(fake_app(embed: nil))
+    end
+  end
+
+  def test_boot_action_refuses_under_preforking_without_opt_in
+    with_const(:Unicorn, Module.new) do
+      assert_equal :refuse, Wurk::Railtie.boot_action(fake_app(embed: nil))
+    end
+  end
+
+  def test_boot_action_embeds_under_preforking_with_opt_in
+    with_const(:Unicorn, Module.new) do
+      assert_equal :embed, Wurk::Railtie.boot_action(fake_app(embed: true))
+    end
+  end
+
+  def test_embed_in_web_defaults_to_false
+    refute Wurk::Railtie.embed_in_web?(fake_app(embed: nil))
+  end
+
+  def test_embed_in_web_reads_the_host_flag
+    assert Wurk::Railtie.embed_in_web?(fake_app(embed: true))
+  end
+
+  # Hosts write `config.wurk.embed_in_web = true`; the namespace must already
+  # exist on the application config or that assignment raises NoMethodError.
+  def test_config_wurk_namespace_is_available_to_hosts
+    assert_respond_to ::Rails.application.config.wurk, :embed_in_web
+  end
+
+  def test_refuse_logs_actionable_guidance
+    io = StringIO.new
+    with_logger(::Logger.new(io)) { Wurk::Railtie.refuse_preforking_boot }
+
+    assert_match(/wurkswarm/, io.string, 'must point the host at the standalone runner')
+    assert_match(/embed_in_web/, io.string, 'must mention the embedded opt-in')
+    assert_match(/WURK_DISABLED/, io.string, 'must mention the silence switch')
+  end
+
   private
+
+  def fake_app(embed:)
+    wurk = ::ActiveSupport::OrderedOptions.new
+    wurk.embed_in_web = embed
+    config = Struct.new(:wurk).new(wurk)
+    Struct.new(:config).new(config)
+  end
+
+  # Define a top-level constant for the block, restoring prior state. Tests in
+  # this file run serially within one parallel_fork worker (no parallelize_me!),
+  # so the global mutation is contained; an already-defined constant is left be.
+  def with_const(name, value)
+    existed = Object.const_defined?(name, false)
+    Object.const_set(name, value) unless existed
+    yield
+  ensure
+    Object.send(:remove_const, name) if !existed && Object.const_defined?(name, false)
+  end
+
+  def with_puma(&)
+    return yield if defined?(::Puma)
+
+    with_const(:Puma, Module.new, &)
+  end
+
+  def with_logger(logger)
+    original = Wurk.configuration.logger
+    Wurk.configuration.logger = logger
+    yield
+  ensure
+    Wurk.configuration.logger = original
+  end
 
   def fake_rake(tasks)
     Struct.new(:top_level_tasks).new(tasks)

--- a/test/engine/railtie_test.rb
+++ b/test/engine/railtie_test.rb
@@ -25,6 +25,20 @@ class RailtieTest < Wurk::Test::EngineCase
     original.nil? ? ENV.delete('WURK_DISABLED') : (ENV['WURK_DISABLED'] = original)
   end
 
+  # `rails console` defines ::Rails::Console before initializers run — a console
+  # session is not a server and must never fork the swarm.
+  def test_skip_boot_is_true_in_rails_console
+    skip '::Rails::Console already defined outside this test' if defined?(::Rails::Console)
+
+    begin
+      ::Rails.const_set(:Console, Class.new)
+
+      assert_predicate Wurk::Railtie, :skip_boot?, 'console mode must never auto-boot the swarm'
+    ensure
+      ::Rails.send(:remove_const, :Console) if ::Rails.const_defined?(:Console, false)
+    end
+  end
+
   # #247 build-context guard. skip_boot? short-circuits on Rails.env.test? in
   # this suite, so the new logic is asserted through `building?` directly.
 

--- a/test/engine/railtie_test.rb
+++ b/test/engine/railtie_test.rb
@@ -4,23 +4,25 @@ require_relative '../engine_test_helper'
 require 'rake' # `::Rake` for the application doubles below
 require 'stringio' # capture the refuse-boot log line
 
-# The railtie owns two boot decisions, both gated by Railtie.skip_boot?:
+# The Railtie is a thin adapter: it registers the `config.wurk` namespace and
+# delegates two boot hooks to Wurk::RailsBoot, which owns the decisions —
 #   * entering server mode before config/initializers load (#191), and
 #   * forking + supervising the swarm in after_initialize.
 # A process that won't run workers (WURK_DISABLED / console / test) is not a
 # server and must do neither — otherwise the test suite itself would fork a
-# swarm and flip Sidekiq.server? on every engine run.
+# swarm and flip Sidekiq.server? on every engine run. The policy lives in
+# RailsBoot (asserted directly below); the config namespace is the Railtie's.
 class RailtieTest < Wurk::Test::EngineCase
   def test_skip_boot_is_true_in_test_environment
     assert_predicate ::Rails.env, :test?, 'precondition: engine tests run under the test env'
-    assert_predicate Wurk::Railtie, :skip_boot?, 'test env must never auto-boot the swarm or enter server mode'
+    assert_predicate Wurk::RailsBoot, :skip_boot?, 'test env must never auto-boot the swarm or enter server mode'
   end
 
   def test_skip_boot_is_true_when_wurk_disabled
     original = ENV.fetch('WURK_DISABLED', nil)
     ENV['WURK_DISABLED'] = '1'
 
-    assert_predicate Wurk::Railtie, :skip_boot?
+    assert_predicate Wurk::RailsBoot, :skip_boot?
   ensure
     original.nil? ? ENV.delete('WURK_DISABLED') : (ENV['WURK_DISABLED'] = original)
   end
@@ -33,7 +35,7 @@ class RailtieTest < Wurk::Test::EngineCase
     begin
       ::Rails.const_set(:Console, Class.new)
 
-      assert_predicate Wurk::Railtie, :skip_boot?, 'console mode must never auto-boot the swarm'
+      assert_predicate Wurk::RailsBoot, :skip_boot?, 'console mode must never auto-boot the swarm'
     ensure
       ::Rails.send(:remove_const, :Console) if ::Rails.const_defined?(:Console, false)
     end
@@ -47,7 +49,7 @@ class RailtieTest < Wurk::Test::EngineCase
   # so forking the swarm hangs/fails the build.
   def test_building_is_true_under_dummy_secret_key_base
     with_env('SECRET_KEY_BASE_DUMMY' => '1') do
-      assert_predicate Wurk::Railtie, :building?, 'asset precompile (SECRET_KEY_BASE_DUMMY) must skip the swarm boot'
+      assert_predicate Wurk::RailsBoot, :building?, 'asset precompile (SECRET_KEY_BASE_DUMMY) must skip the swarm boot'
     end
   end
 
@@ -57,7 +59,7 @@ class RailtieTest < Wurk::Test::EngineCase
   def test_building_is_true_during_a_rake_task
     with_env('SECRET_KEY_BASE_DUMMY' => nil) do
       with_rake_application(fake_rake(['assets:precompile'])) do
-        assert_predicate Wurk::Railtie, :building?, 'a running rake task must skip the swarm boot'
+        assert_predicate Wurk::RailsBoot, :building?, 'a running rake task must skip the swarm boot'
       end
     end
   end
@@ -65,7 +67,7 @@ class RailtieTest < Wurk::Test::EngineCase
   def test_building_is_false_without_dummy_secret_or_rake_task
     with_env('SECRET_KEY_BASE_DUMMY' => nil) do
       with_rake_application(fake_rake([])) do
-        refute_predicate Wurk::Railtie, :building?, 'a plain server boot must not be treated as a build step'
+        refute_predicate Wurk::RailsBoot, :building?, 'a plain server boot must not be treated as a build step'
       end
     end
   end
@@ -77,7 +79,7 @@ class RailtieTest < Wurk::Test::EngineCase
 
     with_env('SECRET_KEY_BASE_DUMMY' => nil) do
       with_rake_application(raising) do
-        refute_predicate Wurk::Railtie, :building?
+        refute_predicate Wurk::RailsBoot, :building?
       end
     end
   end
@@ -91,27 +93,27 @@ class RailtieTest < Wurk::Test::EngineCase
 
   def test_preforking_web_server_is_false_in_a_plain_boot
     with_env('WEB_CONCURRENCY' => nil) do
-      refute_predicate Wurk::Railtie, :preforking_web_server?,
+      refute_predicate Wurk::RailsBoot, :preforking_web_server?,
                        'a non-clustered boot must keep the swarm-fork path enabled'
     end
   end
 
   def test_unicorn_is_always_preforking
     with_const(:Unicorn, Module.new) do
-      assert_predicate Wurk::Railtie, :preforking_web_server?
+      assert_predicate Wurk::RailsBoot, :preforking_web_server?
     end
   end
 
   def test_passenger_is_always_preforking
     with_const(:PhusionPassenger, Module.new) do
-      assert_predicate Wurk::Railtie, :preforking_web_server?
+      assert_predicate Wurk::RailsBoot, :preforking_web_server?
     end
   end
 
   def test_puma_cluster_detected_via_web_concurrency
     with_puma do
       with_env('WEB_CONCURRENCY' => '3') do
-        assert_predicate Wurk::Railtie, :preforking_web_server?, 'Puma + WEB_CONCURRENCY>0 is cluster mode'
+        assert_predicate Wurk::RailsBoot, :preforking_web_server?, 'Puma + WEB_CONCURRENCY>0 is cluster mode'
       end
     end
   end
@@ -119,35 +121,35 @@ class RailtieTest < Wurk::Test::EngineCase
   def test_puma_single_mode_is_not_preforking
     with_puma do
       with_env('WEB_CONCURRENCY' => '0') do
-        refute_predicate Wurk::Railtie, :puma_cluster?, 'WEB_CONCURRENCY=0 is single (threaded) mode'
+        refute_predicate Wurk::RailsBoot, :puma_cluster?, 'WEB_CONCURRENCY=0 is single (threaded) mode'
       end
     end
   end
 
   def test_boot_action_forks_when_not_preforking
     with_env('WEB_CONCURRENCY' => nil) do
-      assert_equal :fork, Wurk::Railtie.boot_action(fake_app(embed: nil))
+      assert_equal :fork, Wurk::RailsBoot.boot_action(fake_app(embed: nil))
     end
   end
 
   def test_boot_action_refuses_under_preforking_without_opt_in
     with_const(:Unicorn, Module.new) do
-      assert_equal :refuse, Wurk::Railtie.boot_action(fake_app(embed: nil))
+      assert_equal :refuse, Wurk::RailsBoot.boot_action(fake_app(embed: nil))
     end
   end
 
   def test_boot_action_embeds_under_preforking_with_opt_in
     with_const(:Unicorn, Module.new) do
-      assert_equal :embed, Wurk::Railtie.boot_action(fake_app(embed: true))
+      assert_equal :embed, Wurk::RailsBoot.boot_action(fake_app(embed: true))
     end
   end
 
   def test_embed_in_web_defaults_to_false
-    refute Wurk::Railtie.embed_in_web?(fake_app(embed: nil))
+    refute Wurk::RailsBoot.embed_in_web?(fake_app(embed: nil))
   end
 
   def test_embed_in_web_reads_the_host_flag
-    assert Wurk::Railtie.embed_in_web?(fake_app(embed: true))
+    assert Wurk::RailsBoot.embed_in_web?(fake_app(embed: true))
   end
 
   # Hosts write `config.wurk.embed_in_web = true`; the namespace must already
@@ -158,7 +160,7 @@ class RailtieTest < Wurk::Test::EngineCase
 
   def test_refuse_logs_actionable_guidance
     io = StringIO.new
-    with_logger(::Logger.new(io)) { Wurk::Railtie.refuse_preforking_boot }
+    with_logger(::Logger.new(io)) { Wurk::RailsBoot.refuse_preforking_boot }
 
     assert_match(/wurkswarm/, io.string, 'must point the host at the standalone runner')
     assert_match(/embed_in_web/, io.string, 'must mention the embedded opt-in')

--- a/test/integration/swarm_boot_test.rb
+++ b/test/integration/swarm_boot_test.rb
@@ -75,11 +75,14 @@ class SwarmBootTest < Wurk::Test::UnitCase
     end
   end
 
-  # #119 (Ent §7.5): a child whose RSS exceeds the memory limit is TERMed and
-  # respawned. A 1 MB limit guarantees every real Ruby child exceeds it. Each
-  # child logs its pid on startup; we boot, wait for the first child to be
-  # fully up (so the supervisor's immediate first memory check can't TERM it
-  # mid-boot), then start the supervisor and watch a different pid take over.
+  # #119 (Ent §7.5): a child whose RSS exceeds the memory limit is recycled
+  # through the rolling-restart state machine — a healthy replacement is spawned
+  # first, and only once it takes over is the bloated child TERMed. A 1 MB limit
+  # guarantees every real Ruby child exceeds it. Each child logs its pid on
+  # startup; we boot, wait for the first child to be fully up (so the
+  # supervisor's immediate first memory check can't recycle it mid-boot), then
+  # start the supervisor and watch a different pid take over AND the original
+  # drain out (it lives on briefly past the replacement's boot).
   def test_swarm_recycles_a_child_that_exceeds_the_memory_limit # rubocop:disable Metrics/AbcSize,Minitest/MultipleAssertions
     log_boot_pids
     @config.memory_limit_mb = 1
@@ -95,7 +98,8 @@ class SwarmBootTest < Wurk::Test::UnitCase
 
       assert pids, "child was never recycled+respawned within #{POLL_TIMEOUT}s (saw #{boot_pids.inspect})"
       refute_equal pids[0], pids[1], 'the bloated child should be replaced by a new pid'
-      refute pid_alive?(original), 'the original (bloated) child should have been terminated'
+      assert wait_until_dead(original),
+             'the original (bloated) child should be TERMed once its replacement took over'
     ensure
       swarm.shutdown(timeout: 5)
       supervisor&.join(10)
@@ -181,6 +185,16 @@ class SwarmBootTest < Wurk::Test::UnitCase
     true
   rescue Errno::ESRCH, Errno::EPERM
     false
+  end
+
+  def wait_until_dead(pid) # rubocop:disable Naming/PredicateMethod
+    deadline = monotonic_now + POLL_TIMEOUT
+    while monotonic_now < deadline
+      return true unless pid_alive?(pid)
+
+      sleep POLL_INTERVAL
+    end
+    !pid_alive?(pid)
   end
 
   def monotonic_now

--- a/test/integration/swarm_supervision_test.rb
+++ b/test/integration/swarm_supervision_test.rb
@@ -22,6 +22,7 @@ class SwarmSupervisionTest < Wurk::Test::UnitCase
     @queue_name = "#{@ns}-q"
     @config = Wurk::Configuration.new
     @config.logger = ::Logger.new(IO::NULL)
+    @config.redis = { url: Wurk::Test.redis_url }
     @config[:timeout] = SHUTDOWN_TIMEOUT
     @observer = RedisClient.config(url: Wurk::Test.redis_url).new_client
   end
@@ -51,6 +52,9 @@ class SwarmSupervisionTest < Wurk::Test::UnitCase
       assert_growing_backoff(key)
       assert_drains_promptly_while_backoff_pending(swarm)
     ensure
+      # A failed assertion must not leave the crash-loop respawning forever;
+      # shutdown is idempotent so the happy path's drain isn't double-counted.
+      swarm.shutdown(timeout: SHUTDOWN_TIMEOUT)
       supervisor&.join(10)
     end
   end
@@ -130,6 +134,9 @@ class SwarmSupervisionTest < Wurk::Test::UnitCase
              "orphaned child #{child_pid} was still alive #{watchdog_timeout}s after its parent was SIGKILL'd"
     ensure
       pipe_read&.close
+      # An early assertion failure (before the parent is KILL'd) would otherwise
+      # leave the parent supervisor alive; it's a no-op once already reaped.
+      shutdown_supervisor_if_alive(parent_pid)
       ::Process.kill('KILL', child_pid) if child_pid && pid_alive?(child_pid)
     end
   end
@@ -250,6 +257,7 @@ class SwarmSupervisionTest < Wurk::Test::UnitCase
   def build_config
     config = Wurk::Configuration.new
     config.logger = ::Logger.new(IO::NULL)
+    config.redis = { url: Wurk::Test.redis_url }
     config[:timeout] = SHUTDOWN_TIMEOUT
     config
   end

--- a/test/integration/swarm_supervision_test.rb
+++ b/test/integration/swarm_supervision_test.rb
@@ -1,0 +1,335 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Real forks, real Redis, real signals. Proves the three behaviors #101's
+# swarm-supervision slice added that the unit-level fake-fork suites
+# (swarm_backoff_test.rb, swarm_restart_test.rb, swarm_orphan_guard_test.rb)
+# can't: (1) the supervise loop truly never blocks the process on a crash-loop
+# backoff or an in-flight restart, (2) a replacement that dies before
+# heartbeating leaves the old child alone and gets retried, (3) an orphaned
+# child really does self-terminate. NEVER mock Redis here.
+class SwarmSupervisionTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  POLL_TIMEOUT = 20.0
+  POLL_INTERVAL = 0.1
+  SHUTDOWN_TIMEOUT = 5
+
+  def setup
+    super
+    @ns = "swarmsup-#{::Process.pid}-#{object_id}"
+    @queue_name = "#{@ns}-q"
+    @config = Wurk::Configuration.new
+    @config.logger = ::Logger.new(IO::NULL)
+    @config[:timeout] = SHUTDOWN_TIMEOUT
+    @observer = RedisClient.config(url: Wurk::Test.redis_url).new_client
+  end
+
+  def teardown
+    @observer&.call('DEL', "#{@ns}-crash-log", "queue:#{@queue_name}", private_queue_key(@queue_name))
+    @observer&.close
+    @config&.reset_redis_pools!
+  ensure
+    super
+  end
+
+  # --- crash-loop backoff, in-process (no real signal needed) ------------
+
+  # A slot whose child crashes at boot must respawn on a growing schedule
+  # (1s -> 2s -> 4s ...) and the supervise loop must still honor a shutdown
+  # instantly even while a slot's respawn is armed for the future — the old
+  # bug slept the respawn delay inline on the supervise thread.
+  def test_crash_loop_backoff_grows_and_term_drains_while_pending
+    key = "#{@ns}-crash-log"
+    install_crash_on_startup(key)
+    swarm = Wurk::Swarm.new(topology: topology_n(1), config: @config, shutdown_timeout: SHUTDOWN_TIMEOUT)
+    swarm.boot(install_signals: false)
+    supervisor = Thread.new { swarm.supervise }
+
+    begin
+      assert_growing_backoff(key)
+      assert_drains_promptly_while_backoff_pending(swarm)
+    ensure
+      supervisor&.join(10)
+    end
+  end
+
+  # --- rolling restart: replacement dies before heartbeat -----------------
+
+  # Killing the replacement while it's still awaiting heartbeat must NOT take
+  # the old (still-healthy) child down with it, and the slot must be retried
+  # (a fresh replacement spawned) once the restart's own backoff elapses.
+  def test_kill_replacement_mid_restart_keeps_old_child_and_retries_slot
+    swarm = Wurk::Swarm.new(topology: topology_n(1), config: @config, shutdown_timeout: SHUTDOWN_TIMEOUT)
+    original = swarm.boot(install_signals: false).first
+    supervisor = Thread.new { swarm.supervise }
+
+    begin
+      swarm.rolling_restart
+      replacement = kill_the_replacement(swarm, original)
+
+      assert_old_child_survives(swarm, original)
+
+      retried = wait_for_new_child(swarm, exclude: [original, replacement])
+
+      assert retried, 'the slot must be retried with a fresh replacement after backoff'
+    ensure
+      swarm.shutdown(timeout: SHUTDOWN_TIMEOUT)
+      supervisor&.join(10)
+    end
+  end
+
+  # --- rolling restart: TERM lands mid-flight ------------------------------
+
+  # A real SIGTERM arriving while a replacement is up but the old child hasn't
+  # been TERMed yet must abort the restart machine and fall through to an
+  # ordinary drain of everything alive — not wait out the restart's own
+  # (up to 30s) heartbeat deadline.
+  def test_term_mid_restart_aborts_to_drain
+    parent_pid, pipe_read = fork_swarm_supervisor(count: 2)
+
+    begin
+      initial_children = read_child_pids(pipe_read)
+
+      assert_equal 2, initial_children.size
+
+      ::Process.kill('USR1', parent_pid)
+
+      assert extra_child_appeared?(parent_pid, initial_children.size),
+             'rolling restart never reached a mid-flight state (replacement never appeared)'
+
+      assert_term_aborts_the_restart(parent_pid)
+    ensure
+      pipe_read&.close
+      shutdown_supervisor_if_alive(parent_pid)
+    end
+  end
+
+  # --- orphan self-termination ---------------------------------------------
+
+  # SIGKILL'ing the supervisor must not leave the children fetching forever:
+  # each one self-terminates (PR_SET_PDEATHSIG on Linux, the portable getppid
+  # watchdog everywhere) within its watchdog window.
+  def test_sigkill_parent_orphans_self_terminate
+    parent_pid, pipe_read = fork_swarm_supervisor(count: 1)
+    child_pid = nil
+
+    begin
+      child_pid = read_child_pids(pipe_read).first
+
+      assert pid_alive?(child_pid), 'child should be alive before its parent is killed'
+
+      ::Process.kill('KILL', parent_pid)
+      reap(parent_pid)
+
+      watchdog_timeout = Wurk::Swarm::OrphanGuard::WATCHDOG_INTERVAL + 10
+      terminated = wait_until_dead(child_pid, watchdog_timeout)
+
+      assert terminated,
+             "orphaned child #{child_pid} was still alive #{watchdog_timeout}s after its parent was SIGKILL'd"
+    ensure
+      pipe_read&.close
+      ::Process.kill('KILL', child_pid) if child_pid && pid_alive?(child_pid)
+    end
+  end
+
+  private
+
+  def topology_n(count)
+    Wurk::Topology.flat(count: count, queues: [@queue_name], concurrency: 1)
+  end
+
+  def assert_growing_backoff(key)
+    timestamps = wait_for_crash_count(key, 3)
+
+    assert timestamps, "expected >=3 crash timestamps, saw #{@observer.call('LRANGE', key, 0, -1).inspect}"
+
+    intervals = timestamps.each_cons(2).map { |a, b| b - a }
+
+    assert_operator intervals[1], :>=, intervals[0] * 1.5,
+                    "respawn backoff must grow across crashes: #{intervals.inspect}"
+  end
+
+  def assert_drains_promptly_while_backoff_pending(swarm)
+    drain_started = monotonic_now
+    swarm.shutdown(timeout: SHUTDOWN_TIMEOUT)
+    drain_elapsed = monotonic_now - drain_started
+
+    assert_operator drain_elapsed, :<, 1.0,
+                    "shutdown must not block on a pending crash-loop backoff, took #{drain_elapsed}s"
+  end
+
+  def kill_the_replacement(swarm, original)
+    replacement = wait_for_new_child(swarm, exclude: [original])
+
+    assert replacement, 'replacement child was never spawned for the restart'
+
+    ::Process.kill('KILL', replacement)
+    sleep POLL_INTERVAL * 3 # let the reaper observe the death before asserting survival
+    replacement
+  end
+
+  def assert_old_child_survives(swarm, original)
+    assert pid_alive?(original), 'old child must survive a replacement that dies before heartbeat'
+    assert_includes swarm.children.keys, original, 'old child must still be tracked by the swarm'
+  end
+
+  def assert_term_aborts_the_restart(parent_pid)
+    drain_started = monotonic_now
+    ::Process.kill('TERM', parent_pid)
+    exited = wait_for_process_exit(parent_pid, SHUTDOWN_TIMEOUT + 5)
+    drain_elapsed = monotonic_now - drain_started
+
+    assert exited, "supervisor never exited after TERM mid-restart (waited #{SHUTDOWN_TIMEOUT + 5}s)"
+    assert_operator drain_elapsed, :<, SHUTDOWN_TIMEOUT + 5,
+                    "TERM mid-restart must abort to an ordinary drain, took #{drain_elapsed}s"
+    assert_empty live_children_of(parent_pid), 'no descendant should survive a TERM mid-restart'
+  end
+
+  # Every child crashes immediately at :startup (before it ever fetches), so
+  # the parent's per-slot backoff is observed without a genuine job/queue
+  # scenario. `exit!` bypasses at_exit/ensure unwinding, the same as a real
+  # segfault or OOM-kill would.
+  def install_crash_on_startup(key)
+    redis_url = Wurk::Test.redis_url
+    @config.on(:startup) do
+      client = RedisClient.config(url: redis_url).new_client
+      client.call('RPUSH', key, ::Process.clock_gettime(::Process::CLOCK_MONOTONIC).to_s)
+      client.call('EXPIRE', key, 60)
+      client.close
+      exit!(1)
+    end
+  end
+
+  def wait_for_crash_count(key, count)
+    deadline = monotonic_now + POLL_TIMEOUT
+    while monotonic_now < deadline
+      raw = @observer.call('LRANGE', key, 0, -1)
+      return raw.map(&:to_f) if raw.size >= count
+
+      sleep POLL_INTERVAL
+    end
+    nil
+  end
+
+  def wait_for_new_child(swarm, exclude:)
+    deadline = monotonic_now + POLL_TIMEOUT
+    while monotonic_now < deadline
+      found = swarm.children.keys.find { |pid| !exclude.include?(pid) }
+      return found if found
+
+      sleep POLL_INTERVAL
+    end
+    nil
+  end
+
+  # --- subprocess supervisor plumbing (real SIGTERM/SIGKILL delivery) ------
+
+  def fork_swarm_supervisor(count:)
+    read_io, write_io = ::IO.pipe
+    pid = ::Process.fork { run_supervisor_subprocess(read_io, write_io, count) }
+    write_io.close
+    [pid, read_io]
+  end
+
+  def run_supervisor_subprocess(read_io, write_io, count)
+    read_io.close
+    $stdout.reopen(IO::NULL)
+    $stderr.reopen(IO::NULL)
+    config = build_config
+    topology = Wurk::Topology.flat(count: count, queues: [@queue_name], concurrency: 1)
+    swarm = Wurk::Swarm.new(topology: topology, config: config, shutdown_timeout: SHUTDOWN_TIMEOUT)
+    swarm.boot(install_signals: true)
+    write_io.puts(swarm.children.keys.join(','))
+    write_io.close
+    swarm.supervise
+    exit 0
+  end
+
+  def build_config
+    config = Wurk::Configuration.new
+    config.logger = ::Logger.new(IO::NULL)
+    config[:timeout] = SHUTDOWN_TIMEOUT
+    config
+  end
+
+  def read_child_pids(pipe)
+    pipe.readline.strip.split(',').map(&:to_i)
+  end
+
+  def extra_child_appeared?(parent_pid, initial_count)
+    deadline = monotonic_now + POLL_TIMEOUT
+    while monotonic_now < deadline
+      return true if live_children_of(parent_pid).size > initial_count
+
+      sleep POLL_INTERVAL
+    end
+    false
+  end
+
+  def wait_for_process_exit(pid, timeout)
+    deadline = monotonic_now + timeout
+    while monotonic_now < deadline
+      return true if ::Process.wait(pid, ::Process::WNOHANG)
+
+      sleep POLL_INTERVAL
+    end
+    false
+  rescue Errno::ECHILD
+    true
+  end
+
+  def live_children_of(parent_pid)
+    ::Dir["/proc/#{parent_pid}/task/*/children"].flat_map do |path|
+      ::File.read(path).split.map(&:to_i)
+    end.uniq
+  rescue Errno::ENOENT
+    []
+  end
+
+  def shutdown_supervisor_if_alive(pid)
+    return unless pid_alive?(pid)
+
+    ::Process.kill('TERM', pid)
+    deadline = monotonic_now + SHUTDOWN_TIMEOUT + 5
+    while monotonic_now < deadline
+      return if ::Process.wait(pid, ::Process::WNOHANG)
+
+      sleep POLL_INTERVAL
+    end
+    ::Process.kill('KILL', pid) if pid_alive?(pid)
+    reap(pid)
+  end
+
+  def reap(pid)
+    ::Process.wait(pid)
+  rescue Errno::ECHILD
+    nil
+  end
+
+  def wait_until_dead(pid, timeout) # rubocop:disable Naming/PredicateMethod
+    deadline = monotonic_now + timeout
+    while monotonic_now < deadline
+      return true unless pid_alive?(pid)
+
+      sleep POLL_INTERVAL
+    end
+    !pid_alive?(pid)
+  end
+
+  def pid_alive?(pid)
+    ::Process.kill(0, pid)
+    true
+  rescue Errno::ESRCH, Errno::EPERM
+    false
+  end
+
+  def monotonic_now
+    ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+  end
+
+  def private_queue_key(queue_name)
+    Wurk::Fetcher::Reliable.private_queue_name("queue:#{queue_name}")
+  end
+end

--- a/test/unit/child_boot_test.rb
+++ b/test/unit/child_boot_test.rb
@@ -10,6 +10,23 @@ require_relative '../test_helper'
 class ChildBootTest < Wurk::Test::UnitCase
   parallelize_me!
 
+  # Records the launcher calls the signal dispatcher makes.
+  class FakeLauncher
+    attr_reader :events
+
+    def initialize
+      @events = []
+    end
+
+    def stop
+      @events << :stop
+    end
+
+    def quiet
+      @events << :quiet
+    end
+  end
+
   def setup
     super
     @config = Wurk::Configuration.new
@@ -22,6 +39,46 @@ class ChildBootTest < Wurk::Test::UnitCase
     @config&.reset_redis_pools!
   ensure
     super
+  end
+
+  # --- self-pipe signal dispatch -----------------------------------------
+
+  def test_parent_pid_defaults_to_live_parent
+    assert_equal ::Process.ppid, @boot.instance_variable_get(:@parent_pid)
+  end
+
+  def test_dispatch_signals_stops_on_term
+    launcher = drive_dispatch('TERM')
+
+    assert_equal [:stop], launcher.events
+  end
+
+  def test_dispatch_signals_quiets_on_tstp_then_stops
+    launcher = drive_dispatch('TSTP', 'TERM')
+
+    assert_equal %i[quiet stop], launcher.events
+  end
+
+  def test_dispatch_signals_reopens_logs_on_usr2_then_stops
+    # USR2 → reopen_logs (best-effort); TERM ends the loop. The IO::NULL logger
+    # reopen is a harmless no-op — we only assert the dispatch reached TERM.
+    launcher = drive_dispatch('USR2', 'TERM')
+
+    assert_equal [:stop], launcher.events
+  end
+
+  def test_install_signal_handlers_wires_self_pipe_dispatch
+    with_saved_traps(%w[TERM INT TSTP USR2]) do
+      launcher = FakeLauncher.new
+      @boot.send(:install_signal_handlers, launcher)
+
+      ::Process.kill('TSTP', ::Process.pid)
+      wait_until { launcher.events.include?(:quiet) }
+      ::Process.kill('TERM', ::Process.pid)
+      @boot.instance_variable_get(:@dispatcher).join(2)
+
+      assert_equal %i[quiet stop], launcher.events
+    end
   end
 
   # PINGs, primes every Lua script, and (with ActiveRecord absent in unit env)
@@ -43,5 +100,34 @@ class ChildBootTest < Wurk::Test::UnitCase
     # its one-SHA-per-script pipeline result proves both the PING (which would
     # have raised first) and the eager load ran on the same checkout.
     assert_equal Wurk::Lua::SCRIPTS.size, result.size
+  end
+
+  private
+
+  # Drives dispatch_signals synchronously against an injected pipe. Every call
+  # must end in TERM so the dispatch loop breaks instead of blocking.
+  def drive_dispatch(*signals)
+    r, w = ::IO.pipe
+    @boot.instance_variable_set(:@signal_read, r)
+    signals.each { |s| w.puts(s) }
+    launcher = FakeLauncher.new
+    @boot.send(:dispatch_signals, launcher)
+    launcher
+  ensure
+    r&.close
+    w&.close
+  end
+
+  def with_saved_traps(signals)
+    saved = signals.to_h { |s| [s, ::Signal.trap(s, 'DEFAULT')] }
+    yield
+  ensure
+    saved&.each { |s, h| ::Signal.trap(s, h || 'DEFAULT') }
+  end
+
+  def wait_until(timeout = 2)
+    deadline = ::Time.now + timeout
+    sleep 0.02 until yield || ::Time.now > deadline
+    yield
   end
 end

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -80,7 +80,7 @@ class CLITest < Wurk::Test::UnitCase
   end
 
   def test_signal_handlers_table
-    assert_equal %w[INT TERM TSTP TTIN INFO].sort, Wurk::CLI::SIGNAL_HANDLERS.keys.sort
+    assert_equal %w[INT TERM TSTP TTIN INFO USR2].sort, Wurk::CLI::SIGNAL_HANDLERS.keys.sort
   end
 
   def test_min_redis_version

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -426,6 +426,20 @@ class CLITest < Wurk::Test::UnitCase
     assert_match(/<no backtrace available>/, io.string)
   end
 
+  # USR2 reopens the logs for logrotate. reopen_logs is private, so the handler
+  # must reach it via __send__ — a plain `cli.reopen_logs` raises NoMethodError
+  # and log rotation silently breaks.
+  def test_handle_signal_usr2_reopens_logs
+    reopened = false
+    logger = ::Logger.new(IO::NULL)
+    logger.define_singleton_method(:reopen) { reopened = true }
+    @cli.config.logger = logger
+
+    @cli.handle_signal('USR2')
+
+    assert reopened, 'USR2 must reopen the logs despite reopen_logs being private'
+  end
+
   # --- run plumbing (without booting Redis/launcher) -----------------
 
   def test_run_short_circuits_when_redis_too_old

--- a/test/unit/health_test.rb
+++ b/test/unit/health_test.rb
@@ -155,17 +155,43 @@ class HealthTest < Wurk::Test::UnitCase
 
   # --- lifecycle ----------------------------------------------------------
 
-  def test_start_idempotency_via_address_in_use
+  def test_second_bind_on_busy_port_polls_instead_of_serving
     launcher = FakeLauncher.new(config: FakeConfig.new)
     @server = build_server(launcher)
     @server.start
     port = @server.port
 
-    # Second server on the same explicit port must not raise — logs and skips.
-    second = Wurk::Health::Server.new(launcher, port: port, bind: '127.0.0.1')
+    # Second server on the same explicit port must not raise; it polls to take
+    # the port over rather than serving or giving up.
+    second = Wurk::Health::Server.new(launcher, port: port, bind: '127.0.0.1', retry_interval: 0.05)
     second.start
+    begin
+      refute_predicate second, :running?, 'second bind on busy port must not serve yet'
+      assert_predicate second, :retrying?, 'second must poll to take the port over'
+    ensure
+      second.stop
+    end
 
-    refute_predicate second, :running?, 'second bind on busy port must skip cleanly'
+    refute_predicate second, :retrying?, 'stop cancels the retry poll'
+  end
+
+  def test_second_child_takes_over_port_after_owner_stops
+    launcher = FakeLauncher.new(config: FakeConfig.new)
+    first = build_server(launcher)
+    first.start
+    port = first.port
+
+    @server = Wurk::Health::Server.new(launcher, port: port, bind: '127.0.0.1', retry_interval: 0.05)
+    @server.start
+
+    refute_predicate @server, :running?, 'the non-owner must not serve while the owner holds the port'
+
+    first.stop # frees the port
+
+    assert wait_until { @server.running? },
+           'the survivor must bind the shared port within a retry interval of the owner exiting'
+  ensure
+    first&.stop
   end
 
   def test_stop_terminates_thread_and_unbinds
@@ -205,16 +231,19 @@ class HealthTest < Wurk::Test::UnitCase
 
   def test_address_in_use_with_nil_config_logger_does_not_raise
     # @config is nil → logger returns nil (the else side of `@config&.logger`)
-    # → logger&.warn in the EADDRINUSE rescue short-circuits without raising.
+    # → logger&.warn in start_retry_loop short-circuits without raising.
     launcher = FakeLauncher.new(config: nil)
     @server = build_server(launcher)
     @server.start
     port = @server.port
 
-    second = Wurk::Health::Server.new(launcher, port: port, bind: '127.0.0.1')
+    second = Wurk::Health::Server.new(launcher, port: port, bind: '127.0.0.1', retry_interval: 0.05)
     second.start
-
-    refute_predicate second, :running?
+    begin
+      refute_predicate second, :running?
+    ensure
+      second.stop
+    end
   end
 
   def test_address_in_use_with_present_config_but_nil_logger_does_not_raise
@@ -226,10 +255,13 @@ class HealthTest < Wurk::Test::UnitCase
     @server.start
     port = @server.port
 
-    second = Wurk::Health::Server.new(launcher, port: port, bind: '127.0.0.1')
+    second = Wurk::Health::Server.new(launcher, port: port, bind: '127.0.0.1', retry_interval: 0.05)
     second.start
-
-    refute_predicate second, :running?
+    begin
+      refute_predicate second, :running?
+    ensure
+      second.stop
+    end
   end
 
   # --- write_response default reason branch ------------------------------
@@ -318,6 +350,14 @@ class HealthTest < Wurk::Test::UnitCase
   def sleep_until_quiet
     deadline = ::Time.now + 0.7
     Kernel.sleep(0.05) while ::Time.now < deadline
+  end
+
+  # Polls the block until it returns truthy or the timeout elapses; returns the
+  # block's final value so callers can assert on it.
+  def wait_until(timeout = 2)
+    deadline = ::Time.now + timeout
+    sleep 0.02 until yield || ::Time.now > deadline
+    yield
   end
 
   # Builds a server bound on 127.0.0.1:0 (OS-assigned port) so parallel

--- a/test/unit/health_test.rb
+++ b/test/unit/health_test.rb
@@ -175,6 +175,23 @@ class HealthTest < Wurk::Test::UnitCase
     refute_predicate second, :retrying?, 'stop cancels the retry poll'
   end
 
+  # A second start on a live instance must be a no-op. Without the guard it
+  # re-binds the same port, hits EADDRINUSE, nulls @server/@thread, and leaks
+  # the original listener so stop can never close it.
+  def test_start_is_idempotent
+    launcher = FakeLauncher.new(config: FakeConfig.new)
+    @server = build_server(launcher)
+    @server.start
+    thread = @server.instance_variable_get(:@thread)
+    listener = @server.instance_variable_get(:@server)
+
+    @server.start
+
+    assert_predicate @server, :running?
+    assert_same thread, @server.instance_variable_get(:@thread), 'accept thread must not be replaced'
+    assert_same listener, @server.instance_variable_get(:@server), 'listener must not be rebound/leaked'
+  end
+
   def test_second_child_takes_over_port_after_owner_stops
     launcher = FakeLauncher.new(config: FakeConfig.new)
     first = build_server(launcher)

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -189,9 +189,12 @@ class LauncherTest < Wurk::Test::UnitCase
     reaper.define_singleton_method(:reclaim!) { reclaimed = true }
 
     launcher.run(async_beat: false)
-    # boot_reclaim runs on a background thread, so join to ensure it completes.
-    launcher.instance_variable_get(:@boot_reclaim_thread)&.join(1.0)
+    # boot_reclaim runs on a background thread; assert the join actually
+    # returns (a bare join(1.0) whose result is ignored could time out under a
+    # slow scheduler and check `reclaimed` before reclaim! ran).
+    reclaim_thread = launcher.instance_variable_get(:@boot_reclaim_thread)
 
+    assert reclaim_thread.join(5.0), 'boot-reclaim thread did not finish in time'
     assert reclaimed, 'run should do a deterministic boot-time orphan reclaim'
   end
 

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -189,6 +189,8 @@ class LauncherTest < Wurk::Test::UnitCase
     reaper.define_singleton_method(:reclaim!) { reclaimed = true }
 
     launcher.run(async_beat: false)
+    # boot_reclaim runs on a background thread, so join to ensure it completes.
+    launcher.instance_variable_get(:@boot_reclaim_thread)&.join(1.0)
 
     assert reclaimed, 'run should do a deterministic boot-time orphan reclaim'
   end

--- a/test/unit/swarm_backoff_test.rb
+++ b/test/unit/swarm_backoff_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Pure per-slot exponential backoff (Swarm::Backoff). Deterministic — the clock
+# is injected, so no sleeping and no forks.
+class SwarmBackoffTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @t = [1000.0]
+    @backoff = Wurk::Swarm::Backoff.new(base: 1.0, cap: 30.0, reset_after: 60.0, clock: -> { @t[0] })
+  end
+
+  def test_unknown_key_is_ready_and_not_pending
+    assert @backoff.ready?(0)
+    refute @backoff.pending?(0)
+  end
+
+  def test_first_failure_uses_base_delay_and_is_pending
+    assert_in_delta 1.0, @backoff.fail(0)
+    assert @backoff.pending?(0)
+    refute @backoff.ready?(0)
+  end
+
+  def test_becomes_ready_once_delay_elapses
+    @backoff.fail(0)
+    @t[0] += 1.0
+
+    assert @backoff.ready?(0)
+  end
+
+  def test_rapid_failures_double_until_capped # rubocop:disable Minitest/MultipleAssertions
+    assert_in_delta 1.0, @backoff.fail(0)
+    assert_in_delta 2.0, @backoff.fail(0)
+    assert_in_delta 4.0, @backoff.fail(0)
+    assert_in_delta 8.0, @backoff.fail(0)
+    assert_in_delta 16.0, @backoff.fail(0)
+    assert_in_delta 30.0, @backoff.fail(0) # 32 clamped to cap
+    assert_in_delta 30.0, @backoff.fail(0)
+  end
+
+  def test_survival_past_reset_window_restarts_streak
+    3.times { @backoff.fail(0) }
+
+    assert_in_delta 1.0, @backoff.fail(0, lifetime: 60.0)
+  end
+
+  def test_short_lifetime_keeps_escalating
+    @backoff.fail(0)
+
+    assert_in_delta 2.0, @backoff.fail(0, lifetime: 59.9)
+  end
+
+  def test_consume_clears_pending_but_preserves_streak
+    @backoff.fail(0)
+    @backoff.consume(0)
+
+    refute @backoff.pending?(0)
+    assert_in_delta 2.0, @backoff.fail(0)
+  end
+
+  def test_clear_forgets_streak_and_schedule
+    2.times { @backoff.fail(0) }
+    @backoff.clear(0)
+
+    refute @backoff.pending?(0)
+    assert_in_delta 1.0, @backoff.fail(0)
+  end
+
+  def test_keys_track_independently
+    @backoff.fail(0)
+    @backoff.fail(0)
+
+    assert_in_delta 1.0, @backoff.fail(1)
+  end
+end

--- a/test/unit/swarm_orphan_guard_test.rb
+++ b/test/unit/swarm_orphan_guard_test.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Wurk::Swarm::OrphanGuard drives orphan detection for swarm children. Unit
+# level: pdeathsig is kept off and the drain action is injected, so nothing
+# actually signals the test process. The real fork + PR_SET_PDEATHSIG proof
+# lives in the integration layer.
+class SwarmOrphanGuardTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  # Forces the libc/prctl path to blow up so the rescue in #set_pdeathsig is
+  # exercised without depending on the platform (minitest/mock is gone in
+  # Minitest 6, so subclass rather than stub).
+  class ExplodingGuard < Wurk::Swarm::OrphanGuard
+    def arm_pdeathsig
+      raise 'no libc'
+    end
+  end
+
+  def setup
+    super
+    @logger = ::Logger.new(IO::NULL)
+    @threads = []
+  end
+
+  def teardown
+    @threads.each { |t| t.kill if t.alive? }
+  ensure
+    super
+  end
+
+  # --- orphaned? ---------------------------------------------------------
+
+  def test_not_orphaned_while_parent_matches
+    guard = build(::Process.ppid)
+
+    refute_predicate guard, :orphaned?
+  end
+
+  def test_orphaned_once_parent_pid_no_longer_matches
+    guard = build(-1) # never our real parent → always "reparented"
+
+    assert_predicate guard, :orphaned?
+  end
+
+  # --- watchdog ----------------------------------------------------------
+
+  def test_watchdog_drains_when_orphaned
+    fired = ::Queue.new
+    guard = build(-1, on_orphan: -> { fired << true })
+
+    thread = track(guard.arm)
+    thread.join(2)
+
+    refute_predicate thread, :alive?, 'watchdog should exit after draining'
+    assert_equal 1, fired.size, 'an orphaned child must drain exactly once'
+  end
+
+  def test_watchdog_stays_quiet_while_supervised
+    fired = ::Queue.new
+    guard = build(::Process.ppid, on_orphan: -> { fired << true })
+
+    thread = track(guard.arm)
+    sleep 0.1 # several 0.02s watchdog ticks
+
+    assert_predicate thread, :alive?, 'watchdog must keep polling while the parent lives'
+    assert_empty fired, 'a supervised child must never self-drain'
+  end
+
+  def test_arm_returns_the_watchdog_thread
+    thread = track(build(::Process.ppid).arm)
+
+    assert_kind_of ::Thread, thread
+  end
+
+  def test_drain_swallows_a_failing_on_orphan_callback
+    guard = build(-1, on_orphan: -> { raise 'boom' })
+
+    thread = track(guard.arm)
+    thread.join(2)
+
+    refute_predicate thread, :alive?, 'a raising drain callback must not wedge the watchdog thread'
+  end
+
+  # --- pdeathsig ---------------------------------------------------------
+
+  def test_pdeathsig_defaults_to_platform_support
+    # No explicit pdeathsig: → the default arg evaluates the platform probe.
+    guard = Wurk::Swarm::OrphanGuard.new(::Process.ppid, logger: @logger)
+
+    assert_equal Wurk::Swarm::OrphanGuard.pdeathsig_supported?,
+                 guard.instance_variable_get(:@pdeathsig)
+  end
+
+  def test_pdeathsig_disabled_is_a_noop
+    guard = Wurk::Swarm::OrphanGuard.new(::Process.ppid, logger: @logger, pdeathsig: false)
+
+    assert_nil guard.send(:set_pdeathsig), 'disabled pdeathsig must not touch the process'
+  end
+
+  def test_pdeathsig_failure_is_swallowed
+    guard = ExplodingGuard.new(::Process.ppid, logger: @logger, pdeathsig: true)
+
+    guard.send(:set_pdeathsig) # arm_pdeathsig raises → the rescue must swallow it
+
+    pass 'a prctl failure must be swallowed, not raised'
+  end
+
+  def test_arm_pdeathsig_sets_parent_death_signal_on_linux
+    skip 'PR_SET_PDEATHSIG is Linux-only' unless Wurk::Swarm::OrphanGuard.pdeathsig_supported?
+
+    guard = Wurk::Swarm::OrphanGuard.new(::Process.ppid, logger: @logger, pdeathsig: true)
+    begin
+      guard.send(:arm_pdeathsig) # real prctl — must return without raising
+    ensure
+      clear_pdeathsig
+    end
+  end
+
+  private
+
+  def build(parent_pid, on_orphan: nil)
+    Wurk::Swarm::OrphanGuard.new(
+      parent_pid, logger: @logger, interval: 0.02, pdeathsig: false, on_orphan: on_orphan
+    )
+  end
+
+  def track(thread)
+    @threads << thread
+    thread
+  end
+
+  # Reset PR_SET_PDEATHSIG to 0 so a test worker that armed it for real can't
+  # be TERMed later if its parent exits first.
+  def clear_pdeathsig
+    require 'fiddle'
+    libc = ::Fiddle.dlopen(nil)
+    ::Fiddle::Function.new(
+      libc['prctl'], [::Fiddle::TYPE_INT, ::Fiddle::TYPE_LONG, ::Fiddle::TYPE_LONG,
+                      ::Fiddle::TYPE_LONG, ::Fiddle::TYPE_LONG], ::Fiddle::TYPE_INT
+    ).call(Wurk::Swarm::OrphanGuard::PR_SET_PDEATHSIG, 0, 0, 0, 0)
+  rescue StandardError
+    nil
+  end
+end

--- a/test/unit/swarm_respawn_test.rb
+++ b/test/unit/swarm_respawn_test.rb
@@ -82,6 +82,38 @@ class SwarmRespawnTest < Wurk::Test::UnitCase
            'a clean exit during drain must not schedule a respawn'
   end
 
+  # A fork/resource failure while respawning must neither escape the supervise
+  # loop nor drop the pending slot — it stays armed and retries once fork
+  # recovers.
+  def test_failed_fork_keeps_slot_pending_and_retries
+    clock = [1000.0]
+    swarm = new_swarm
+    inject_respawn_clock(swarm, -> { clock[0] })
+    swarm.boot(install_signals: false)
+    idx = crash_first_child(swarm)
+
+    fork_ok = [false]
+    next_pid = [20_000]
+    swarm.define_singleton_method(:fork_child) do |_slot, _index|
+      raise Errno::EAGAIN, 'resource temporarily unavailable' unless fork_ok[0]
+
+      next_pid[0] += 1
+    end
+
+    clock[0] += Wurk::Swarm::RESPAWN_BACKOFF
+    swarm.send(:spawn_due_respawns) # a failed fork must not raise out of supervise
+
+    assert_equal 0, slot_count(swarm, idx), 'a failed fork must not add a child'
+    assert swarm.instance_variable_get(:@respawn_backoff).pending?(idx),
+           'a failed respawn stays pending for retry instead of being dropped'
+
+    fork_ok[0] = true
+    clock[0] += Wurk::Swarm::Backoff::CAP
+    swarm.send(:spawn_due_respawns)
+
+    assert_equal 1, slot_count(swarm, idx), 'the slot refills once fork succeeds after backoff'
+  end
+
   private
 
   def topology

--- a/test/unit/swarm_respawn_test.rb
+++ b/test/unit/swarm_respawn_test.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Swarm subclass that hands back fake PIDs instead of forking, so the
+# crash-respawn scheduling can be driven without real processes.
+class RespawnTestSwarm < Wurk::Swarm
+  def initialize(**kwargs)
+    super
+    @fake_pid = 10_000
+  end
+
+  private
+
+  def fork_child(_slot, _idx)
+    @fake_pid += 1
+  end
+end
+
+# Crash-loop respawn wiring of Wurk::Swarm, driven fork-free: fork_child is
+# overridden to hand back fake PIDs and the respawn backoff runs off an injected
+# clock, so the supervise-thread scheduling (arm on crash → respawn once the
+# per-slot backoff window elapses, never sleeping) is asserted deterministically
+# without real processes. The real-fork proof lives in the integration layer.
+class SwarmRespawnTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  Status = ::Struct.new(:exitstatus)
+
+  def setup
+    super
+    @config = Wurk::Configuration.new
+    @config.logger = ::Logger.new(IO::NULL)
+  end
+
+  def test_crashed_child_is_removed_and_armed_for_respawn
+    swarm = boot_swarm
+    pid, meta = swarm.children.first
+
+    swarm.send(:on_child_exit, pid, Status.new(1))
+
+    refute_includes swarm.children.keys, pid
+    assert swarm.instance_variable_get(:@respawn_backoff).pending?(meta[:index]),
+           'a crashed slot must be scheduled for respawn'
+  end
+
+  def test_respawn_defers_until_backoff_window_elapses
+    clock = [1000.0]
+    swarm = new_swarm
+    inject_respawn_clock(swarm, -> { clock[0] })
+    swarm.boot(install_signals: false)
+    idx = crash_first_child(swarm)
+
+    swarm.send(:spawn_due_respawns)
+
+    assert_equal 0, slot_count(swarm, idx), 'no respawn while the backoff window is open'
+
+    clock[0] += Wurk::Swarm::RESPAWN_BACKOFF
+    swarm.send(:spawn_due_respawns)
+
+    assert_equal 1, slot_count(swarm, idx), 'slot is refilled once the backoff elapses'
+  end
+
+  def test_spawn_due_respawns_is_a_noop_while_stopping
+    swarm = boot_swarm
+    idx = crash_first_child(swarm)
+    swarm.instance_variable_set(:@stopping, true)
+
+    swarm.send(:spawn_due_respawns)
+
+    assert_equal 0, slot_count(swarm, idx)
+  end
+
+  def test_exit_during_shutdown_is_logged_not_respawned
+    swarm = boot_swarm
+    swarm.instance_variable_set(:@stopping, true)
+    pid, meta = swarm.children.first
+
+    swarm.send(:on_child_exit, pid, Status.new(0))
+
+    refute swarm.instance_variable_get(:@respawn_backoff).pending?(meta[:index]),
+           'a clean exit during drain must not schedule a respawn'
+  end
+
+  private
+
+  def topology
+    Wurk::Topology.flat(count: 1, queues: ['default'], concurrency: 1)
+  end
+
+  def new_swarm
+    RespawnTestSwarm.new(topology: topology, config: @config)
+  end
+
+  def boot_swarm
+    swarm = new_swarm
+    swarm.boot(install_signals: false)
+    swarm
+  end
+
+  # Kill the slot-0 child and return its slot index.
+  def crash_first_child(swarm)
+    pid, meta = swarm.children.first
+    swarm.send(:on_child_exit, pid, Status.new(1))
+    meta[:index]
+  end
+
+  def inject_respawn_clock(swarm, clock)
+    swarm.instance_variable_set(:@respawn_backoff,
+                                Wurk::Swarm::Backoff.new(base: Wurk::Swarm::RESPAWN_BACKOFF, clock: clock))
+  end
+
+  def slot_count(swarm, idx)
+    swarm.children.count { |_pid, meta| meta[:index] == idx }
+  end
+end

--- a/test/unit/swarm_restart_test.rb
+++ b/test/unit/swarm_restart_test.rb
@@ -66,6 +66,35 @@ class SwarmRestartTest < Wurk::Test::UnitCase
     assert_equal 2, @spawns.size
   end
 
+  # A fork/resource failure while spawning the replacement must requeue the
+  # slot (not drop the restart work item) and must not escape `advance`.
+  def test_spawn_failure_requeues_slot_and_retries_after_backoff # rubocop:disable Minitest/MultipleAssertions
+    fail_next = [true]
+    spawner = lambda do |slot, idx|
+      raise Errno::EAGAIN, 'resource temporarily unavailable' if fail_next[0]
+
+      fake_spawn(slot, idx)
+    end
+    restart = Wurk::Swarm::Restart.new(config_with_spawn(spawner))
+
+    restart.enqueue([100])
+    restart.advance # spawn raises → requeue slot, arm backoff, no in-flight restart
+
+    assert_empty @spawns, 'a failed spawn must not register a replacement'
+    assert_nil restart.instance_variable_get(:@current), 'a failed spawn must not start an in-flight restart'
+    assert_empty @kills, 'the old child must not be touched when the replacement never spawned'
+
+    fail_next[0] = false
+    restart.advance # backoff not elapsed → still waiting
+
+    assert_empty @spawns, 'the retry is paced by the per-slot backoff'
+
+    @t[0] += 1.0
+    restart.advance # backoff elapsed → replacement spawns
+
+    assert_equal 1, @spawns.size, 'the slot retries once the backoff elapses'
+  end
+
   def test_heartbeat_timeout_proceeds_to_term_old
     @restart.enqueue([100])
     @restart.advance # spawn
@@ -163,6 +192,12 @@ class SwarmRestartTest < Wurk::Test::UnitCase
   def reap(pid)
     @children.delete(pid)
     @restart.claim_exit(pid)
+  end
+
+  def config_with_spawn(spawn)
+    cfg = config
+    cfg.spawn = spawn
+    cfg
   end
 
   def config

--- a/test/unit/swarm_restart_test.rb
+++ b/test/unit/swarm_restart_test.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Drives the Swarm::Restart state machine against fake collaborators — no
+# forks, no Redis, injected clock. Covers the
+# spawn → await_heartbeat → term_old → await_exit → done sequence plus the
+# replacement-death retry, heartbeat timeout, drain-timeout KILL, and abort.
+class SwarmRestartTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  SLOT = :slot_token # opaque; Restart only passes it through to spawn
+
+  def setup
+    super
+    @t = [1000.0]
+    @next_pid = [200]
+    @children = { 100 => { slot: SLOT, index: 0 } } # the "old" child
+    @beating = []
+    @spawns = []
+    @kills = []
+    @backoff = Wurk::Swarm::Backoff.new(base: 1.0, cap: 30.0, reset_after: 60.0, clock: -> { @t[0] })
+    @restart = Wurk::Swarm::Restart.new(config)
+  end
+
+  def test_idle_when_nothing_queued
+    assert_predicate @restart, :idle?
+  end
+
+  def test_happy_path_replaces_slot_then_drains_old # rubocop:disable Minitest/MultipleAssertions
+    @restart.enqueue([100])
+
+    @restart.advance # spawn replacement
+
+    assert_equal 1, @spawns.size
+    assert_empty @kills, 'old must not be TERMed before the replacement heartbeats'
+
+    @beating << @spawns.first[:pid]
+    @restart.advance # heartbeat seen → TERM old, enter await_exit
+
+    assert_equal [[100, 'TERM']], @kills
+
+    reap(100)        # old drains and exits
+    @restart.advance # await_exit → finish
+
+    assert_predicate @restart, :idle?
+  end
+
+  def test_replacement_death_keeps_old_and_retries_after_backoff # rubocop:disable Minitest/MultipleAssertions
+    @restart.enqueue([100])
+    @restart.advance # spawn first replacement
+
+    reap(@spawns.first[:pid]) # replacement dies before heartbeat
+    @restart.advance          # retry_slot: old kept, backoff armed
+
+    assert_empty @kills, 'the surviving old child must never be killed'
+    assert_equal 1, @spawns.size, 'no immediate respawn — retry is backed off'
+
+    @restart.advance # backoff not elapsed → still waiting
+
+    assert_equal 1, @spawns.size
+
+    @t[0] += 1.0
+    @restart.advance # backoff elapsed → new replacement
+
+    assert_equal 2, @spawns.size
+  end
+
+  def test_heartbeat_timeout_proceeds_to_term_old
+    @restart.enqueue([100])
+    @restart.advance # spawn
+
+    @t[0] += 31      # exceed heartbeat_wait (30) with no heartbeat
+    @restart.advance # proceed anyway → TERM old
+
+    assert_equal [[100, 'TERM']], @kills
+  end
+
+  def test_overrunning_old_is_killed_after_drain_timeout
+    drive_to_await_exit
+
+    @t[0] += 26      # exceed drain_timeout (25)
+    @restart.advance # KILL old
+
+    assert_equal [[100, 'TERM'], [100, 'KILL']], @kills
+
+    @restart.advance # must not re-KILL while awaiting the reap
+
+    assert_equal 2, @kills.size
+
+    reap(100)
+    @restart.advance
+
+    assert_predicate @restart, :idle?
+  end
+
+  def test_claim_exit_ignores_unrelated_pid
+    @restart.enqueue([100])
+    @restart.advance
+
+    refute @restart.claim_exit(999)
+  end
+
+  def test_replacement_death_after_takeover_is_a_normal_crash
+    drive_to_await_exit
+
+    # In await_exit the replacement owns the slot; its death is an ordinary
+    # crash the swarm respawns, so the machine must not claim it.
+    refute @restart.claim_exit(@spawns.first[:pid])
+  end
+
+  def test_enqueue_skips_in_flight_slot
+    @restart.enqueue([100])
+    @restart.advance          # 100 in flight
+    @restart.enqueue([100])   # in-flight → ignored
+
+    @beating << @spawns.first[:pid]
+    @restart.advance          # TERM old
+    reap(100)
+    @restart.advance          # finish
+
+    assert_predicate @restart, :idle?
+    assert_equal 1, @spawns.size, 'the in-flight slot must not be restarted twice'
+  end
+
+  def test_enqueue_collapses_duplicate_pids
+    @restart.enqueue([100, 100])
+    @restart.advance
+
+    assert_equal 1, @spawns.size
+  end
+
+  def test_stale_queue_head_is_dropped
+    @restart.enqueue([100])
+    @children.delete(100) # old vanished before the restart started
+
+    @restart.advance
+
+    assert_empty @spawns
+    assert_predicate @restart, :idle?
+  end
+
+  def test_abort_drops_queue_and_in_flight
+    @restart.enqueue([100])
+    @restart.advance
+
+    refute_predicate @restart, :idle?
+
+    @restart.abort
+
+    assert_predicate @restart, :idle?
+  end
+
+  private
+
+  def drive_to_await_exit
+    @restart.enqueue([100])
+    @restart.advance # spawn
+    @beating << @spawns.first[:pid]
+    @restart.advance # heartbeat seen → TERM old, await_exit
+  end
+
+  def reap(pid)
+    @children.delete(pid)
+    @restart.claim_exit(pid)
+  end
+
+  def config
+    Wurk::Swarm::Restart::Config.new(
+      spawn: method(:fake_spawn),
+      kill: ->(pid, sig) { @kills << [pid, sig] },
+      heartbeat: ->(pid) { @beating.include?(pid) },
+      describe: ->(pid) { @children[pid] },
+      now: -> { @t[0] },
+      logger: ::Logger.new(IO::NULL),
+      heartbeat_wait: 30,
+      drain_timeout: 25,
+      backoff: @backoff
+    )
+  end
+
+  def fake_spawn(slot, idx)
+    pid = @next_pid[0]
+    @next_pid[0] += 1
+    @children[pid] = { slot: slot, index: idx }
+    @spawns << { slot: slot, index: idx, pid: pid }
+    pid
+  end
+end

--- a/test/unit/swarm_signals_test.rb
+++ b/test/unit/swarm_signals_test.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Self-pipe signal handling of Wurk::Swarm, driven fork-free. fork_child hands
+# back fake PIDs and shutdown/relay are captured, so the trap → pipe → drain
+# dispatch is asserted without real processes or poisoning the runner's signal
+# handlers. The real-signal proof lives in the integration layer.
+class SwarmSignalsTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  # Fork-free swarm that records the drain-side effects instead of touching
+  # real children.
+  class SignalSpySwarm < Wurk::Swarm
+    attr_reader :shutdown_calls, :relayed
+
+    def initialize(**kwargs)
+      super
+      @shutdown_calls = 0
+      @relayed = []
+      @fake_pid = 9000
+    end
+
+    def shutdown(**)
+      @shutdown_calls += 1
+    end
+
+    private
+
+    def fork_child(_slot, _idx)
+      @fake_pid += 1
+    end
+
+    def relay_signal(sig)
+      @relayed << sig
+    end
+  end
+
+  def setup
+    super
+    @config = Wurk::Configuration.new
+    @config.logger = ::Logger.new(IO::NULL)
+  end
+
+  # --- drain dispatch (injected pipe, no real traps) ---------------------
+
+  def test_drain_signals_is_a_noop_without_a_pipe
+    swarm = booted
+
+    swarm.send(:drain_signals) # @signal_read is nil in the install_signals:false path
+
+    assert_equal 0, swarm.shutdown_calls
+  end
+
+  def test_read_pending_signal_returns_nil_when_pipe_empty
+    swarm = booted
+    inject_pipe(swarm)
+
+    assert_nil swarm.send(:read_pending_signal)
+  end
+
+  def test_term_signal_drains
+    swarm = booted
+    feed(swarm, 'TERM')
+
+    swarm.send(:drain_signals)
+
+    assert_equal 1, swarm.shutdown_calls
+  end
+
+  def test_tstp_signal_relays_quiet
+    swarm = booted
+    feed(swarm, 'TSTP')
+
+    swarm.send(:drain_signals)
+
+    assert_equal ['TSTP'], swarm.relayed
+  end
+
+  def test_usr1_signal_enqueues_a_rolling_restart
+    swarm = booted
+    feed(swarm, 'USR1')
+
+    swarm.send(:drain_signals)
+
+    refute_predicate swarm.instance_variable_get(:@restart), :idle?
+  end
+
+  def test_drain_processes_every_buffered_signal_in_one_tick
+    swarm = booted
+    feed(swarm, 'TSTP', 'TSTP', 'TERM')
+
+    swarm.send(:drain_signals)
+
+    assert_equal %w[TSTP TSTP], swarm.relayed
+    assert_equal 1, swarm.shutdown_calls
+  end
+
+  # --- real trap install (restores the runner's handlers) ----------------
+
+  def test_install_signal_handlers_wires_the_self_pipe_trap
+    with_saved_traps(%w[TERM INT TSTP USR1]) do
+      swarm = booted # fake children so a rolling restart has a slot to queue
+      swarm.send(:install_signal_handlers)
+
+      assert swarm.instance_variable_get(:@signal_read), 'a read end must be opened'
+
+      ::Process.kill('USR1', ::Process.pid) # trapped → writes to the pipe, does not terminate
+      swarm.instance_variable_get(:@signal_read).wait_readable(1)
+      swarm.send(:drain_signals)
+
+      refute_predicate swarm.instance_variable_get(:@restart), :idle?,
+                       'the trapped USR1 must reach the rolling-restart machine'
+    end
+  end
+
+  private
+
+  def topology
+    Wurk::Topology.flat(count: 1, queues: ['default'], concurrency: 1)
+  end
+
+  def booted
+    swarm = SignalSpySwarm.new(topology: topology, config: @config)
+    swarm.boot(install_signals: false)
+    swarm
+  end
+
+  def inject_pipe(swarm)
+    r, w = ::IO.pipe
+    swarm.instance_variable_set(:@signal_read, r)
+    swarm.instance_variable_set(:@signal_write, w)
+    [r, w]
+  end
+
+  def feed(swarm, *signals)
+    _r, w = inject_pipe(swarm)
+    signals.each { |s| w.puts(s) }
+  end
+
+  # Snapshots and restores the process's disposition for `signals` so a test
+  # that installs real traps can't leak them into the rest of the run.
+  def with_saved_traps(signals)
+    saved = signals.to_h { |s| [s, ::Signal.trap(s, 'DEFAULT')] }
+    yield
+  ensure
+    saved&.each { |s, h| ::Signal.trap(s, h || 'DEFAULT') }
+  end
+end

--- a/wurk.gemspec
+++ b/wurk.gemspec
@@ -52,4 +52,10 @@ Gem::Specification.new do |spec|
   # has neither — without these, `require "wurk"` raises LoadError on Ruby 3.4+.
   spec.add_dependency "base64", ">= 0.1", "< 1"
   spec.add_dependency "logger", ">= 1.5", "< 2"
+  # fiddle left the default gems in Ruby 4.0. The swarm's Linux PR_SET_PDEATHSIG
+  # orphan-guard fast-path (lib/wurk/swarm/orphan_guard.rb) requires it; without
+  # the dep it silently degrades to the getppid watchdog on Ruby 4.0 (and the
+  # orphan-guard test errors on LoadError). Declaring it keeps the kernel-level
+  # path working there, exactly as base64/logger keep `require "wurk"` working.
+  spec.add_dependency "fiddle", ">= 1.0", "< 2"
 end


### PR DESCRIPTION
## Summary
- Railtie refuses to auto-fork the swarm under a preforking web server (Puma cluster/Unicorn/Passenger), with an `embed_in_web` opt-in.
- Swarm supervise loop never sleeps: per-slot exponential crash-loop backoff (1s→30s cap), non-blocking rolling-restart state machine (TERM/INT aborts mid-restart), drain-per-tick reaping.
- Orphan protection (PR_SET_PDEATHSIG + portable getppid watchdog), self-pipe trap safety, parent-owned health-port rebind, plus small USR1/USR2/boot_reclaim fixes.
- New real-fork/real-Redis/real-signal integration coverage proving: crash-loop backoff grows and TERM still drains promptly mid-backoff; a replacement killed before heartbeat leaves the old child alive and the slot retries; a real SIGTERM mid-restart aborts to an ordinary drain; SIGKILL'ing the supervisor leaves orphaned children to self-terminate. Plus the missing console-mode case in the Railtie `skip_boot?` unit matrix.

## Test plan
- [x] `bin/rake test` (full suite green except pre-existing, unrelated `CronTest` DST fold-hour failures)
- [x] `bin/rake test TEST=test/integration/swarm_supervision_test.rb` (run 4x, stable)
- [x] `bin/rake test TEST=test/unit/swarm_test.rb`
- [x] `bin/rake test TEST=test/engine/railtie_test.rb`
- [x] `COVERAGE=1 bin/rake test` — line 96.77%, branch 90.71% (≥90% gate)
- [x] `bundle exec rubocop` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More robust worker supervision with tick-driven restarts, crash backoff, rolling-restart retries, and orphan protection.
  * Health check server can now retry binding a busy port and take over once the owner stops.
  * Added support for reopening CLI logs on `USR2`.
* **Bug Fixes**
  * Better handling under preforking web servers, with clearer refusal behavior and safer operation.
* **Documentation**
  * Expanded Rails startup, preforking-server guidance, embedded mode instructions, and `WURK_DISABLED=1` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->