### PR TITLE
fix(batch): idempotent registration, scheduler/limiter roundtrip fixes

### DIFF
--- a/lib/wurk.rb
+++ b/lib/wurk.rb
@@ -263,8 +263,12 @@ require_relative 'wurk/middleware/interrupt_handler'
 
 # Limiter server middleware: catches OverLimit, reschedules onto the same
 # queue with `Time.now + backoff` until `overrated` hits the reschedule cap.
-# Registered AFTER Batch::ServerMiddleware so a rescheduled OverLimit
-# unwinds back through the batch onion without ack'ing success.
+# Registered AFTER Batch::ServerMiddleware, so in the chain Batch is OUTER
+# and Limiter is INNER (`add` appends; entry 0 is outermost). A reschedule
+# therefore unwinds *outward through* the batch onion — which is why it
+# raises `Limiter::Rescheduled` (a JobRetry::Skip) rather than returning: a
+# normal return would make the outer Batch middleware ack success for a job
+# that never ran. The Skip signal makes Batch skip both acks instead.
 # Spec: docs/target/sidekiq-ent.md §1.4.
 Wurk.configuration.server_middleware.add(Wurk::Limiter::ServerMiddleware)
 

--- a/lib/wurk/batch.rb
+++ b/lib/wurk/batch.rb
@@ -185,6 +185,9 @@ module Wurk
       collect_jobs(&block)
       # By the time we check, the buffer (if any) has flushed, so `total`
       # reflects everything the block pushed — a flat count is reliable.
+      # Scheduled (`perform_in`) jobs count here too: BATCH_SCHEDULE moves
+      # `total` at creation, so a scheduled-only block does not misfire the
+      # marker as if it were empty.
       enqueue_empty_marker if job_count == pre_count
       @mutable = false
       self

--- a/lib/wurk/batch/server_middleware.rb
+++ b/lib/wurk/batch/server_middleware.rb
@@ -17,8 +17,9 @@ module Wurk
     # failure → BATCH_ACK_FAILED → the jid joins `b-<bid>-failed` and
     # `failures` reflects the count of currently-failing jobs. A later
     # successful retry clears it; a terminal death moves it to `b-<bid>-died`.
-    # Clean handled exits (JobRetry::Skip from expiry/interrupt, cooperative
-    # IterableJob interruption) are re-raised without counting as failures.
+    # Clean handled exits (JobRetry::Skip — from the interrupt handler or a
+    # Limiter::Rescheduled re-enqueue — and cooperative IterableJob
+    # interruption) are re-raised as neither success nor failure.
     #
     # Invalidated batches short-circuit: the job is skipped without
     # raising — counts as a "success" for batch purposes per spec §12.
@@ -43,9 +44,12 @@ module Wurk
 
       private
 
-      # A handled/skip exit or a cooperative interruption is not a failure —
-      # re-raise it untouched. Any other exception means the job failed and
-      # will retry (or eventually die): record it before re-raising.
+      # A handled/skip exit — including a Limiter::Rescheduled, where the
+      # limiter already re-enqueued the job (Rescheduled < JobRetry::Skip <
+      # Handled) — or a cooperative interruption is *neither* success nor
+      # failure: re-raise it untouched, acking neither. Any other exception
+      # means the job failed and will retry (or eventually die): record it
+      # before re-raising.
       def run_and_ack(bid, jid)
         yield
         ack_success(bid, jid)

--- a/lib/wurk/client.rb
+++ b/lib/wurk/client.rb
@@ -246,10 +246,24 @@ module Wurk
 
     def atomic_push(conn, payloads)
       if payloads.first['at']
-        conn.pipelined { |pipe| push_scheduled(pipe, payloads) }
+        push_scheduled_split(conn, payloads)
       else
         push_immediate(conn, payloads)
       end
+    end
+
+    # Scheduled payloads split like push_immediate: a `bid`-carrying job (a
+    # `perform_in` inside `batch.jobs`) must register into its batch at creation
+    # via BATCH_SCHEDULE so `total`/`pending` move now — a bare ZADD would leave
+    # the batch counters at zero and the empty-marker check would misfire. Plain
+    # scheduled jobs take the bare ZADD. Separate pipelines for the same
+    # NOSCRIPT-replay reason as push_immediate: a Lua NOSCRIPT surfaces only at
+    # pipeline finalize, so a unified retry would replay the plain ZADD and
+    # duplicate the scheduled entry.
+    def push_scheduled_split(conn, payloads)
+      batched, plain = payloads.partition { |j| j['bid'] }
+      conn.pipelined { |pipe| push_scheduled(pipe, plain) } unless plain.empty?
+      push_batched_scheduled_pipelined(conn, batched) unless batched.empty?
     end
 
     def push_scheduled(conn, payloads)
@@ -288,6 +302,17 @@ module Wurk
       conn.pipelined { |pipe| push_batched(pipe, batched, now, eval_method: :eval_with_source) }
     end
 
+    # Same NOSCRIPT-recovery shape as push_batched_pipelined, for the scheduled
+    # batched path (BATCH_SCHEDULE instead of BATCH_PUSH).
+    def push_batched_scheduled_pipelined(conn, batched)
+      conn.pipelined { |pipe| push_batched_scheduled(pipe, batched) }
+    rescue RedisClient::CommandError => e
+      raise unless e.message.to_s.start_with?('NOSCRIPT')
+
+      Wurk::Lua::Loader.script_load_all(conn)
+      conn.pipelined { |pipe| push_batched_scheduled(pipe, batched, eval_method: :eval_with_source) }
+    end
+
     def push_plain(conn, payloads, now)
       grouped = payloads.group_by { |j| j['queue'] }
       conn.call('SADD', 'queues', *grouped.keys)
@@ -317,6 +342,25 @@ module Wurk
           keys: ["b-#{j['bid']}", "b-#{j['bid']}-jids", "queue:#{j['queue']}", 'queues',
                  "b-#{j['bid']}-died", 'dead-batches'],
           argv: [j['queue'], j['jid'], Wurk.dump_json(j), j['bid']]
+        )
+      end
+    end
+
+    # Scheduled batched jobs route through BATCH_SCHEDULE: the SADD-guarded
+    # total/pending increment registers the job in its batch at creation, and
+    # the ZADD defers it onto `schedule`. Payload is stripped of `at`/
+    # `enqueued_at` exactly like push_scheduled — `enqueued_at` is stamped fresh
+    # at promotion, never while the job sits scheduled (spec §7.1). One Redis
+    # round-trip per job because the Lua binds per-job KEYS; scheduled batch
+    # enqueue is not the hot path.
+    def push_batched_scheduled(conn, payloads, eval_method: :eval_cached)
+      payloads.each do |j|
+        Wurk::Lua::Loader.public_send(
+          eval_method,
+          conn,
+          :batch_schedule,
+          keys: ['schedule', "b-#{j['bid']}", "b-#{j['bid']}-jids"],
+          argv: [j['at'].to_s, Wurk.dump_json(j.except('enqueued_at', 'at')), j['jid']]
         )
       end
     end

--- a/lib/wurk/dead_set.rb
+++ b/lib/wurk/dead_set.rb
@@ -38,9 +38,24 @@ module Wurk
       Wurk.redis do |conn|
         conn.pipelined do |pipe|
           pipe.call('ZREMRANGEBYSCORE', @name, '-inf', "(#{cutoff}")
-          pipe.call('ZREMRANGEBYRANK', @name, 0, -(max_jobs + 1))
+          pipe.call('ZREMRANGEBYRANK', @name, 0, -max_jobs)
         end
       end
+      true
+    end
+
+    # ZADD the raw JSON payload (score = now) then apply the two-axis #trim.
+    # Shared primitive behind both morgue entry points so the trim runs on
+    # EVERY kill (spec §31.8), including the malformed-JSON path:
+    #   * JobRetry#send_to_morgue — exhausted retries
+    #   * Processor#parse_or_kill — unparseable payloads
+    # No death handlers: JobRetry fires its own via #run_death_handlers and the
+    # malformed path has no parseable job to hand a handler. `max_jobs:` /
+    # `timeout:` propagate to #trim (see there for the override rationale).
+    def kill_raw(payload, max_jobs: nil, timeout: nil) # rubocop:disable Naming/PredicateMethod
+      now = ::Process.clock_gettime(::Process::CLOCK_REALTIME)
+      Wurk.redis { |conn| conn.call('ZADD', @name, now.to_s, payload) }
+      trim(max_jobs: max_jobs, timeout: timeout)
       true
     end
 

--- a/lib/wurk/job_retry.rb
+++ b/lib/wurk/job_retry.rb
@@ -2,6 +2,7 @@
 
 require 'zlib'
 require_relative 'component'
+require_relative 'dead_set'
 
 module Wurk
   # Owns the retry pipeline. When perform raises, JobRetry decides whether to
@@ -262,10 +263,7 @@ module Wurk
 
     def send_to_morgue(msg)
       logger.info { "Adding dead #{msg['class']} job #{msg['jid']}" }
-      payload = Wurk.dump_json(msg)
-      now = ::Time.now.to_f
-      redis { |conn| conn.call('ZADD', Keys::DEAD, now.to_s, payload) }
-      DeadSet.new.trim
+      DeadSet.new.kill_raw(Wurk.dump_json(msg))
     end
 
     def run_death_handlers(job, exception)

--- a/lib/wurk/limiter/server_middleware.rb
+++ b/lib/wurk/limiter/server_middleware.rb
@@ -1,14 +1,28 @@
 # frozen_string_literal: true
 
+require_relative '../job_retry'
+
 module Wurk
   module Limiter
+    # Control signal raised after a job has been rescheduled: the limiter has
+    # already re-enqueued it (via `Client.push` at `Time.now + backoff`), so
+    # the run is *neither* a success nor a failure. Subclassing
+    # `JobRetry::Skip` routes it through the existing "middleware re-pushed the
+    # job — ack cleanly, book no retry" contract: the retrier re-raises it
+    # untouched, the outer Batch middleware skips both acks (its `rescue
+    # Handled` re-raises), and the Processor acks the UnitOfWork. Returning
+    # normally instead would let the outer Batch onion ack success for a job
+    # that never ran. Internal only — not part of the Sidekiq drop-in surface.
+    class Rescheduled < Wurk::JobRetry::Skip; end
+
     # Catches OverLimit (and any class registered in `Limiter.config.errors`),
     # bumps `job['overrated']`, and decides what to do next:
     #
     #   * reschedule disabled (`reschedule: 0`) → re-raise so the normal
     #     retry/dead pipeline handles it (spec §1.2/§1.4 behaviour).
     #   * still under the cap → reschedule onto the same queue at
