### PR TITLE
fix(metrics): stop top_jobs double-counting; 4-digit-year j| key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Wurk are recorded here. Format: [Keep a Changelog](https:
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-07-18
+
+### Fixed
+- **Metrics — `top_jobs` double-counted throughput and the per-job series had false 10× spikes** — the writer kept a `j|<date>|H:m0` 10-minute rollup whose key format collides with the real minute-0 bucket, so every job at a minute ending 1–9 was also folded into that decade's `x0` key, turning it into a decade total. `Metrics::Query` then summed the `x0` bucket alongside the individual minutes, roughly doubling every count in the Metrics "top jobs" table and putting a ~10× spike at every `:00/:10/:20…` point on the per-job chart. The rollup is removed (stock Sidekiq never persisted it — its daily/hourly rollups are commented out — and reads the last N per-minute keys), which fixes the count with no read-side change and drops ~⅓ of the per-job metric-write commands on the hot path.
+- **Metrics — per-minute key now uses a 4-digit year (`j|YYYYMMDD|…`)** — the bucket key used a 2-digit year (`j|YYMMDD|…`) while stock Sidekiq (and Wurk's own deploy-marks key) use `YYYYMMDD`, so a Sidekiq→Wurk drop-in swap silently orphaned the existing metrics history. Keys now match Sidekiq, so migrated data resolves unchanged.
+
+### Changed
+- **Profiler — profile persist is one round-trip** — `Profiler.store` pipelines its `HSET` + `EXPIRE` + `ZADD` (was three sequential calls). Same keys/TTL; off the hot path (opt-in profiling).
+
 ## [1.1.1] - 2026-07-18
 
 ### Fixed

--- a/docs/target/sidekiq-free.md
+++ b/docs/target/sidekiq-free.md
@@ -107,9 +107,8 @@ cancelled : timestamp (int) if cancelled
 
 | Key | Type | Purpose |
 |---|---|---|
-| `j\|<YYMMDD>\|<H>:<M>` | HASH | per-minute job execution metrics, TTL = `MID_TERM` (3 days) |
-| `j\|<YYMMDD>\|<H>:<m0>` | HASH | 10-minute bucket (last digit of minute stripped), TTL = `SHORT_TERM` (8 hours) |
-| `<klass>-<YYMMDD>-<H>` | HASH | hourly histogram per class |
+| `j\|<YYYYMMDD>\|<H>:<M>` | HASH | per-minute job execution metrics, TTL = `MID_TERM` (3 days). Same key Sidekiq writes, so migrated data resolves unchanged |
+| `<klass>-<YYYYMMDD>-<H>` | HASH | hourly histogram per class |
 | `<YYYYMMDD>-marks` | HASH | deploy marks for day, field=iso8601 ts, value=label, TTL = 90 days |
 | `deploylock-<label>` | STRING | per-label deploy mark lock, EX 60 NX |
 

--- a/lib/wurk/metrics/history.rb
+++ b/lib/wurk/metrics/history.rb
@@ -6,42 +6,42 @@ module Wurk
   module Metrics
     # Ent feature parity (§5): server middleware that records per-job-class
     # execution metrics into Redis time-buckets. The on-the-wire schema is
-    # wire-compat with Sidekiq 8.x's history pane so dashboards built against
-    # `j|YYMMDD|H:M` HASH keys keep working unchanged.
+    # wire-compat with Sidekiq's history pane — Sidekiq keys the per-minute
+    # HASH as `j|<YYYYMMDD>|<H>:<M>`, so dashboards (and Sidekiq data migrated
+    # in place) keep resolving against the same key after a drop-in swap.
     #
     # Bucket layout (spec: docs/target/sidekiq-free.md §1.6):
     #
-    #   j|YYMMDD|H:M    HASH   per-minute bucket, TTL = MID_TERM (3 days)
-    #     <klass>|p     INT    processed count
-    #     <klass>|f     INT    failed count
-    #     <klass>|ms    INT    total ms spent
+    #   j|YYYYMMDD|H:M    HASH   per-minute bucket, TTL = MID_TERM (3 days)
+    #     <klass>|p       INT    processed count
+    #     <klass>|f       INT    failed count
+    #     <klass>|ms      INT    total ms spent
     #
-    #   j|YYMMDD|H:m0   HASH   10-minute rollup (last digit zeroed),
-    #                          TTL = SHORT_TERM (8 hours) — short window for
-    #                          quick aggregate queries without scanning 600 minute keys.
+    #   <klass>-YYYYMMDD-H  HASH per-class hourly histogram, TTL = MID_TERM
     #
-    #   <klass>-YYMMDD-H  HASH per-class hourly histogram, TTL = MID_TERM
+    # We deliberately do NOT write a `H:m0` 10-minute rollup. Its key format
+    # collides with the real minute-0 bucket, so rolling x1..x9 into it turns
+    # that minute's value into a decade total — and the read side (Query) then
+    # sums the minute-0 bucket alongside x1..x9 and double-counts. Sidekiq
+    # itself doesn't keep that rollup (the daily/hourly rollups are commented
+    # out in its ExecutionTracker); Query reads the last N per-minute keys.
     #
-    # Every bucket TTL is set on first write (EXPIRE NX-equivalent: only when
-    # the HASH was newly created in this call) — re-asserting TTL on every
-    # write would keep the bucket alive indefinitely while traffic continues,
-    # but that's the desired behavior here: as long as a class keeps running,
-    # we keep the minute bucket around for the retention window measured from
+    # Every bucket TTL is set on every write (not NX): as long as a class keeps
+    # running we keep its bucket around for the retention window measured from
     # *last write*, not from first write. So we EXPIRE unconditionally.
     #
-    # The middleware is hot-path — every successful job pays for it. Writes
-    # are pipelined in a single round-trip per job (1 HINCRBY × 3 + 1 EXPIRE
-    # per bucket × 3 buckets = 12 commands, batched).
+    # The middleware is hot-path — every successful job pays for it. Writes are
+    # pipelined in a single round-trip per job (1 HINCRBY × 2 + 1 EXPIRE per
+    # bucket × 2 buckets = 6 commands, batched).
     class History
       include Wurk::Middleware::ServerMiddleware
 
       # Per spec §1.6 — naming mirrors the upstream constants so anyone
       # grepping the Sidekiq source for `MID_TERM` lands here.
       MID_TERM = 3 * 24 * 60 * 60      # 3 days, in seconds
-      SHORT_TERM = 8 * 60 * 60         # 8 hours, in seconds
 
       MINUTE_KEY_PREFIX = 'j|'
-      DATE_FORMAT = '%y%m%d'           # YYMMDD — two-digit year per spec
+      DATE_FORMAT = '%Y%m%d'           # YYYYMMDD — matches Sidekiq's j| key
 
       def call(_worker, job, _queue)
         klass = job['class']
@@ -74,28 +74,20 @@ module Wurk
 
           ms = duration_ms.to_i
           ms = 0 if ms.negative?
-          buckets = { minute: minute_key(at), rollup: rollup_key(at), hour: hour_key(klass, at) }
+          buckets = { minute: minute_key(at), hour: hour_key(klass, at) }
           with_pool(redis_pool) { |conn| pipeline_write(conn, klass, ms, success, buckets) }
           nil
         end
 
-        # Minute + 10-min rollup share a per-class `|p|f|ms` field layout;
-        # the hourly bucket is already class-scoped so its fields are bare
-        # `p|f|ms`. Pipeline all 9 commands in one round-trip.
+        # The minute bucket carries per-class `<klass>|p|f|ms` fields; the
+        # hourly bucket is already class-scoped so its fields are bare
+        # `p|f|ms`. Pipeline all 6 commands in one round-trip.
         def pipeline_write(conn, klass, ms, success, buckets)
           outcome = success ? 'p' : 'f'
           class_outcome = "#{klass}|#{outcome}"
           class_ms = "#{klass}|ms"
           conn.pipelined do |pipe|
             incr_bucket(pipe, buckets[:minute], [class_outcome, class_ms, ms, MID_TERM])
-            # The minute key and the 10-min rollup key coincide whenever the
-            # minute ends in 0 (rollup zeroes the last digit). Writing both
-            # would double-count the shared field — the minute write above
-            # already lands on it — so skip the rollup write then. Minutes
-            # x1..x9 still accumulate into the x0 rollup key as normal.
-            unless buckets[:rollup] == buckets[:minute]
-              incr_bucket(pipe, buckets[:rollup], [class_outcome, class_ms, ms, SHORT_TERM])
-            end
             incr_bucket(pipe, buckets[:hour], [outcome, 'ms', ms, MID_TERM])
           end
         end
@@ -113,12 +105,6 @@ module Wurk
           t = time.utc
           format("#{MINUTE_KEY_PREFIX}%<date>s|%<hr>d:%<min>d",
                  date: t.strftime(DATE_FORMAT), hr: t.hour, min: t.min)
-        end
-
-        def rollup_key(time)
-          t = time.utc
-          format("#{MINUTE_KEY_PREFIX}%<date>s|%<hr>d:%<min>d",
-                 date: t.strftime(DATE_FORMAT), hr: t.hour, min: (t.min / 10) * 10)
         end
 
         def hour_key(klass, time)

--- a/lib/wurk/profiler.rb
+++ b/lib/wurk/profiler.rb
@@ -50,11 +50,13 @@ module Wurk
         key = profile_key(token, jid)
         gz = gzip(gecko_json)
         with_pool(pool) do |conn|
-          conn.call('HSET', key, 'jid', jid, 'type', type, 'token', token,
-                    'started_at', started_at.to_i, 'elapsed', elapsed_ms.to_i,
-                    'size', gz.bytesize, 'sid', sid.to_s, 'data', gz)
-          conn.call('EXPIRE', key, TTL)
-          conn.call('ZADD', Keys::PROFILES, (now + TTL).to_i, key)
+          conn.pipelined do |pipe|
+            pipe.call('HSET', key, 'jid', jid, 'type', type, 'token', token,
+                      'started_at', started_at.to_i, 'elapsed', elapsed_ms.to_i,
+                      'size', gz.bytesize, 'sid', sid.to_s, 'data', gz)
+            pipe.call('EXPIRE', key, TTL)
+            pipe.call('ZADD', Keys::PROFILES, (now + TTL).to_i, key)
+          end
         end
         key
       end

--- a/lib/wurk/version.rb
+++ b/lib/wurk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wurk
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end

--- a/test/unit/metrics_history_test.rb
+++ b/test/unit/metrics_history_test.rb
@@ -23,12 +23,12 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
         c.call('DEL', *keys) unless keys.empty?
         break if cursor == '0'
       end
-      # Per-class fields live in shared, non-class-named minute/rollup buckets
-      # that SCAN can't reach. HDEL our fields from every bucket this test
-      # could have written: the fixed @at bucket (record tests) AND the
-      # current-time bucket (middleware tests record at Time.now).
-      bucket_keys = [@at, ::Time.now.utc].flat_map do |t|
-        [Wurk::Metrics::History.minute_key(t), Wurk::Metrics::History.rollup_key(t)]
+      # Per-class fields live in shared, non-class-named minute buckets that
+      # SCAN can't reach. HDEL our fields from every bucket this test could
+      # have written: the fixed @at bucket (record tests) AND the current-time
+      # bucket (middleware tests record at Time.now).
+      bucket_keys = [@at, ::Time.now.utc].map do |t|
+        Wurk::Metrics::History.minute_key(t)
       end
       bucket_keys.uniq.each do |key|
         c.call('HDEL', key, "#{@klass}|p", "#{@klass}|f", "#{@klass}|ms")
@@ -41,26 +41,20 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
   # ---- bucket key formatting -----------------------------------------------
 
   def test_minute_key_format
-    assert_equal 'j|260521|14:37', Wurk::Metrics::History.minute_key(@at)
-  end
-
-  def test_rollup_key_zeroes_last_digit_of_minute
-    assert_equal 'j|260521|14:30', Wurk::Metrics::History.rollup_key(@at)
-    assert_equal 'j|260521|14:30', Wurk::Metrics::History.rollup_key(::Time.utc(2026, 5, 21, 14, 39))
-    assert_equal 'j|260521|14:40', Wurk::Metrics::History.rollup_key(::Time.utc(2026, 5, 21, 14, 40))
+    assert_equal 'j|20260521|14:37', Wurk::Metrics::History.minute_key(@at)
   end
 
   def test_hour_key_format
-    assert_equal 'FooJob-260521-14', Wurk::Metrics::History.hour_key('FooJob', @at)
+    assert_equal 'FooJob-20260521-14', Wurk::Metrics::History.hour_key('FooJob', @at)
   end
 
   def test_minute_key_uses_utc
     local_time = ::Time.utc(2026, 5, 21, 23, 30) + 60
 
-    assert_equal 'j|260521|23:31', Wurk::Metrics::History.minute_key(local_time)
+    assert_equal 'j|20260521|23:31', Wurk::Metrics::History.minute_key(local_time)
   end
 
-  # ---- record() writes to all three buckets --------------------------------
+  # ---- record() writes to both buckets -------------------------------------
 
   def test_record_writes_processed_counter_in_minute_bucket
     Wurk::Metrics::History.record(@klass, 42, success: true, at: @at)
@@ -90,28 +84,21 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
     assert_equal '35', val
   end
 
-  def test_record_writes_rollup_bucket
-    Wurk::Metrics::History.record(@klass, 15, success: true, at: @at)
-
-    rollup = Wurk::Metrics::History.rollup_key(@at)
-    val = Wurk.redis { |c| c.call('HGET', rollup, "#{@klass}|p") }
-
-    assert_equal '1', val
-  end
-
-  # Regression: at minutes ending in 0 the minute and rollup keys coincide,
-  # so record must write the shared field once (not twice → "2").
-  def test_record_does_not_double_count_at_rollup_boundary
-    at = ::Time.utc(2026, 5, 21, 14, 30, 0)
-    minute = Wurk::Metrics::History.minute_key(at)
+  # Regression (#metrics-double-count): we must NOT write a `H:m0` 10-minute
+  # rollup. Its key would coincide with the minute-0 bucket, so a write at any
+  # minute x1..x9 would inflate the minute-0 value into a decade total — which
+  # the read side then sums alongside x1..x9 and double-counts. A minute x1..x9
+  # write must touch its own minute key and nothing in that decade's x0 key.
+  def test_record_does_not_write_a_ten_minute_rollup_bucket
+    at = ::Time.utc(2026, 5, 21, 14, 37, 0)
+    x0 = ::Time.utc(2026, 5, 21, 14, 30, 0)
     Wurk::Metrics::History.record(@klass, 5, success: true, at: at)
 
-    assert_equal minute, Wurk::Metrics::History.rollup_key(at), 'precondition: keys collide at x0 minutes'
-    val = Wurk.redis { |c| c.call('HGET', minute, "#{@klass}|p") }
+    x0_val = Wurk.redis { |c| c.call('HGET', Wurk::Metrics::History.minute_key(x0), "#{@klass}|p") }
 
-    assert_equal '1', val
+    assert_nil x0_val, 'x1..x9 write must not bleed into the decade x0 bucket'
   ensure
-    Wurk.redis { |c| c.call('HDEL', minute, "#{@klass}|p", "#{@klass}|f", "#{@klass}|ms") } if minute
+    Wurk.redis { |c| c.call('HDEL', Wurk::Metrics::History.minute_key(x0), "#{@klass}|p") }
   end
 
   def test_record_writes_hourly_bucket
@@ -133,15 +120,6 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
 
     assert_operator ttl, :>, Wurk::Metrics::History::MID_TERM - 60
     assert_operator ttl, :<=, Wurk::Metrics::History::MID_TERM
-  end
-
-  def test_record_sets_rollup_ttl_to_short_term
-    Wurk::Metrics::History.record(@klass, 1, success: true, at: @at)
-
-    ttl = Wurk.redis { |c| c.call('TTL', Wurk::Metrics::History.rollup_key(@at)) }
-
-    assert_operator ttl, :>, Wurk::Metrics::History::SHORT_TERM - 60
-    assert_operator ttl, :<=, Wurk::Metrics::History::SHORT_TERM
   end
 
   def test_record_sets_hourly_ttl_to_mid_term

--- a/test/unit/metrics_query_test.rb
+++ b/test/unit/metrics_query_test.rb
@@ -33,14 +33,13 @@ class MetricsQueryTest < Wurk::Test::UnitCase
     super
   end
 
-  # Per-class fields only — never DEL the shared minute/rollup buckets, or
-  # other parallel tests for the same minute will lose their writes.
+  # Per-class fields only — never DEL the shared minute buckets, or other
+  # parallel tests for the same minute will lose their writes.
   def delete_class_fields(conn)
-    [@now, @now - 60, @now - 120].each do |t|
-      [Wurk::Metrics::History.minute_key(t), Wurk::Metrics::History.rollup_key(t)].each do |key|
-        [@klass_a, @klass_b].each do |kls|
-          conn.call('HDEL', key, "#{kls}|p", "#{kls}|f", "#{kls}|ms", "#{kls}|x", "#{kls}nodelim")
-        end
+    [@now, @now - 60, @now - 120, @now - 180, @now - 240, @now - 300, @now - 360, @now - 420].each do |t|
+      key = Wurk::Metrics::History.minute_key(t)
+      [@klass_a, @klass_b].each do |kls|
+        conn.call('HDEL', key, "#{kls}|p", "#{kls}|f", "#{kls}|ms", "#{kls}|x", "#{kls}nodelim")
       end
     end
   end
@@ -107,6 +106,21 @@ class MetricsQueryTest < Wurk::Test::UnitCase
 
     assert_equal({ p: 1, f: 1, ms: 300 }, found[@klass_a])
     assert_equal({ p: 1, f: 0, ms: 50 }, found[@klass_b])
+  end
+
+  # Regression (#metrics-double-count): before the fix, a job at minute x1..x9
+  # was also written into that decade's x0 key (the old 10-min rollup), so a
+  # window spanning the x0 minute summed each job twice. @now is 14:37; these
+  # three land at 14:31/32/33 (all in decade 14:30), and a 10-minute window
+  # reaches back over 14:30. The total must be 3, not 6.
+  def test_top_jobs_does_not_double_count_across_the_rollup_boundary
+    [31, 32, 33].each do |m|
+      Wurk::Metrics::History.record(@klass_a, 100, success: true, at: ::Time.utc(2026, 5, 21, 14, m, 0))
+    end
+
+    found = Wurk::Metrics::Query.top_jobs(minutes: 10, now: @now).to_h
+
+    assert_equal({ p: 3, f: 0, ms: 300 }, found[@klass_a])
   end
 
   def test_top_jobs_sorted_descending_by_volume

--- a/test/unit/metrics_query_test.rb
+++ b/test/unit/metrics_query_test.rb
@@ -267,6 +267,10 @@ class MetricsQueryTest < Wurk::Test::UnitCase
     assert(points.all? { |p| p[:size].zero? && p[:latency].zero? })
   end
 
+  def test_queue_history_returns_empty_when_no_queues
+    assert_equal [], Wurk::Metrics::Query.queue_history('1m', 300, queues: [], now: @now)
+  end
+
   def test_queue_history_rejects_unknown_bucket
     assert_raises(ArgumentError) { Wurk::Metrics::Query.queue_history('2m', 300, queues: ['x'], now: @now) }
   end

--- a/test/unit/metrics_queue_rollup_test.rb
+++ b/test/unit/metrics_queue_rollup_test.rb
@@ -34,6 +34,17 @@ class MetricsQueueRollupTest < Wurk::Test::UnitCase
     super
   end
 
+  # A missing or malformed head-of-line payload must yield 0.0 latency for that
+  # queue, never bubble up and abort the whole sampling pass.
+  def test_head_latency_is_zero_for_missing_or_malformed_payloads
+    now_ms = @epoch_min * 1000
+
+    assert_in_delta 0.0, @qr.send(:head_latency, [], now_ms)          # empty LRANGE → nil
+    assert_in_delta 0.0, @qr.send(:head_latency, nil, now_ms)         # non-array nil
+    assert_in_delta 0.0, @qr.send(:head_latency, ['not json'], now_ms) # unparseable
+    assert_in_delta 0.0, @qr.send(:head_latency, ['[1,2,3]'], now_ms)  # valid JSON, wrong shape
+  end
+
   def test_sample_writes_size_for_each_queue_at_every_resolution
     seed_queue(@q1, depth: 3)
     seed_queue(@q2, depth: 1)

--- a/test/unit/profiler_test.rb
+++ b/test/unit/profiler_test.rb
@@ -41,6 +41,22 @@ class ProfilerTest < Wurk::Test::UnitCase
     end
   end
 
+  # Forked workers persist through their own capsule pool, so `store` accepts an
+  # explicit `pool:` — exercise that path (not just the default `Wurk.redis`).
+  def test_store_writes_through_an_explicit_pool
+    pool = Wurk::RedisPool.new(size: 1, url: Wurk::Test.redis_url)
+    key = Wurk::Profiler.store(jid: 'jp', type: 'vernier', gecko_json: GECKO,
+                               started_at: ::Time.at(1_700_000_000), elapsed_ms: 7, token: 'tp', pool: pool)
+
+    assert_equal 'tp-jp', key
+    Wurk.redis do |c|
+      assert_equal 'jp', c.call('HGET', key, 'jid')
+      assert_operator c.call('ZSCORE', Wurk::Keys::PROFILES, key).to_i, :>, 0
+    end
+  ensure
+    pool&.disconnect!
+  end
+
   def test_store_score_is_future_expiry
     key = Wurk::Profiler.store(jid: 'j2', type: 'vernier', gecko_json: GECKO,
                                started_at: ::Time.now, elapsed_ms: 1, token: 't2')


### PR DESCRIPTION
## Metrics — two correctness bugs (both proven against real Redis + Sidekiq 7.3.10 source)

### 1. `top_jobs` double-counts; per-job series has false 10× spikes
The writer kept a `j|<date>|H:m0` 10-minute rollup whose key format **collides with the real minute-0 bucket** (`history.rb`). Every job at a minute ending 1–9 also incremented that decade's `x0` key, turning it into a decade total. `Metrics::Query#aggregate_minutes` then summed the `x0` bucket **alongside** the individual minutes.

**Proof:** recorded 3 jobs (14:31/32/33) → `top_jobs(minutes:10)` returned `p:6, ms:600`; `for_job`'s `14:30` point showed `3` instead of `0`. On the dashboard this ~doubles every Top-Jobs throughput number and spikes the per-job chart 10× at every `:00/:10/:20…`.

Stock Sidekiq **never persists** that rollup — its daily/hourly rollups are commented out in `ExecutionTracker`, and `Query` reads the last N per-minute keys. So the `m0` write is **removed**: fixes the count with no read-side change and drops ~⅓ of the per-job metric-write commands on the hot path (6 commands/job instead of 9).

### 2. `j|` key used a 2-digit year → orphaned metrics on drop-in swap
Wurk wrote `j|260521|…`; Sidekiq (and Wurk's own deploy-marks key) use `j|20260521|…`. Now matches Sidekiq, so migrated data resolves unchanged.

## Profiles — checked, clean
`ProfileSet` already pipelines metadata-only `HMGET`. One minor win applied: `Profiler.store` now pipelines `HSET`+`EXPIRE`+`ZADD` into one round-trip (off the hot path).

## Tests
- New read-side regression: `test_top_jobs_does_not_double_count_across_the_rollup_boundary` (asserts 3, not 6).
- New write-side regression: `test_record_does_not_write_a_ten_minute_rollup_bucket`.
- Removed the three `m0`-rollup write tests; year-format assertions updated.
- Full suite: **2529 runs, 0 failures, 0 errors**. Rubocop clean.

Updates spec §1.6 (drops the `m0` row, `YYYYMMDD` for both `j|` and the hourly key).