### PR TITLE
fix: web/API hardening — CSRF, pool isolation, SSE/search bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ Wurk::Web.use(Rack::Auth::Basic, "Wurk") { |user, pass| user == ENV["WURK_USER"]
 
 Ship a viewer-only board (e.g. a public demo) with no auth code at all by setting `WURK_WEB_READ_ONLY=1` — every mutating request returns 403 and the SPA hides destructive actions.
 
+### Security notes
+
+- **`Wurk::Web.use` and the `authorization` hook gate the dashboard's routes and JSON API** — every controller under the engine mount goes through them.
+- **`/wurk-assets/*` (the precompiled SPA's JS/CSS/font bundle) is served unauthenticated, by design.** It's inserted into the host app's own middleware stack ahead of the engine's routes, so it never reaches `Wurk::Web.use`/`authorization`. This is safe because the bundle carries no data — no job payloads, no Redis reads, nothing per-user — it's a static shell, same trust model as any Rails app's `public/assets`. Everything data-bearing (stats, queues, jobs) is served by the JSON API, which *is* gated. If you need to hide even the existence of the bundle (e.g. compliance requires the mount path itself stay secret), put a reverse-proxy rule in front of `/wurk-assets` rather than relying on the engine.
+- Redis being unreachable surfaces to the SPA as a structured `503 {"error": "redis_unavailable"}` (JSON endpoints) or an SSE `error` event (the live stream), never a raw 500 — the client can branch on it instead of parsing an HTML error page.
+
 ## Encryption
 
 A drop-in for `Sidekiq::Enterprise::Crypto`. It encrypts the **last** positional argument of a job with AES-256-GCM — the client middleware seals it on push, the server middleware opens it before `perform`. Earlier args stay plaintext so you can still triage on `user_id`.

--- a/app/controllers/concerns/wurk/same_origin_guard.rb
+++ b/app/controllers/concerns/wurk/same_origin_guard.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Wurk
+  # Sidekiq's CSRF model (spec §25.1) for the dashboard's token-less, cookie-
+  # authenticated surfaces. The SolidJS SPA (JSON fetch) and host-registered
+  # extension forms send no Rails authenticity token, so `protect_from_forgery`
+  # can't apply — guard unsafe methods with a same-origin check instead. A
+  # cross-site page can drive a victim's browser but cannot forge
+  # `Sec-Fetch-Site: same-origin` (the browser sets it); a missing header is
+  # denied too, since only a non-browser client omits it and it carries no
+  # ambient session cookie to abuse.
+  #
+  # Mirrors the standalone Rack surface (Wurk::Web#safe_request?) so every
+  # mutating dashboard entry point enforces one rule.
+  module SameOriginGuard
+    extend ActiveSupport::Concern
+
+    # Non-mutating methods need no origin check. Matches Wurk::Web::SAFE_METHODS;
+    # kept local so this engine concern carries no lib load-order dependency.
+    SAFE_METHODS = %w[GET HEAD OPTIONS TRACE].freeze
+
+    included do
+      # SPA/extension requests never carry a Rails CSRF token; the same-origin
+      # check below is the CSRF defense in its place.
+      skip_forgery_protection
+      before_action :verify_same_origin!
+    end
+
+    private
+
+    def verify_same_origin!
+      head :forbidden unless safe_request?
+    end
+
+    def safe_request?
+      SAFE_METHODS.include?(request.request_method) ||
+        request.headers['Sec-Fetch-Site'] == 'same-origin'
+    end
+  end
+end

--- a/app/controllers/concerns/wurk/sse_streaming.rb
+++ b/app/controllers/concerns/wurk/sse_streaming.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Wurk
+  # Drives the `/api/stream` SSE loop (headers, tick cadence, tear-down).
+  # Split out of ApiController so the periodic-stats-push mechanics — which
+  # don't change per action — stay separate from the request/response mapping
+  # ApiController owns.
+  module SseStreaming
+    extend ActiveSupport::Concern
+
+    private
+
+    def stream_headers!
+      response.headers['Content-Type'] = 'text/event-stream'
+      response.headers['Cache-Control'] = 'no-cache'
+      response.headers['X-Accel-Buffering'] = 'no'
+    end
+
+    def drive_stream(sse, tick, max_dur)
+      deadline = monotime + max_dur
+      loop do
+        sse.write(stream_tick_payload, event: 'stats')
+        break if monotime >= deadline
+
+        sleep tick
+      end
+    rescue ::IOError, ::ActionController::Live::ClientDisconnected
+      # client closed; nothing to clean up.
+    rescue *::Wurk::Configuration::REDIS_ERROR_CLASSES => e
+      # Headers are already flushed by the time a tick hits Redis, so the
+      # 503 ApplicationController's rescue_from renders for a plain request
+      # can't happen here — emit a structured SSE event instead and close;
+      # the SPA's EventSource reconnects and gets a fresh chance at Redis.
+      logger.warn("wurk web: stream redis unavailable (#{e.class}: #{e.message})")
+      sse.write({ error: 'redis_unavailable' }, event: 'error')
+    ensure
+      sse.close
+    end
+
+    def monotime
+      ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+    end
+
+    def stream_tick_payload
+      ::Wurk::Api::Serializers.stats_payload(::Wurk::Stats.new).merge(at: ::Time.now.to_f)
+    end
+  end
+end

--- a/app/controllers/concerns/wurk/stream_concurrency_guard.rb
+++ b/app/controllers/concerns/wurk/stream_concurrency_guard.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Wurk
+  # Per-process cap on concurrent SSE streams. ActionController::Live pins one
+  # Puma thread for every open `/api/stream`; without a bound, a burst of stale
+  # browser tabs could hold every thread and starve the JSON API. Past the cap
+  # we 503 with Retry-After — the SPA's EventSource reconnects (and its polling
+  # fallback honors Retry-After) once a slot frees. Per-process is the right
+  # scope: it's this process's own thread pool we're protecting.
+  module StreamConcurrencyGuard
+    extend ActiveSupport::Concern
+
+    MAX_CONCURRENT_STREAMS = 10
+    RETRY_AFTER_SECONDS = 3
+
+    @open = 0
+    @lock = Mutex.new
+
+    class << self
+      # Reserve a stream slot; false when the cap is already reached.
+      def acquire
+        @lock.synchronize do
+          return false if @open >= MAX_CONCURRENT_STREAMS
+
+          @open += 1
+          true
+        end
+      end
+
+      def release
+        @lock.synchronize { @open -= 1 if @open.positive? }
+      end
+    end
+
+    private
+
+    # Runs the SSE body only while holding a slot, releasing it however the
+    # stream ends (client disconnect, cap-duration, error). 503 + Retry-After
+    # past the cap instead of tying up a thread on an unservable request.
+    def with_stream_slot
+      unless StreamConcurrencyGuard.acquire
+        response.headers['Retry-After'] = RETRY_AFTER_SECONDS.to_s
+        return head :service_unavailable
+      end
+
+      begin
+        yield
+      ensure
+        StreamConcurrencyGuard.release
+      end
+    end
+  end
+end

--- a/app/controllers/wurk/api_controller.rb
+++ b/app/controllers/wurk/api_controller.rb
@@ -19,9 +19,12 @@ module Wurk
     # same-origin CSRF defense (spec §25.1) so every mutating endpoint is
     # protected — GET reads (incl. #stream SSE) stay reachable.
     include SameOriginGuard
+    # Bounds concurrent SSE streams per process (503 past the cap) so stale
+    # dashboard tabs can't pin every Puma thread. Provides #with_stream_slot.
+    include StreamConcurrencyGuard
 
     STREAM_TICK_SECONDS = 2.0
-    STREAM_MAX_DURATION = 600.0
+    STREAM_MAX_DURATION = 120.0
 
     HISTORY_WINDOW_UNITS = { 's' => 1, 'm' => 60, 'h' => 3600, 'd' => 86_400 }.freeze
     DEFAULT_HISTORY_WINDOW = 24 * 3600
@@ -260,10 +263,11 @@ module Wurk
 
     def search
       substr = params[:substr].to_s
-      return render(json: { substr: substr, total: 0, hits: [] }) if substr.empty?
+      return render(json: { substr: substr, total: 0, hits: [], truncated: false }) if substr.empty?
 
-      hits = ::Wurk::Web::Search.new(substr, kinds: parse_search_kinds(params), limit: parse_search_limit(params)).to_a
-      render json: { substr: substr, total: hits.size, hits: hits }
+      search = ::Wurk::Web::Search.new(substr, kinds: parse_search_kinds(params), limit: parse_search_limit(params))
+      hits = search.to_a
+      render json: { substr: substr, total: hits.size, hits: hits, truncated: search.truncated? }
     end
 
     # Profiles list (v8.0+). The SPA links each row to /profiles/:key (view)
@@ -276,16 +280,20 @@ module Wurk
     # SSE: one `event: stats` per tick with a fresh Stats snapshot. Caps at
     # `STREAM_MAX_DURATION` so a stale browser tab can't tie a Rails worker
     # forever — the client reconnects automatically when the stream closes.
+    # Bounded per process by StreamConcurrencyGuard (503 + Retry-After past the
+    # cap) so a burst of tabs can't pin every Puma thread.
     #
     # `?max_duration=` and `?tick=` are test/debug knobs; the SPA never sets
     # them. `?max_duration=0` emits one tick and closes.
     def stream
-      stream_headers!
-      clamp = ::Wurk::Api::Pagination.method(:clamp_float)
-      tick = clamp.call(params[:tick], 0.0, STREAM_TICK_SECONDS, STREAM_TICK_SECONDS)
-      max_dur = clamp.call(params[:max_duration], 0.0, STREAM_MAX_DURATION, STREAM_MAX_DURATION)
-      sse = ::ActionController::Live::SSE.new(response.stream, retry: (STREAM_TICK_SECONDS * 1000).to_i)
-      drive_stream(sse, tick, max_dur)
+      with_stream_slot do
+        stream_headers!
+        clamp = ::Wurk::Api::Pagination.method(:clamp_float)
+        tick = clamp.call(params[:tick], 0.0, STREAM_TICK_SECONDS, STREAM_TICK_SECONDS)
+        max_dur = clamp.call(params[:max_duration], 0.0, STREAM_MAX_DURATION, STREAM_MAX_DURATION)
+        sse = ::ActionController::Live::SSE.new(response.stream, retry: (STREAM_TICK_SECONDS * 1000).to_i)
+        drive_stream(sse, tick, max_dur)
+      end
     end
 
     private
@@ -403,13 +411,8 @@ module Wurk
     # reads in limiter_row (which folds in live status).
     def limiter_rows(names, page)
       (names.slice(page[:page] * page[:count], page[:count]) || []).map do |name|
-        ::Wurk::Api::Serializers.limiter_row(name, limiter_meta(name))
+        ::Wurk::Api::Serializers.limiter_row(name, ::Wurk::Web::Enterprise::Limits.metadata(name))
       end
-    end
-
-    def limiter_meta(name)
-      raw = ::Wurk.redis { |c| c.call('HGETALL', "lmtr:#{name}") }
-      raw.is_a?(Array) ? raw.each_slice(2).to_h : raw
     end
 
     def stream_headers!

--- a/app/controllers/wurk/api_controller.rb
+++ b/app/controllers/wurk/api_controller.rb
@@ -22,6 +22,8 @@ module Wurk
     # Bounds concurrent SSE streams per process (503 past the cap) so stale
     # dashboard tabs can't pin every Puma thread. Provides #with_stream_slot.
     include StreamConcurrencyGuard
+    # Owns the #stream action's tick loop (headers, cadence, tear-down).
+    include SseStreaming
 
     STREAM_TICK_SECONDS = 2.0
     STREAM_MAX_DURATION = 120.0
@@ -413,34 +415,6 @@ module Wurk
       (names.slice(page[:page] * page[:count], page[:count]) || []).map do |name|
         ::Wurk::Api::Serializers.limiter_row(name, ::Wurk::Web::Enterprise::Limits.metadata(name))
       end
-    end
-
-    def stream_headers!
-      response.headers['Content-Type'] = 'text/event-stream'
-      response.headers['Cache-Control'] = 'no-cache'
-      response.headers['X-Accel-Buffering'] = 'no'
-    end
-
-    def drive_stream(sse, tick, max_dur)
-      deadline = monotime + max_dur
-      loop do
-        sse.write(stream_tick_payload, event: 'stats')
-        break if monotime >= deadline
-
-        sleep tick
-      end
-    rescue ::IOError, ::ActionController::Live::ClientDisconnected
-      # client closed; nothing to clean up.
-    ensure
-      sse.close
-    end
-
-    def monotime
-      ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
-    end
-
-    def stream_tick_payload
-      ::Wurk::Api::Serializers.stats_payload(::Wurk::Stats.new).merge(at: ::Time.now.to_f)
     end
 
     def render_cron_action(success)

--- a/app/controllers/wurk/api_controller.rb
+++ b/app/controllers/wurk/api_controller.rb
@@ -27,6 +27,10 @@ module Wurk
 
     STREAM_TICK_SECONDS = 2.0
     STREAM_MAX_DURATION = 120.0
+    # Positive floor for `?tick=`: a zero/negative tick would `sleep 0` the SSE
+    # loop into a tight Redis-read/write spin (Live runs it in a spawned thread)
+    # for up to STREAM_MAX_DURATION. Clamp before it reaches drive_stream.
+    STREAM_MIN_TICK_SECONDS = 0.1
 
     HISTORY_WINDOW_UNITS = { 's' => 1, 'm' => 60, 'h' => 3600, 'd' => 86_400 }.freeze
     DEFAULT_HISTORY_WINDOW = 24 * 3600
@@ -291,7 +295,7 @@ module Wurk
       with_stream_slot do
         stream_headers!
         clamp = ::Wurk::Api::Pagination.method(:clamp_float)
-        tick = clamp.call(params[:tick], 0.0, STREAM_TICK_SECONDS, STREAM_TICK_SECONDS)
+        tick = clamp.call(params[:tick], STREAM_MIN_TICK_SECONDS, STREAM_TICK_SECONDS, STREAM_TICK_SECONDS)
         max_dur = clamp.call(params[:max_duration], 0.0, STREAM_MAX_DURATION, STREAM_MAX_DURATION)
         sse = ::ActionController::Live::SSE.new(response.stream, retry: (STREAM_TICK_SECONDS * 1000).to_i)
         drive_stream(sse, tick, max_dur)

--- a/app/controllers/wurk/api_controller.rb
+++ b/app/controllers/wurk/api_controller.rb
@@ -15,21 +15,16 @@ module Wurk
   # in `docs/target/sidekiq-{free,pro,ent}.md`.
   class ApiController < ApplicationController
     include ActionController::Live
+    # The SPA is a token-less JSON client; SameOriginGuard supplies Sidekiq's
+    # same-origin CSRF defense (spec §25.1) so every mutating endpoint is
+    # protected — GET reads (incl. #stream SSE) stay reachable.
+    include SameOriginGuard
 
     STREAM_TICK_SECONDS = 2.0
     STREAM_MAX_DURATION = 600.0
 
     HISTORY_WINDOW_UNITS = { 's' => 1, 'm' => 60, 'h' => 3600, 'd' => 86_400 }.freeze
     DEFAULT_HISTORY_WINDOW = 24 * 3600
-
-    skip_forgery_protection only: %i[
-      stream reset_limiter pause_cron unpause_cron enqueue_cron
-      clear_queue delete_queue_job pause_queue unpause_queue
-      retries_bulk retries_all retry_job
-      scheduled_bulk scheduled_all scheduled_job
-      dead_bulk dead_all dead_job
-      quiet_process stop_process
-    ]
 
     # Per-set action whitelists. Maps the SPA's action name to the
     # SortedEntry/JobSet method. Anything not listed 400s — keeps the bulk/

--- a/app/controllers/wurk/application_controller.rb
+++ b/app/controllers/wurk/application_controller.rb
@@ -14,8 +14,20 @@ module Wurk
     # checkout.
     around_action :scope_web_redis_pool
 
+    # A blip/outage surfacing here is the *same* condition RedisPool already
+    # retried and gave up on (its `on_error` hook already fired — #101).
+    # Report it to the SPA as a structured, retryable 503 instead of letting
+    # it fall through to Rails' generic 500 error page, which would leak a
+    # backtrace and give the client nothing to branch on.
+    rescue_from(*::Wurk::Configuration::REDIS_ERROR_CLASSES) { |ex| render_redis_unavailable(ex) }
+
     private
 
     def scope_web_redis_pool(&) = ::Wurk::Web::PoolScope.scope(&)
+
+    def render_redis_unavailable(ex)
+      logger.warn("wurk web: redis unavailable (#{ex.class}: #{ex.message})")
+      render json: { error: 'redis_unavailable' }, status: :service_unavailable
+    end
   end
 end

--- a/app/controllers/wurk/application_controller.rb
+++ b/app/controllers/wurk/application_controller.rb
@@ -1,7 +1,21 @@
 # frozen_string_literal: true
 
+require 'wurk/web'
+
 module Wurk
   class ApplicationController < ::ActionController::Base
     protect_from_forgery with: :exception
+
+    # Route every dashboard/API/SSE Redis read through the dedicated web pool
+    # (disjoint from the worker pool, #101) so dashboard load can't exhaust the
+    # connections a co-located worker needs. Wraps the whole action — including
+    # the SSE stream, which ActionController::Live runs (filters and all) in a
+    # spawned thread, so the thread-local set here still covers each tick's
+    # checkout.
+    around_action :scope_web_redis_pool
+
+    private
+
+    def scope_web_redis_pool(&) = ::Wurk::Web::PoolScope.scope(&)
   end
 end

--- a/app/controllers/wurk/extensions_controller.rb
+++ b/app/controllers/wurk/extensions_controller.rb
@@ -12,11 +12,9 @@ module Wurk
   # client-side route (no extension registered under that name — e.g. a browser
   # refresh on /wurk/ext/<tab>/) falls through to the SPA shell instead of 404.
   class ExtensionsController < DashboardController
-    # Extension forms carry no Rails CSRF token. Parity with Sidekiq's own
-    # CSRF model instead (spec §25.1): unsafe methods must be same-origin per
-    # Sec-Fetch-Site; cross-site requests are denied. GETs are unaffected.
-    skip_forgery_protection
-    before_action :verify_same_origin!, unless: -> { request.get? || request.head? }
+    # Extension forms carry no Rails CSRF token — SameOriginGuard supplies
+    # Sidekiq's same-origin CSRF defense (spec §25.1) in its place.
+    include SameOriginGuard
 
     def show
       result = Web::Extension::Renderer.call(
@@ -44,13 +42,6 @@ module Wurk
       # Extension output is host-registered server code, same trust model as
       # Sidekiq::Web rendering its extensions — not user input.
       render html: body.html_safe, layout: false, status: status
-    end
-
-    # Spec §25.1: unsafe methods require `Sec-Fetch-Site: same-origin` — a
-    # missing header is denied too, like stock Sidekiq (a non-browser client
-    # must spoof the header deliberately; a cookie-carrying browser can't).
-    def verify_same_origin!
-      head :forbidden unless request.headers['Sec-Fetch-Site'] == 'same-origin'
     end
   end
 end

--- a/app/controllers/wurk/profiles_controller.rb
+++ b/app/controllers/wurk/profiles_controller.rb
@@ -38,7 +38,7 @@ module Wurk
     private
 
     def profile_blob(key)
-      Wurk.redis { |conn| conn.call('HGET', key, 'data') }
+      ::Wurk::ProfileRecord.data_for(key)
     end
 
     # POSTs the gzipped profile to the Firefox profiler's compressed-store.

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -95,6 +95,7 @@ module Wurk
       @client_chain = Middleware::Chain.new
       @server_chain = Middleware::Chain.new
       @redis_config = { url: ENV.fetch('REDIS_URL', 'redis://localhost:6379/0') }
+      @web_redis_pool = nil
       @logger = nil
       @thread_priority = DEFAULT_THREAD_PRIORITY
       @frozen = false
@@ -177,11 +178,13 @@ module Wurk
       default_capsule.redis_pool
     end
 
-    # Disconnect and drop every capsule's cached pools (main + fetch). Used by
-    # Wurk::Swarm so the parent never leaks sockets into forks and each child
-    # can build fresh ones.
+    # Disconnect and drop every capsule's cached pools (main + fetch) plus the
+    # web pool. Used by Wurk::Swarm so the parent never leaks sockets into forks
+    # and each child can build fresh ones.
     def reset_redis_pools!
       @capsules.each_value(&:reset_redis_pools!)
+      @web_redis_pool&.disconnect!
+      @web_redis_pool = nil
     end
 
     def new_redis_pool(size, name = 'custom')
@@ -190,6 +193,39 @@ module Wurk
 
     def redis(&)
       redis_pool.with(&)
+    end
+
+    # --- Web dashboard Redis pool ----------------------------------------
+
+    # Default connection count for the dedicated web pool (#web_redis_pool).
+    WEB_POOL_DEFAULT_SIZE = 5
+
+    # Deliberately short checkout wait for the web pool: a saturated dashboard
+    # should fail fast rather than tie up a web-server thread queuing for a slot.
+    WEB_POOL_TIMEOUT = 1.0
+
+    # Connections in the dedicated web pool. `config.web_pool_size = N` overrides
+    # the default; independent of `config.redis[:size]`, which sizes the worker
+    # capsules — the two pools are deliberately disjoint (#101).
+    def web_pool_size
+      @options[:web_pool_size] || WEB_POOL_DEFAULT_SIZE
+    end
+
+    def web_pool_size=(size)
+      guard_frozen!
+      @options[:web_pool_size] = Integer(size)
+    end
+
+    # Dedicated Redis pool for the dashboard / JSON API / SSE, disjoint from
+    # every worker capsule's pool. Dashboard load — an API burst, a long-lived
+    # SSE stream — can no longer drain the connections a co-located (embedded)
+    # worker needs to fetch and heartbeat, and vice versa: the #101 `0/N`
+    # pool-exhaustion incident. Lazy, so a headless worker that never serves the
+    # dashboard builds nothing; web entry points route `Wurk.redis` here through
+    # Wurk::Web::PoolScope. The Configuration instance is never frozen (only its
+    # @options/@capsules are), so this `||=` is safe to fire post-boot.
+    def web_redis_pool
+      @web_redis_pool ||= build_redis_pool(size: web_pool_size, name: 'web', pool_timeout: WEB_POOL_TIMEOUT)
     end
 
     # --- Service locator (extension registry) ----------------------------
@@ -514,10 +550,12 @@ module Wurk
     # `size`/`name` are pool-structural (the caller owns them); every other
     # key the host set via `config.redis = {...}` — url, the split timeouts,
     # reconnect_attempts, driver, … — flows through to RedisPool verbatim.
-    # Every pool built here is wired to the redis-error telemetry dispatcher.
-    def build_redis_pool(size:, name:)
+    # `overrides` win over the host config (the web pool pins its own
+    # pool_timeout this way). Every pool built here is wired to the redis-error
+    # telemetry dispatcher.
+    def build_redis_pool(size:, name:, **overrides)
       RedisPool.new(size: size, name: name, on_error: method(:dispatch_redis_error),
-                    **@redis_config.except(:size, :name))
+                    **@redis_config.except(:size, :name), **overrides)
     end
 
     # Fan a RedisPool retry/give-up event out to the registered handlers. A

--- a/lib/wurk/engine.rb
+++ b/lib/wurk/engine.rb
@@ -45,6 +45,18 @@ module Wurk
     # Precompiled SPA lives in vendor/assets/dashboard; the engine serves
     # those files as static assets under the /wurk-assets mount point via
     # AssetMount (above).
+    #
+    # Deliberately unauthenticated: this middleware is inserted straight into
+    # the *host app's* middleware stack (`app.middleware`), not the engine's
+    # own (`middleware.use` in this class, below) — so it runs before
+    # anything wired via `Wurk::Web.use`/`Authorization` even sees the
+    # request, and `/wurk-assets/*` is reachable without passing either
+    # check. That's intentional, not an oversight: the bundle is the
+    # compiled JS/CSS/font shell only (no job payloads, no Redis reads, no
+    # per-user state — every data-bearing byte comes from the JSON API,
+    # which *does* sit behind the engine's Authorization middleware). It's
+    # the same trust model as serving `public/assets` from any other Rails
+    # app. See README "Security notes" for the full reasoning.
     initializer 'wurk.assets' do |app|
       assets_path = Wurk::Engine.root.join('vendor', 'assets', 'dashboard')
       if assets_path.exist?

--- a/lib/wurk/history.rb
+++ b/lib/wurk/history.rb
@@ -4,6 +4,7 @@ require_relative 'component'
 require_relative 'keys'
 require_relative 'stats'
 require_relative 'metrics/statsd'
+require_relative 'timer_loop'
 
 module Wurk
   # Sidekiq Enterprise §5 Historical Metrics snapshotter. A leader-gated
@@ -63,30 +64,18 @@ module Wurk
 
     def initialize(config)
       @config = config
-      @interval = config.history_interval
       @collector = config.history_collector
       @stream_cap = config[:history_stream_cap] || STREAM_CAP
-      @done = false
-      @mutex = ::Mutex.new
-      @sleeper = ::ConditionVariable.new
+      @timer = TimerLoop.new(config.history_interval)
       @thread = nil
     end
 
     def start
-      @thread ||= safe_thread('history-snapshot') do # rubocop:disable Naming/MemoizedInstanceVariableName
-        wait
-        until @done
-          tick
-          wait
-        end
-      end
+      @thread ||= safe_thread('history-snapshot') { @timer.run { tick } } # rubocop:disable Naming/MemoizedInstanceVariableName
     end
 
     def terminate
-      @mutex.synchronize do
-        @done = true
-        @sleeper.signal
-      end
+      @timer.terminate
     end
 
     # Leader-gated: only the elected leader emits, so N workers don't each
@@ -163,12 +152,6 @@ module Wurk
       return @collector.call(client) if @collector
 
       values.each { |field, value| client.gauge("sidekiq.#{field}", value) }
-    end
-
-    def wait
-      @mutex.synchronize do
-        @sleeper.wait(@mutex, @interval) unless @done
-      end
     end
   end
 end

--- a/lib/wurk/metrics/queue_rollup.rb
+++ b/lib/wurk/metrics/queue_rollup.rb
@@ -3,6 +3,7 @@
 require_relative '../component'
 require_relative '../keys'
 require_relative '../job_record'
+require_relative '../timer_loop'
 require_relative 'rollup'
 
 module Wurk
@@ -45,28 +46,16 @@ module Wurk
 
       def initialize(config)
         @config = config
-        @done = false
-        @mutex = ::Mutex.new
-        @sleeper = ::ConditionVariable.new
-        @tick_interval = config[:metrics_rollup_interval] || DEFAULT_TICK_SECONDS
+        @timer = TimerLoop.new(config[:metrics_rollup_interval] || DEFAULT_TICK_SECONDS)
         @thread = nil
       end
 
       def start
-        @thread ||= safe_thread('queue-metrics') do # rubocop:disable Naming/MemoizedInstanceVariableName
-          wait
-          until @done
-            tick
-            wait
-          end
-        end
+        @thread ||= safe_thread('queue-metrics') { @timer.run { tick } } # rubocop:disable Naming/MemoizedInstanceVariableName
       end
 
       def terminate
-        @mutex.synchronize do
-          @done = true
-          @sleeper.signal
-        end
+        @timer.terminate
       end
 
       # Leader-gated: only the elected leader samples, so N workers don't each
@@ -139,12 +128,6 @@ module Wurk
         Wurk::JobRecord.latency_from(enqueued_at, now_ms).round(2)
       rescue ::JSON::ParserError, ::TypeError, ::ArgumentError
         0.0
-      end
-
-      def wait
-        @mutex.synchronize do
-          @sleeper.wait(@mutex, @tick_interval) unless @done
-        end
       end
     end
   end

--- a/lib/wurk/metrics/rollup.rb
+++ b/lib/wurk/metrics/rollup.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../component'
+require_relative '../timer_loop'
 require_relative 'history'
 
 module Wurk
@@ -53,28 +54,16 @@ module Wurk
 
       def initialize(config)
         @config = config
-        @done = false
-        @mutex = ::Mutex.new
-        @sleeper = ::ConditionVariable.new
-        @tick_interval = config[:metrics_rollup_interval] || DEFAULT_TICK_SECONDS
+        @timer = TimerLoop.new(config[:metrics_rollup_interval] || DEFAULT_TICK_SECONDS)
         @thread = nil
       end
 
       def start
-        @thread ||= safe_thread('metrics-rollup') do # rubocop:disable Naming/MemoizedInstanceVariableName
-          wait
-          until @done
-            tick
-            wait
-          end
-        end
+        @thread ||= safe_thread('metrics-rollup') { @timer.run { tick } } # rubocop:disable Naming/MemoizedInstanceVariableName
       end
 
       def terminate
-        @mutex.synchronize do
-          @done = true
-          @sleeper.signal
-        end
+        @timer.terminate
       end
 
       # Leader-gated: only the elected leader writes the cluster-total series,
@@ -157,12 +146,6 @@ module Wurk
 
       def floor_min(time)
         (time.to_i / 60) * 60
-      end
-
-      def wait
-        @mutex.synchronize do
-          @sleeper.wait(@mutex, @tick_interval) unless @done
-        end
       end
     end
   end

--- a/lib/wurk/profile_set.rb
+++ b/lib/wurk/profile_set.rb
@@ -39,6 +39,14 @@ module Wurk
   class ProfileRecord
     attr_reader :jid, :type, :token, :size, :elapsed
 
+    # Fetch the stored gzipped blob for a profile storage key ("<token>-<jid>")
+    # straight from Redis, without materializing the whole record — the Profiles
+    # data endpoint streams it to the browser as-is. nil if the HASH is gone.
+    # Owns the `data` HASH-field name so web callers don't hardcode the schema.
+    def self.data_for(key)
+      Wurk.redis { |conn| conn.call('HGET', key, 'data') }
+    end
+
     def initialize(hash)
       @hash = hash
       @jid = hash['jid']
@@ -59,7 +67,7 @@ module Wurk
     # bytes — the web layer streams them straight to the browser with a gzip
     # Content-Encoding. Returns nil if the HASH expired between list and read.
     def data
-      Wurk.redis { |conn| conn.call('HGET', key, 'data') }
+      self.class.data_for(key)
     end
   end
 end

--- a/lib/wurk/timer_loop.rb
+++ b/lib/wurk/timer_loop.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Wurk
+  # Mutex/CV "tick every N seconds until told to stop" primitive shared by
+  # every leader-gated periodic component (History, Metrics::Rollup,
+  # Metrics::QueueRollup). Each of those used to hand-roll the same
+  # `@mutex`/`@sleeper`/`@done` dance; this is that dance, extracted once.
+  #
+  # The host owns thread spawning (it needs its own `safe_thread` from
+  # Component for logger/handle_exception context) and the leader-gate check
+  # inside its `tick` — TimerLoop only owns the interval wait and the
+  # start/terminate signaling around it:
+  #
+  #   @timer = Wurk::TimerLoop.new(interval)
+  #   @thread ||= safe_thread('my-loop') { @timer.run { tick } }
+  #   def terminate = @timer.terminate
+  class TimerLoop
+    def initialize(interval)
+      @interval = interval
+      @done = false
+      @mutex = ::Mutex.new
+      @sleeper = ::ConditionVariable.new
+    end
+
+    # Waits one interval, then yields repeatedly (waiting between calls)
+    # until #terminate is called. Matches the existing components' "don't
+    # tick immediately on boot" behavior.
+    def run
+      wait
+      until @done
+        yield
+        wait
+      end
+    end
+
+    def terminate
+      @mutex.synchronize do
+        @done = true
+        @sleeper.signal
+      end
+    end
+
+    def wait
+      @mutex.synchronize do
+        @sleeper.wait(@mutex, @interval) unless @done
+      end
+    end
+  end
+end

--- a/lib/wurk/web.rb
+++ b/lib/wurk/web.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'web/config'
+require_relative 'web/pool_scope'
 require_relative 'web/search'
 require_relative 'web/enterprise'
 require_relative 'web/batch_status'

--- a/lib/wurk/web/pool_scope.rb
+++ b/lib/wurk/web/pool_scope.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Wurk
+  class Web
+    # Routes `Wurk.redis` onto the dedicated web pool (Wurk::Configuration
+    # #web_redis_pool) for the duration of a block.
+    #
+    # The dashboard, JSON API, and SSE stream run in the host's web process and
+    # reach Redis through the same inspector objects (Stats, Queue, Search, …) a
+    # worker uses — all of which call `Wurk.redis`. Left on the default pool, a
+    # burst of dashboard traffic or a long-held SSE stream could drain the
+    # connections a co-located (embedded) worker needs to make progress, and
+    # vice versa: the #101 pool-exhaustion incident.
+    #
+    # `Wurk.redis_pool` resolves its pool by calling `#redis_pool` on
+    # `Thread.current[:wurk_capsule]` (falling back to the default capsule).
+    # Pointing that thread-local at a handle whose `#redis_pool` is the web pool
+    # diverts every nested `Wurk.redis` call with no per-call-site change. The
+    # prior value is restored on exit so a reused web-server thread — or a
+    # nested scope — is left untouched.
+    module PoolScope
+      class << self
+        def scope
+          prev = Thread.current[:wurk_capsule]
+          Thread.current[:wurk_capsule] = handle
+          yield
+        ensure
+          Thread.current[:wurk_capsule] = prev
+        end
+
+        def handle
+          @handle ||= Handle.new
+        end
+      end
+
+      # Minimal capsule-shaped duck type: Wurk.redis_pool only ever calls
+      # `#redis_pool` on the thread-local. Resolved lazily so a post-fork
+      # `reset_redis_pools!` rebuild is picked up transparently.
+      class Handle
+        def redis_pool
+          Wurk.configuration.web_redis_pool
+        end
+      end
+    end
+  end
+end

--- a/lib/wurk/web/rack_app.rb
+++ b/lib/wurk/web/rack_app.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'extension'
+require_relative 'pool_scope'
 
 module Wurk
   class Web
@@ -29,7 +30,7 @@ module Wurk
       # auth here would break `run Sidekiq::Web` / rack-test parity with
       # upstream Sidekiq, which also doesn't auth-gate `Sidekiq::Web.call`.
       def call(env)
-        config.rack_app(method(:dispatch)).call(env)
+        PoolScope.scope { config.rack_app(method(:dispatch)).call(env) }
       end
 
       private

--- a/lib/wurk/web/search.rb
+++ b/lib/wurk/web/search.rb
@@ -12,9 +12,12 @@ module Wurk
     # on Retry/Scheduled/Dead pages, substring across job payload via ZSCAN").
     # Wurk ships it free, extended to also cover the queue LIST.
     #
-    # ZSET stores use `ZSCAN MATCH *needle*` (the substring is literal,
-    # wrapped in glob stars — Redis matches the raw JSON payload). The queue
-    # LIST falls back to a paged LRANGE filter since LIST has no SCAN.
+    # ZSET stores are ZSCAN-paged and filtered client-side against the literal
+    # substring — the same shape as the queue LIST's paged LRANGE filter —
+    # rather than `ZSCAN MATCH`: MATCH returns only matches, never the count of
+    # elements Redis walked, so a no-match keystroke couldn't be metered and
+    # could round-trip an enormous ZSET. Both paths charge the shared scan
+    # budget so a keystroke never full-walks a multi-million-entry store.
     #
     # Result shape mirrors `Wurk::Api::Serializers#sorted_entry` so the SPA
     # renders search hits with the same component as a sorted-set row.
@@ -42,9 +45,10 @@ module Wurk
         @scanned = 0
       end
 
-      # True when a queue scan stopped at a bound (per-queue cap or per-request
-      # budget) with elements left unexamined — the hit list may be incomplete.
-      # Meaningful only after `each`/`to_a` has driven the scan.
+      # True when a scan stopped at a bound (a queue's per-queue cap, a sorted
+      # set's page loop, or the shared per-request budget) with elements left
+      # unexamined — the hit list may be incomplete. Meaningful only after
+      # `each`/`to_a` has driven the scan.
       def truncated? = @truncated
 
       # Streams matching hits across every selected store. Stops at `limit`.
@@ -121,10 +125,33 @@ module Wurk
         [size, cap].min
       end
 
+      # ZSCAN-pages a sorted set, filtering client-side and metering the
+      # elements Redis returns against the shared budget so a rare/no-match
+      # keystroke can't round-trip an arbitrarily large ZSET. Flags @truncated
+      # when the budget stops the scan with entries still unexamined (cursor not
+      # yet wrapped back to 0).
       def search_sorted_set(kind, &)
         set = sorted_set_for(kind)
-        set.scan(@substring, ZSCAN_PAGE) do |value, score|
-          yield sorted_row(kind, set.name, SortedEntry.new(set, score, value))
+        cursor = '0'
+        loop do
+          cursor, page = Wurk.redis { |c| c.call('ZSCAN', set.name, cursor, 'COUNT', ZSCAN_PAGE) }
+          emit_sorted_hits(kind, set, page, &)
+          @scanned += page.size / 2
+          break if cursor == '0'
+          next if @scanned < SCAN_BUDGET
+
+          @truncated = true
+          break
+        end
+      end
+
+      # Yields a sorted_row for each element on this ZSCAN page whose raw JSON
+      # contains the literal substring (client-side filter — see the class note).
+      def emit_sorted_hits(kind, set, page)
+        page.each_slice(2) do |value, score|
+          next unless value.include?(@substring)
+
+          yield sorted_row(kind, set.name, SortedEntry.new(set, score.to_f, value))
         end
       end
 

--- a/lib/wurk/web/search.rb
+++ b/lib/wurk/web/search.rb
@@ -24,6 +24,12 @@ module Wurk
       KINDS = %w[queues retry scheduled dead].freeze
       QUEUE_PAGE = 50
       ZSCAN_PAGE = 200
+      # A queue LIST has no SCAN, so a keystroke must never full-walk a
+      # multi-million-entry queue. Bound each queue's scan and the whole
+      # request's scan; `truncated?` flips when we stop early so the API can
+      # tell the UI it's showing partial results.
+      SCAN_LIMIT_PER_QUEUE = 5_000
+      SCAN_BUDGET = 20_000
 
       attr_reader :substring, :kinds, :limit
 
@@ -32,7 +38,14 @@ module Wurk
         @kinds = (Array(kinds).map(&:to_s) & KINDS)
         @kinds = KINDS.dup if @kinds.empty?
         @limit = limit.to_i.clamp(1, MAX_LIMIT)
+        @truncated = false
+        @scanned = 0
       end
+
+      # True when a queue scan stopped at a bound (per-queue cap or per-request
+      # budget) with elements left unexamined — the hit list may be incomplete.
+      # Meaningful only after `each`/`to_a` has driven the scan.
+      def truncated? = @truncated
 
       # Streams matching hits across every selected store. Stops at `limit`.
       # Yields Hashes shaped like sorted_entry payloads with an extra
@@ -41,6 +54,8 @@ module Wurk
         return enum_for(:each) unless block_given?
         return if @substring.empty?
 
+        @scanned = 0
+        @truncated = false
         emitted = 0
         each_hit do |row|
           yield row
@@ -66,27 +81,44 @@ module Wurk
 
       def search_queues
         Queue.all.each do |queue|
-          paged_lrange(queue.name) do |payload|
+          if @scanned >= SCAN_BUDGET
+            @truncated = true
+            break
+          end
+
+          scan_queue_list(queue.name) do |payload|
             next unless payload.include?(@substring)
 
-            record = JobRecord.new(payload, queue.name)
-            yield queue_row(queue.name, record)
+            yield queue_row(queue.name, JobRecord.new(payload, queue.name))
           end
         end
       end
 
-      def paged_lrange(queue_name, &block)
+      # LRANGE-pages one queue LIST, yielding each raw payload to the substring
+      # filter. `LLEN` gives the exact size up front (see #queue_scan_stop), so
+      # we scan a bounded prefix and never full-walk the LIST from a keystroke.
+      def scan_queue_list(queue_name, &)
         key = Keys.queue(queue_name)
-        page = 0
-        loop do
-          start = page * QUEUE_PAGE
-          stop = start + QUEUE_PAGE - 1
-          slice = Wurk.redis { |c| c.call('LRANGE', key, start, stop) }
-          slice.each(&block)
-          break if slice.size < QUEUE_PAGE
+        stop_at = queue_scan_stop(Wurk.redis { |c| c.call('LLEN', key) })
+        start = 0
+        while start < stop_at
+          slice = Wurk.redis { |c| c.call('LRANGE', key, start, [start + QUEUE_PAGE, stop_at].min - 1) }
+          break if slice.empty?
 
-          page += 1
+          slice.each(&)
+          start += slice.size
         end
+        @scanned += start
+      end
+
+      # Elements to examine in a queue of `size`: the smaller of the per-queue
+      # cap and the request budget still unspent. Flags @truncated when the
+      # queue holds more than we'll scan, so the flag is set only for a genuine
+      # partial result.
+      def queue_scan_stop(size)
+        cap = [SCAN_LIMIT_PER_QUEUE, SCAN_BUDGET - @scanned].min
+        @truncated = true if size > cap
+        [size, cap].min
       end
 
       def search_sorted_set(kind, &)

--- a/test/engine/api_endpoints_test.rb
+++ b/test/engine/api_endpoints_test.rb
@@ -474,6 +474,22 @@ class ApiEndpointsTest < Wurk::Test::EngineCase
     assert decoded.key?('processed'), "decoded payload missing :processed key, got #{decoded.keys.inspect}"
   end
 
+  # With every stream slot held, the next connection is refused with 503 +
+  # Retry-After instead of pinning another Puma thread. Slots are filled/freed
+  # directly so the assertion is deterministic (no real concurrency needed).
+  def test_stream_503_when_at_concurrent_cap
+    cap = ::Wurk::StreamConcurrencyGuard::MAX_CONCURRENT_STREAMS
+    cap.times { ::Wurk::StreamConcurrencyGuard.acquire }
+
+    get '/wurk/api/stream?max_duration=0&tick=0'
+
+    assert_equal 503, last_response.status
+    assert_equal ::Wurk::StreamConcurrencyGuard::RETRY_AFTER_SECONDS.to_s,
+                 last_response.headers['Retry-After']
+  ensure
+    cap.times { ::Wurk::StreamConcurrencyGuard.release }
+  end
+
   private
 
   def json_body

--- a/test/engine/api_mutations_test.rb
+++ b/test/engine/api_mutations_test.rb
@@ -20,6 +20,9 @@ require_relative '../engine_test_helper'
 class ApiMutationsTest < Wurk::Test::EngineCase
   def setup
     super
+    # SameOriginGuard 403s unsafe methods lacking this header; a same-origin SPA
+    # fetch always sends it, so default it for every mutation in this suite.
+    header 'Sec-Fetch-Site', 'same-origin'
     @ns = "wurkmut:#{::Process.pid}:#{object_id}"
     @queue = "#{@ns}-q"
     @class_name = "ApiMutationJob@#{@ns}"

--- a/test/engine/busy_control_test.rb
+++ b/test/engine/busy_control_test.rb
@@ -11,6 +11,9 @@ class BusyControlTest < Wurk::Test::EngineCase
 
   def setup
     super
+    # SameOriginGuard 403s unsafe methods lacking this header; a same-origin SPA
+    # fetch always sends it, so default it for every mutation in this suite.
+    header 'Sec-Fetch-Site', 'same-origin'
     @ns = "wurkbusy:#{::Process.pid}:#{object_id.to_s(16)}"
     @identity = "host-#{@ns}:1234:abcd"
   end

--- a/test/engine/csrf_same_origin_test.rb
+++ b/test/engine/csrf_same_origin_test.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require_relative '../engine_test_helper'
+
+# Proves Wurk::SameOriginGuard (#101 web/API hardening) actually rejects
+# forged cross-site mutations and lets real same-origin traffic through, for
+# every mutating route the engine exposes — not just the handful individual
+# suites happen to cover with the header pre-set in `setup`.
+#
+# Route-table-driven: ALL_MUTATING_ROUTES enumerates every non-GET route in
+# config/routes.rb (ApiController + ExtensionsController). The 403 direction
+# needs no seeded data — the guard runs in a `before_action` and rejects
+# before the action ever touches Redis, so arbitrary path params are safe to
+# probe. The 2xx direction drops the three `.../all/:cmd` bulk-drain routes
+# (retries/scheduled/dead): they UNLINK the *global* zset wholesale, and other
+# parallelize_me! suites in this worker's Redis DB push fixtures onto those
+# same un-namespaced keys — draining them here would flake sibling tests for
+# a property those suites already cover directly (ApiMutationsTest).
+class CsrfSameOriginTest < Wurk::Test::EngineCase
+  def setup
+    super
+    @ns = "wurkcsrf:#{::Process.pid}:#{object_id}"
+    @queue = "#{@ns}-clear-q"
+    @del_queue = "#{@ns}-del-q"
+    @class_name = "CsrfJob@#{@ns}"
+    @lid = ::Digest::SHA1.hexdigest(@ns)[0, 16]
+    @limiter = "lmt-#{@ns}"
+    @identity = "host-#{@ns}:1:aa"
+
+    @del_jid = seed_queue_job(@del_queue)
+    @retry_key = seed_zset_entry('retry')
+    @sched_key = seed_zset_entry('schedule')
+    @dead_key = seed_zset_entry('dead')
+    seed_cron_loop
+    seed_process(@identity)
+  end
+
+  def teardown
+    ::Wurk.redis do |c|
+      c.call('DEL', "queue:#{@del_queue}")
+      c.call('SREM', 'queues', @del_queue, @queue)
+      c.call('SREM', ::Wurk::Keys::PAUSED_SET, @queue)
+      cleanup_zset(c, 'retry')
+      cleanup_zset(c, 'schedule')
+      cleanup_zset(c, 'dead')
+      c.call('SREM', ::Wurk::Cron::PERIODIC_KEY, @lid)
+      c.call('DEL', "#{::Wurk::Cron::LOOP_PREFIX}#{@lid}", "#{::Wurk::Cron::HISTORY_PREFIX}#{@lid}")
+      c.call('SREM', ::Wurk::Keys::PROCESSES, @identity)
+      c.call('DEL', @identity, "#{@identity}-signals")
+    end
+  ensure
+    super
+  end
+
+  # Every mutating route the engine exposes, GET/HEAD/OPTIONS excluded.
+  # Params are placeholders where the 403 check never reaches the action.
+  def all_mutating_routes
+    [
+      { path: "/wurk/api/queues/#{@queue}/clear" },
+      { path: "/wurk/api/queues/#{@del_queue}/delete", params: { jid: @del_jid } },
+      { path: "/wurk/api/queues/#{@queue}/pause" },
+      { path: "/wurk/api/queues/#{@queue}/unpause" },
+      { path: '/wurk/api/retries', params: { cmd: 'delete', keys: [] } },
+      { path: '/wurk/api/retries/all/delete' },
+      { path: "/wurk/api/retries/#{@retry_key}", params: { cmd: 'delete' } },
+      { path: '/wurk/api/scheduled', params: { cmd: 'delete', keys: [] } },
+      { path: '/wurk/api/scheduled/all/delete' },
+      { path: "/wurk/api/scheduled/#{@sched_key}", params: { cmd: 'delete' } },
+      { path: '/wurk/api/dead', params: { cmd: 'delete', keys: [] } },
+      { path: '/wurk/api/dead/all/delete' },
+      { path: "/wurk/api/dead/#{@dead_key}", params: { cmd: 'retry' } },
+      { path: '/wurk/api/busy/quiet', params: { identity: @identity } },
+      { path: '/wurk/api/busy/stop', params: { identity: @identity } },
+      { path: "/wurk/api/limiters/#{@limiter}/reset" },
+      { path: "/wurk/api/cron/#{@lid}/pause" },
+      { path: "/wurk/api/cron/#{@lid}/unpause" },
+      { path: "/wurk/api/cron/#{@lid}/enqueue" },
+      { path: "/wurk/ext/csrf-unregistered-#{@ns}" }
+    ].freeze
+  end
+
+  # `.../all/:cmd` bulk-drain routes wipe the whole global zset — excluded
+  # here (see class comment); everything else must reach the controller and
+  # succeed for a genuine same-origin request.
+  def safe_2xx_routes
+    all_mutating_routes.reject { |r| r[:path].include?('/all/') }
+  end
+
+  def test_every_mutating_route_403s_without_same_origin_header
+    all_mutating_routes.each do |route|
+      post route[:path], route[:params] || {}
+
+      assert_equal 403, last_response.status,
+                   "expected 403 for POST #{route[:path]} without Sec-Fetch-Site, got #{last_response.status}"
+    end
+  end
+
+  def test_every_safe_route_succeeds_with_same_origin_header
+    header 'Sec-Fetch-Site', 'same-origin'
+
+    safe_2xx_routes.each do |route|
+      post route[:path], route[:params] || {}
+
+      assert_includes 200..299, last_response.status,
+                      "expected 2xx for POST #{route[:path]} with Sec-Fetch-Site: same-origin, " \
+                      "got #{last_response.status}: #{last_response.body[0, 300]}"
+    end
+  end
+
+  # Reads (GET, incl. SSE) are safe methods — SameOriginGuard never blocks
+  # them, header or not. Sanity check so the guard's SAFE_METHODS allowlist
+  # doesn't regress into blocking dashboard reads.
+  def test_get_requests_are_never_blocked
+    get '/wurk/api/stats'
+
+    assert_equal 200, last_response.status
+  end
+
+  private
+
+  def seed_queue_job(queue)
+    jid = ::SecureRandom.hex(12)
+    payload = {
+      'class' => @class_name, 'args' => [1], 'queue' => queue, 'jid' => jid,
+      'created_at' => ::Time.now.to_f, 'enqueued_at' => ::Time.now.to_f, 'retry_count' => 0
+    }
+    ::Wurk.redis do |c|
+      c.call('SADD', 'queues', queue)
+      c.call('LPUSH', "queue:#{queue}", ::Wurk.dump_json(payload))
+    end
+    jid
+  end
+
+  # Seeds one entry in the given global zset, returning its URL-encoded
+  # "<score>|<jid>" route key (matches the SPA's encodeURIComponent).
+  def seed_zset_entry(name)
+    score = ::Time.now.to_f
+    jid = ::SecureRandom.hex(12)
+    payload = {
+      'class' => @class_name, 'args' => [1], 'queue' => @queue, 'jid' => jid,
+      'created_at' => score, 'enqueued_at' => score, 'retry_count' => 1,
+      'error_class' => 'RuntimeError', 'error_message' => 'boom'
+    }
+    ::Wurk.redis { |c| c.call('ZADD', name, score.to_s, ::Wurk.dump_json(payload)) }
+    ::CGI.escape("#{score}|#{jid}")
+  end
+
+  def seed_cron_loop
+    ::Wurk.redis do |c|
+      c.call('SADD', ::Wurk::Cron::PERIODIC_KEY, @lid)
+      c.call(
+        'HSET', "#{::Wurk::Cron::LOOP_PREFIX}#{@lid}",
+        'schedule', '* * * * *', 'klass', @class_name,
+        'options', ::JSON.dump('queue' => @queue, 'args' => [1]), 'tz', '', 'paused', '0'
+      )
+    end
+  end
+
+  def seed_process(identity)
+    info = {
+      'hostname' => 'testhost', 'pid' => 1234, 'tag' => @ns, 'concurrency' => 5,
+      'queues' => ['default'], 'identity' => identity, 'version' => ::Wurk::VERSION, 'embedded' => false
+    }
+    ::Wurk.redis do |c|
+      c.call('SADD', ::Wurk::Keys::PROCESSES, identity)
+      c.call('HSET', identity, 'info', ::Wurk.dump_json(info),
+             'busy', '0', 'beat', ::Time.now.to_f.to_s, 'quiet', 'false', 'rss', '1000',
+             'rtt_us', '10', 'concurrency', '5')
+    end
+  end
+
+  def cleanup_zset(conn, key)
+    conn.call('ZRANGEBYSCORE', key, '-inf', '+inf').each do |raw|
+      parsed = begin
+        ::Wurk.load_json(raw)
+      rescue ::JSON::ParserError
+        nil
+      end
+      next unless parsed.is_a?(Hash) && parsed['class'] == @class_name
+
+      conn.call('ZREM', key, raw)
+    end
+  end
+end

--- a/test/engine/csrf_same_origin_test.rb
+++ b/test/engine/csrf_same_origin_test.rb
@@ -17,6 +17,8 @@ require_relative '../engine_test_helper'
 # same un-namespaced keys — draining them here would flake sibling tests for
 # a property those suites already cover directly (ApiMutationsTest).
 class CsrfSameOriginTest < Wurk::Test::EngineCase
+  parallelize_me!
+
   def setup
     super
     @ns = "wurkcsrf:#{::Process.pid}:#{object_id}"

--- a/test/engine/redis_unavailable_test.rb
+++ b/test/engine/redis_unavailable_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require_relative '../engine_test_helper'
+
+# Proves a Redis blip surfacing inside an engine action renders as a
+# structured, retryable signal instead of Rails' generic 500 error page
+# (#101 debrief: the SPA needs something to branch on, not a backtrace).
+#
+# Forces the failure at the `Wurk::Api::Serializers.stats_payload` boundary —
+# the one place both the plain JSON `#stats` action and the SSE `#stream`
+# tick read Redis — rather than mocking the Redis client itself (never mock
+# Redis in engine/integration tests; this simulates the *exception class*
+# RedisPool already raises after exhausting its own retries, not the
+# transport).
+class RedisUnavailableTest < Wurk::Test::EngineCase
+  parallelize_me!
+
+  def test_json_action_returns_structured_503_on_redis_error
+    with_stats_payload_raising(RedisClient::CannotConnectError.new('boom')) do
+      get '/wurk/api/stats'
+    end
+
+    assert_equal 503, last_response.status
+    assert_equal 'redis_unavailable', json_body[:error]
+  end
+
+  def test_json_action_returns_structured_503_on_pool_timeout
+    with_stats_payload_raising(ConnectionPool::TimeoutError.new('boom')) do
+      get '/wurk/api/stats'
+    end
+
+    assert_equal 503, last_response.status
+    assert_equal 'redis_unavailable', json_body[:error]
+  end
+
+  # Headers are already flushed by the time an SSE tick hits Redis, so the
+  # stream can't switch to a 503 status — it emits a structured `error` event
+  # and closes instead of dying mid-stream with a raw exception.
+  def test_stream_emits_structured_error_event_on_redis_error
+    with_stats_payload_raising(RedisClient::CannotConnectError.new('boom')) do
+      get '/wurk/api/stream?max_duration=0&tick=0'
+    end
+
+    assert_equal 200, last_response.status
+    assert_includes last_response.body, 'event: error'
+    assert_equal 'redis_unavailable', stream_event_payload['error']
+  end
+
+  private
+
+  def stream_event_payload
+    payload_line = last_response.body.lines.find { |l| l.start_with?('data: ') }
+    ::JSON.parse(payload_line.delete_prefix('data: '))
+  end
+
+  def with_stats_payload_raising(error)
+    original = ::Wurk::Api::Serializers.method(:stats_payload)
+    ::Wurk::Api::Serializers.define_singleton_method(:stats_payload) { |*| raise error }
+    yield
+  ensure
+    ::Wurk::Api::Serializers.define_singleton_method(:stats_payload, original)
+  end
+
+  def json_body
+    ::JSON.parse(last_response.body, symbolize_names: true)
+  end
+end

--- a/test/engine/web_extensions_test.rb
+++ b/test/engine/web_extensions_test.rb
@@ -7,6 +7,8 @@ require_relative '../engine_test_helper'
 # The wire shape here is what the SPA's Limits / Periodic / Historical
 # tabs render against.
 class WebExtensionsTest < Wurk::Test::EngineCase
+  parallelize_me!
+
   def setup
     super
     # SameOriginGuard 403s unsafe methods lacking this header; a same-origin SPA

--- a/test/engine/web_extensions_test.rb
+++ b/test/engine/web_extensions_test.rb
@@ -9,6 +9,9 @@ require_relative '../engine_test_helper'
 class WebExtensionsTest < Wurk::Test::EngineCase
   def setup
     super
+    # SameOriginGuard 403s unsafe methods lacking this header; a same-origin SPA
+    # fetch always sends it, so default it for every mutation in this suite.
+    header 'Sec-Fetch-Site', 'same-origin'
     @ns = "wurkwebx:#{Process.pid}:#{object_id}"
     @queue = "#{@ns}-q"
     @class_name = "WebExtJob@#{@ns}"

--- a/test/engine/web_pool_isolation_test.rb
+++ b/test/engine/web_pool_isolation_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative '../engine_test_helper'
+
+# Proves the engine's dashboard/API stack routes its Redis reads through the
+# dedicated web pool (#101). The Wurk::ApplicationController around_action wraps
+# every action in Wurk::Web::PoolScope, so `Wurk.redis` inside the action
+# resolves via the web-pool handle rather than the worker (default capsule)
+# pool — dashboard load can't exhaust the connections a co-located worker needs.
+class WebPoolIsolationTest < Wurk::Test::EngineCase
+  parallelize_me!
+
+  def teardown
+    restore_handle
+    Wurk.configuration.reset_redis_pools!
+  ensure
+    super
+  end
+
+  def test_api_request_resolves_redis_through_the_web_pool
+    web = ::Wurk.configuration.web_redis_pool
+    spy_handle_resolutions(web)
+
+    get '/wurk/api/stats'
+
+    assert_equal 200, last_response.status, "non-200: #{last_response.body[0, 300]}"
+    assert_operator @resolutions, :>, 0,
+                    'the API action should resolve Wurk.redis through the web-pool handle'
+  end
+
+  # Outside a request there is no web scope, so `Wurk.redis` stays on the worker
+  # pool — the diversion is strictly request-scoped and doesn't leak onto the
+  # Rack::Test thread afterwards.
+  def test_request_scope_does_not_leak_onto_the_thread
+    assert_nil Thread.current[:wurk_capsule]
+
+    get '/wurk/api/stats'
+
+    assert_nil Thread.current[:wurk_capsule], 'web pool binding must be cleared after the request'
+  end
+
+  private
+
+  # Records each time the handle resolves its pool (i.e. each in-action
+  # `Wurk.redis` call) while still returning the real pool so the request works.
+  def spy_handle_resolutions(web)
+    @resolutions = 0
+    @handle = ::Wurk::Web::PoolScope.handle
+    counter = -> { @resolutions += 1 }
+    @handle.define_singleton_method(:redis_pool) do
+      counter.call
+      web
+    end
+  end
+
+  def restore_handle
+    return unless @handle&.singleton_methods&.include?(:redis_pool)
+
+    @handle.singleton_class.send(:remove_method, :redis_pool)
+  end
+end

--- a/test/engine/web_pool_isolation_test.rb
+++ b/test/engine/web_pool_isolation_test.rb
@@ -18,8 +18,7 @@ class WebPoolIsolationTest < Wurk::Test::EngineCase
   end
 
   def test_api_request_resolves_redis_through_the_web_pool
-    web = ::Wurk.configuration.web_redis_pool
-    spy_handle_resolutions(web)
+    spy_handle_resolutions
 
     get '/wurk/api/stats'
 
@@ -41,21 +40,38 @@ class WebPoolIsolationTest < Wurk::Test::EngineCase
 
   private
 
-  # Records each time the handle resolves its pool (i.e. each in-action
-  # `Wurk.redis` call) while still returning the real pool so the request works.
-  def spy_handle_resolutions(web)
+  # Counts pool resolutions WITHOUT redefining the shared PoolScope.handle
+  # singleton (which every concurrent request would see): swaps in a double that
+  # tallies only resolutions on this test's own thread — Rack::Test runs the
+  # action inline — and delegates live to the real web pool, so a sibling
+  # request resolves the correct, never-stale pool and can't inflate the count.
+  # teardown#restore_handle puts the untouched original back.
+  def spy_handle_resolutions
     @resolutions = 0
-    @handle = ::Wurk::Web::PoolScope.handle
-    counter = -> { @resolutions += 1 }
-    @handle.define_singleton_method(:redis_pool) do
-      counter.call
-      web
-    end
+    @original_handle = ::Wurk::Web::PoolScope.handle
+    spy = ResolutionCountingHandle.new(::Thread.current) { @resolutions += 1 }
+    ::Wurk::Web::PoolScope.instance_variable_set(:@handle, spy)
   end
 
   def restore_handle
-    return unless @handle&.singleton_methods&.include?(:redis_pool)
+    return unless defined?(@original_handle) && @original_handle
 
-    @handle.singleton_class.send(:remove_method, :redis_pool)
+    ::Wurk::Web::PoolScope.instance_variable_set(:@handle, @original_handle)
+  end
+
+  # Web-pool handle double: increments the counter only when the resolving
+  # thread is the test's own, then returns the live web pool exactly as the real
+  # PoolScope::Handle would — no captured (staleable) pool, no global mutation
+  # of the shared handle.
+  class ResolutionCountingHandle
+    def initialize(test_thread, &counter)
+      @test_thread = test_thread
+      @counter = counter
+    end
+
+    def redis_pool
+      @counter.call if ::Thread.current == @test_thread
+      ::Wurk.configuration.web_redis_pool
+    end
   end
 end

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -289,6 +289,82 @@ class ConfigurationTest < Wurk::Test::UnitCase
     @config.reset_redis_pools!
   end
 
+  # --- Web dashboard pool (#101) -----------------------------------------
+
+  def test_web_redis_pool_defaults_to_size_five
+    assert_equal 5, Wurk::Configuration::WEB_POOL_DEFAULT_SIZE
+    assert_equal Wurk::Configuration::WEB_POOL_DEFAULT_SIZE, @config.web_redis_pool.size
+  ensure
+    @config.reset_redis_pools!
+  end
+
+  def test_web_redis_pool_pins_short_pool_timeout
+    assert_in_delta 1.0, Wurk::Configuration::WEB_POOL_TIMEOUT
+    assert_equal Wurk::Configuration::WEB_POOL_TIMEOUT, @config.web_redis_pool.pool_timeout
+  ensure
+    @config.reset_redis_pools!
+  end
+
+  # A host tuning the worker pools' checkout wait must not lengthen the web
+  # pool's — it stays 1.0 so a saturated dashboard fails fast.
+  def test_web_redis_pool_timeout_overrides_host_config
+    @config.redis = { url: Wurk::Test.redis_url, pool_timeout: 9.0 }
+
+    assert_in_delta 1.0, @config.web_redis_pool.pool_timeout
+    assert_in_delta 9.0, @config.default_capsule.redis_pool.pool_timeout
+  ensure
+    @config.reset_redis_pools!
+  end
+
+  def test_web_pool_size_is_configurable
+    @config.web_pool_size = 12
+
+    assert_equal 12, @config.web_pool_size
+    assert_equal 12, @config.web_redis_pool.size
+  ensure
+    @config.reset_redis_pools!
+  end
+
+  def test_web_pool_size_is_disjoint_from_redis_size_override
+    @config.redis = { size: 42 }
+
+    assert_equal 42, @config.default_capsule.redis_pool.size
+    assert_equal Wurk::Configuration::WEB_POOL_DEFAULT_SIZE, @config.web_redis_pool.size
+  ensure
+    @config.reset_redis_pools!
+  end
+
+  def test_web_redis_pool_is_memoized
+    assert_same @config.web_redis_pool, @config.web_redis_pool
+  ensure
+    @config.reset_redis_pools!
+  end
+
+  def test_web_redis_pool_is_distinct_from_worker_pool
+    refute_same @config.web_redis_pool, @config.default_capsule.redis_pool
+  ensure
+    @config.reset_redis_pools!
+  end
+
+  def test_reset_redis_pools_rebuilds_web_pool
+    before = @config.web_redis_pool
+    @config.reset_redis_pools!
+
+    refute_same before, @config.web_redis_pool
+  ensure
+    @config.reset_redis_pools!
+  end
+
+  def test_reset_redis_pools_is_safe_when_web_pool_never_built
+    @config.reset_redis_pools! # must not raise on the nil web pool
+  end
+
+  def test_web_pool_size_setter_raises_when_frozen
+    @config.freeze!
+
+    assert_raises(FrozenError) { @config.web_pool_size = 3 }
+  end
+
   # --- service locator ---------------------------------------------------
 
   def test_register_and_lookup

--- a/test/unit/metrics_rollup_test.rb
+++ b/test/unit/metrics_rollup_test.rb
@@ -121,19 +121,21 @@ class MetricsRollupTest < Wurk::Test::UnitCase
   end
   # rubocop:enable Metrics/AbcSize
 
-  # `wait` short-circuits the ConditionVariable wait when @done is already
-  # set (the `unless @done` else branch) so terminate-then-wait returns at once.
-  def test_wait_returns_immediately_once_done
+  # `TimerLoop#wait` short-circuits the ConditionVariable wait once terminated
+  # (the `unless @done` else branch) so terminate-then-wait returns at once.
+  # Mutex/CV mechanics live in Wurk::TimerLoop now (test/unit/timer_loop_test.rb);
+  # this just confirms Rollup wires #terminate through to its @timer.
+  def test_terminate_makes_timer_wait_return_immediately
     @rollup.terminate
 
     completed = false
     t = Thread.new do
-      @rollup.send(:wait)
+      @rollup.instance_variable_get(:@timer).wait
       completed = true
     end
     t.join(2.0)
 
-    assert completed, 'wait must return immediately when @done is set'
+    assert completed, 'wait must return immediately once terminated'
   ensure
     t&.kill
   end

--- a/test/unit/timer_loop_test.rb
+++ b/test/unit/timer_loop_test.rb
@@ -24,6 +24,10 @@ class TimerLoopTest < Wurk::Test::UnitCase
     thread.join(2.0)
 
     assert_equal [:tick], ticks
+  ensure
+    timer&.terminate
+    thread&.join(2.0)
+    thread&.kill if thread&.alive?
   end
 
   def test_run_ticks_repeatedly_until_terminated

--- a/test/unit/timer_loop_test.rb
+++ b/test/unit/timer_loop_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Pins Wurk::TimerLoop, the mutex/CV "tick every N seconds until stopped"
+# primitive shared by History, Metrics::Rollup and Metrics::QueueRollup
+# (previously duplicated in each).
+class TimerLoopTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def test_run_waits_before_first_tick
+    timer = Wurk::TimerLoop.new(0.05)
+    ticks = []
+
+    thread = Thread.new do
+      timer.run do
+        ticks << :tick
+        timer.terminate
+      end
+    end
+    sleep(0.01)
+
+    assert_empty ticks, 'must not tick before the first interval elapses'
+    thread.join(2.0)
+
+    assert_equal [:tick], ticks
+  end
+
+  def test_run_ticks_repeatedly_until_terminated
+    timer = Wurk::TimerLoop.new(0.01)
+    ticks = 0
+
+    thread = Thread.new { timer.run { ticks += 1 } }
+    poll_until(2.0) { ticks >= 3 }
+    timer.terminate
+    thread.join(2.0)
+
+    assert_operator ticks, :>=, 3
+  end
+
+  # terminate signals the CV, so a thread blocked in #wait returns immediately
+  # rather than waiting out the full interval.
+  def test_terminate_wakes_a_blocked_wait
+    timer = Wurk::TimerLoop.new(60)
+    started = false
+    completed = false
+
+    thread = Thread.new do
+      started = true
+      timer.wait
+      completed = true
+    end
+    poll_until(2.0) { started }
+    timer.terminate
+    thread.join(2.0)
+
+    assert completed, 'terminate must wake a thread blocked in #wait'
+  end
+
+  # Once @done is set, #wait short-circuits (the `unless @done` branch)
+  # instead of blocking on the ConditionVariable at all.
+  def test_wait_returns_immediately_once_done
+    timer = Wurk::TimerLoop.new(60)
+    timer.terminate
+
+    completed = false
+    thread = Thread.new do
+      timer.wait
+      completed = true
+    end
+    thread.join(2.0)
+
+    assert completed, 'wait must return immediately once terminated'
+  end
+
+  def test_run_never_yields_once_terminated_before_start
+    timer = Wurk::TimerLoop.new(60)
+    timer.terminate
+
+    ticked = false
+    thread = Thread.new { timer.run { ticked = true } }
+    thread.join(2.0)
+
+    refute ticked, 'run must not tick if already terminated before the first wait'
+  end
+
+  private
+
+  def poll_until(timeout)
+    deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + timeout
+    sleep(0.005) until yield || ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) > deadline
+  end
+end

--- a/test/unit/web_pool_scope_test.rb
+++ b/test/unit/web_pool_scope_test.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Dedicated web pool (#101): the dashboard / JSON API / SSE run on their own
+# Redis pool, disjoint from the worker capsules', so dashboard load can't
+# exhaust the connections a co-located worker needs (and vice versa).
+# Wurk::Web::PoolScope routes `Wurk.redis` onto that pool for the request.
+class WebPoolScopeTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def teardown
+    Thread.current[:wurk_capsule] = nil
+    # This class builds the global config's web/worker pools; drop them so a
+    # sibling class in the same fork rebuilds lazily against its own DB.
+    Wurk.configuration.reset_redis_pools!
+  ensure
+    super
+  end
+
+  # --- routing -----------------------------------------------------------
+
+  def test_scope_routes_wurk_redis_to_the_web_pool
+    # Baseline outside the scope: the default capsule (worker) pool.
+    refute_same Wurk.configuration.web_redis_pool, Wurk.redis_pool
+
+    Wurk::Web::PoolScope.scope do
+      assert_same Wurk.configuration.web_redis_pool, Wurk.redis_pool
+    end
+  end
+
+  def test_scope_restores_thread_local_afterwards
+    assert_nil Thread.current[:wurk_capsule]
+
+    Wurk::Web::PoolScope.scope { assert_equal Wurk::Web::PoolScope.handle, Thread.current[:wurk_capsule] }
+
+    assert_nil Thread.current[:wurk_capsule]
+  end
+
+  def test_scope_restores_thread_local_after_exception
+    assert_nil Thread.current[:wurk_capsule]
+
+    assert_raises(RuntimeError) { Wurk::Web::PoolScope.scope { raise 'boom' } }
+
+    assert_nil Thread.current[:wurk_capsule]
+  end
+
+  # A worker thread that already carries a capsule binding is restored, not
+  # clobbered, on the way out of a web scope.
+  def test_scope_restores_prior_capsule_binding
+    cap = Wurk.configuration.default_capsule
+    Thread.current[:wurk_capsule] = cap
+
+    Wurk::Web::PoolScope.scope do
+      assert_same Wurk.configuration.web_redis_pool, Wurk.redis_pool
+    end
+
+    assert_same cap, Thread.current[:wurk_capsule]
+  end
+
+  def test_nested_scopes_restore_to_outer
+    Wurk::Web::PoolScope.scope do
+      outer = Wurk.redis_pool
+
+      Wurk::Web::PoolScope.scope { assert_same outer, Wurk.redis_pool }
+
+      assert_same outer, Wurk.redis_pool
+    end
+  end
+
+  # --- handle ------------------------------------------------------------
+
+  def test_handle_is_memoized
+    assert_same Wurk::Web::PoolScope.handle, Wurk::Web::PoolScope.handle
+  end
+
+  # The handle resolves the pool on each call, so a post-fork reset rebuild is
+  # picked up transparently rather than pinning a stale pool.
+  def test_handle_resolves_current_web_pool_after_reset
+    first = nil
+    Wurk::Web::PoolScope.scope { first = Wurk.redis_pool }
+
+    Wurk.configuration.reset_redis_pools!
+
+    Wurk::Web::PoolScope.scope { refute_same first, Wurk.redis_pool }
+  end
+
+  # --- isolation ---------------------------------------------------------
+
+  # The headline guarantee: saturating the web pool leaves the worker pool
+  # fully available. Uses a local config so the small web pool doesn't perturb
+  # the shared global one.
+  def test_saturated_web_pool_does_not_starve_worker_pool
+    config = isolated_config(web_pool_size: 1)
+    web = config.web_redis_pool
+    hold = hold_only_connection(web)
+
+    assert_equal 0, web.available, 'the only web connection should be checked out'
+    assert_pool_usable config.default_capsule.redis_pool
+  ensure
+    hold&.release
+    config&.reset_redis_pools!
+  end
+
+  # A background thread holding a pool's only connection until #release, so a
+  # test can prove a *different* pool stays available while it's checked out.
+  Hold = Struct.new(:thread, :release_queue) do
+    def release
+      release_queue << :go
+      thread.join(2)
+    end
+  end
+
+  private
+
+  def isolated_config(web_pool_size:)
+    config = Wurk::Configuration.new
+    config.redis = { url: Wurk::Test.redis_url }
+    config.web_pool_size = web_pool_size
+    config
+  end
+
+  # Checks out (and holds) a connection from a size-1 pool on a background
+  # thread, blocking until it is held, so the pool is saturated for the caller.
+  def hold_only_connection(pool)
+    gate = Queue.new
+    release = Queue.new
+    thread = Thread.new do
+      pool.with do |conn|
+        conn.call('PING')
+        gate << :held
+        release.pop
+      end
+    end
+    gate.pop
+    Hold.new(thread, release)
+  end
+
+  def assert_pool_usable(pool)
+    assert_operator pool.available, :>, 0, 'the pool must retain free slots'
+    assert_equal 'PONG', pool.with { |conn| conn.call('PING') }, 'checkout must still succeed'
+  end
+end

--- a/test/unit/web_search_test.rb
+++ b/test/unit/web_search_test.rb
@@ -124,6 +124,27 @@ class WebSearchTest < Wurk::Test::UnitCase
     assert_equal total, hits.select { |h| h[:klass] == @class_a }.size
   end
 
+  def test_search_small_queue_is_not_truncated
+    push_to_queue(@class_a, [@needle])
+
+    search = Wurk::Web::Search.new(@needle, kinds: ['queues'])
+    search.to_a
+
+    refute_predicate search, :truncated?
+  end
+
+  # A queue longer than the per-queue scan cap must stop early and flag
+  # truncation rather than full-walk the LIST from a single keystroke.
+  def test_search_truncates_queue_past_scan_cap
+    seed_queue(Wurk::Web::Search::SCAN_LIMIT_PER_QUEUE + 1)
+
+    search = Wurk::Web::Search.new("absent-#{@ns}", kinds: ['queues'])
+    hits = search.to_a
+
+    assert_empty(hits.select { |h| h[:name] == @queue })
+    assert_predicate search, :truncated?
+  end
+
   # Queue payload with no enqueued_at / created_at exercises the nil sides
   # of `record.enqueued_at&.to_f` (line 115) and `record.created_at&.to_f`
   # (line 116) in queue_row.
@@ -162,6 +183,16 @@ class WebSearchTest < Wurk::Test::UnitCase
   end
 
   private
+
+  # Bulk-seed a queue with `count` non-matching payloads in one RPUSH so the
+  # scan-cap tests can exceed SCAN_LIMIT_PER_QUEUE without thousands of calls.
+  def seed_queue(count)
+    payload = Wurk.dump_json(bare_payload(@class_a, ['filler']))
+    Wurk.redis do |c|
+      c.call('SADD', 'queues', @queue)
+      c.call('RPUSH', "queue:#{@queue}", *Array.new(count, payload))
+    end
+  end
 
   def push_bare_to_queue(klass, args)
     payload = bare_payload(klass, args)

--- a/test/unit/web_search_test.rb
+++ b/test/unit/web_search_test.rb
@@ -145,6 +145,30 @@ class WebSearchTest < Wurk::Test::UnitCase
     assert_predicate search, :truncated?
   end
 
+  # A keystroke against a queue with thousands of non-matching jobs must never
+  # full-walk the LIST: round trips stay bounded by the scan cap, not the
+  # queue's real size. Thread-local Thread.current[:wurk_capsule] override (not
+  # a global monkeypatch) so counting is safe under this class's parallelize_me!.
+  def test_search_bounds_round_trips_on_a_huge_no_match_queue
+    seed_queue(10_000)
+    counter = RoundTripCounter.new(Wurk.redis_pool)
+    Thread.current[:wurk_capsule] = counter
+
+    search = Wurk::Web::Search.new("absent-#{@ns}", kinds: ['queues'])
+    hits = search.to_a
+
+    assert_empty hits
+    assert_predicate search, :truncated?
+    # Queue.all (1 SMEMBERS) + LLEN (1) + one LRANGE per QUEUE_PAGE up to
+    # SCAN_LIMIT_PER_QUEUE — never proportional to the queue's real size (10k
+    # would need ~200 LRANGE calls to full-walk instead of the capped ~100).
+    max_round_trips = 2 + (Wurk::Web::Search::SCAN_LIMIT_PER_QUEUE / Wurk::Web::Search::QUEUE_PAGE)
+
+    assert_operator counter.count, :<=, max_round_trips
+  ensure
+    Thread.current[:wurk_capsule] = nil
+  end
+
   # Queue payload with no enqueued_at / created_at exercises the nil sides
   # of `record.enqueued_at&.to_f` (line 115) and `record.created_at&.to_f`
   # (line 116) in queue_row.
@@ -183,6 +207,25 @@ class WebSearchTest < Wurk::Test::UnitCase
   end
 
   private
+
+  # Delegating pool that counts checkouts (one per `Wurk.redis` block). Doubles
+  # as its own `Thread.current[:wurk_capsule]` binding (`#redis_pool` returns
+  # self) so a test can measure round trips without a global monkeypatch.
+  class RoundTripCounter
+    attr_reader :count
+
+    def initialize(pool)
+      @pool = pool
+      @count = 0
+    end
+
+    def with(&)
+      @count += 1
+      @pool.with(&)
+    end
+
+    def redis_pool = self
+  end
 
   # Bulk-seed a queue with `count` non-matching payloads in one RPUSH so the
   # scan-cap tests can exceed SCAN_LIMIT_PER_QUEUE without thousands of calls.

--- a/test/unit/web_search_test.rb
+++ b/test/unit/web_search_test.rb
@@ -169,6 +169,33 @@ class WebSearchTest < Wurk::Test::UnitCase
     Thread.current[:wurk_capsule] = nil
   end
 
+  # A no-match keystroke against a sorted set larger than the shared request
+  # budget must stop at SCAN_BUDGET rather than ZSCAN the whole ZSET. Binds a
+  # round-trip-counting capsule to this thread (not a global monkeypatch) so
+  # counting is safe under this class's parallelize_me!. ZSCAN's COUNT is only a
+  # hint, so the assertion bounds round trips below a full walk rather than at an
+  # exact page count.
+  def test_search_bounds_scan_on_a_huge_no_match_sorted_set
+    seed_size = 2 * Wurk::Web::Search::SCAN_BUDGET
+    seed_zset('retry', seed_size)
+    counter = RoundTripCounter.new(Wurk.redis_pool)
+    Thread.current[:wurk_capsule] = counter
+
+    search = Wurk::Web::Search.new("absent-#{@ns}", kinds: ['retry'])
+    hits = search.to_a
+
+    assert_empty hits
+    assert_predicate search, :truncated?
+    # A full walk would need seed_size / ZSCAN_PAGE ZSCANs; the budget caps the
+    # scan near SCAN_BUDGET / ZSCAN_PAGE — strictly fewer, proving it stops at
+    # the request budget, not the ZSET's real size.
+    full_walk = seed_size / Wurk::Web::Search::ZSCAN_PAGE
+
+    assert_operator counter.count, :<, full_walk
+  ensure
+    Thread.current[:wurk_capsule] = nil
+  end
+
   # Queue payload with no enqueued_at / created_at exercises the nil sides
   # of `record.enqueued_at&.to_f` (line 115) and `record.created_at&.to_f`
   # (line 116) in queue_row.
@@ -235,6 +262,17 @@ class WebSearchTest < Wurk::Test::UnitCase
       c.call('SADD', 'queues', @queue)
       c.call('RPUSH', "queue:#{@queue}", *Array.new(count, payload))
     end
+  end
+
+  # Bulk-seed a sorted set with `count` distinct non-matching members in one
+  # ZADD so the scan-budget test can exceed SCAN_BUDGET without thousands of
+  # calls. A filler class (not @class_a/@class_b) keeps teardown's cleanup_zset
+  # from ZREMing them one-by-one; the worker's FLUSHDB clears them. Each payload
+  # carries a unique jid, so no two members collide.
+  def seed_zset(name, count)
+    filler = "SearchFiller@#{@ns}"
+    args = Array.new(count) { |i| [i, Wurk.dump_json(bare_payload(filler, ['filler']))] }.flatten
+    Wurk.redis { |c| c.call('ZADD', name, *args) }
   end
 
   def push_bare_to_queue(klass, args)


### PR DESCRIPTION
## Summary
- CSRF: `SameOriginGuard` on every engine mutating endpoint (`Sec-Fetch-Site: same-origin`), extracted for `ApiController` + `ExtensionsController`, mirroring the standalone Rack path.
- Dedicated web Redis pool (disjoint from worker pools) via `Wurk::Web::PoolScope`, so dashboard load can't starve worker fetch/processing.
- SSE stream cap (`StreamConcurrencyGuard`, 503 + Retry-After past 10 concurrent) and lowered max duration; `Wurk::Web::Search` bounds per-queue/per-request scan (`truncated` flag) so a keystroke never full-walks a huge queue LIST.
- `Wurk::TimerLoop` extraction (History/Metrics::Rollup/Metrics::QueueRollup dedup), structured `redis_unavailable` 503s, asset-mount authorization doc.
- New route-table-driven test proving the CSRF guard actually 403s every mutating route without the header and passes with it (previous suites only ever sent the header, never proved the reject path) + a Redis round-trip-counting test proving Search's scan stays bounded on a 10k-job no-match queue.

## Test plan
- [x] `bin/rake test` (2521 runs, 2 pre-existing unrelated DST failures in `cron_test.rb`, confirmed failing on `origin/main` too)
- [x] `bin/rake test TEST=test/engine/csrf_same_origin_test.rb`
- [x] `bin/rake test TEST=test/unit/web_search_test.rb`
- [x] `bundle exec rubocop` on touched files (clean)
- [x] `COVERAGE=1 bin/rake test` — line 96.79%, branch 90.87% (both ≥90% gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added same-origin protection for dashboard and extension mutations.
  * Documented asset access, authorization boundaries, and Redis outage behavior.

* **Reliability**
  * Redis failures now return structured 503 responses and SSE error events.
  * Limited concurrent live streams and reduced maximum stream duration.

* **Performance**
  * Added bounded search scanning with truncation indicators.
  * Isolated dashboard traffic through a dedicated Redis connection pool.

* **Bug Fixes**
  * Profile data lookups now consistently use profile storage records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->