-    #     `Time.now + backoff` via `Client.push`.
+    #     `Time.now + backoff` via `Client.push`, then raise `Rescheduled` so
+    #     the outcome is neither success nor failure (batch onion skips acks).
     #   * cap reached (`overrated >= reschedule`, default 20) → **poison
     #     brake** (#16): a job that's still rate-limited after N reschedules
     #     is saturating the limiter, so instead of dumping it into another
@@ -58,6 +72,7 @@ module Wurk
         backoff_proc = (limiter && limiter.options[:backoff]) || Wurk::Limiter.config.backoff
         delay = backoff_proc.call(limiter, job, exc).to_f
         Wurk::Client.new.push(job.merge('at' => ::Time.now.to_f + delay))
+        raise Rescheduled
       end
 
       # Poison brake: stamp a clear reason, drop the job in the dead set, and

--- a/lib/wurk/lua.rb
+++ b/lib/wurk/lua.rb
@@ -37,20 +37,31 @@ module Wurk
     # Pro reliable scheduler: atomically promote all due jobs in a sorted
     # set to their target queues. Pure-Ruby promotion does ZRANGE → ZREM →
     # LPUSH non-atomically and can lose jobs on a mid-step crash.
+    #
+    # Each promoted payload is restamped with a fresh `enqueued_at` (ARGV[3],
+    # epoch ms): that field marks arrival on an *immediate* queue, so a job
+    # leaving `schedule`/`retry` must get a new one at promotion rather than
+    # keep its stale scheduled-origin value (or none). This matches the default
+    # Ruby scheduler, whose push path restamps `enqueued_at` too
+    # (Client#push_plain / #push_batched) — so both schedulers emit
+    # wire-identical promoted payloads (spec §7.1).
     # KEYS = [sorted_set, queues_set]
-    # ARGV = [now, queue_prefix]
+    # ARGV = [now, queue_prefix, now_ms]
     # Returns the number of jobs promoted.
     # Order matters: decode + push BEFORE zrem. Redis Lua has no rollback,
     # so a failed cjson.decode after a zrem would lose the job. Decode first;
-    # push first; only then remove from the sorted set. Worst case is a
-    # crash between lpush and zrem → at-least-once redelivery, never loss.
+    # push first; only then remove from the sorted set — and zrem the ORIGINAL
+    # member, not the restamped copy. Worst case is a crash between lpush and
+    # zrem → at-least-once redelivery, never loss.
     RELIABLE_SCHEDULE_PROMOTE = <<~LUA
       local jobs = redis.call("zrangebyscore", KEYS[1], "-inf", ARGV[1])
       for i = 1, #jobs do
         local job = jobs[i]
-        local q = cjson.decode(job)["queue"]
+        local decoded = cjson.decode(job)
+        decoded["enqueued_at"] = tonumber(ARGV[3])
+        local q = decoded["queue"]
         redis.call("sadd", KEYS[2], q)
-        redis.call("lpush", ARGV[2] .. q, job)
+        redis.call("lpush", ARGV[2] .. q, cjson.encode(decoded))
         redis.call("zrem", KEYS[1], job)
       end
       return #jobs
@@ -113,6 +124,31 @@ module Wurk
       end
       redis.call("sadd", KEYS[4], ARGV[1])
       redis.call("lpush", KEYS[3], ARGV[3])
+      return 1
+    LUA
+
+    # Pro Batch: register a scheduled (`at`) job into a batch AND ZADD it onto
+    # the `schedule` set, atomically. This is the deferred sibling of BATCH_PUSH:
+    # same SADD-guarded total/pending counting, but the enqueue action is a ZADD
+    # (schedule for later) instead of an LPUSH (queue now). A `perform_in` inside
+    # `batch.jobs` must move `total`/`pending` at *creation* — otherwise the
+    # empty-marker check (batch.rb) sees no counter movement and fires
+    # `:complete`/`:success` while real jobs still sit in `schedule`.
+    #
+    # No died / dead-batches handling (unlike BATCH_PUSH): a job scheduled at
+    # creation time is always new to the batch. When the scheduler later promotes
+    # it, the re-push routes through BATCH_PUSH, whose guard finds the jid already
+    # live (SADD == 0) → pure LPUSH, no recount. So registration happens exactly
+    # once, here, at enqueue.
+    # KEYS = [schedule, b-<bid>, b-<bid>-jids]
+    # ARGV = [at_score, job_json, jid]
+    # Returns 1.
+    BATCH_SCHEDULE = <<~LUA
+      if redis.call("sadd", KEYS[3], ARGV[3]) == 1 then
+        redis.call("hincrby", KEYS[2], "total", 1)
+        redis.call("hincrby", KEYS[2], "pending", 1)
+      end
+      redis.call("zadd", KEYS[1], ARGV[1], ARGV[2])
       return 1
     LUA
 
@@ -289,6 +325,7 @@ module Wurk
       reliable_schedule_promote: RELIABLE_SCHEDULE_PROMOTE,
       reliable_requeue: RELIABLE_REQUEUE,
       batch_push: BATCH_PUSH,
+      batch_schedule: BATCH_SCHEDULE,
       batch_ack_success: BATCH_ACK_SUCCESS,
       batch_ack_failed: BATCH_ACK_FAILED,
       batch_ack_complete: BATCH_ACK_COMPLETE,

--- a/lib/wurk/lua.rb
+++ b/lib/wurk/lua.rb
@@ -79,6 +79,13 @@ module Wurk
     # Pro Batch: register a job into a batch and push it to its queue
     # atomically. Keeps total/pending in sync with the jids set.
     #
+    # SADD into the live jids set is the registration guard: total/pending
+    # increment only when the jid is genuinely new (SADD == 1). A jid already
+    # live is a re-push — a retry or scheduled promotion re-enqueueing a job
+    # that never left the batch — so it re-LPUSHes the payload but must NOT
+    # recount, or pending inflates past the acks and `:success` never fires
+    # (spec §2.3/§2.5: total = distinct jobs added, pending = not-yet-succeeded).
+    #
     # A jid found in `b-<bid>-died` is a manual retry of a dead job (morgue
     # "retry" / "add to queue") — it rejoins the live set without recounting:
     # total and pending already include it, because a death never decrements
@@ -99,9 +106,10 @@ module Wurk
           redis.call("zrem", KEYS[6], ARGV[4])
         end
       else
-        redis.call("hincrby", KEYS[1], "total", 1)
-        redis.call("hincrby", KEYS[1], "pending", 1)
-        redis.call("sadd", KEYS[2], ARGV[2])
+        if redis.call("sadd", KEYS[2], ARGV[2]) == 1 then
+          redis.call("hincrby", KEYS[1], "total", 1)
+          redis.call("hincrby", KEYS[1], "pending", 1)
+        end
       end
       redis.call("sadd", KEYS[4], ARGV[1])
       redis.call("lpush", KEYS[3], ARGV[3])

--- a/lib/wurk/lua.rb
+++ b/lib/wurk/lua.rb
@@ -45,6 +45,22 @@ module Wurk
     # Ruby scheduler, whose push path restamps `enqueued_at` too
     # (Client#push_plain / #push_batched) — so both schedulers emit
     # wire-identical promoted payloads (spec §7.1).
+    #
+    # The restamp is a surgical string patch, NOT a cjson.decode -> cjson.encode
+    # round-trip: cjson maps every JSON number to a Lua double, so re-encoding
+    # would silently corrupt integer args past 2^53 (snowflake IDs, 64-bit
+    # counters) and reformat 15+ digit numbers into scientific notation --
+    # breaking wire-compat AND diverging from the loss-free Ruby scheduler,
+    # whose Ruby-side JSON keeps big integers exact. So the stored member is
+    # preserved byte-for-byte and only its top-level `enqueued_at` is rewritten:
+    # replaced in place when present (retry members keep theirs), inserted after
+    # the opening brace when absent (schedule members are stored stripped of it,
+    # via Client#push_scheduled). cjson.decode is still called -- but only to
+    # read the `queue` string and test for a top-level `enqueued_at`, never to
+    # re-serialize, so a lossy decode never reaches the payload. (Residual: a
+    # retry member whose user args embed a numeric key literally named
+    # `enqueued_at` ahead of the top-level one patches the arg instead --
+    # vanishingly rare, and still strictly safer than round-tripping every arg.)
     # KEYS = [sorted_set, queues_set]
     # ARGV = [now, queue_prefix, now_ms]
     # Returns the number of jobs promoted.
@@ -58,10 +74,15 @@ module Wurk
       for i = 1, #jobs do
         local job = jobs[i]
         local decoded = cjson.decode(job)
-        decoded["enqueued_at"] = tonumber(ARGV[3])
         local q = decoded["queue"]
+        local stamped
+        if decoded["enqueued_at"] == nil then
+          stamped = string.gsub(job, "^{", '{"enqueued_at":' .. ARGV[3] .. ",", 1)
+        else
+          stamped = string.gsub(job, '"enqueued_at":%-?%d[%d.eE+-]*', '"enqueued_at":' .. ARGV[3], 1)
+        end
         redis.call("sadd", KEYS[2], q)
-        redis.call("lpush", ARGV[2] .. q, cjson.encode(decoded))
+        redis.call("lpush", ARGV[2] .. q, stamped)
         redis.call("zrem", KEYS[1], job)
       end
       return #jobs

--- a/lib/wurk/processor.rb
+++ b/lib/wurk/processor.rb
@@ -175,8 +175,9 @@ module Wurk
           ack = true
         end
       rescue Wurk::JobRetry::Handled
-        # JobRetry::Skip (subclass) or Handled — retry layer / middleware has
-        # already booked the outcome; safe to ack.
+        # Handled / JobRetry::Skip (incl. Limiter::Rescheduled, where the
+        # limiter middleware already re-enqueued the job) — the retry layer or
+        # a middleware booked the outcome and recorded no retry; ack the UoW.
         ack = true
       rescue Wurk::Shutdown
         # Don't ack — UoW stays in private list and is reclaimed on reboot.

--- a/lib/wurk/processor.rb
+++ b/lib/wurk/processor.rb
@@ -2,9 +2,9 @@
 
 require_relative 'component'
 require_relative 'context'
+require_relative 'dead_set'
 require_relative 'job_logger'
 require_relative 'job_retry'
-require_relative 'keys'
 require_relative 'profiler'
 
 module Wurk
@@ -186,16 +186,15 @@ module Wurk
       end
     end
 
-    # Parse JSON; on failure ZADD the raw payload to the dead set and ack.
+    # Parse JSON; on failure send the raw payload to the dead set (ZADD +
+    # trim, via the shared DeadSet#kill_raw so the malformed path caps the
+    # morgue exactly like send_to_morgue does — spec §31.8/§31.9) and ack.
     # Returns nil to signal "no further processing".
     def parse_or_kill(jobstr, uow)
       Wurk.load_json(jobstr)
     rescue ::JSON::ParserError => e
       handle_exception(e, { context: 'Invalid JSON', jobstr: jobstr })
-      now = ::Process.clock_gettime(::Process::CLOCK_REALTIME)
-      @capsule.redis do |conn|
-        conn.call('ZADD', Keys::DEAD, now.to_s, jobstr)
-      end
+      DeadSet.new.kill_raw(jobstr)
       uow.acknowledge
       nil
     end

--- a/lib/wurk/scheduled.rb
+++ b/lib/wurk/scheduled.rb
@@ -60,8 +60,20 @@ module Wurk
           jobstr = @config.redis { |conn| Wurk::Lua::Loader.eval_cached(conn, :zpopbyscore, keys: [sset], argv: [now]) }
           break unless jobstr
 
-          @client.push(Wurk.load_json(jobstr))
+          push_promoted(jobstr, sset)
         end
+      end
+
+      # A raising `@client.push` (bad payload, transient Redis error) must not
+      # abort the drain and strand the remaining due jobs until the next poll —
+      # rescue per-job, report, continue. The already-popped job IS lost here
+      # (ZPOPBYSCORE removed it); that pop→push loss window is the default
+      # scheduler's known tradeoff — `reliable_scheduler!` (ReliableEnq) is the
+      # loss-free fix, so we don't re-engineer around it here.
+      def push_promoted(jobstr, sset)
+        @client.push(Wurk.load_json(jobstr))
+      rescue StandardError => e
+        handle_exception(e, { context: 'scheduler_promote', set: sset })
       end
 
       def real_time
@@ -102,7 +114,7 @@ module Wurk
           conn,
           :reliable_schedule_promote,
           keys: [sset, Keys::QUEUES_SET],
-          argv: [real_time.to_s, Keys::QUEUE_PREFIX]
+          argv: [real_time.to_s, Keys::QUEUE_PREFIX, real_ms.to_s]
         )
       end
 

--- a/test/integration/batch_retry_roundtrip_test.rb
+++ b/test/integration/batch_retry_roundtrip_test.rb
@@ -1,0 +1,375 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'securerandom'
+
+# Top-level worker classes so Object.const_get resolves inside forked
+# children (constant table is inherited; Minitest lexical scope is not).
+
+# Never fails — the batch's "already-succeeded" sibling job.
+class BatchRoundtripSimpleWorker
+  include Wurk::Job
+
+  def perform(redis_url, marker_key)
+    client = RedisClient.config(url: redis_url).new_client
+    client.call('SET', marker_key, '1', 'EX', 60)
+  ensure
+    client&.close
+  end
+end
+
+# Fails on its first attempt, succeeds on every attempt after. `attempts_key`
+# is INCRed on every dispatch so the test can observe exactly when the first
+# (failing) attempt happened without racing the retry promotion.
+class BatchRoundtripFlakyWorker
+  include Wurk::Job
+
+  sidekiq_options retry: true
+  # A few real seconds of headroom (plus job_retry's own jitter) so the test
+  # can positively observe the "still pending, not yet acked" window before
+  # forcing the retry ZSET entry due for promotion.
+  sidekiq_retry_in { 5 }
+
+  def perform(redis_url, attempts_key, marker_key)
+    client = RedisClient.config(url: redis_url).new_client
+    attempt = client.call('INCR', attempts_key)
+    raise "boom on attempt #{attempt}" if attempt == 1
+
+    client.call('SET', marker_key, '1', 'EX', 60)
+  ensure
+    client&.close
+  end
+end
+
+# perform_in-in-batch sentinel: only runs once promoted off the `schedule`
+# ZSET onto its queue.
+class BatchRoundtripScheduledWorker
+  include Wurk::Job
+
+  def perform(redis_url, marker_key)
+    client = RedisClient.config(url: redis_url).new_client
+    client.call('SET', marker_key, '1', 'EX', 60)
+  ensure
+    client&.close
+  end
+end
+
+# Holds the concurrent limiter's only slot until `release_key` appears —
+# pins open the exact window in which a sibling batch job hits OverLimit.
+class BatchRoundtripLimiterGateWorker
+  include Wurk::Job
+
+  def perform(redis_url, limiter_name, running_key, release_key)
+    client = RedisClient.config(url: redis_url).new_client
+    limiter = Wurk::Limiter.concurrent(limiter_name, 1, wait_timeout: 30)
+    limiter.within_limit do
+      client.call('SET', running_key, '1', 'EX', 60)
+      deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + 20
+      until client.call('EXISTS', release_key) == 1
+        if ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) > deadline
+          raise "#{release_key} never set — test driver lost?"
+        end
+
+        sleep 0.05
+      end
+    end
+  ensure
+    client&.close
+  end
+end
+
+# Waits for the gate to actually hold the limiter slot, then attempts to
+# acquire it itself with `wait_timeout: 0` — guaranteed OverLimit on the
+# first (gate-held) attempt, guaranteed success on a later attempt (after
+# the gate releases and the limiter reschedule promotes this job again).
+class BatchRoundtripLimiterContenderWorker
+  include Wurk::Job
+
+  def perform(redis_url, limiter_name, running_key, attempts_key, marker_key)
+    client = RedisClient.config(url: redis_url).new_client
+    deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + 20
+    until client.call('EXISTS', running_key) == 1
+      if ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) > deadline
+        raise "#{running_key} never set — gate job never started?"
+      end
+
+      sleep 0.05
+    end
+    client.call('INCR', attempts_key)
+    limiter = Wurk::Limiter.concurrent(limiter_name, 1, wait_timeout: 0, backoff: ->(*) { 0.05 })
+    limiter.within_limit { client.call('SET', marker_key, '1', 'EX', 60) }
+  ensure
+    client&.close
+  end
+end
+
+# Real forks, real Redis, real perform. Headline regression for 04-batch-
+# scheduler-logic: a batch containing a retried, a scheduled, or a rate-
+# limited job must complete with correct `total`/`pending` counters and fire
+# `:success` exactly once. Before the SADD-guard fix (BATCH_PUSH/BATCH_SCHEDULE)
+# and the Limiter::Rescheduled control signal, any re-push of a live jid
+# double-counted `pending` (so `:success` never fired) or the outer Batch
+# middleware acked a job that hadn't actually run. NEVER mock Redis here.
+class BatchRetryRoundtripTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  POLL_TIMEOUT = 20.0
+  POLL_INTERVAL = 0.1
+  # How long a "not yet fired" assertion must HOLD once the observation
+  # window is provably open before we trust it (vs. just winning a read race).
+  HOLD_WINDOW = 0.4
+
+  def setup
+    super
+    @ns = "batchrt-#{Process.pid}-#{object_id}"
+    @queue_name = "#{@ns}-q"
+    @config = build_config
+    @observer = RedisClient.config(url: Wurk::Test.redis_url).new_client
+    @bids = []
+  end
+
+  def teardown
+    cleanup_batches!
+    cleanup_queue!
+    purge_stray_due_entries!('retry')
+    purge_stray_due_entries!('schedule')
+    @observer&.close
+    @config&.reset_redis_pools!
+  ensure
+    super
+  end
+
+  # The headline regression (plan 04, "Done when"): batch of 2, one job fails
+  # once then succeeds on retry. `:success` must fire exactly once, `total`
+  # stays 2 (never re-incremented by the retry re-push), `pending` ends at 0.
+  def test_batch_with_one_flaky_job_retries_to_success_once_with_correct_counters # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Minitest/MultipleAssertions
+    marker_a     = "#{@ns}-marker-a"
+    attempts_key = "#{@ns}-attempts"
+    marker_b     = "#{@ns}-marker-b"
+    batch = track(Wurk::Batch.new)
+    batch.jobs do
+      Wurk::Client.push('class' => BatchRoundtripSimpleWorker.name,
+                        'args' => [Wurk::Test.redis_url, marker_a],
+                        'queue' => @queue_name, 'retry' => false)
+      Wurk::Client.push('class' => BatchRoundtripFlakyWorker.name,
+                        'args' => [Wurk::Test.redis_url, attempts_key, marker_b],
+                        'queue' => @queue_name, 'retry' => true)
+    end
+
+    assert_equal '2', batch_field(batch, 'total'), 'total must count both jobs at registration'
+
+    with_swarm(topology(concurrency: 2)) do
+      assert wait_until { @observer.call('EXISTS', marker_a) == 1 },
+             "simple job's marker never appeared — batch job never ran"
+      assert wait_until { @observer.call('GET', attempts_key).to_i >= 1 },
+             'flaky job never made its first (failing) attempt'
+
+      # Observation window: the simple job succeeded (pending 2→1) and the
+      # flaky job has failed once and is awaiting retry promotion — pending
+      # must hold at 1 and :success/:complete must not have fired.
+      hold_deadline = monotonic_now + HOLD_WINDOW
+      while monotonic_now < hold_deadline
+        assert_equal '1', batch_field(batch, 'pending'),
+                     'pending must reflect only the simple job succeeding, not a premature ack'
+        assert_nil batch_field(batch, 'success'), ':success fired before the flaky job actually succeeded'
+        sleep POLL_INTERVAL
+      end
+
+      force_due_now!('retry', attempts_key)
+
+      assert wait_until { @observer.call('EXISTS', marker_b) == 1 },
+             'flaky job never succeeded on retry'
+      assert wait_until { batch_field(batch, 'success') == '1' },
+             "batch :success never fired within #{POLL_TIMEOUT}s"
+    end
+
+    assert_equal '2', batch_field(batch, 'total'), 'retry re-push must not re-increment total'
+    assert_equal '0', batch_field(batch, 'pending'), 'pending must reach 0 once both jobs have succeeded'
+    assert_equal '1', batch_field(batch, 'complete')
+    assert_equal 2, @observer.call('GET', attempts_key).to_i,
+                 'flaky job must run exactly twice: once failing, once succeeding'
+  end
+
+  # A `perform_in` job registered inside `batch.jobs` must move `total`/
+  # `pending` at creation (BATCH_SCHEDULE) — otherwise the empty-marker check
+  # sees no counter movement and fires `:complete`/`:success` immediately,
+  # while the real job still sits unpromoted in `schedule`.
+  def test_perform_in_inside_batch_does_not_fire_premature_complete # rubocop:disable Metrics/AbcSize,Minitest/MultipleAssertions
+    marker = "#{@ns}-scheduled-marker"
+    batch = track(Wurk::Batch.new)
+    target_at = ::Process.clock_gettime(::Process::CLOCK_REALTIME) + 0.5
+    batch.jobs do
+      Wurk::Client.push('class' => BatchRoundtripScheduledWorker.name,
+                        'args' => [Wurk::Test.redis_url, marker],
+                        'queue' => @queue_name, 'retry' => false, 'at' => target_at)
+    end
+
+    assert_equal '1', batch_field(batch, 'total'),
+                 'BATCH_SCHEDULE must register the scheduled job at creation'
+    assert_equal '1', batch_field(batch, 'pending')
+    assert_nil batch_field(batch, 'complete'),
+               ':complete must not fire while the scheduled job still sits in `schedule`'
+
+    with_swarm(topology(concurrency: 1)) do
+      assert wait_until { @observer.call('EXISTS', marker) == 1 },
+             'scheduled job was never promoted + run'
+      assert wait_until { batch_field(batch, 'complete') == '1' },
+             "batch :complete never fired within #{POLL_TIMEOUT}s"
+    end
+
+    assert_equal '1', batch_field(batch, 'total'), 'promotion re-push must not re-increment total'
+    assert_equal '0', batch_field(batch, 'pending')
+    assert_equal '1', batch_field(batch, 'success')
+  end
+
+  # Limiter × Batch (#18): a job that hits OverLimit inside a batch gets
+  # rescheduled by Wurk::Limiter::ServerMiddleware, which raises
+  # Wurk::Limiter::Rescheduled — neither success nor failure. The outer Batch
+  # middleware must skip BOTH acks (no premature success, no spurious retry
+  # bookkeeping) until the job actually runs to completion.
+  def test_limiter_reschedule_inside_batch_does_not_fire_premature_ack # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Minitest/MultipleAssertions
+    limiter_name = "#{@ns}-limiter"
+    running_key  = "#{@ns}-running"
+    release_key  = "#{@ns}-release"
+    attempts_key = "#{@ns}-contender-attempts"
+    marker       = "#{@ns}-contender-marker"
+    batch = track(Wurk::Batch.new)
+    batch.jobs do
+      Wurk::Client.push('class' => BatchRoundtripLimiterGateWorker.name,
+                        'args' => [Wurk::Test.redis_url, limiter_name, running_key, release_key],
+                        'queue' => @queue_name, 'retry' => false)
+      Wurk::Client.push('class' => BatchRoundtripLimiterContenderWorker.name,
+                        'args' => [Wurk::Test.redis_url, limiter_name, running_key, attempts_key, marker],
+                        'queue' => @queue_name, 'retry' => false)
+    end
+
+    assert_equal '2', batch_field(batch, 'total')
+
+    with_swarm(topology(concurrency: 2)) do
+      assert wait_until { @observer.call('EXISTS', running_key) == 1 },
+             'gate job never acquired the limiter slot'
+      assert wait_until { @observer.call('GET', attempts_key).to_i >= 1 },
+             'contender job never attempted to acquire the (held) limiter slot'
+
+      # The contender's first attempt must OverLimit → reschedule → neither
+      # ack fires. Hold this window before releasing the gate.
+      hold_deadline = monotonic_now + HOLD_WINDOW
+      while monotonic_now < hold_deadline
+        refute_equal '1', @observer.call('GET', marker), 'contender must not succeed while the gate holds the slot'
+        assert_equal '2', batch_field(batch, 'pending'),
+                     'pending must not drop — a rescheduled job is neither success nor failure'
+        assert_nil batch_field(batch, 'success'), ':success fired before the contender actually ran'
+        sleep POLL_INTERVAL
+      end
+
+      @observer.call('SET', release_key, '1', 'EX', 60)
+
+      assert wait_until { @observer.call('EXISTS', marker) == 1 },
+             'contender job never succeeded after the gate released'
+      assert wait_until { batch_field(batch, 'success') == '1' },
+             "batch :success never fired within #{POLL_TIMEOUT}s"
+    ensure
+      @observer.call('SET', release_key, '1', 'EX', 60) # never strand the gated worker
+    end
+
+    assert_equal '2', batch_field(batch, 'total'), 'limiter reschedule re-push must not re-increment total'
+    assert_equal '0', batch_field(batch, 'pending')
+    assert_operator @observer.call('GET', attempts_key).to_i, :>=, 2,
+                    'contender must have attempted at least twice: once OverLimit, once successful'
+  end
+
+  private
+
+  def build_config
+    config = Wurk::Configuration.new
+    config.logger = ::Logger.new(IO::NULL)
+    config[:timeout] = 5
+    # Fast scheduler cadence so retry/schedule promotion happens quickly.
+    config[:poll_interval_average] = 0.25
+    config[:scheduler_initial_wait] = 0.1
+    # Require-time registrations only touch the global Wurk.configuration; a
+    # fresh Configuration starts with a bare chain, and without these the
+    # ack/rescue paths under test never run at all.
+    config.server_middleware.add(Wurk::Batch::ServerMiddleware)
+    config.server_middleware.add(Wurk::Limiter::ServerMiddleware)
+    config
+  end
+
+  def cleanup_batches!
+    @observer&.call('UNLINK', *@bids.flat_map { |bid| Wurk::Batch.keys_for(bid) })
+    @bids.each { |bid| @observer&.call('ZREM', 'batches', bid) }
+  end
+
+  def cleanup_queue!
+    @observer&.call('DEL', "queue:#{@queue_name}", private_queue_key(@queue_name))
+    @observer&.call('SREM', 'queues', @queue_name)
+  end
+
+  def track(batch)
+    @bids << batch.bid
+    batch
+  end
+
+  def topology(concurrency:)
+    Wurk::Topology.flat(count: 1, queues: [@queue_name], concurrency: concurrency)
+  end
+
+  def with_swarm(topo)
+    swarm = Wurk::Swarm.new(topology: topo, config: @config, shutdown_timeout: 5)
+    swarm.boot(install_signals: false)
+    supervisor = Thread.new { swarm.supervise }
+    yield
+  ensure
+    swarm&.shutdown(timeout: 5)
+    supervisor&.join(10)
+  end
+
+  # Finds the due-set member belonging to `needle` (a Redis key baked into
+  # the job's args) and rescoring it to 0 so the next (fast) poll cycle
+  # promotes it immediately — bypasses job_retry's real backoff+jitter
+  # without touching the counting/registration logic under test.
+  def force_due_now!(set_key, needle)
+    deadline = monotonic_now + POLL_TIMEOUT
+    loop do
+      raise "#{needle} never appeared in `#{set_key}` — retry never scheduled?" if monotonic_now > deadline
+
+      member = @observer.call('ZRANGE', set_key, 0, -1).find { |m| m.include?(needle) }
+      if member
+        @observer.call('ZADD', set_key, 0, member)
+        return
+      end
+      sleep POLL_INTERVAL
+    end
+  end
+
+  # Belt-and-suspenders: an aborted test (assertion failure mid-flight)
+  # could leave one of our jobs sitting in the shared global `retry`/
+  # `schedule` ZSET. Sweep anything tagged with our namespace so it can't
+  # linger and confuse a later test class sharing this worker's Redis DB.
+  def purge_stray_due_entries!(set_key)
+    members = @observer.call('ZRANGE', set_key, 0, -1).select { |m| m.include?(@ns) }
+    @observer.call('ZREM', set_key, *members) unless members.empty?
+  end
+
+  def batch_field(batch, field)
+    @observer.call('HGET', "b-#{batch.bid}", field)
+  end
+
+  def wait_until # rubocop:disable Naming/PredicateMethod
+    deadline = monotonic_now + POLL_TIMEOUT
+    until monotonic_now > deadline
+      return true if yield
+
+      sleep POLL_INTERVAL
+    end
+    false
+  end
+
+  def monotonic_now
+    ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+  end
+
+  def private_queue_key(queue_name)
+    Wurk::Fetcher::Reliable.private_queue_name("queue:#{queue_name}")
+  end
+end

--- a/test/integration/batch_retry_roundtrip_test.rb
+++ b/test/integration/batch_retry_roundtrip_test.rb
@@ -159,9 +159,9 @@ class BatchRetryRoundtripTest < Wurk::Test::UnitCase
     assert_equal '2', batch_field(batch, 'total'), 'total must count both jobs at registration'
 
     with_swarm(topology(concurrency: 2)) do
-      assert wait_until { @observer.call('EXISTS', marker_a) == 1 },
+      assert wait_until? { @observer.call('EXISTS', marker_a) == 1 },
              "simple job's marker never appeared — batch job never ran"
-      assert wait_until { @observer.call('GET', attempts_key).to_i >= 1 },
+      assert wait_until? { @observer.call('GET', attempts_key).to_i >= 1 },
              'flaky job never made its first (failing) attempt'
 
       # Observation window: the simple job succeeded (pending 2→1) and the
@@ -177,9 +177,9 @@ class BatchRetryRoundtripTest < Wurk::Test::UnitCase
 
       force_due_now!('retry', attempts_key)
 
-      assert wait_until { @observer.call('EXISTS', marker_b) == 1 },
+      assert wait_until? { @observer.call('EXISTS', marker_b) == 1 },
              'flaky job never succeeded on retry'
-      assert wait_until { batch_field(batch, 'success') == '1' },
+      assert wait_until? { batch_field(batch, 'success') == '1' },
              "batch :success never fired within #{POLL_TIMEOUT}s"
     end
 
@@ -211,9 +211,9 @@ class BatchRetryRoundtripTest < Wurk::Test::UnitCase
                ':complete must not fire while the scheduled job still sits in `schedule`'
 
     with_swarm(topology(concurrency: 1)) do
-      assert wait_until { @observer.call('EXISTS', marker) == 1 },
+      assert wait_until? { @observer.call('EXISTS', marker) == 1 },
              'scheduled job was never promoted + run'
-      assert wait_until { batch_field(batch, 'complete') == '1' },
+      assert wait_until? { batch_field(batch, 'complete') == '1' },
              "batch :complete never fired within #{POLL_TIMEOUT}s"
     end
 
@@ -246,9 +246,9 @@ class BatchRetryRoundtripTest < Wurk::Test::UnitCase
     assert_equal '2', batch_field(batch, 'total')
 
     with_swarm(topology(concurrency: 2)) do
-      assert wait_until { @observer.call('EXISTS', running_key) == 1 },
+      assert wait_until? { @observer.call('EXISTS', running_key) == 1 },
              'gate job never acquired the limiter slot'
-      assert wait_until { @observer.call('GET', attempts_key).to_i >= 1 },
+      assert wait_until? { @observer.call('GET', attempts_key).to_i >= 1 },
              'contender job never attempted to acquire the (held) limiter slot'
 
       # The contender's first attempt must OverLimit → reschedule → neither
@@ -264,9 +264,9 @@ class BatchRetryRoundtripTest < Wurk::Test::UnitCase
 
       @observer.call('SET', release_key, '1', 'EX', 60)
 
-      assert wait_until { @observer.call('EXISTS', marker) == 1 },
+      assert wait_until? { @observer.call('EXISTS', marker) == 1 },
              'contender job never succeeded after the gate released'
-      assert wait_until { batch_field(batch, 'success') == '1' },
+      assert wait_until? { batch_field(batch, 'success') == '1' },
              "batch :success never fired within #{POLL_TIMEOUT}s"
     ensure
       @observer.call('SET', release_key, '1', 'EX', 60) # never strand the gated worker
@@ -355,7 +355,7 @@ class BatchRetryRoundtripTest < Wurk::Test::UnitCase
     @observer.call('HGET', "b-#{batch.bid}", field)
   end
 
-  def wait_until # rubocop:disable Naming/PredicateMethod
+  def wait_until?
     deadline = monotonic_now + POLL_TIMEOUT
     until monotonic_now > deadline
       return true if yield

--- a/test/unit/batch_lifecycle_test.rb
+++ b/test/unit/batch_lifecycle_test.rb
@@ -276,6 +276,33 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
     assert_equal 0, Wurk::Batch::Status.new(batch.bid).failures
   end
 
+  # #18: a Limiter reschedule inside a batch is *neither* success nor failure.
+  # The Limiter middleware (INNER of Batch) re-enqueues the job and raises
+  # Limiter::Rescheduled (a JobRetry::Skip); the Batch middleware must skip
+  # both acks — pending stays put, no failure recorded, no :success. :success
+  # fires only once the rescheduled job later runs to success.
+  def test_limiter_reschedule_inside_batch_is_neither_success_nor_failure # rubocop:disable Minitest/MultipleAssertions,Metrics/AbcSize
+    batch = new_batch(success: 'S')
+    batch.jobs { perform_one }
+    jid = jid_for(@queue, batch.bid)
+
+    mw = build_server_middleware
+    assert_raises(Wurk::Limiter::Rescheduled) do
+      mw.call(nil, { 'bid' => batch.bid, 'jid' => jid }, @queue) { raise Wurk::Limiter::Rescheduled }
+    end
+
+    status = Wurk::Batch::Status.new(batch.bid)
+
+    assert_equal 1, status.pending, 'a rescheduled job must not ack success'
+    assert_equal 0, status.failures, 'a rescheduled job must not ack failure'
+    assert_equal 0, callbacks_fired(event: 'success', bid: batch.bid), ':success must not fire on reschedule'
+
+    ack_success(batch.bid, jid) # the rescheduled job later runs to success
+
+    assert_equal 0, Wurk::Batch::Status.new(batch.bid).pending
+    assert_equal 1, callbacks_fired(event: 'success', bid: batch.bid)
+  end
+
   # --- #212: dead job manually retried to success ------------------------
 
   # Spec §2.4: ":success never fires unless the dead job is manually retried

--- a/test/unit/batch_test.rb
+++ b/test/unit/batch_test.rb
@@ -175,6 +175,43 @@ class BatchTest < Wurk::Test::UnitCase
     assert_operator Wurk::Batch::Status.new(batch.bid).total, :>=, 1
   end
 
+  # A scheduled (`at`) job inside #jobs registers into the batch at creation via
+  # BATCH_SCHEDULE: total/pending move now, the jid joins the live set, and the
+  # payload waits in `schedule` (not the queue). Promotion later re-pushes it
+  # through BATCH_PUSH's guard — jid already live → no double count.
+  def test_scheduled_job_in_jobs_block_counts_and_registers # rubocop:disable Minitest/MultipleAssertions,Metrics/AbcSize
+    at    = future_at
+    batch = track(Wurk::Batch.new)
+    batch.jobs { perform_one_scheduled(at) }
+
+    assert_equal 1, Wurk::Batch::Status.new(batch.bid).total
+    assert_equal 1, Wurk::Batch::Status.new(batch.bid).pending
+
+    member, score = mine_in_schedule(batch.bid)
+
+    refute_nil member, 'scheduled batched job must land in the `schedule` zset'
+    assert_equal batch.bid, member['bid']
+    assert_in_delta at, score.to_f, 0.01
+    assert_equal(1, @pool.with { |c| c.call('SISMEMBER', "b-#{batch.bid}-jids", member['jid']) })
+  end
+
+  def test_scheduled_job_in_jobs_block_is_not_pushed_to_queue
+    batch = track(Wurk::Batch.new)
+    batch.jobs { perform_one_scheduled(future_at) }
+
+    assert_equal(0, @pool.with { |c| c.call('LLEN', "queue:#{@queue}") })
+  end
+
+  # The empty-marker check keys off `total`; because BATCH_SCHEDULE moves it, a
+  # scheduled-only block is NOT mistaken for empty. A misfire would BATCH_PUSH a
+  # Batch::Empty marker → total would be 2.
+  def test_scheduled_only_block_does_not_enqueue_empty_marker
+    batch = track(Wurk::Batch.new)
+    batch.jobs { perform_one_scheduled(future_at) }
+
+    assert_equal 1, Wurk::Batch::Status.new(batch.bid).total
+  end
+
   def test_jobs_block_raises_without_block
     batch = track(Wurk::Batch.new)
 
@@ -427,6 +464,28 @@ class BatchTest < Wurk::Test::UnitCase
   # active Thread.current[Wurk::Batch::THREAD_KEY] (set inside #jobs).
   def perform_one(_batch)
     Wurk::Client.push('class' => @class_name, 'args' => [], 'queue' => @queue)
+  end
+
+  # Scheduled sibling of perform_one — a future `at` routes through the batched
+  # scheduled path (BATCH_SCHEDULE). `bid` is stamped by the client middleware
+  # from the active Thread.current[Wurk::Batch::THREAD_KEY].
+  def perform_one_scheduled(at)
+    Wurk::Client.push('class' => @class_name, 'args' => [], 'queue' => @queue, 'at' => at)
+  end
+
+  def future_at
+    ::Process.clock_gettime(::Process::CLOCK_REALTIME) + 600
+  end
+
+  # redis-client returns ZRANGE WITHSCORES as [[member, score], ...]. FLUSHDB
+  # teardown + serial-within-class means `schedule` holds only this test's jobs.
+  def mine_in_schedule(bid)
+    @pool.with { |c| c.call('ZRANGE', 'schedule', 0, -1, 'WITHSCORES') }.filter_map do |member, score|
+      payload = JSON.parse(member)
+      [payload, score] if payload['bid'] == bid
+    rescue JSON::ParserError
+      next
+    end.first
   end
 
   def queued_jids

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -10,8 +10,11 @@ require 'json'
 # the expand_at / expand_spread validation matrix.
 #
 # Real Redis only (Wurk::Test.redis_url); teardown's worker-DB FLUSHDB gives
-# each test a clean slate, so SCRIPT FLUSH / crafted WRONGTYPE keys here can't
-# bleed into siblings (classes run sequentially within a worker).
+# each test a clean slate. NOSCRIPT recovery is driven by an injected once-firing
+# fake (NoscriptOncePool), never a real SCRIPT FLUSH — a global flush clears the
+# server-wide Lua cache and would race peer parallel_fork workers (the EVALSHA
+# cache is shared across their isolated DBs). Crafted WRONGTYPE keys are
+# DB-scoped, so they can't bleed into siblings either.
 class ClientTest < Wurk::Test::UnitCase
   parallelize_me!
 
@@ -91,13 +94,13 @@ class ClientTest < Wurk::Test::UnitCase
 
   # --- push_batched_pipelined NOSCRIPT recovery (else branch) --------------
 
-  def test_flush_batched_reloads_lua_after_script_flush
-    @pool.with { |c| c.call('SCRIPT', 'FLUSH') }
+  def test_flush_batched_reloads_lua_after_noscript
+    client = Wurk::Client.new(pool: NoscriptOncePool.new(@pool))
 
-    @client.flush_batched([batched_payload(jid: 'b2' + ('0' * 22))])
+    client.flush_batched([batched_payload(jid: 'b2' + ('0' * 22))])
 
     assert_equal 1, @pool.with { |c| c.call('LLEN', "queue:#{@queue}") },
-                 'NOSCRIPT must trigger script_load_all + EVAL-source retry, then succeed'
+                 'a simulated NOSCRIPT must trigger script_load_all + EVAL-source retry, then succeed'
   ensure
     cleanup_batch
   end
@@ -120,14 +123,14 @@ class ClientTest < Wurk::Test::UnitCase
   # the immediate-path recovery tests so the scheduled path's rescue/re-raise
   # branches stay covered.
 
-  def test_scheduled_batched_push_reloads_lua_after_script_flush
+  def test_scheduled_batched_push_reloads_lua_after_noscript
     @bid = "BS-#{Process.pid}-#{object_id}"
-    @pool.with { |c| c.call('SCRIPT', 'FLUSH') }
+    client = Wurk::Client.new(pool: NoscriptOncePool.new(@pool))
 
-    @client.push(scheduled_batched_item)
+    client.push(scheduled_batched_item)
 
     assert_equal('1', @pool.with { |c| c.call('HGET', "b-#{@bid}", 'total') },
-                 'NOSCRIPT on BATCH_SCHEDULE must reload + EVAL-source retry, then register')
+                 'a simulated NOSCRIPT on BATCH_SCHEDULE must reload + EVAL-source retry, then register')
   ensure
     cleanup_scheduled_batch
   end
@@ -261,6 +264,46 @@ class ClientTest < Wurk::Test::UnitCase
   class HaltMiddleware
     def call(_worker, _job, _queue, _redis)
       nil
+    end
+  end
+
+  # Wraps a pool so the first #pipelined on a checked-out connection raises a
+  # simulated NOSCRIPT once, then forwards to the real connection. Exercises the
+  # client's pipeline reload/retry branch WITHOUT a real SCRIPT FLUSH — a global
+  # flush clears the server-wide Lua cache and would race peer parallel_fork
+  # workers whose EVALSHA cache is shared across the isolated DBs. The
+  # EVAL-source retry still runs against real Redis, so the batch is genuinely
+  # registered — the same fake-NOSCRIPT seam lua_loader_test.rb uses.
+  class NoscriptOncePool
+    def initialize(real)
+      @real = real
+      @fired = false
+    end
+
+    def with
+      @real.with { |conn| yield NoscriptGate.new(conn, self) }
+    end
+
+    def fire!
+      @fired = true
+    end
+
+    def fired? = @fired
+
+    # The client only ever calls #pipelined on the fetched connection on these
+    # batched paths; the first call raises a one-shot NOSCRIPT, the rest forward.
+    class NoscriptGate
+      def initialize(conn, gate)
+        @conn = conn
+        @gate = gate
+      end
+
+      def pipelined(&)
+        return @conn.pipelined(&) if @gate.fired?
+
+        @gate.fire!
+        raise RedisClient::CommandError, 'NOSCRIPT No matching script. Use EVAL.'
+      end
     end
   end
 end

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -115,6 +115,34 @@ class ClientTest < Wurk::Test::UnitCase
     cleanup_batch
   end
 
+  # --- push_batched_scheduled_pipelined NOSCRIPT recovery -----------------
+  # Scheduled-in-batch jobs (`bid` + `at`) route through BATCH_SCHEDULE; mirror
+  # the immediate-path recovery tests so the scheduled path's rescue/re-raise
+  # branches stay covered.
+
+  def test_scheduled_batched_push_reloads_lua_after_script_flush
+    @bid = "BS-#{Process.pid}-#{object_id}"
+    @pool.with { |c| c.call('SCRIPT', 'FLUSH') }
+
+    @client.push(scheduled_batched_item)
+
+    assert_equal('1', @pool.with { |c| c.call('HGET', "b-#{@bid}", 'total') },
+                 'NOSCRIPT on BATCH_SCHEDULE must reload + EVAL-source retry, then register')
+  ensure
+    cleanup_scheduled_batch
+  end
+
+  def test_scheduled_batched_push_reraises_non_noscript_command_error
+    @bid = "BS2-#{Process.pid}-#{object_id}"
+    # b-<bid> as a String makes BATCH_SCHEDULE's HINCRBY raise WRONGTYPE — a
+    # CommandError that is not NOSCRIPT, so it must propagate, not retry.
+    @pool.with { |c| c.call('SET', "b-#{@bid}", 'not-a-hash') }
+
+    assert_raises(RedisClient::CommandError) { @client.push(scheduled_batched_item) }
+  ensure
+    cleanup_scheduled_batch
+  end
+
   # --- push_bulk all-halted: line 163 else (compacted empty) --------------
 
   def test_push_bulk_with_halting_middleware_pushes_nothing
@@ -199,10 +227,20 @@ class ClientTest < Wurk::Test::UnitCase
     { 'class' => @class_name, 'args' => [1], 'queue' => @queue, 'jid' => jid, 'bid' => @bid }
   end
 
+  # A `bid` + future `at` payload — the scheduled sibling of batched_payload.
+  def scheduled_batched_item
+    { 'class' => @class_name, 'args' => [1], 'queue' => @queue, 'bid' => @bid, 'at' => future_seconds(600) }
+  end
+
   def cleanup_batch
     @pool.with do |c|
       c.call('DEL', "queue:#{@queue}", "b-#{@bid}", "b-#{@bid}-jids")
     end
+  end
+
+  def cleanup_scheduled_batch
+    cleanup_schedule
+    @pool.with { |c| c.call('DEL', "b-#{@bid}", "b-#{@bid}-jids") }
   end
 
   def mine_in_schedule

--- a/test/unit/dead_set_test.rb
+++ b/test/unit/dead_set_test.rb
@@ -112,12 +112,40 @@ class DeadSetTest < Wurk::Test::UnitCase
 
   # --- trim --------------------------------------------------------------
 
+  # Sidekiq's rank trim is `ZREMRANGEBYRANK dead 0 -max_jobs` (spec §31.8),
+  # which keeps max_jobs-1 of a full set — NOT max_jobs. Drop-in contract:
+  # match it byte-for-byte. Seeding 5 recent entries (scores dodge the
+  # timeout axis) and trimming to max_jobs:3 must leave exactly the 2
+  # highest-scored survivors; the old `-(max_jobs+1)` would leave 3.
   def test_trim_caps_to_dead_max_jobs
-    payloads = seed_dead((0...5).map { |i| [i.to_f, "tm-#{@ns}-#{i}"] })
-    dead_set.trim(max_jobs: 2, timeout: 60_000)
-    survivors = payloads.count { |p| @pool.with { |c| c.call('ZSCORE', @dead, p) } }
+    now = ::Process.clock_gettime(::Process::CLOCK_REALTIME)
+    payloads = seed_dead((0...5).map { |i| [now + i, "tm-#{@ns}-#{i}"] })
+    dead_set.trim(max_jobs: 3, timeout: 60_000)
 
-    assert_operator survivors, :<=, 2
+    survivors = payloads.select { |p| @pool.with { |c| c.call('ZSCORE', @dead, p) } }
+
+    assert_equal payloads.last(2), survivors
+  end
+
+  # kill_raw is the shared morgue primitive behind JobRetry#send_to_morgue and
+  # Processor#parse_or_kill: ZADD the raw payload (score=now) then #trim, no
+  # death handlers. Recent seed scores isolate the rank axis from the timeout
+  # axis so only the -max_jobs cap decides survivors.
+  def test_kill_raw_adds_raw_payload_and_trims
+    now = ::Process.clock_gettime(::Process::CLOCK_REALTIME)
+    seed_dead((0...4).map { |i| [now - 4 + i, "kr-seed-#{@ns}-#{i}"] })
+    raw = "raw-#{@ns}"
+
+    dead_set.kill_raw(raw, max_jobs: 2, timeout: 60_000)
+
+    score = @pool.with { |c| c.call('ZSCORE', @dead, raw) }
+
+    refute_nil score, 'raw payload must be ZADDed'
+    assert_operator score.to_f, :>=, now
+    # 4 seeded + raw = 5, capped to max_jobs-1 = 1 survivor: the newest (raw).
+    survivors = @pool.with { |c| c.call('ZRANGE', @dead, 0, -1) }
+
+    assert_equal [raw], survivors
   end
 
   def test_trim_evicts_expired_by_score

--- a/test/unit/limiter_test.rb
+++ b/test/unit/limiter_test.rb
@@ -243,7 +243,11 @@ class LimiterTest < Wurk::Test::UnitCase
 
   # ----- server middleware reschedule path -----------------------------
 
-  def test_server_middleware_reschedules_on_over_limit
+  # A reschedule raises Wurk::Limiter::Rescheduled (a JobRetry::Skip) so the
+  # run is neither success nor failure — the outer Batch onion skips both acks
+  # and the Processor acks the UoW with no retry record. The push to `schedule`
+  # happens before the raise. (#18)
+  def test_server_middleware_reschedules_on_over_limit # rubocop:disable Metrics/AbcSize
     l = Wurk::Limiter.bucket("mw-#{@suffix}", 1, :minute, wait_timeout: 0, reschedule: 5)
     jid = "mwj#{@suffix}"
     job = { 'class' => 'NoopWorker', 'args' => [1], 'queue' => 'default', 'jid' => jid }
@@ -251,7 +255,9 @@ class LimiterTest < Wurk::Test::UnitCase
     mw.config = Wurk.configuration
 
     begin
-      mw.call(nil, job, 'default') { raise Wurk::Limiter::OverLimit.new(l, job) }
+      assert_raises(Wurk::Limiter::Rescheduled) do
+        mw.call(nil, job, 'default') { raise Wurk::Limiter::OverLimit.new(l, job) }
+      end
 
       assert_equal 1, job['overrated']
       # Scheduled push lands in the global `schedule` ZSET with score = at.
@@ -323,7 +329,7 @@ class LimiterTest < Wurk::Test::UnitCase
   # A registered custom error that exposes neither #limiter nor #job= drives
   # the else sides of `respond_to?(:limiter)` / `respond_to?(:job=)` plus the
   # nil-limiter `reschedule_cap` short-circuit (default cap, reschedule path).
-  def test_server_middleware_handles_plain_registered_error
+  def test_server_middleware_handles_plain_registered_error # rubocop:disable Metrics/AbcSize
     custom = Class.new(StandardError)
     Wurk::Limiter.config.errors << custom
     job = { 'class' => 'NoopWorker', 'args' => [], 'queue' => 'default', 'jid' => "pln#{@suffix}" }
@@ -331,7 +337,9 @@ class LimiterTest < Wurk::Test::UnitCase
     mw.config = Wurk.configuration
 
     begin
-      mw.call(nil, job, 'default') { raise custom, 'throttled' }
+      assert_raises(Wurk::Limiter::Rescheduled) do
+        mw.call(nil, job, 'default') { raise custom, 'throttled' }
+      end
 
       assert_equal 1, job['overrated'], 'plain registered error still counts as over-limit'
       scored = Wurk.redis { |c| c.call('ZRANGE', 'schedule', 0, -1) }
@@ -346,7 +354,7 @@ class LimiterTest < Wurk::Test::UnitCase
 
   # A limiter type with no `:reschedule` option (concurrent) → reschedule_cap
   # hits the `cap.nil? ? DEFAULT_RESCHEDULE` then-side via the default.
-  def test_server_middleware_uses_default_cap_when_limiter_has_no_reschedule_option
+  def test_server_middleware_uses_default_cap_when_limiter_has_no_reschedule_option # rubocop:disable Minitest/MultipleAssertions,Metrics/AbcSize
     l = Wurk::Limiter.concurrent("nocap-#{@suffix}", 1, wait_timeout: 0)
 
     refute l.options.key?(:reschedule), 'concurrent limiter carries no reschedule option'
@@ -355,7 +363,9 @@ class LimiterTest < Wurk::Test::UnitCase
     mw.config = Wurk.configuration
 
     begin
-      mw.call(nil, job, 'default') { raise Wurk::Limiter::OverLimit.new(l, job) }
+      assert_raises(Wurk::Limiter::Rescheduled) do
+        mw.call(nil, job, 'default') { raise Wurk::Limiter::OverLimit.new(l, job) }
+      end
 
       assert_equal 1, job['overrated']
       scored = Wurk.redis { |c| c.call('ZRANGE', 'schedule', 0, -1) }
@@ -366,6 +376,20 @@ class LimiterTest < Wurk::Test::UnitCase
         c.call('ZRANGE', 'schedule', 0, -1).each { |p| c.call('ZREM', 'schedule', p) if p.include?("ncj#{@suffix}") }
       end
     end
+  end
+
+  # The whole reschedule mechanism depends on Batch being OUTER of Limiter in
+  # the server chain (`add` appends; entry 0 is outermost). If Limiter were
+  # outer, a Rescheduled would unwind before Batch saw it and the batch onion
+  # would never learn the job didn't run. Guard the invariant. (#18)
+  def test_batch_middleware_is_registered_outer_of_limiter
+    klasses = Wurk.configuration.server_middleware.map(&:klass)
+    batch_i = klasses.index(Wurk::Batch::ServerMiddleware)
+    limiter_i = klasses.index(Wurk::Limiter::ServerMiddleware)
+
+    refute_nil batch_i, 'Batch::ServerMiddleware must be registered'
+    refute_nil limiter_i, 'Limiter::ServerMiddleware must be registered'
+    assert_operator batch_i, :<, limiter_i, 'Batch must be OUTER (registered before) Limiter'
   end
 
   # ----- DEFAULT_BACKOFF non-Hash job branch ---------------------------

--- a/test/unit/lua_test.rb
+++ b/test/unit/lua_test.rb
@@ -32,7 +32,7 @@ class LuaTest < Wurk::Test::UnitCase
   def test_scripts_registry_holds_expected_keys
     assert_equal(
       %i[zpopbyscore bulk_push reliable_schedule_promote reliable_requeue
-         batch_push batch_ack_success batch_ack_failed batch_ack_complete batch_invalidate
+         batch_push batch_schedule batch_ack_success batch_ack_failed batch_ack_complete batch_invalidate
          batch_append_callback
          fast_delete_job fast_delete_by_class release_if_owner
          limiter_concurrent_acquire limiter_concurrent_release
@@ -133,7 +133,7 @@ class LuaTest < Wurk::Test::UnitCase
       c.call('ZADD', sset, 100, '{"queue":"alpha","jid":"a"}', 150, '{"queue":"beta","jid":"b"}',
              900, '{"queue":"alpha","jid":"future"}')
       count = Wurk::Lua::Loader.eval_cached(
-        c, :reliable_schedule_promote, keys: [sset, qset], argv: [500, "#{@ns}:queue:"]
+        c, :reliable_schedule_promote, keys: [sset, qset], argv: [500, "#{@ns}:queue:", 1_700_000_000_000]
       )
 
       assert_equal 2, count
@@ -142,6 +142,28 @@ class LuaTest < Wurk::Test::UnitCase
       assert_equal 1, c.call('ZCARD', sset)
       assert_equal 2, c.call('SCARD', qset)
       c.call('DEL', "#{@ns}:queue:alpha", "#{@ns}:queue:beta")
+    end
+  end
+
+  # Promotion stamps a fresh integer `enqueued_at` (ARGV[3]) — a scheduled job
+  # arriving on an immediate queue must carry the promotion instant, matching
+  # the default Ruby scheduler's push restamp (spec §7.1). The original stored
+  # member is ZREM'd verbatim; the pushed copy is re-encoded with the stamp.
+  def test_reliable_schedule_promote_stamps_fresh_enqueued_at
+    sset = "#{@ns}:schedule"
+    qset = "#{@ns}:queues"
+    now_ms = 1_700_000_000_000
+    @pool.with do |c|
+      c.call('ZADD', sset, 100, '{"queue":"alpha","jid":"a"}')
+      Wurk::Lua::Loader.eval_cached(
+        c, :reliable_schedule_promote, keys: [sset, qset], argv: [500, "#{@ns}:queue:", now_ms]
+      )
+      promoted = Wurk.load_json(c.call('LRANGE', "#{@ns}:queue:alpha", 0, -1).first)
+
+      assert_equal now_ms, promoted['enqueued_at']
+      assert_kind_of Integer, promoted['enqueued_at']
+      assert_equal 'a', promoted['jid']
+      c.call('DEL', "#{@ns}:queue:alpha")
     end
   end
 
@@ -209,6 +231,45 @@ class LuaTest < Wurk::Test::UnitCase
       assert_equal '2', c.call('HGET', bkey, 'pending')
       assert_equal 2, c.call('SCARD', jids)
       c.call('DEL', list)
+    end
+  end
+
+  # BATCH_SCHEDULE registers a scheduled-in-batch job at creation: counts
+  # total/pending (SADD guard), SADDs the jid live, and ZADDs the payload onto
+  # `schedule` — so `total` moves even though nothing hits a queue yet.
+  def test_batch_schedule_registers_counts_jid_and_zadds # rubocop:disable Minitest/MultipleAssertions
+    sched = "#{@ns}:schedule"
+    bkey  = "#{@ns}:b-s"
+    jids  = "#{@ns}:b-s-jids"
+    @pool.with do |c|
+      Wurk::Lua::Loader.eval_cached(
+        c, :batch_schedule, keys: [sched, bkey, jids], argv: ['1700000000.5', '{"jid":"JID1"}', 'JID1']
+      )
+
+      assert_equal '1', c.call('HGET', bkey, 'total')
+      assert_equal '1', c.call('HGET', bkey, 'pending')
+      assert_equal 1, c.call('SISMEMBER', jids, 'JID1')
+      assert_equal '{"jid":"JID1"}', c.call('ZRANGE', sched, 0, -1).first
+      assert_in_delta 1_700_000_000.5, c.call('ZSCORE', sched, '{"jid":"JID1"}').to_f, 0.001
+      c.call('DEL', sched)
+    end
+  end
+
+  # Same SADD-guard idempotency as batch_push: a jid already live re-ZADDs the
+  # payload (a promotion that rescheduled, say) but must not recount.
+  def test_batch_schedule_repush_of_live_jid_does_not_recount # rubocop:disable Minitest/MultipleAssertions
+    sched = "#{@ns}:schedule"
+    bkey  = "#{@ns}:b-sr"
+    jids  = "#{@ns}:b-sr-jids"
+    argv  = ['1700000000', '{"jid":"JID1"}', 'JID1']
+    @pool.with do |c|
+      2.times { Wurk::Lua::Loader.eval_cached(c, :batch_schedule, keys: [sched, bkey, jids], argv: argv) }
+
+      assert_equal '1', c.call('HGET', bkey, 'total'), 're-schedule must not recount total'
+      assert_equal '1', c.call('HGET', bkey, 'pending'), 're-schedule must not recount pending'
+      assert_equal 1, c.call('SCARD', jids)
+      assert_equal 1, c.call('ZCARD', sched)
+      c.call('DEL', sched)
     end
   end
 

--- a/test/unit/lua_test.rb
+++ b/test/unit/lua_test.rb
@@ -166,6 +166,52 @@ class LuaTest < Wurk::Test::UnitCase
     end
   end
 
+  # SADD-guard idempotency: re-pushing a jid already in the live set (a retry
+  # or scheduled promotion re-enqueueing a job that never left the batch) must
+  # re-LPUSH the payload but must NOT recount total/pending — else pending
+  # inflates past the acks and :success never fires (spec §2.3/§2.5).
+  def test_batch_push_repush_of_live_jid_does_not_recount # rubocop:disable Minitest/MultipleAssertions
+    bkey = "#{@ns}:b-rp"
+    jids = "#{@ns}:b-rp-jids"
+    list = "#{@ns}:queue:default"
+    qset = "#{@ns}:queues"
+    keys = [bkey, jids, list, qset, "#{@ns}:b-rp-died", "#{@ns}:dead-batches"]
+    argv = ['default', 'JID1', '{"jid":"JID1"}', 'rp']
+    @pool.with do |c|
+      2.times { Wurk::Lua::Loader.eval_cached(c, :batch_push, keys: keys, argv: argv) }
+
+      assert_equal '1', c.call('HGET', bkey, 'total'), 're-push must not recount total'
+      assert_equal '1', c.call('HGET', bkey, 'pending'), 're-push must not recount pending'
+      assert_equal 1, c.call('SCARD', jids)
+      assert_equal 2, c.call('LLEN', list), 're-push must still re-enqueue the payload'
+      c.call('DEL', list)
+    end
+  end
+
+  # The guard must not over-suppress: distinct jids each register once. Guards
+  # §2.3 re-entrancy — `batch.jobs { ... }` adding siblings grows total.
+  def test_batch_push_counts_each_distinct_jid
+    bkey = "#{@ns}:b-dj"
+    jids = "#{@ns}:b-dj-jids"
+    list = "#{@ns}:queue:default"
+    qset = "#{@ns}:queues"
+    died = "#{@ns}:b-dj-died"
+    dead = "#{@ns}:dead-batches"
+    @pool.with do |c|
+      %w[A B].each do |jid|
+        Wurk::Lua::Loader.eval_cached(
+          c, :batch_push, keys: [bkey, jids, list, qset, died, dead],
+                          argv: ['default', jid, %({"jid":"#{jid}"}), 'dj']
+        )
+      end
+
+      assert_equal '2', c.call('HGET', bkey, 'total')
+      assert_equal '2', c.call('HGET', bkey, 'pending')
+      assert_equal 2, c.call('SCARD', jids)
+      c.call('DEL', list)
+    end
+  end
+
   # #212: pushing a jid found in the died set is a manual retry of a dead
   # job — it rejoins the live set without recounting (total/pending already
   # include it), and draining the died set clears the death mark so a later

--- a/test/unit/lua_test.rb
+++ b/test/unit/lua_test.rb
@@ -148,7 +148,8 @@ class LuaTest < Wurk::Test::UnitCase
   # Promotion stamps a fresh integer `enqueued_at` (ARGV[3]) — a scheduled job
   # arriving on an immediate queue must carry the promotion instant, matching
   # the default Ruby scheduler's push restamp (spec §7.1). The original stored
-  # member is ZREM'd verbatim; the pushed copy is re-encoded with the stamp.
+  # member is ZREM'd verbatim; the pushed copy keeps its original bytes and only
+  # has its top-level `enqueued_at` string-patched in (never a full cjson re-encode).
   def test_reliable_schedule_promote_stamps_fresh_enqueued_at
     sset = "#{@ns}:schedule"
     qset = "#{@ns}:queues"
@@ -164,6 +165,42 @@ class LuaTest < Wurk::Test::UnitCase
       assert_kind_of Integer, promoted['enqueued_at']
       assert_equal 'a', promoted['jid']
       c.call('DEL', "#{@ns}:queue:alpha")
+    end
+  end
+
+  # Regression: promotion patches only `enqueued_at`, never a cjson round-trip —
+  # cjson maps args to Lua doubles, dropping precision past 2^53 and reformatting
+  # 15+ digit ints to scientific notation. Insert branch: schedule members are
+  # stored with no `enqueued_at`, so it is inserted while args stay byte-for-byte.
+  def test_reliable_schedule_promote_preserves_large_int_args_on_insert
+    sset = "#{@ns}:schedule"
+    big  = 9_007_199_254_740_993     # 2^53 + 1: not representable as an IEEE double
+    snow = 1_533_231_640_038_055_945 # 19-digit snowflake id
+    @pool.with do |c|
+      c.call('ZADD', sset, 100, %({"class":"J","args":[#{big},#{snow}],"queue":"alpha","jid":"a"}))
+      promote(c, sset)
+      raw = c.call('LRANGE', "#{@ns}:queue:alpha", 0, -1).first
+
+      assert_includes raw, snow.to_s, 'snowflake id must not reformat to scientific notation'
+      assert_equal [big, snow], Wurk.load_json(raw)['args'], 'big int args must survive verbatim'
+      c.call('DEL', "#{@ns}:queue:alpha")
+    end
+  end
+
+  # Replace branch: retry members carry an `enqueued_at`; promotion swaps a fresh
+  # stamp in place (exactly one key, no duplicate) while a large int arg stays exact.
+  def test_reliable_schedule_promote_preserves_large_int_args_on_replace
+    sset = "#{@ns}:schedule"
+    big  = 9_007_199_254_740_993
+    @pool.with do |c|
+      c.call('ZADD', sset, 100, %({"class":"R","args":[#{big}],"queue":"beta","jid":"b","enqueued_at":1600000000000}))
+      promote(c, sset)
+      raw = c.call('LRANGE', "#{@ns}:queue:beta", 0, -1).first
+
+      assert_equal [big], Wurk.load_json(raw)['args'], 'big int arg must survive verbatim'
+      assert_equal 1_700_000_000_000, Wurk.load_json(raw)['enqueued_at'], 'stamp must be replaced in place'
+      assert_equal 1, raw.scan('"enqueued_at"').size, 'replace must not leave a duplicate key'
+      c.call('DEL', "#{@ns}:queue:beta")
     end
   end
 
@@ -447,5 +484,13 @@ class LuaTest < Wurk::Test::UnitCase
       assert_equal 0, c.call('EXISTS', jids)
       assert_equal '1', c.call('HGET', bkey, 'invalidated')
     end
+  end
+
+  private
+
+  def promote(conn, sset, now_ms = 1_700_000_000_000)
+    Wurk::Lua::Loader.eval_cached(
+      conn, :reliable_schedule_promote, keys: [sset, "#{@ns}:queues"], argv: [500, "#{@ns}:queue:", now_ms]
+    )
   end
 end

--- a/test/unit/processor_test.rb
+++ b/test/unit/processor_test.rb
@@ -268,6 +268,25 @@ class ProcessorTest < Wurk::Test::UnitCase
     assert_equal 0, llen(private_queue)
   end
 
+  # The malformed-JSON path routes through DeadSet#kill_raw, so it trims like
+  # send_to_morgue does (spec §31.8: trim on every kill). A 1970-epoch entry is
+  # far older than the default dead_timeout (180d) and must be evicted.
+  def test_process_one_trims_dead_set_on_parse_fail
+    ancient = "ancient-#{@queue_name}"
+    @dead_members << ancient
+    @pool.with { |c| c.call('ZADD', Wurk::Keys::DEAD, 1.0, ancient) }
+
+    payload = "{still-not-json-#{@queue_name}"
+    @dead_members << payload
+    @pool.with { |c| c.call('LPUSH', @public_queue, payload) }
+
+    @processor.process_one
+
+    assert_includes @pool.with { |c| c.call('ZRANGE', Wurk::Keys::DEAD, 0, -1) }, payload
+    assert_nil @pool.with { |c| c.call('ZSCORE', Wurk::Keys::DEAD, ancient) },
+               'malformed-JSON path must trim expired dead entries'
+  end
+
   # --- middleware integration -----------------------------------------
 
   def test_server_middleware_runs_around_perform

--- a/test/unit/scheduled_poller_test.rb
+++ b/test/unit/scheduled_poller_test.rb
@@ -95,9 +95,29 @@ class ScheduledPollerTest < Wurk::Test::UnitCase
     @pool.with do |c|
       assert_equal 0, c.call('ZCARD', @schedule)
       assert_equal 1, c.call('LLEN', @queue_list)
-      assert_equal job, Wurk.load_json(c.call('LRANGE', @queue_list, 0, -1).first)
+      promoted = Wurk.load_json(c.call('LRANGE', @queue_list, 0, -1).first)
+      # Promotion restamps enqueued_at (immediate-queue arrival); strip it so the
+      # rest equals the scheduled payload. Freshness has its own test below.
+      promoted.delete('enqueued_at')
+
+      assert_equal job, promoted
       assert_equal 1, c.call('SISMEMBER', 'queues', @queue)
     end
+  end
+
+  # Reliable promotion stamps a fresh integer enqueued_at, matching the default
+  # Enq path (whose client push restamps it). Both schedulers emit wire-identical
+  # promoted payloads (spec §7.1).
+  def test_reliable_enq_stamps_fresh_enqueued_at_on_promotion
+    schedule_job(set: @schedule, at: Time.now.to_f - 5)
+    before = ::Process.clock_gettime(::Process::CLOCK_REALTIME, :millisecond)
+
+    Wurk::Scheduled::ReliableEnq.new(@config).enqueue_jobs([@schedule])
+
+    promoted = Wurk.load_json(@pool.with { |c| c.call('LRANGE', @queue_list, 0, -1).first })
+
+    assert_kind_of Integer, promoted['enqueued_at']
+    assert_operator promoted['enqueued_at'], :>=, before
   end
 
   def test_reliable_enq_leaves_future_jobs_in_set
@@ -152,6 +172,38 @@ class ScheduledPollerTest < Wurk::Test::UnitCase
     assert_equal(1, @pool.with { |c| c.call('ZCARD', @schedule) })
     assert_equal(0, @pool.with { |c| c.call('LLEN', @queue_list) })
   end
+
+  # A raising push on one due job must not abort the drain: the remaining due
+  # jobs still get promoted, and the failure is reported to the error handlers.
+  # (The popped-then-failed job is lost — the default scheduler's known pop→push
+  # tradeoff; ReliableEnq is the loss-free path.)
+  # rubocop:disable Metrics/AbcSize, Minitest/MultipleAssertions
+  def test_drain_continues_after_a_failing_push_and_reports_it
+    2.times { |i| schedule_job(set: @schedule, at: Time.now.to_f - 10 + i) }
+    captured = []
+    @config.error_handlers.clear
+    @config.error_handlers << ->(ex, _ctx, _cfg) { captured << ex }
+
+    enq = Wurk::Scheduled::Enq.new(@config)
+    pushed = []
+    calls = 0
+    client = Object.new
+    client.define_singleton_method(:push) do |job|
+      calls += 1
+      raise 'push blew up' if calls == 1
+
+      pushed << job
+    end
+    enq.instance_variable_set(:@client, client)
+
+    enq.enqueue_jobs([@schedule])
+
+    assert_equal 0, @pool.with { |c| c.call('ZCARD', @schedule) }, 'both due jobs must be popped despite the raise'
+    assert_equal 1, pushed.size, 'the second job must still be pushed after the first raises'
+    assert_equal 1, captured.size
+    assert_equal 'push blew up', captured.first.message
+  end
+  # rubocop:enable Metrics/AbcSize, Minitest/MultipleAssertions
 
   # --- Poller#enqueue -----------------------------------------------
 


### PR DESCRIPTION
## Summary
PR group **Batch / Limiter / Scheduler Logic (slice 04)**. Root cause: any `bid`-carrying client push was treated as new batch registration, so retry/scheduled promotion re-registration inflated `pending` past the ack count — `:success` never fired.

- Idempotent batch registration: `BATCH_PUSH` guards `total`/`pending` increments on `SADD jids == 1`, so a retry/scheduled re-push re-enqueues the payload without recounting.
- `BATCH_SCHEDULE` registers `perform_in`-inside-`batch.jobs` jobs (total/pending + ZADD) atomically at creation, so the empty-marker check doesn't misfire `:complete` before the job promotes.
- `Wurk::Limiter::Rescheduled` control signal: an OverLimit reschedule inside a batch is neither success nor failure — the outer Batch middleware skips both acks until the job actually runs.
- Dead-set trim on the malformed-JSON kill path (`parse_or_kill`), plus the `-max_jobs` off-by-one fix (`dead_set.rb`).
- **New**: `test/integration/batch_retry_roundtrip_test.rb` — real forks, real Redis, headline regression proof: batch of 2 (one flaky-then-succeeds) fires `:success` once with `total==2`/`pending==0`; `perform_in`-in-batch doesn't fire premature `:complete`; limiter-reschedule-in-batch doesn't fire premature acks.

## Test plan
- [x] `bin/rake test TEST=test/integration/batch_retry_roundtrip_test.rb` — 3 runs, 46 assertions, green
- [x] `bin/rake test TEST=test/unit/lua_test.rb` — green (SADD-guard idempotency)
- [x] `bin/rake test TEST=test/unit/dead_set_test.rb` — green (trim bound)
- [x] `bin/rake test:parity` — green
- [x] `bin/rake test` (full suite) — green modulo two pre-existing, unrelated flakes (TZ-dependent `CronTest` DST fold tests pass under `TZ=UTC`; `reaper_kill9_test.rb` passes in isolation — resource-contention flake under full-suite parallel load, not touched by this PR)
- [x] `bundle exec rubocop test/integration/batch_retry_roundtrip_test.rb` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduled jobs within batches now count toward batch progress and completion correctly.
  * Added support for recording raw, unparseable job payloads in the dead-job set.
* **Bug Fixes**
  * Prevented premature batch success or completion during retries and limiter-based rescheduling.
  * Scheduled job promotion now continues processing remaining jobs if one job fails.
  * Improved duplicate-job accounting to prevent inflated batch totals.
* **Reliability**
  * Scheduled jobs receive refreshed enqueue timestamps when promoted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->