### PR TITLE
fix: close 8 silent-failure bugs found by the documentation audit

### DIFF
--- a/docs/batches.md
+++ b/docs/batches.md
@@ -68,7 +68,7 @@ registered into the batch at *creation* time (not at promotion), so `total` and
 | `#bid` | String | Batch id, generated at `new` |
 | `#description` / `#description=` | String | Shown in the dashboard |
 | `#callback_queue` / `#callback_queue=` | String | Queue for callback jobs (default `"default"`) |
-| `#callback_class` / `#callback_class=` | String | Stored and round-tripped; **not** used to resolve callbacks (see [Divergences](#divergences-from-sidekiq-pro)) |
+| `#callback_class` / `#callback_class=` | String or Class | The class a bare `"#method"` callback spec resolves against. A `Class` is normalized to its name; set it **before the first `#jobs` call** |
 | `#tags` / `#tags=` | Array&lt;String&gt; | Coerced to strings; indexed at `tags:<tag>` |
 | `#autoflush` / `#autoflush=` | `true` or positive Integer | Buffer pushes inside `#jobs` |
 | `#linger` / `#linger=` | Integer seconds | Post-success retention override |
@@ -113,9 +113,29 @@ batch.on(:complete, "ImportCallback#finished", "account_id" => 42)
 batch.on(:death,    PagerCallback)
 ```
 
-The target may be a Class, a `"Klass"` string, a `"Klass#method"` string, or
-anything responding to `name`. Anything else raises `ArgumentError`, as does an
-unknown event or a non-Hash `options`.
+The target may be a Class, a `"Klass"` string, a `"Klass#method"` string, or a
+class-less `"#method"` string that resolves against the batch's
+`callback_class`. Anything else raises `ArgumentError`, as does an unknown
+event or a non-Hash `options`.
+
+| Target | Invokes |
+|---|---|
+| `ImportCallback` | `ImportCallback.new.on_success(status, options)` |
+| `"ImportCallback"` | `ImportCallback.new.on_success(status, options)` |
+| `"ImportCallback#finished"` | `ImportCallback.new.finished(status, options)` |
+| `"#finished"` | `<callback_class>.new.finished(status, options)` |
+
+Set `callback_class` **before the first `#jobs` call** if you use the
+class-less form — like `description` and `tags`, it is only persisted at first
+flush, and a `"#method"` target can't resolve without it.
+
+A target that can't be resolved at run time — unknown constant, a module rather
+than a class, a missing or private method, or a class-less form with no
+`callback_class` — raises `Wurk::Batch::CallbackJob::UnresolvableTarget` and
+goes **straight to the dead set on the first attempt** rather than retrying for
+25 attempts. A `NameError` doesn't heal with time, so you see it in the Dead
+tab immediately; fix the class and retry the entry from there. Errors raised by
+the callback body itself keep the normal retry backoff.
 
 The contract is a **class with a no-argument constructor**:
 
@@ -436,13 +456,9 @@ whole feature is Lua-script atomicity.
 
 ## Divergences from Sidekiq Pro
 
-Wurk implements the batch surface in `docs/target/sidekiq-pro.md` §2. Three
+Wurk implements the batch surface in `docs/target/sidekiq-pro.md` §2. Two
 deliberate differences:
 
-- **`#callback_class` is inert.** Pro documents it as the class used to resolve
-  a bare `"#method"` callback spec. Wurk stores and round-trips the field for
-  wire compatibility but never reads it — a string target must name a resolvable
-  constant (`"ImportCallback"` or `"ImportCallback#finished"`).
 - **`Status#failure_info` always returns `[]`.** The Pro 8 data model drops the
   `b-<bid>-failinfo` hash in favour of the `failed_jids` set, which Wurk tracks;
   per-jid error payloads are intentionally not persisted. The method exists so

--- a/docs/iterable-jobs.md
+++ b/docs/iterable-jobs.md
@@ -197,28 +197,31 @@ Redis writes.
 | Event | What the run loop sees | Result |
 |---|---|---|
 | `TERM` / `INT`, in-flight finishes before `shutdown_timeout` | nothing — the loop runs to completion | job completes normally |
-| `TERM` / `INT`, still running at the deadline | `Wurk::Shutdown` (a subclass of `Interrupt`) raised into the thread | the unit of work is bulk-requeued; the job re-runs later and resumes from the **last periodic checkpoint** |
-| `TSTP` (quiet) | nothing | in-flight iteration continues to completion; no new jobs are fetched |
+| `TERM` / `INT` | the loop sees `interrupted?` at the next iteration boundary | **final** flush, `on_stop`, then a head-of-queue re-push; resumes from the exact cursor |
+| `TSTP` (quiet) | same as `TERM` — quiet sets the same processor flag | same as `TERM`; matches upstream Sidekiq |
 | `USR1` (rolling restart) | same as `TERM` on the old slot | same as `TERM` |
+| Still inside one long iteration at the deadline | `Wurk::Shutdown` (a subclass of `Interrupt`) raised into the thread | the unit of work is bulk-requeued; resumes from the **last periodic checkpoint** |
 | `SIGKILL` | nothing | the payload is still in the process's private list and is reclaimed on next boot; resumes from the last checkpoint |
-| `Wurk::Job::Interrupted` raised | `rescue Interrupted` in `perform` | **final** flush, `on_stop`, re-raise → `InterruptHandler` re-pushes at the head of the queue |
+| `Wurk::Job::Interrupted` raised by your code | `rescue Interrupted` in `perform` | same as `TERM` |
 
-Only the last row gets a final flush and an immediate head-of-queue re-push.
-The `Wurk::Shutdown` path is a hard kill: the last periodic checkpoint is what
-survives, and redelivery comes from reliable fetch reclaiming the private list.
+The loop polls the processor's shutdown flag at the top of every iteration, so
+a graceful stop checkpoints and re-pushes exactly where it left off. Only a
+single iteration that outlives `shutdown_timeout` falls back to the hard-kill
+path, where the last periodic checkpoint is what survives.
 
 ### Interrupting cooperatively
 
-The run loop raises `Interrupted` on its own **only for cancellation** (§5). It
-does not poll the processor's shutdown flag. If you want a long single iteration
-to bail out early on shutdown, check it yourself — `interrupted?` comes from
-`Wurk::Worker` and is true once the processor is stopping:
+You no longer need to poll the flag yourself for the common case. If one
+iteration is long enough that you want to bail out *inside* it, `interrupted?`
+comes from `Wurk::Worker` and is true once the processor is stopping:
 
 ```ruby
 def each_iteration(batch)
-  raise Wurk::Job::Interrupted if interrupted?
+  batch.each do |row|
+    raise Wurk::Job::Interrupted if interrupted?
 
-  batch.each { |row| process(row) }
+    process(row)
+  end
 end
 ```
 
@@ -282,12 +285,14 @@ Ordering on the two terminal paths:
 
 ```
 completion:    … → flush(final) → on_complete → DEL it-<jid>
-interruption:  … → flush(final) → on_cancel (if cancelled) → on_stop → re-raise
+interruption:  … → flush(final) → on_stop → re-raise
+cancellation:  … → on_cancel → on_stop → on_complete → DEL it-<jid>
 ```
 
 `on_stop` fires for a cancellation too — it is "the loop stopped early", not
-"the loop stopped without being cancelled". `on_complete` and `on_stop` are
-mutually exclusive.
+"the loop stopped without being cancelled". A cancelled run is treated as
+*completed* (matching upstream Sidekiq 8.1), so it fires `on_complete` as well
+and deletes its state; an interrupted run does not.
 
 `around_iteration` is the hook for per-item instrumentation, timeouts, or
 transactions:
@@ -410,9 +415,11 @@ the gem swap and vice versa.
   fixed at 5 seconds for both flushing and cancellation polling. Iterations
   should be short enough that a five-second granularity is meaningful; a single
   iteration that takes ten minutes checkpoints once, at its end.
-- **A cancelled job that gets re-pushed stays cancelled.** The `cancelled` field
-  outlives the run, so the resumed execution trips on its very first check and
-  interrupts again. That flag lives for `CANCELLATION_PERIOD` (3 days).
+- **A cancelled job terminates instead of re-cycling.** Cancellation returns
+  rather than raising `Interrupted`, so `InterruptHandler` never re-pushes it,
+  and the `it-<jid>` state — `cancelled` field included — is deleted. The
+  3-day `CANCELLATION_PERIOD` TTL now only bounds a cancel marker set for a job
+  that has not started yet.
 - **Define `include Wurk::IterableJob` before any `perform`.** The
   `method_added` guard is installed by the include and cannot see methods
   defined above it.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -88,7 +88,7 @@ Window caps (`WindowTooWide < ArgumentError` when exceeded):
 | Call | Cap | Reads |
 |------|-----|-------|
 | `top_jobs(minutes:)` | `MAX_MINUTES` = 480 (8h) | per-minute `j\|…` buckets |
-| `top_jobs(hours:)` | `MAX_HOURS` = 72, but converted to `hours * 60` minutes and re-capped at 480 — so **8 hours is the real ceiling** | per-minute buckets |
+| `top_jobs(hours:)` | `MAX_HOURS` = 72 (3d), matching the per-minute bucket retention | per-minute buckets |
 | `for_job(minutes:)` | 480 | per-minute buckets |
 | `for_job(hours:)` | 72 (3d) | per-class hourly buckets |
 | `history` / `queue_history` | window clamped to the bucket's TTL (24h / 7d / 30d) | `jr\|…` / `qm\|…` |

--- a/docs/periodic-jobs.md
+++ b/docs/periodic-jobs.md
@@ -259,29 +259,42 @@ This is the part that surprises people, so read it before you ship your first
 schedule change.
 
 The `lid` is derived from schedule + class + options. Change any of them and you
-get a **different loop**, registered alongside the old one:
+get a **different loop** — so registration prunes the ones it supersedes.
 
-- **Edited a schedule** (`"0 4 * * *"` → `"0 5 * * *"`)? The new loop is
-  registered; the old one stays in Redis and keeps firing on the old schedule.
-- **Deleted a `register` line?** Nothing removes it. It keeps firing.
-- **Renamed the job class or changed `args`/`queue`/`retry`?** Same story.
+After a `config.periodic` block registers, Wurk removes every loop in the
+registry whose `klass` matches a class that block registered and whose `lid`
+isn't one it just wrote. So:
 
-Nothing prunes orphans automatically. Clean up explicitly — either from a
-console after the deploy, or from the same initializer before you register:
+- **Edited a schedule** (`"0 4 * * *"` → `"0 5 * * *"`)? The old loop is pruned
+  on the next worker boot. Only the new schedule fires.
+- **Changed `args`/`queue`/`retry`?** Same — superseded, pruned.
+- **Deleted the `register` line entirely?** **Not** pruned. Nothing in the
+  surviving code mentions that class, so no scope can see it. It keeps firing.
+  Remove it explicitly.
+
+Pruning is scoped by class precisely so it stays safe: a process that registers
+only some of your loops never touches the others, and a process that registers
+none — a client-only or web process — deletes nothing.
 
 ```ruby
-# one-off, from `rails runner`, once the new workers have booted and registered
+# a deleted register line still needs a manual removal, once, after deploy
 Wurk::Cron::LoopSet.new.each do |lp|
-  next unless lp.klass == "NightlyJob" && lp.schedule == "0 4 * * *" # the stale one
+  next unless lp.klass == "RetiredJob"
   Wurk::Cron.unregister(lp.lid)
 end
 ```
 
-The second surprise: **registration resets the paused flag.** `register` writes
-the whole loop hash, including `paused => "0"`, so a loop you paused in the
-dashboard un-pauses on the next worker boot unless you registered it with
-`paused: true`. Treat the dashboard pause as an incident tool, not a
-configuration mechanism.
+> **Two registrars that disagree about one class will flap.** If process A
+> registers `K` on one schedule and process B registers `K` on another, each
+> boot prunes the other's loop. This includes the window in a rolling deploy
+> where an old-code process boots after a new-code one; it converges once only
+> one code version is booting. Don't register the same class from two different
+> configs.
+
+Pause state belongs to the runtime, not to the code: `paused` is written with
+`HSETNX`, so a code-declared `paused: true` is the **initial** value at first
+registration, and a pause or unpause from the dashboard survives every
+subsequent boot.
 
 ---
 
@@ -352,10 +365,11 @@ crontab (`*/5 * * * *`). `sidekiq-scheduler`'s `enabled: false` maps to
   freezes the date of the deploy, forever.
 - **Registration happens in server processes only.** If no worker has booted
   since you added a loop, it isn't in Redis and the dashboard won't show it.
-- **Loops persist across deploys** and outlive the code that registered them.
+- **Loops persist across deploys.** Superseded ones are pruned by class on the
+  next registration; a loop whose `register` line was deleted outright is not.
   See the deploy section above.
-- **A dashboard pause is undone by the next boot** unless the loop is registered
-  with `paused: true`.
+- **A dashboard pause survives deploys** — `paused` is only initialized from
+  code, never overwritten by it.
 - **Enqueue-now doesn't move the schedule.** The next scheduled fire happens as
   planned.
 - **History is capped at 25 fires** per loop and holds only `[fired_at, jid]`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -371,19 +371,20 @@ The whole `Sidekiq::Testing` / `Sidekiq::Queues` / `Sidekiq::Job` test surface i
 implemented, under the same names, with the same semantics. In practice a suite
 moves over untouched. Two things to check:
 
-**1. `require "sidekiq/testing"` no longer implies `fake!`.** The path still
-resolves (it loads Wurk), but Wurk's default mode is `:disable`. Under Sidekiq,
-requiring that file switched you into fake mode as a side effect; here a suite
-that relied on it will start writing to real Redis and every `MyJob.jobs`
-assertion will come back empty. Add one explicit line to your test helper:
+**1. `require "sidekiq/testing"` switches you into fake mode**, exactly as it
+does under Sidekiq — so a suite that relied on that side effect keeps working
+untouched. It prints a deprecation warning once per process, matching upstream,
+and it never overrides a mode you chose explicitly, so this is safe:
 
 ```ruby
 # test/test_helper.rb
-Sidekiq::Testing.fake!
+require "sidekiq/testing"
+Sidekiq::Testing.disable!   # respected — the require does not fight you
 ```
 
-There is no deprecation warning on the require — the file is a plain
-`require "wurk"`.
+Prefer setting the mode explicitly and dropping the require. Note the side
+effect is process-global: don't `require "sidekiq/testing"` from a file that a
+non-testing process loads.
 
 **2. `Sidekiq::Testing` is a module, not a class.** Wurk implements it as a
 module with singleton methods. Every documented call (`fake!`, `inline!`,

--- a/docs/unique-jobs.md
+++ b/docs/unique-jobs.md
@@ -228,9 +228,10 @@ Sidekiq::Enterprise::Unique.locked?("ChargeJob", [1, 2_500])
 # two-arg form: assumes the default queue from Wurk.default_job_options
 ```
 
-The probe computes the key from `[class, queue, args]`. It does **not** run
-`sidekiq_unique_context`, so for a worker with a custom context use
-`Wurk::Unique.lock_key_for(job_hash)` to get the real key.
+The probe routes through the same derivation as the push path, so it honors
+`sidekiq_unique_context` and the ActiveJob narrowing below.
+`Wurk::Unique.lock_key(klass, queue, args)` stays available if you want the
+verbatim triple digest without any context hook applied.
 
 There is no built-in "unlock" API and **no dashboard view of unique locks** —
 the dashboard shows queues, retries, and dead jobs, not lock keys. To clear a
@@ -255,12 +256,15 @@ every push (new IV each time), so no two pushes of the "same" job ever produce
 the same args — and therefore never the same digest. Dedup silently stops
 working.
 
-This is a documented invariant, **not enforced in code**: nothing raises, and
-the behavior additionally depends on which middleware was registered first,
-since both `Sidekiq::Enterprise.unique!` and `Crypto.enable` append to the same
-client chain. Don't rely on the ordering — keep the two features on different
-workers. If you need both, encrypt a payload stored elsewhere and pass an
-opaque, stable id as the job argument.
+Wurk **enforces this**: pushing a worker that sets both `unique_for:` and
+`encrypt: true` while encryption is enabled raises
+`Wurk::Unique::ConfigurationError` naming the worker and both options. The
+check runs per push in the client middleware, so it fires the same way in
+either initializer order.
+
+This is stricter than Sidekiq Enterprise, which documents the incompatibility
+but lets the silent mis-dedup through. If you need both, encrypt a payload
+stored elsewhere and pass an opaque, stable id as the job argument.
 
 ---
 
@@ -278,10 +282,8 @@ opaque, stable id as the job argument.
   Sidekiq::Testing.server_middleware { |c| c.add(Wurk::Unique::ServerMiddleware) }
   ```
 
-- **`perform_inline` / `perform_sync`** call `perform` directly, bypassing both
-  chains entirely — no lock is taken and none is released. (Sidekiq Enterprise
-  7.3.2+ runs its unique server middleware in client mode so `perform_inline`
-  honors locks; Wurk does not. Divergence.)
+- **`perform_inline` / `perform_sync`** run the real client and server chains
+  (matching Sidekiq 8), so a lock is taken and released around the run.
 - Tests that enqueue the same job repeatedly will see `nil` JIDs unless each
   test clears the `unique:*` keys or uses distinct args. The usual fix is to
   skip activation in the test env: `Sidekiq::Enterprise.unique! unless Rails.env.test?`.
@@ -291,11 +293,28 @@ opaque, stable id as the job argument.
 ## 11. ActiveJob
 
 `sidekiq_options unique_for:` works on an ActiveJob class — the adapter merges
-the wrapped class's options into the payload. **But the default digest never
-matches**, because every ActiveJob payload's args are `[job.serialize]`, and
-that hash carries a fresh `job_id` (and `enqueued_at`) on every push.
+the wrapped class's options into the payload, and Wurk narrows the digest for
+you. An ActiveJob payload's args are `[job.serialize]`, a hash carrying a fresh
+`job_id` and `enqueued_at` on every push; digesting it verbatim would never
+match. So when the wire class is an ActiveJob wrapper and the single arg
+carries `job_class` + `arguments`, the context becomes:
 
-To dedup ActiveJob work, define the context hook on the wrapper class, which is
+```ruby
+[job["class"], job["queue"], data["job_class"], data["arguments"]]
+```
+
+Per-push fields are dropped: `job_id`, `provider_job_id`, `enqueued_at`,
+`scheduled_at`, `executions`, `exception_executions`, `priority`, `locale`,
+`timezone`. Retry counters are excluded deliberately — keeping them would make
+a retry re-push compute a different key and miss its own lock. The wrapper
+class name stays in the context so an ActiveJob `Foo` and a plain worker `Foo`
+with the same args can't collide.
+
+Matching is by wire class name, so it works in an enqueue-only process that has
+never loaded the job class. An app that subclasses the wrapper under its own
+name won't be matched — use the hook below for that.
+
+To override the default, define the context hook on the wrapper class, which is
 what `job["class"]` names on the wire:
 
 ```ruby

--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -2,3 +2,5 @@
 
 # Drop-in require path (see lib/sidekiq.rb). Wurk loads this surface whole.
 require 'wurk'
+
+Wurk::Testing.deprecated_require!

--- a/lib/wurk/batch.rb
+++ b/lib/wurk/batch.rb
@@ -60,8 +60,8 @@ module Wurk
     # accumulate here instead of round-tripping per job.
     BUFFER_KEY = :wurk_batch_buffer
 
-    attr_reader :bid, :parent_bid, :linger
-    attr_accessor :description, :callback_queue, :callback_class, :autoflush
+    attr_reader :bid, :parent_bid, :linger, :callback_class
+    attr_accessor :description, :callback_queue, :autoflush
 
     def self.keys_for(bid)
       base = "b-#{bid}"
@@ -106,6 +106,14 @@ module Wurk
       return unless @flushed_once
 
       Wurk.redis { |conn| conn.call('HSET', "b-#{@bid}", 'linger', @linger.to_s) }
+    end
+
+    # Supplies the class for a class-less `"#method"` callback spec (§2.2).
+    # Accepts a Class or a String and stores a String either way, so the
+    # in-memory value matches what a batch reopened by bid reads back — and so
+    # `CallbackJob` never has to care which form the caller used.
+    def callback_class=(value)
+      @callback_class = value.nil? ? nil : callback_target(value)
     end
 
     def parent

--- a/lib/wurk/batch/callback_job.rb
+++ b/lib/wurk/batch/callback_job.rb
@@ -4,33 +4,73 @@ require_relative '../worker'
 
 module Wurk
   class Batch
-    # Worker that runs a single batch callback. Target may be a Class name
-    # ("MyCallback" → `MyCallback.new.on_<event>(status, options)`) or a
-    # "Klass#method" spec ("Foo#bar" → `Foo.new.bar(status, options)`).
-    # Failures retry like any ordinary job — callbacks MUST be idempotent.
+    # Worker that runs a single batch callback. The target spec is one of:
+    #
+    #   "MyCallback"      → MyCallback.new.on_<event>(status, options)
+    #   "MyCallback#done" → MyCallback.new.done(status, options)
+    #   "#done"           → <batch callback_class>.new.done(status, options)
+    #
+    # The class-less form takes its class from the batch's `callback_class`
+    # (spec §2.2), read from `b-<bid>` at run time — the spec travels through
+    # the job payload as a plain String, so nothing here depends on anything
+    # that a JSON round trip could lose.
+    #
+    # Failures inside the callback retry like any ordinary job — callbacks
+    # MUST be idempotent.
     #
     # Spec: docs/target/sidekiq-pro.md §2.4.
     class CallbackJob
       include Wurk::Job
 
+      # The spec names a class or a method that isn't there. Distinct from a
+      # failure raised *by* the callback so the retry policy can tell the two
+      # apart.
+      class UnresolvableTarget < StandardError; end
+
       sidekiq_options retry: true
 
+      # A missing constant or method does not heal with time, so the default 25
+      # retries over ~21 days would only delay the news. Go straight to the dead
+      # set on the first attempt: death handlers fire, the operator sees it now,
+      # and the Dead tab's retry button is the recovery path once the callback
+      # class is restored. Anything else the callback raises keeps normal retry.
+      sidekiq_retry_in { |_count, exception| :kill if exception.is_a?(UnresolvableTarget) }
+
       def perform(bid, target_spec, event, options)
-        klass, method = resolve(target_spec, event)
+        klass, method = resolve(bid, target_spec.to_s, event)
         instance = klass.new
-        status   = Wurk::Batch::Status.new(bid)
-        instance.public_send(method, status, options || {})
+        unless instance.respond_to?(method)
+          raise UnresolvableTarget, "batch #{bid}: #{klass}##{method} is not a public method"
+        end
+
+        instance.public_send(method, Wurk::Batch::Status.new(bid), options || {})
       end
 
       private
 
-      def resolve(spec, event)
-        if spec.include?('#')
-          klass_name, method_name = spec.split('#', 2)
-          [Object.const_get(klass_name), method_name.to_sym]
-        else
-          [Object.const_get(spec), :"on_#{event}"]
+      def resolve(bid, spec, event)
+        return [constantize(bid, spec), :"on_#{event}"] unless spec.include?('#')
+
+        klass_name, method_name = spec.split('#', 2)
+        klass_name = callback_class_for(bid) if klass_name.empty?
+        [constantize(bid, klass_name), method_name.to_sym]
+      end
+
+      def constantize(bid, name)
+        if name.nil? || name.empty?
+          raise UnresolvableTarget, "batch #{bid}: callback spec names no class and the batch has no callback_class"
         end
+
+        const = Object.const_get(name)
+        raise UnresolvableTarget, "batch #{bid}: callback target #{name} is not a Class" unless const.is_a?(::Class)
+
+        const
+      rescue NameError
+        raise UnresolvableTarget, "batch #{bid}: callback class #{name.inspect} is not defined"
+      end
+
+      def callback_class_for(bid)
+        Wurk.redis { |conn| conn.call('HGET', "b-#{bid}", 'callback_class') }
       end
     end
   end

--- a/lib/wurk/cron.rb
+++ b/lib/wurk/cron.rb
@@ -24,7 +24,7 @@ module Wurk
   #     so a re-registration of the same loop is idempotent.
   #   * `Cron::Manager` — registration DSL. `mgr.register(cron, klass, **opts)`
   #     with `tz=` mass-setter. Writes to Redis (`periodic` SET + `loops:{lid}`
-  #     HASH).
+  #     HASH) and prunes superseded loops for the classes it registers.
   #   * `Cron::LoopSet` — Enumerable view (`each`/`size`/`fetch(lid)`).
   #   * `Cron::ConfigTester` — boot-time validator. Verifies cron syntax and
   #     that every worker class constant resolves.
@@ -397,10 +397,14 @@ module Wurk
       attr_accessor :tz
       attr_reader :loops
 
-      def initialize(config = nil)
+      # `prune: false` registers without superseding — ConfigTester uses it so
+      # validating a config never deletes a live loop.
+      def initialize(config = nil, prune: true)
         @config = config
         @loops = []
         @tz = nil
+        @prune = prune
+        @pruned_klasses = {}
       end
 
       def register(cron, klass, **opts)
@@ -410,7 +414,23 @@ module Wurk
         loop_obj = Loop.new(schedule: cron, klass: klass_name, options: normalized, tz: tz)
         @loops << loop_obj
         Cron.persist(loop_obj)
+        prune_superseded(klass_name)
         loop_obj
+      end
+
+      private
+
+      # Once per class per boot: everything else registered for that class is
+      # a leftover from a previous deploy (the lid hashes schedule+options, so
+      # an edited `register` line yields a new loop and orphans the old one).
+      # Registering the same class twice in one block is fine — the second
+      # register re-persists its loop right after the first one's prune.
+      def prune_superseded(klass_name)
+        return unless @prune
+        return if @pruned_klasses[klass_name]
+
+        @pruned_klasses[klass_name] = true
+        Cron.prune_superseded(klass_name, @loops.map(&:lid))
       end
     end
 
@@ -470,7 +490,7 @@ module Wurk
       def verify(&block)
         raise ArgumentError, 'block required' unless block
 
-        mgr = Manager.new
+        mgr = Manager.new(prune: false)
         block.call(mgr)
         mgr.loops.each { |lp| resolve_klass!(lp.klass) }
         mgr.loops
@@ -666,17 +686,46 @@ module Wurk
         Loop.new(schedule: cron, klass: worker_class.to_s, options: merged).tap { |lp| persist(lp) }
       end
 
+      # `paused` is written with HSETNX, not HSET: a code-declared `paused:`
+      # option is only the *initial* value at first registration, after which
+      # the field belongs to the runtime (Web UI pause/unpause). Writing it
+      # unconditionally un-paused a dashboard-paused loop on the next boot.
       def persist(loop_obj)
+        fields = loop_obj.to_redis_hash
+        paused = fields.delete('paused')
+        key = "#{LOOP_PREFIX}#{loop_obj.lid}"
         Wurk.redis do |c|
           c.call('SADD', PERIODIC_KEY, loop_obj.lid)
-          c.call('HSET', "#{LOOP_PREFIX}#{loop_obj.lid}", *loop_obj.to_redis_hash.flatten)
+          c.call('HSET', key, *fields.flatten)
+          c.call('HSETNX', key, 'paused', paused)
         end
         loop_obj
       end
 
-      # Drop a loop entirely. Used by the Web UI delete action and by the
-      # config-reload path so a removed `register(...)` line vanishes from
-      # Redis on next boot.
+      # Drop every registered loop for `klass` except `keep_lids` — the loops a
+      # booting process just registered for that class. Editing a schedule or
+      # any option changes the lid, so without this the pre-edit loop stays in
+      # `periodic` and keeps firing next to its replacement, forever.
+      #
+      # Scoped to one class deliberately: the registry is fleet-wide, so a
+      # process that registers a subset of the fleet's loops (or none at all,
+      # e.g. a client-only app) must never delete loops for classes it doesn't
+      # register. Idempotent and safe to race — two processes booting the same
+      # code compute the same candidate set, and SREM/DEL repeat harmlessly.
+      def prune_superseded(klass, keep_lids)
+        keep = Array(keep_lids)
+        stale = Wurk.redis do |c|
+          candidates = c.call('SMEMBERS', PERIODIC_KEY) - keep
+          candidates.select { |lid| c.call('HGET', "#{LOOP_PREFIX}#{lid}", 'klass') == klass }
+        end
+        stale.each { |lid| unregister(lid) }
+        stale
+      end
+
+      # Drop a loop entirely: registry membership, hash, and fire history.
+      # Public API for retiring a loop whose `register(...)` line is gone (no
+      # process registers its class any more, so `prune_superseded` cannot see
+      # it); also the primitive behind pruning and ConfigTester rollback.
       def unregister(lid)
         Wurk.redis do |c|
           c.call('SREM', PERIODIC_KEY, lid)

--- a/lib/wurk/iterable_job.rb
+++ b/lib/wurk/iterable_job.rb
@@ -173,9 +173,11 @@ module Wurk
       fire_lifecycle_start
       @executions += 1
 
-      run_iterations(args)
-
-      finalize_complete
+      if run_iterations(args) == :cancelled
+        finalize_cancelled
+      else
+        finalize_complete
+      end
     rescue Interrupted
       finalize_interrupted
       raise
@@ -205,17 +207,37 @@ module Wurk
     def run_iterations(args)
       enum = build_enumerator(*args, cursor: @cursor)
       enum.each do |item, new_cursor|
-        raise Interrupted if cancelled?
+        return :cancelled if cancelled?
+
+        # Cooperative shutdown. `interrupted?` (Wurk::Worker) is true once the
+        # owning Processor is stopping — quiet, TERM, or a rolling restart.
+        # Without this the loop would run until hard_shutdown raises
+        # Wurk::Shutdown (an Interrupt, not a RuntimeError), which skips the
+        # rescue below and loses everything since the last periodic flush.
+        raise Interrupted if interrupted?
 
         @current_object = item
         around_iteration { each_iteration(item, *args) }
         @cursor = new_cursor
         maybe_flush_state
       end
+      :completed
     end
 
     def finalize_complete
       flush_state(final: true)
+      on_complete
+      delete_state
+    end
+
+    # Cancellation is terminal, not an interruption: the job must NOT be
+    # re-pushed, and the state HASH — `cancelled` field included — must go,
+    # otherwise the resumed run would trip on its own flag and re-push again
+    # every cycle until CANCELLATION_PERIOD expires. Callback order matches
+    # upstream Sidekiq, which treats a cancelled run as completed.
+    def finalize_cancelled
+      on_cancel
+      on_stop
       on_complete
       delete_state
     end

--- a/lib/wurk/metrics/query.rb
+++ b/lib/wurk/metrics/query.rb
@@ -12,10 +12,14 @@ module Wurk
     # external dashboarding code; both rely on the same HGETALL fan-out
     # over a contiguous range of minute / hour keys.
     #
-    # Window caps are spec-enforced:
+    # Window caps are spec-enforced (§20 "DoS caps"), one per argument:
     #
-    #   minutes ≤ 480  (8h — same as the 10-minute rollup retention)
+    #   minutes ≤ 480  (8h)
     #   hours   ≤ 72   (3d — same as MID_TERM retention)
+    #
+    # `hours:` is validated against MAX_HOURS only, never re-checked against
+    # MAX_MINUTES after the ×60 conversion: the minute buckets it reads live
+    # for MID_TERM (3 days), so the whole 72h window is backed by real data.
     #
     # A wider window has no data to read anyway (the buckets are TTL'd out),
     # so we fail loudly rather than silently returning sparse results.
@@ -34,9 +38,8 @@ module Wurk
       # sorted by volume (p + f) descending so the UI's "top jobs" table
       # renders without a second sort pass.
       def top_jobs(class_filter: nil, minutes: 60, hours: nil, now: ::Time.now)
-        minutes = hours * 60 if hours
-        cap_hours!(hours) if hours
-        rows = aggregate_minutes(now, cap_minutes!(minutes)).to_a
+        window = hours ? cap_hours!(hours) * 60 : cap_minutes!(minutes)
+        rows = aggregate_minutes(now, window).to_a
         rows = rows.select { |(k, _)| k.start_with?(class_filter) } if class_filter && !class_filter.empty?
         rows.sort_by { |(_k, s)| -(s[:p] + s[:f]) }
       end

--- a/lib/wurk/sorted_entry.rb
+++ b/lib/wurk/sorted_entry.rb
@@ -24,6 +24,12 @@ module Wurk
       @parent = parent
     end
 
+    # JobRecord resolves the queue eagerly and only from a pre-parsed Hash;
+    # a sorted-set entry is almost always built from the raw JSON string, so
+    # read it off the payload instead. Lazy on purpose — a scan over a large
+    # set must not pay JSON cost for entries nobody inspects.
+    def queue = @queue ||= item['queue']
+
     def id = "#{score}|#{jid}"
 
     def at = ::Time.at(score).utc

--- a/lib/wurk/testing.rb
+++ b/lib/wurk/testing.rb
@@ -56,12 +56,31 @@ module Wurk
         end
       end
 
-      # In-process server-middleware chain used for inline execution. Empty by
+      # In-process server-middleware chain used by `:inline` mode. Empty by
       # default — configure with `Sidekiq::Testing.server_middleware { |c| ... }`.
+      # Deliberately NOT the globally configured chain: Sidekiq builds a fresh
+      # empty chain here too, and inline tests that suddenly ran batch/limiter/
+      # metrics middleware would diverge from a migrated suite's expectations.
+      # `perform_inline` is the explicit-execution path and does use the real
+      # chains (see Wurk::Worker::Setter#perform_inline).
       def server_middleware
         @server_middleware ||= ::Wurk::Middleware::Chain.new(::Wurk.configuration)
         yield @server_middleware if block_given?
         @server_middleware
+      end
+
+      # `require "sidekiq/testing"` flips Sidekiq into fake mode as a side
+      # effect; a migrated suite that never calls `fake!` would otherwise push
+      # into real Redis while every `MyJob.jobs` assertion came back empty.
+      # Deprecated in Sidekiq 8 in favour of `Sidekiq.testing!` — hence the
+      # warning. A mode already chosen (globally or for this thread) means the
+      # suite is explicit: don't override it, and don't warn again.
+      def deprecated_require!
+        return if ::Thread.current[THREAD_KEY] || @mode
+
+        ::Kernel.warn '⛔️ `require "sidekiq/testing"` is deprecated and will be removed in Sidekiq 9.0. ' \
+                      'Use `Sidekiq.testing!(:fake)` instead.'
+        fake!
       end
 
       # --- push hooks invoked by Wurk::Client#raw_push -------------------

--- a/lib/wurk/unique.rb
+++ b/lib/wurk/unique.rb
@@ -8,7 +8,9 @@ require_relative 'lua'
 module Wurk
   # Sidekiq Enterprise unique jobs. Best-effort dedup at enqueue time keyed
   # by a SHA256 digest of `[class, queue, args]` (overridable via
-  # `sidekiq_unique_context`). Three lock-release strategies:
+  # `sidekiq_unique_context`; ActiveJob-wrapped payloads narrow to the wrapped
+  # class + its arguments — see `active_job_context`). Three lock-release
+  # strategies:
   #
   #   * `unique_until: :success` (default) — lock retained through retries;
   #     server middleware DELs it on successful perform. Surviving across
@@ -46,6 +48,21 @@ module Wurk
     KEY_PREFIX = 'unique:'
     DEFAULT_UNTIL = :success
     VALID_UNTIL = %i[success start].freeze
+
+    # Class names that carry an ActiveJob payload as their single arg. The
+    # canonical one Wurk writes is `Sidekiq::ActiveJob::Wrapper`; the others
+    # appear in payloads enqueued by older Sidekiq/Rails versions still sitting
+    # in Redis at gem-swap time.
+    ACTIVE_JOB_WRAPPERS = [
+      'Sidekiq::ActiveJob::Wrapper',
+      'Wurk::ActiveJob::Wrapper',
+      'ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper',
+      'ActiveJob::QueueAdapters::WurkAdapter::JobWrapper'
+    ].freeze
+
+    # Raised at enqueue when a worker opts into both `unique_for:` and
+    # `encrypt: true` (§3.8: mutually exclusive).
+    class ConfigurationError < StandardError; end
 
     # Ent parity: a job that dies automatically releases its lock so a
     # duplicate can enqueue immediately. Manual API/UI kills keep the lock
@@ -94,9 +111,9 @@ module Wurk
         nil
       end
 
-      # Compute the lock key for an arbitrary `(queue, klass, args)` triple.
-      # Used by both the client middleware and the public `locked?` probe so
-      # they cannot drift.
+      # Compute the lock key for an arbitrary `(queue, klass, args)` triple,
+      # bypassing `sidekiq_unique_context`. Public so operators can compute
+      # the key of a worker that uses the default context (docs §8).
       def lock_key(klass, queue, args)
         context = [klass.to_s, queue.to_s, args]
         "#{KEY_PREFIX}#{Digest::SHA256.hexdigest(JSON.dump(context))}"
@@ -112,17 +129,48 @@ module Wurk
 
       # Default: `[class, queue, args]`. Workers may override by defining
       # `self.sidekiq_unique_context(job)` returning any JSON-serializable
-      # value (e.g. a subset of args). Spec §3.5.
+      # value (e.g. a subset of args). Spec §3.5. ActiveJob-wrapped payloads
+      # get a narrowed default (see `active_job_context`) because their raw
+      # args can never repeat.
       def unique_context(job)
         klass = resolve_class(job['class'])
-        if klass.respond_to?(:sidekiq_unique_context)
-          klass.sidekiq_unique_context(job)
-        else
-          [job['class'], job['queue'], job['args']]
-        end
+        return klass.sidekiq_unique_context(job) if klass.respond_to?(:sidekiq_unique_context)
+
+        active_job_context(job) || [job['class'], job['queue'], job['args']]
       end
 
       private
+
+      # An ActiveJob payload's args are `[job.serialize]`, and that hash
+      # carries a fresh `job_id` plus an `enqueued_at` timestamp on every
+      # push — digesting it verbatim produces a new key every time, so
+      # nothing is ever deduped. Identity is therefore narrowed to the two
+      # fields that describe *which* job this is:
+      #
+      #   * `job_class`  — the real worker; the wire `class` is only the wrapper.
+      #   * `arguments`  — the serialized perform args.
+      #
+      # Everything else in the serialized hash is per-push state, not
+      # identity: `job_id`/`provider_job_id` (fresh per push), `enqueued_at`
+      # and `scheduled_at` (timestamps), `executions`/`exception_executions`
+      # (retry counters, so a retry re-push would otherwise miss its own
+      # lock), `priority`, `locale` and `timezone` (ambient request state —
+      # the same logical job enqueued from a different locale is still the
+      # same job). `queue_name` is dropped as redundant: the wire-level
+      # `job["queue"]` it was copied into is already in the context, keeping
+      # the "queue is part of the key" rule identical to the plain path.
+      #
+      # The wrapper class name stays in the context so an ActiveJob and a
+      # plain worker of the same name and args can't collide on one lock.
+      def active_job_context(job)
+        return nil unless ACTIVE_JOB_WRAPPERS.include?(job['class'].to_s)
+
+        data = job['args']
+        data = data.first if data.is_a?(::Array) && data.size == 1
+        return nil unless data.is_a?(::Hash) && data.key?('job_class') && data.key?('arguments')
+
+        [job['class'], job['queue'], data['job_class'], data['arguments']]
+      end
 
       def resolve_class(name)
         return nil if name.nil? || name.to_s.empty?
@@ -171,7 +219,10 @@ module Wurk
     # @return [String, nil] owning jid, or nil when the lock is free.
     def self.locked?(queue_or_klass, klass_or_args = nil, args = nil)
       queue, klass, payload = normalize_locked_args(queue_or_klass, klass_or_args, args)
-      key = lock_key(klass, queue, payload)
+      # Routed through lock_key_for, not lock_key: the probe must honor
+      # `sidekiq_unique_context` (and the ActiveJob default) or it reports
+      # "free" for every worker that customizes its digest.
+      key = lock_key_for('class' => klass.to_s, 'queue' => queue.to_s, 'args' => payload)
       Wurk.redis { |c| c.call('GET', key) }
     end
 
@@ -203,10 +254,28 @@ module Wurk
         ttl = effective_ttl(job)
         return yield if ttl.nil?
 
+        reject_encrypted!(job)
         acquire_or_drop(redis_pool, job, Wurk::Unique.lock_key_for(job), ttl, &)
       end
 
       private
+
+      # §3.8: unique + encryption are mutually exclusive. Both features append
+      # to the same client chain, so whether the digest sees plaintext args or
+      # a random-IV envelope depended purely on which initializer ran first —
+      # and in the envelope case uniqueness silently never matched again.
+      # Failing the push is the only outcome that is identical in both
+      # orderings and impossible to miss. The check is per job, so the two
+      # features still coexist fine on *different* workers.
+      def reject_encrypted!(job)
+        return unless job['encrypt']
+        return unless defined?(Wurk::Encryption) && Wurk::Encryption.enabled?
+
+        raise Wurk::Unique::ConfigurationError,
+              "#{job['class']} sets both `unique_for` and `encrypt: true`, which cannot work: " \
+              'encryption rewrites the last argument with a fresh IV on every push, so the ' \
+              'unique digest never repeats. Drop one of the two options on this worker.'
+      end
 
       # Add `at - now` delay to the base TTL so a scheduled job's lock
       # spans the wait + execution window (§3.4). Returns nil when the

--- a/lib/wurk/web/enterprise.rb
+++ b/lib/wurk/web/enterprise.rb
@@ -42,11 +42,33 @@ module Wurk
         # row remains in the UI. Mirrors the §1.5 `#reset` surface — the
         # name is wire-compat, so the trailing-? rule doesn't apply here.
         def reset(name) # rubocop:disable Naming/PredicateMethod
+          limiter = rebuild(name)
+          # Reconstruct the limiter and delegate: only the type itself knows
+          # its state keys. A bucket's counter lives at `lmtr-b:<name>:<epoch>`,
+          # so the bare-prefix DEL below never touched it.
+          limiter ? limiter.reset : reset_by_prefix(name)
+          true
+        end
+
+        # Read-only reconstruction (`register: false`) from the persisted
+        # metadata. Returns nil when the meta HASH is gone or malformed —
+        # LIST membership has no TTL, so a name can outlive its metadata.
+        def rebuild(name)
+          meta = metadata(name)
+          return nil if meta.nil? || meta.empty?
+
+          options = meta['options'] ? ::JSON.parse(meta['options']) : {}
+          Wurk::Limiter.build(name, meta['type'], options)
+        rescue StandardError
+          nil
+        end
+
+        # Metadata-less fallback: wipe every type's un-suffixed state key.
+        def reset_by_prefix(name)
           Wurk.redis do |c|
-            %W[lmtr-cs:#{name} lmtr-b:#{name} lmtr-w:#{name} lmtr-l:#{name}
+            %W[lmtr-cs:#{name} lmtr-w:#{name} lmtr-l:#{name}
                lmtr-p:#{name} lmtr-stats:#{name}].each { |k| c.call('DEL', k) }
           end
-          true
         end
       end
 

--- a/lib/wurk/worker.rb
+++ b/lib/wurk/worker.rb
@@ -132,12 +132,12 @@ module Wurk
         Wurk::Worker::Setter.new(self, {}).perform_async(*)
       end
 
-      # Run `#perform` synchronously in the current thread (no Redis). Useful in
-      # tests and for inline execution.
+      # Run the job synchronously in the current thread, through both middleware
+      # chains (see {Wurk::Worker::Setter#perform_inline}). Useful in tests.
       #
-      # @return [Object] the return value of `#perform`
+      # @return [true, nil] nil when middleware halted the job, true otherwise
       def perform_inline(*)
-        new.perform(*)
+        Wurk::Worker::Setter.new(self, {}).perform_inline(*)
       end
       alias perform_sync perform_inline
 

--- a/lib/wurk/worker/setter.rb
+++ b/lib/wurk/worker/setter.rb
@@ -31,8 +31,24 @@ module Wurk
         @klass.client_push(@opts.merge('class' => @klass, 'args' => args))
       end
 
-      def perform_inline(*)
-        @klass.new.perform(*)
+      # Explicit synchronous execution. Runs the payload through the real client
+      # AND server middleware chains rather than calling `perform` directly:
+      # unique-job locks are taken by the client chain and released only by the
+      # server chain (bypassing both leaked every lock until its TTL), and batch
+      # callbacks fire from server middleware. Mirrors Sidekiq's Setter#perform_inline,
+      # including its return contract — nil when middleware halts the job, else true.
+      def perform_inline(*args)
+        config = Wurk.configuration
+        item = normalize_item(@opts.merge('class' => @klass, 'args' => args))
+        pushed = config.client_middleware.invoke(item['class'], item, item['queue'], config.redis_pool) do
+          verify_json(item)
+          item
+        end
+        return nil unless pushed
+
+        # Round-trip through JSON so the job sees exactly the arguments a real
+        # worker would after the payload has crossed Redis.
+        run_job(Wurk.load_json(Wurk.dump_json(item)), config)
       end
       alias perform_sync perform_inline
 
@@ -57,6 +73,17 @@ module Wurk
       end
 
       private
+
+      def run_job(msg, config)
+        instance = @klass.new
+        instance.jid = msg['jid']
+        instance.bid = msg['bid'] if instance.respond_to?(:bid=)
+        ran = config.server_middleware.invoke(instance, msg, msg['queue']) do
+          instance.perform(*msg['args'])
+          true
+        end
+        ran ? true : nil
+      end
 
       def absolute_at(interval)
         unless interval.is_a?(Numeric) || interval.is_a?(Time)

--- a/test/unit/batch_callback_job_test.rb
+++ b/test/unit/batch_callback_job_test.rb
@@ -1,0 +1,252 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'json'
+
+# Collector for the callback targets below. Tests within a UnitCase run
+# serially, but the mutex keeps this honest if that ever changes.
+module WurkBatchCbRecorder
+  MUTEX = Mutex.new
+  CALLS = Hash.new { |h, k| h[k] = [] }
+
+  def self.record(name, status, options)
+    MUTEX.synchronize { CALLS[status.bid] << [name, options] }
+  end
+
+  def self.calls_for(bid)
+    MUTEX.synchronize { CALLS[bid].dup }
+  end
+end
+
+# Resolution runs through `Object.const_get`, so the targets must be real
+# top-level constants — an anonymous class with a stubbed `name` is not
+# resolvable and would prove nothing.
+class WurkBatchCbTarget
+  def on_success(status, options) = WurkBatchCbRecorder.record(:on_success, status, options)
+  def on_complete(status, options) = WurkBatchCbRecorder.record(:on_complete, status, options)
+  def on_death(status, options) = WurkBatchCbRecorder.record(:on_death, status, options)
+  def shipped(status, options) = WurkBatchCbRecorder.record(:shipped, status, options)
+  def capture(status, options) = WurkBatchCbRecorder.record(status.class, status, options)
+
+  private
+
+  def hidden(status, options) = WurkBatchCbRecorder.record(:hidden, status, options)
+end
+
+# Resolvable, instantiable, and carrying none of the callback methods.
+class WurkBatchCbBare
+  def some_other_method; end
+end
+
+# Drives Wurk::Batch::CallbackJob against real Redis. Asserts the target-spec
+# forms of docs/target/sidekiq-pro.md §2.2/§2.4 — bare class name, "Klass#method",
+# and the class-less "#method" that takes its class from the batch's
+# `callback_class` — plus what happens when a spec resolves to nothing.
+class BatchCallbackJobTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @pool = Wurk.configuration.redis_pool
+    @class_name = "BatchCbJob@#{Process.pid}-#{object_id}"
+    @queue = "cbq-#{Process.pid}-#{object_id}"
+    @bids = []
+  end
+
+  def teardown
+    @pool.with do |conn|
+      @bids.uniq.each do |bid|
+        conn.call('UNLINK', *Wurk::Batch.keys_for(bid))
+        conn.call('ZREM', 'batches', bid)
+      end
+      conn.call('DEL', "queue:#{@queue}")
+      conn.call('SREM', 'queues', @queue)
+    end
+  ensure
+    super
+  end
+
+  # --- target spec forms -------------------------------------------------
+
+  def test_class_name_spec_invokes_on_event
+    bid = batch_with(nil).bid
+
+    perform(bid, 'WurkBatchCbTarget', 'success', 'k' => 1)
+
+    assert_equal [[:on_success, { 'k' => 1 }]], WurkBatchCbRecorder.calls_for(bid)
+  end
+
+  def test_class_name_spec_derives_the_method_from_the_event
+    bid = batch_with(nil).bid
+
+    perform(bid, 'WurkBatchCbTarget', 'complete', {})
+    perform(bid, 'WurkBatchCbTarget', 'death', {})
+
+    assert_equal %i[on_complete on_death], WurkBatchCbRecorder.calls_for(bid).map(&:first)
+  end
+
+  def test_klass_hash_method_spec_invokes_the_named_method
+    bid = batch_with(nil).bid
+
+    perform(bid, 'WurkBatchCbTarget#shipped', 'success', 'oid' => 7)
+
+    assert_equal [[:shipped, { 'oid' => 7 }]], WurkBatchCbRecorder.calls_for(bid)
+  end
+
+  # The defect: `callback_class` was stored, round-tripped, and never read, so
+  # a class-less spec silently never fired.
+  def test_class_less_spec_resolves_via_the_batch_callback_class
+    bid = batch_with('WurkBatchCbTarget').bid
+
+    perform(bid, '#shipped', 'success', 'oid' => 9)
+
+    assert_equal [[:shipped, { 'oid' => 9 }]], WurkBatchCbRecorder.calls_for(bid)
+  end
+
+  def test_class_less_spec_resolves_when_callback_class_was_set_as_a_class
+    bid = batch_with(WurkBatchCbTarget).bid
+
+    perform(bid, '#shipped', 'complete', {})
+
+    assert_equal [[:shipped, {}]], WurkBatchCbRecorder.calls_for(bid)
+  end
+
+  # The recorder keys on `status.bid`, so a hit under this bid already proves
+  # the Status was built for this batch; assert its type too.
+  def test_callback_receives_a_status_for_its_own_batch
+    bid = batch_with(nil).bid
+
+    perform(bid, 'WurkBatchCbTarget#capture', 'success', {})
+
+    assert_equal [[Wurk::Batch::Status, {}]], WurkBatchCbRecorder.calls_for(bid)
+  end
+
+  def test_nil_options_become_an_empty_hash
+    bid = batch_with(nil).bid
+
+    Wurk::Batch::CallbackJob.new.perform(bid, 'WurkBatchCbTarget#shipped', 'success', nil)
+
+    assert_equal [[:shipped, {}]], WurkBatchCbRecorder.calls_for(bid)
+  end
+
+  # --- end to end through the enqueue path -------------------------------
+
+  # The full path: `on` persists the spec, Callbacks enqueues a CallbackJob,
+  # the payload is JSON in Redis, and performing it from the parsed args must
+  # still resolve. Guards the class-less form against a JSON round trip.
+  def test_class_less_spec_survives_the_enqueue_round_trip
+    batch = batch_with('WurkBatchCbTarget')
+    batch.on(:success, '#shipped', 'oid' => 11)
+
+    Wurk::Batch::Callbacks.enqueue_callbacks(batch.bid, 'success')
+    args = enqueued_callback_args(batch.bid)
+
+    assert_equal [batch.bid, '#shipped', 'success', { 'oid' => 11 }], args
+
+    Wurk::Batch::CallbackJob.new.perform(*args)
+
+    assert_equal [[:shipped, { 'oid' => 11 }]], WurkBatchCbRecorder.calls_for(batch.bid)
+  end
+
+  # --- unresolvable targets ----------------------------------------------
+
+  def test_unknown_constant_raises_unresolvable_target
+    bid = batch_with(nil).bid
+
+    error = assert_raises(Wurk::Batch::CallbackJob::UnresolvableTarget) do
+      perform(bid, 'NoSuchCallbackConstant', 'success', {})
+    end
+
+    assert_match(/NoSuchCallbackConstant/, error.message)
+  end
+
+  def test_unknown_constant_in_klass_hash_method_spec_raises_unresolvable_target
+    bid = batch_with(nil).bid
+
+    assert_raises(Wurk::Batch::CallbackJob::UnresolvableTarget) do
+      perform(bid, 'NoSuchCallbackConstant#shipped', 'success', {})
+    end
+  end
+
+  def test_class_less_spec_without_callback_class_raises_unresolvable_target
+    bid = batch_with(nil).bid
+
+    error = assert_raises(Wurk::Batch::CallbackJob::UnresolvableTarget) do
+      perform(bid, '#shipped', 'success', {})
+    end
+
+    assert_match(/callback_class/, error.message)
+  end
+
+  def test_missing_method_raises_unresolvable_target
+    bid = batch_with(nil).bid
+
+    error = assert_raises(Wurk::Batch::CallbackJob::UnresolvableTarget) do
+      perform(bid, 'WurkBatchCbTarget#no_such_method', 'success', {})
+    end
+
+    assert_match(/no_such_method/, error.message)
+  end
+
+  def test_private_method_raises_unresolvable_target
+    bid = batch_with(nil).bid
+
+    assert_raises(Wurk::Batch::CallbackJob::UnresolvableTarget) do
+      perform(bid, 'WurkBatchCbTarget#hidden', 'success', {})
+    end
+  end
+
+  def test_missing_on_event_method_raises_unresolvable_target
+    bid = batch_with(nil).bid
+
+    error = assert_raises(Wurk::Batch::CallbackJob::UnresolvableTarget) do
+      perform(bid, 'WurkBatchCbBare', 'success', {})
+    end
+
+    assert_match(/on_success/, error.message)
+  end
+
+  # A constant that resolves to something you can't instantiate is just as
+  # unrecoverable as one that doesn't resolve at all — same treatment.
+  def test_non_class_constant_raises_unresolvable_target
+    bid = batch_with(nil).bid
+
+    error = assert_raises(Wurk::Batch::CallbackJob::UnresolvableTarget) do
+      perform(bid, 'WurkBatchCbRecorder', 'success', {})
+    end
+
+    assert_match(/not a Class/, error.message)
+  end
+
+  # An unresolvable target never heals, so it goes to the dead set on the
+  # first attempt instead of crash-looping for ~21 days. Anything else the
+  # callback raises keeps the default backoff.
+  def test_retry_policy_kills_unresolvable_targets_only
+    block = Wurk::Batch::CallbackJob.sidekiq_retry_in_block
+
+    assert_equal :kill, block.call(0, Wurk::Batch::CallbackJob::UnresolvableTarget.new, {})
+    assert_nil block.call(0, RuntimeError.new('callback blew up'), {})
+  end
+
+  private
+
+  def perform(bid, spec, event, options)
+    Wurk::Batch::CallbackJob.new.perform(bid, spec, event, options)
+  end
+
+  def batch_with(callback_class)
+    batch = Wurk::Batch.new
+    @bids << batch.bid
+    batch.callback_queue = @queue
+    batch.callback_class = callback_class
+    batch.jobs { Wurk::Client.push('class' => @class_name, 'args' => [], 'queue' => @queue) }
+    batch
+  end
+
+  def enqueued_callback_args(bid)
+    @pool.with { |c| c.call('LRANGE', "queue:#{@queue}", 0, -1) }
+         .map { |raw| JSON.parse(raw) }
+         .find { |job| job['class'] == 'Wurk::Batch::CallbackJob' && job['args'][0] == bid }
+         &.fetch('args')
+  end
+end

--- a/test/unit/batch_test.rb
+++ b/test/unit/batch_test.rb
@@ -101,6 +101,38 @@ class BatchTest < Wurk::Test::UnitCase
     assert_equal 'cb-q', reopened.callback_queue
   end
 
+  def test_callback_class_round_trips
+    batch = track(Wurk::Batch.new)
+    batch.callback_class = 'MyCallbacks'
+    batch.jobs { perform_one(batch) }
+
+    reopened = track(Wurk::Batch.new(batch.bid))
+
+    assert_equal 'MyCallbacks', reopened.callback_class
+  end
+
+  def test_callback_class_accepts_a_class_and_stores_its_name
+    klass = Class.new { def self.name = 'BatchTestCbClass' }
+    batch = track(Wurk::Batch.new)
+    batch.callback_class = klass
+
+    assert_equal 'BatchTestCbClass', batch.callback_class
+  end
+
+  def test_callback_class_accepts_nil
+    batch = track(Wurk::Batch.new)
+    batch.callback_class = 'MyCallbacks'
+    batch.callback_class = nil
+
+    assert_nil batch.callback_class
+  end
+
+  def test_callback_class_rejects_a_value_that_names_nothing
+    batch = track(Wurk::Batch.new)
+
+    assert_raises(ArgumentError) { batch.callback_class = 42 }
+  end
+
   def test_tags_round_trip
     batch = track(Wurk::Batch.new)
     batch.tags = [@tag_customer, @tag_job]

--- a/test/unit/cron_test.rb
+++ b/test/unit/cron_test.rb
@@ -20,6 +20,10 @@ class CronTest < Wurk::Test::UnitCase
   class DSTWorker # rubocop:disable Lint/EmptyClass
   end
 
+  # Resolvable constant for the ConfigTester pruning checks.
+  class PruneWorker # rubocop:disable Lint/EmptyClass
+  end
+
   def setup
     super
     @suffix = "cron#{Process.pid}#{object_id}"
@@ -245,13 +249,14 @@ class CronTest < Wurk::Test::UnitCase
   def test_register_writes_klass_to_loop_hash
     lp = register_for_persist_test
 
-    assert_equal 'CronTest::FooWorker', loop_hash(lp.lid)['klass']
+    assert_equal persist_klass, loop_hash(lp.lid)['klass']
   end
 
   def test_register_idempotent_for_same_inputs
     mgr = Wurk::Cron::Manager.new
-    a = mgr.register('*/5 * * * *', 'CronTest::FooWorker')
-    b = mgr.register('*/5 * * * *', 'CronTest::FooWorker')
+    klass = "CronTest::Idem#{@suffix}"
+    a = mgr.register('*/5 * * * *', klass)
+    b = mgr.register('*/5 * * * *', klass)
     @lids << a.lid
     membership = Wurk.redis { |c| c.call('SISMEMBER', Wurk::Cron::PERIODIC_KEY, a.lid) }
 
@@ -262,7 +267,7 @@ class CronTest < Wurk::Test::UnitCase
   def test_manager_tz_default_applies_to_subsequent_registers
     mgr = Wurk::Cron::Manager.new
     mgr.tz = 'America/Chicago'
-    lp = mgr.register('0 4 * * *', 'CronTest::FooWorker')
+    lp = mgr.register('0 4 * * *', "CronTest::TzDefault#{@suffix}")
     @lids << lp.lid
 
     assert_equal 'America/Chicago', lp.tz
@@ -271,7 +276,7 @@ class CronTest < Wurk::Test::UnitCase
   def test_manager_per_call_tz_overrides_default
     mgr = Wurk::Cron::Manager.new
     mgr.tz = 'America/Chicago'
-    lp = mgr.register('0 4 * * *', 'CronTest::FooWorker', tz: 'Asia/Tokyo')
+    lp = mgr.register('0 4 * * *', "CronTest::TzOverride#{@suffix}", tz: 'Asia/Tokyo')
     @lids << lp.lid
 
     assert_equal 'Asia/Tokyo', lp.tz
@@ -283,6 +288,111 @@ class CronTest < Wurk::Test::UnitCase
     @lids << lp.lid
 
     assert_equal 'CronTest::FooWorker', lp.klass
+  end
+
+  # ---- Superseded-loop pruning ----------------------------------------
+
+  def test_register_prunes_superseded_loop_for_same_class
+    klass = "CronTest::Edited#{@suffix}"
+    old = Wurk::Cron::Manager.new.register('0 4 * * *', klass)
+    fresh = Wurk::Cron::Manager.new.register('0 5 * * *', klass)
+    @lids << old.lid << fresh.lid
+    lids = Wurk::Cron::LoopSet.new.map(&:lid)
+
+    refute_includes lids, old.lid, 'the pre-edit loop must not keep firing'
+    assert_includes lids, fresh.lid
+  end
+
+  def test_pruned_loop_hash_and_history_are_deleted
+    klass = "CronTest::EditedKeys#{@suffix}"
+    old = Wurk::Cron::Manager.new.register('0 4 * * *', klass)
+    @lids << old.lid
+    seed_history(old.lid)
+    @lids << Wurk::Cron::Manager.new.register('0 5 * * *', klass).lid
+
+    assert_empty loop_hash(old.lid)
+    assert_empty history_entries(old.lid)
+  end
+
+  # The registry is fleet-wide: a process registering only part of it (or an
+  # app that registers nothing at all) must not wipe another process's loops.
+  def test_register_of_a_subset_leaves_other_classes_alone
+    kept = Wurk::Cron::Manager.new.register('0 4 * * *', "CronTest::SubsetKept#{@suffix}")
+    other = Wurk::Cron::Manager.new.register('0 6 * * *', "CronTest::SubsetOther#{@suffix}")
+    @lids << kept.lid << other.lid
+    lids = Wurk::Cron::LoopSet.new.map(&:lid)
+
+    assert_includes lids, kept.lid
+    assert_includes lids, other.lid
+  end
+
+  def test_manager_that_registers_nothing_prunes_nothing
+    lp = Wurk::Cron::Manager.new.register('0 4 * * *', "CronTest::ClientOnly#{@suffix}")
+    @lids << lp.lid
+
+    Wurk::Cron::Manager.new # a client-only process: config.periodic never called
+
+    assert_includes Wurk::Cron::LoopSet.new.map(&:lid), lp.lid
+  end
+
+  # Two schedules for one class in a single block: the second register must
+  # survive the first one's prune (and re-registering the whole set is a no-op).
+  def test_register_keeps_every_loop_declared_for_the_same_class
+    klass = "CronTest::Twice#{@suffix}"
+    first_boot = register_pair(klass)
+    second_boot = register_pair(klass)
+    @lids.concat(first_boot)
+
+    assert_equal first_boot, second_boot, 'the same block must produce the same lids on every boot'
+    assert_equal first_boot.sort, (Wurk::Cron::LoopSet.new.map(&:lid) & first_boot).sort
+  end
+
+  def test_config_tester_does_not_prune_live_loops
+    live = Wurk::Cron::Manager.new.register('7 3 * * *', 'CronTest::PruneWorker')
+    @lids << live.lid
+    block = ->(mgr) { mgr.register('9 3 * * *', 'CronTest::PruneWorker') }
+    @lids.concat(Wurk::Cron::ConfigTester.new.verify(&block).map(&:lid))
+
+    assert_includes Wurk::Cron::LoopSet.new.map(&:lid), live.lid
+  end
+
+  # ---- Pause survives re-registration ---------------------------------
+
+  def test_runtime_pause_survives_re_registration
+    klass = "CronTest::Paused#{@suffix}"
+    lp = Wurk::Cron::Manager.new.register('0 4 * * *', klass)
+    @lids << lp.lid
+    Wurk::Web::Enterprise::Periodic.pause(lp.lid)
+
+    Wurk::Cron::Manager.new.register('0 4 * * *', klass)
+
+    assert_equal '1', loop_hash(lp.lid)['paused']
+    assert_predicate Wurk::Cron::LoopSet.new.fetch(lp.lid), :paused?
+  end
+
+  def test_runtime_unpause_survives_re_registration_of_a_paused_loop
+    klass = "CronTest::Unpaused#{@suffix}"
+    lp = Wurk::Cron::Manager.new.register('0 4 * * *', klass, paused: true)
+    @lids << lp.lid
+    Wurk::Web::Enterprise::Periodic.unpause(lp.lid)
+
+    Wurk::Cron::Manager.new.register('0 4 * * *', klass, paused: true)
+
+    assert_equal '0', loop_hash(lp.lid)['paused']
+  end
+
+  def test_paused_option_is_the_initial_state_at_first_registration
+    lp = Wurk::Cron::Manager.new.register('0 4 * * *', "CronTest::BornPaused#{@suffix}", paused: true)
+    @lids << lp.lid
+
+    assert_equal '1', loop_hash(lp.lid)['paused']
+  end
+
+  def test_register_defaults_to_unpaused
+    lp = Wurk::Cron::Manager.new.register('0 4 * * *', "CronTest::BornRunning#{@suffix}")
+    @lids << lp.lid
+
+    assert_equal '0', loop_hash(lp.lid)['paused']
   end
 
   # ---- Top-level register(name, cron, klass, args) --------------------
@@ -1097,11 +1207,30 @@ class CronTest < Wurk::Test::UnitCase
     loop_obj.local_components(nf)[0, 3]
   end
 
+  # Registration now prunes superseded loops for the class it registers, so a
+  # test must own its class name or it deletes a concurrent test's loop.
   def register_for_persist_test
     mgr = Wurk::Cron::Manager.new
-    lp = mgr.register('*/5 * * * *', 'CronTest::FooWorker', queue: 'low')
+    lp = mgr.register('*/5 * * * *', persist_klass, queue: 'low')
     @lids << lp.lid
     lp
+  end
+
+  def persist_klass
+    "CronTest::Persist#{@suffix}"
+  end
+
+  def register_pair(klass)
+    mgr = Wurk::Cron::Manager.new
+    [mgr.register('0 4 * * *', klass).lid, mgr.register('0 16 * * *', klass).lid]
+  end
+
+  def seed_history(lid)
+    Wurk.redis { |c| c.call('LPUSH', "#{Wurk::Cron::HISTORY_PREFIX}#{lid}", '[1,"jid"]') }
+  end
+
+  def history_entries(lid)
+    Wurk.redis { |c| c.call('LRANGE', "#{Wurk::Cron::HISTORY_PREFIX}#{lid}", 0, -1) }
   end
 
   def loop_hash(lid)

--- a/test/unit/iterable_job_test.rb
+++ b/test/unit/iterable_job_test.rb
@@ -278,10 +278,10 @@ class IterableJobTest < Wurk::Test::UnitCase
     end
   end
 
-  def test_cancel_during_iteration_raises_interrupted_on_next_step
+  def test_cancel_during_iteration_stops_the_loop_without_interrupting
     worker = SelfCancelling.new
+    worker.perform
 
-    assert_raises(Wurk::IterableJob::Interrupted) { worker.perform }
     assert_equal [1], worker.seen
   end
 
@@ -316,6 +316,22 @@ class IterableJobTest < Wurk::Test::UnitCase
     end
   end
 
+  # Cancels and then raises Interrupted from the same iteration — the only
+  # way a run reaches the interrupt path with @cancelled_at set now that
+  # cancellation terminates the loop on its own.
+  class CancelThenInterrupt
+    include Wurk::IterableJob
+
+    def build_enumerator(*, cursor:)
+      Enumerator.new { |y| y << [1, 1] }
+    end
+
+    def each_iteration(_item, *)
+      cancel!
+      raise Wurk::IterableJob::Interrupted
+    end
+  end
+
   def random_jid
     @_jid_counter ||= 0
     @_jid_counter += 1
@@ -328,6 +344,10 @@ class IterableJobTest < Wurk::Test::UnitCase
 
   def cleanup_iteration_key(jid)
     redis.with { |c| c.call('DEL', "it-#{jid}") }
+  end
+
+  def state_exists?(jid)
+    redis.with { |c| c.call('EXISTS', "it-#{jid}") } == 1
   end
 
   def test_cancel_persists_to_iteration_hash_when_jid_set
@@ -382,7 +402,7 @@ class IterableJobTest < Wurk::Test::UnitCase
   # run. Splitting would obscure the contract — the field set IS the spec.
   def test_interrupted_perform_persists_state_hash # rubocop:disable Metrics/AbcSize,Minitest/MultipleAssertions
     jid = random_jid
-    worker = CancelOnSecond.new
+    worker = CancelThenInterrupt.new
     worker.jid = jid
 
     begin
@@ -403,7 +423,7 @@ class IterableJobTest < Wurk::Test::UnitCase
 
   def test_interrupted_run_uses_cancellation_period_ttl
     jid = random_jid
-    worker = CancelOnSecond.new
+    worker = CancelThenInterrupt.new
     worker.jid = jid
 
     begin
@@ -556,13 +576,14 @@ class IterableJobTest < Wurk::Test::UnitCase
     def each_iteration(_) = cancel!
     def on_cancel         = events << :cancel
     def on_stop           = events << :stop
+    def on_complete       = events << :complete
   end
 
-  def test_on_cancel_and_on_stop_fire_when_cancelled
+  def test_cancelled_run_fires_cancel_stop_complete_in_order
     worker = StopOnly.new
-    assert_raises(Wurk::IterableJob::Interrupted) { worker.perform }
+    worker.perform
 
-    assert_equal %i[cancel stop], worker.events
+    assert_equal %i[cancel stop complete], worker.events
   end
 
   # --- branch: interrupted WITHOUT cancellation (line 190 else) -------
@@ -598,10 +619,10 @@ class IterableJobTest < Wurk::Test::UnitCase
     refute_predicate worker, :cancelled?
   end
 
-  # --- branch: load_state with cancelled present (line 209 then) ------
+  # --- branch: load_state with cancelled present ----------------------
 
   # State hash carries a `cancelled` timestamp; load_state must set
-  # @cancelled_at so the very first iteration trips and raises Interrupted.
+  # @cancelled_at so the very first iteration trips and the run terminates.
   def test_load_state_with_cancelled_field_trips_immediately
     jid = random_jid
 
@@ -617,9 +638,123 @@ class IterableJobTest < Wurk::Test::UnitCase
 
       worker = ResumableJob.new
       worker.jid = jid
+      worker.perform
 
-      assert_raises(Wurk::IterableJob::Interrupted) { worker.perform }
       assert_empty worker.seen, 'no iteration runs once cancelled state is loaded'
+    ensure
+      cleanup_iteration_key(jid)
+    end
+  end
+
+  # A resumed cancelled job must not raise Interrupted — raising would send it
+  # back through InterruptHandler, which LPUSHes it to the head of the queue,
+  # and the reloaded `cancelled` field would spin that cycle for three days.
+  # The state HASH must be gone so nothing can trip on it again.
+  def test_cancelled_run_deletes_state_instead_of_re_enqueueing
+    jid = random_jid
+
+    begin
+      ts = ::Process.clock_gettime(::Process::CLOCK_REALTIME).to_i
+      redis.with { |c| c.call('HSET', "it-#{jid}", 'ex', '1', 'c', ::JSON.generate(0), 'cancelled', ts) }
+
+      worker = ResumableJob.new
+      worker.jid = jid
+      worker.perform
+
+      refute state_exists?(jid), 'cancelled state hash deleted so the resumed job cannot re-cancel'
+    ensure
+      cleanup_iteration_key(jid)
+    end
+  end
+
+  def test_self_cancelled_run_deletes_state
+    jid = random_jid
+    worker = CancelOnSecond.new
+    worker.jid = jid
+
+    begin
+      worker.perform
+
+      refute state_exists?(jid), 'state deleted when the job cancels itself mid-run'
+    ensure
+      cleanup_iteration_key(jid)
+    end
+  end
+
+  # --- cooperative shutdown -------------------------------------------
+
+  # Stands in for Wurk::Processor: `interrupted?` (Wurk::Worker) asks the
+  # attached context whether it is stopping.
+  class StoppingContext
+    def initialize(stop_after:)
+      @stop_after = stop_after
+      @calls = 0
+    end
+
+    def stopping?
+      @calls += 1
+      @calls > @stop_after
+    end
+  end
+
+  def test_shutdown_flushes_cursor_and_raises_interrupted
+    jid = random_jid
+    worker = ResumableJob.new
+    worker.jid = jid
+    # Not stopping for the first check, stopping from the second on: one item
+    # is processed, then the loop bails before touching the next.
+    worker._context = StoppingContext.new(stop_after: 1)
+
+    begin
+      assert_raises(Wurk::IterableJob::Interrupted) { worker.perform }
+      assert_equal [0], worker.seen
+
+      cursor = redis.with { |c| c.call('HGET', "it-#{jid}", 'c') }
+
+      assert_equal 1, ::JSON.parse(cursor), 'cursor of the last completed iteration is flushed'
+    ensure
+      cleanup_iteration_key(jid)
+    end
+  end
+
+  def test_job_resumes_from_flushed_cursor_after_shutdown
+    jid = random_jid
+    stopped = ResumableJob.new
+    stopped.jid = jid
+    stopped._context = StoppingContext.new(stop_after: 2)
+
+    begin
+      assert_raises(Wurk::IterableJob::Interrupted) { stopped.perform }
+
+      resumed = ResumableJob.new
+      resumed.jid = jid
+      resumed.perform
+
+      assert_equal [2], resumed.seen, 'resumed run picks up exactly where the flush left off'
+    ensure
+      cleanup_iteration_key(jid)
+    end
+  end
+
+  def test_shutdown_fires_on_stop_without_on_cancel
+    worker = HookTracer.new
+    worker._context = StoppingContext.new(stop_after: 0)
+
+    assert_raises(Wurk::IterableJob::Interrupted) { worker.perform }
+    assert_equal %i[start stop], worker.events
+  end
+
+  def test_cancellation_wins_over_shutdown
+    jid = random_jid
+    worker = StopOnly.new
+    worker.jid = jid
+    worker._context = StoppingContext.new(stop_after: 0)
+
+    begin
+      worker.cancel!
+      worker.perform
+
+      assert_equal %i[cancel stop complete], worker.events
     ensure
       cleanup_iteration_key(jid)
     end

--- a/test/unit/limiter_test.rb
+++ b/test/unit/limiter_test.rb
@@ -149,6 +149,22 @@ class LimiterTest < Wurk::Test::UnitCase
     end
   end
 
+  # Regression: the dashboard's Reset DEL'd a bare `lmtr-b:<name>` key, but a
+  # bucket's counter lives at `lmtr-b:<name>:<epoch>` — so Reset reported
+  # success and left the limiter exhausted.
+  def test_web_reset_clears_bucket_epoch_counter
+    name = "bkweb-#{@suffix}"
+    l = Wurk::Limiter.bucket(name, 5, :minute)
+    l.within_limit {} # consumes one of the period's 5
+
+    assert_equal 1, l.size
+
+    Wurk::Web::Enterprise::Limits.reset(name)
+
+    assert_equal 0, l.size
+    @pool.with { |c| assert_empty c.call('KEYS', "lmtr-b:#{name}:*") }
+  end
+
   # ----- configure --------------------------------------------------
 
   def test_configure_sets_backoff

--- a/test/unit/metrics_query_test.rb
+++ b/test/unit/metrics_query_test.rb
@@ -144,6 +144,20 @@ class MetricsQueryTest < Wurk::Test::UnitCase
     assert_includes klasses, @klass_a
   end
 
+  # Regression: `hours:` used to be re-validated against MAX_MINUTES after the
+  # ×60 conversion, so anything above 8h raised WindowTooWide and the
+  # documented 72h ceiling was unreachable. The minute buckets it reads live
+  # for MID_TERM (3 days), so the whole range is backed by data.
+  def test_top_jobs_hours_reaches_the_documented_ceiling
+    Wurk::Metrics::History.record(@klass_a, 5, success: true, at: @now)
+
+    [9, Wurk::Metrics::Query::MAX_HOURS].each do |hours|
+      rows = Wurk::Metrics::Query.top_jobs(hours: hours, now: @now)
+
+      assert_includes rows.map(&:first), @klass_a, "hours: #{hours}"
+    end
+  end
+
   def test_top_jobs_hours_arg_converts_to_minutes
     Wurk::Metrics::History.record(@klass_a, 7, success: true, at: @now)
 

--- a/test/unit/sidekiq_entrypoint_test.rb
+++ b/test/unit/sidekiq_entrypoint_test.rb
@@ -9,9 +9,12 @@ class SidekiqEntrypointTest < Wurk::Test::UnitCase
   parallelize_me!
 
   # Every passthrough except sidekiq/rails (needs Rails — loading it here
-  # would leak `defined?(Rails)` into every other parallel test) and
-  # sidekiq/cli (flips this process into server mode — same leak problem).
-  # Both are covered by dedicated cold-load subprocess tests below.
+  # would leak `defined?(Rails)` into every other parallel test), sidekiq/cli
+  # (flips this process into server mode — same leak problem) and
+  # sidekiq/testing (flips the process into :fake, which breaks every test
+  # class that later shares this fork). All three are covered by dedicated
+  # cold-load subprocess tests — see test/unit/testing_require_test.rb for the
+  # sidekiq/testing side effect.
   PASSTHROUGHS = %w[
     sidekiq
     sidekiq/api
@@ -21,7 +24,6 @@ class SidekiqEntrypointTest < Wurk::Test::UnitCase
     sidekiq/middleware/chain
     sidekiq/redis_connection
     sidekiq/scheduled
-    sidekiq/testing
     sidekiq/version
     sidekiq/web
     sidekiq/worker

--- a/test/unit/testing_require_test.rb
+++ b/test/unit/testing_require_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# `require "sidekiq/testing"` must flip the process into fake mode, exactly as
+# upstream does — without it a migrated suite silently enqueues into real Redis
+# while every `MyJob.jobs` assertion comes back empty.
+#
+# Every case runs in a subprocess: the require's side effect is process-global
+# and one-way by design, so asserting it in-process would leak fake mode into
+# every other test class sharing this fork.
+class TestingRequireTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  LIB = File.expand_path('../../lib', __dir__)
+
+  def ruby(code)
+    IO.popen([RbConfig.ruby, '-I', LIB, '-e', code], err: %i[child out], &:read)
+  end
+
+  def test_require_sidekiq_testing_enables_fake_mode
+    out = ruby('require "sidekiq/testing"; print "MODE=" + Sidekiq::Testing.mode.to_s')
+
+    assert_includes out, 'MODE=fake'
+  end
+
+  def test_require_sidekiq_testing_warns_that_it_is_deprecated
+    out = ruby('require "sidekiq/testing"')
+
+    assert_includes out, 'deprecated'
+  end
+
+  def test_deprecation_warning_points_at_the_replacement_api
+    out = ruby('require "sidekiq/testing"')
+
+    assert_includes out, 'Sidekiq.testing!'
+  end
+
+  def test_require_does_not_override_an_explicitly_chosen_mode
+    out = ruby('require "sidekiq"; Sidekiq::Testing.disable!; require "sidekiq/testing"; ' \
+               'print "MODE=" + Sidekiq::Testing.mode.to_s')
+
+    assert_includes out, 'MODE=disable'
+  end
+
+  def test_require_does_not_warn_when_a_mode_was_chosen_explicitly
+    out = ruby('require "sidekiq"; Sidekiq::Testing.fake!; require "sidekiq/testing"')
+
+    refute_includes out, 'deprecated'
+  end
+
+  def test_warning_is_emitted_once_per_process
+    out = ruby('require "sidekiq/testing"; Wurk::Testing.deprecated_require!; ' \
+               'Wurk::Testing.deprecated_require!')
+
+    assert_equal 1, out.scan('deprecated').size
+  end
+end

--- a/test/unit/testing_test.rb
+++ b/test/unit/testing_test.rb
@@ -44,6 +44,18 @@ class TestingModesTest < Wurk::Test::UnitCase
     super
   end
 
+  # The flip side — that the require DOES warn and enable fake mode from a
+  # clean process — is process-global and one-way, so it lives in
+  # test/unit/testing_require_test.rb as a subprocess test.
+  def test_deprecated_require_respects_an_explicit_mode
+    Wurk::Testing.disable!
+
+    out = capture_io { Wurk::Testing.deprecated_require! }.last
+
+    assert_empty out, 'must not warn once the suite has chosen a mode'
+    assert_predicate Wurk::Testing, :disabled?, 'must not override an explicit disable!'
+  end
+
   # --- fake mode ----------------------------------------------------------
 
   def test_fake_collects_jobs_without_running
@@ -169,6 +181,85 @@ class TestingModesTest < Wurk::Test::UnitCase
       refute_predicate Wurk::Testing, :disabled?
       assert_predicate Wurk::Testing, :inline?
     end
+  end
+
+  # --- perform_inline middleware ------------------------------------------
+  # perform_inline used to call `perform` directly, so a unique-jobs lock taken
+  # by client middleware was never released by its server counterpart and batch
+  # callbacks never fired. It now runs both real chains, like Sidekiq.
+
+  class RecordingClientMiddleware
+    def self.calls = @calls ||= []
+
+    def call(job_class, item, queue, _pool)
+      self.class.calls << [job_class, item['args'], queue]
+      yield
+    end
+  end
+
+  class RecordingServerMiddleware
+    def self.calls = @calls ||= []
+
+    def call(worker, job, queue)
+      self.class.calls << [worker.jid, job['args'], queue]
+      yield
+    end
+  end
+
+  class HaltingClientMiddleware
+    def call(*)
+      nil
+    end
+  end
+
+  def with_middleware(client: nil, server: nil)
+    config = Wurk.configuration
+    config.client_middleware.add(client) if client
+    config.server_middleware.add(server) if server
+    yield
+  ensure
+    config.client_middleware.remove(client) if client
+    config.server_middleware.remove(server) if server
+  end
+
+  def test_perform_inline_runs_client_middleware
+    RecordingClientMiddleware.calls.clear
+
+    with_middleware(client: RecordingClientMiddleware) { FakeJob.perform_inline(11) }
+
+    assert_equal [['TestingModesTest::FakeJob', [11], 'testq']], RecordingClientMiddleware.calls
+  end
+
+  def test_perform_inline_runs_server_middleware_around_a_jid_bearing_instance
+    RecordingServerMiddleware.calls.clear
+
+    with_middleware(server: RecordingServerMiddleware) { FakeJob.perform_inline(11) }
+    jid, args, queue = RecordingServerMiddleware.calls.fetch(0)
+
+    assert_equal [String, [11], 'testq'], [jid.class, args, queue]
+    assert_equal [11], FakeJob.ran
+  end
+
+  def test_perform_inline_returns_true_when_the_job_runs
+    assert FakeJob.perform_inline(14)
+  end
+
+  def test_setter_perform_inline_runs_server_middleware_with_its_queue
+    RecordingServerMiddleware.calls.clear
+
+    with_middleware(server: RecordingServerMiddleware) do
+      FakeJob.set(queue: 'override').perform_inline(12)
+    end
+
+    assert_equal [12], FakeJob.ran
+    assert_equal 'override', RecordingServerMiddleware.calls.fetch(0).last
+  end
+
+  def test_perform_inline_halted_by_client_middleware_does_not_run
+    result = with_middleware(client: HaltingClientMiddleware) { FakeJob.perform_inline(13) }
+
+    assert_nil result
+    assert_empty FakeJob.ran
   end
 
   # --- Sidekiq drop-in aliases -------------------------------------------

--- a/test/unit/unique_test.rb
+++ b/test/unit/unique_test.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 require_relative '../test_helper'
+# The wrapper class is only autoloaded by the ActiveJob adapter; the unique
+# tests need the real constant so `sidekiq_unique_context` resolution can be
+# exercised on it. It has no ActiveJob load-time dependency.
+require_relative '../../lib/wurk/active_job/wrapper'
 
 class UniqueTest < Wurk::Test::UnitCase
   # NOT parallelize_me! — these tests flip the process-wide
@@ -100,6 +104,142 @@ class UniqueTest < Wurk::Test::UnitCase
       b = Wurk::Unique.lock_key_for({ 'class' => 'CustomContextJob', 'queue' => 'q', 'args' => [1, 'other'] })
 
       assert_equal a, b
+    end
+  end
+
+  # ---- ActiveJob-wrapped payloads (#317 audit) -------------------------
+
+  def test_active_job_digest_ignores_per_push_identifiers
+    a = Wurk::Unique.lock_key_for(active_job_payload)
+    b = Wurk::Unique.lock_key_for(active_job_payload)
+
+    assert_equal a, b, 'job_id/enqueued_at churn must not change the digest'
+  end
+
+  def test_active_job_digest_differs_by_arguments
+    a = Wurk::Unique.lock_key_for(active_job_payload(arguments: [1]))
+    b = Wurk::Unique.lock_key_for(active_job_payload(arguments: [2]))
+
+    refute_equal a, b
+  end
+
+  def test_active_job_digest_differs_by_wrapped_class
+    a = Wurk::Unique.lock_key_for(active_job_payload(job_class: 'AJobA'))
+    b = Wurk::Unique.lock_key_for(active_job_payload(job_class: 'AJobB'))
+
+    refute_equal a, b
+  end
+
+  def test_active_job_digest_differs_by_queue
+    a = Wurk::Unique.lock_key_for(active_job_payload(queue: 'q1'))
+    b = Wurk::Unique.lock_key_for(active_job_payload(queue: 'q2'))
+
+    refute_equal a, b
+  end
+
+  def test_active_job_digest_recognizes_legacy_wrapper_names
+    canonical = Wurk::Unique.lock_key_for(active_job_payload)
+    legacy = Wurk::Unique.lock_key_for(
+      active_job_payload(wrapper: 'ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper')
+    )
+
+    # Different wrapper names are still distinct keys, but both must be
+    # narrowed (i.e. stable across pushes) rather than falling back to args.
+    refute_equal canonical, legacy
+    assert_equal legacy, Wurk::Unique.lock_key_for(
+      active_job_payload(wrapper: 'ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper')
+    )
+  end
+
+  def test_active_job_dedup_drops_second_push
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      first = active_job_payload(jid: 'aj-1', job_class: "AJ#{@suffix}").merge('unique_for' => 600)
+      second = active_job_payload(jid: 'aj-2', job_class: "AJ#{@suffix}").merge('unique_for' => 600)
+      track_key(first)
+
+      assert invoke_client(first)
+      refute invoke_client(second), 'a second ActiveJob push of the same job must be deduped'
+      assert_equal('aj-1', redis_call('GET', Wurk::Unique.lock_key_for(first)))
+    end
+  end
+
+  def test_active_job_wrapper_honors_sidekiq_unique_context
+    hook = ->(job) { ['custom', job['args'].first['arguments'].first] }
+    with_wrapper_context(hook) do
+      a = Wurk::Unique.lock_key_for(active_job_payload(arguments: [7, 'noise']))
+      b = Wurk::Unique.lock_key_for(active_job_payload(arguments: [7, 'other']))
+
+      assert_equal a, b
+      assert_equal "unique:#{Digest::SHA256.hexdigest(JSON.dump(['custom', 7]))}", a
+    end
+  end
+
+  def test_plain_job_with_activejob_shaped_arg_is_not_narrowed
+    # Only the known wrapper class names opt into the narrowed context; a
+    # plain worker whose arg happens to look like a serialized AJ keeps the
+    # verbatim [class, queue, args] digest.
+    job = { 'class' => 'PlainJob', 'queue' => 'q',
+            'args' => [{ 'job_class' => 'X', 'arguments' => [1], 'job_id' => 'a' }] }
+    expected = "unique:#{Digest::SHA256.hexdigest(JSON.dump(['PlainJob', 'q', job['args']]))}"
+
+    assert_equal expected, Wurk::Unique.lock_key_for(job)
+  end
+
+  def test_wrapper_with_non_activejob_args_falls_back_to_default_context
+    job = { 'class' => 'Sidekiq::ActiveJob::Wrapper', 'queue' => 'q', 'args' => [1, 2] }
+    expected = "unique:#{Digest::SHA256.hexdigest(JSON.dump(['Sidekiq::ActiveJob::Wrapper', 'q', [1, 2]]))}"
+
+    assert_equal expected, Wurk::Unique.lock_key_for(job)
+  end
+
+  # ---- unique + encryption are rejected, in either order ---------------
+
+  def test_encrypted_unique_job_raises_configuration_error
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      with_crypto do
+        job = build_job(jid: 'enc-1', ttl: 60).merge('encrypt' => true)
+
+        error = assert_raises(Wurk::Unique::ConfigurationError) { invoke_client(job) }
+
+        assert_match(/unique_for/, error.message)
+        assert_match(/encrypt/, error.message)
+      end
+    end
+  end
+
+  def test_encrypted_job_without_unique_for_is_untouched
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      with_crypto do
+        job = { 'class' => 'X', 'queue' => 'q', 'args' => ['s'], 'jid' => 'enc-2', 'encrypt' => true }
+
+        assert invoke_client(job)
+      end
+    end
+  end
+
+  def test_unique_job_without_encrypt_is_untouched_while_crypto_enabled
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      with_crypto do
+        job = build_job(jid: 'enc-3', ttl: 60)
+        track_key(job)
+
+        assert invoke_client(job)
+      end
+    end
+  end
+
+  def test_encrypted_unique_job_raises_when_crypto_disabled_is_false
+    # Crypto not enabled: `encrypt: true` is inert, so uniqueness proceeds.
+    ENABLE_MUTEX.synchronize do
+      Wurk::Unique.enable!
+      job = build_job(jid: 'enc-4', ttl: 60).merge('encrypt' => true)
+      track_key(job)
+
+      assert invoke_client(job)
     end
   end
 
@@ -644,7 +784,78 @@ class UniqueTest < Wurk::Test::UnitCase
     end
   end
 
+  def test_locked_honors_sidekiq_unique_context
+    klass = Class.new do
+      def self.name = 'LockedContextJob'
+
+      def self.sidekiq_unique_context(job)
+        ['LockedContextJob', [job['args'].first]]
+      end
+    end
+    stub_const('LockedContextJob', klass) do
+      job = { 'class' => 'LockedContextJob', 'queue' => 'q', 'args' => [5, 'noise'] }
+      key = Wurk::Unique.lock_key_for(job)
+      Wurk.redis { |c| c.call('SET', key, 'ctx-holder', 'EX', 60) }
+      @keys << key
+
+      assert_equal 'ctx-holder', Wurk::Unique.locked?('q', 'LockedContextJob', [5, 'noise']),
+                   'locked? must agree with lock_key_for for a custom context'
+    end
+  end
+
+  def test_locked_agrees_with_lock_key_for_on_active_job
+    job = active_job_payload(job_class: "AJLocked#{@suffix}")
+    key = Wurk::Unique.lock_key_for(job)
+    Wurk.redis { |c| c.call('SET', key, 'aj-holder', 'EX', 60) }
+    @keys << key
+
+    assert_equal 'aj-holder',
+                 Wurk::Unique.locked?(job['queue'], job['class'], job['args'])
+  end
+
   private
+
+  # Mimics a real ActiveJob push: `args` is `[job.serialize]`, and `job_id` /
+  # `enqueued_at` are fresh on every call.
+  def active_job_payload(job_class: 'AJDemoJob', arguments: [1, 'x'], queue: 'q',
+                         jid: 'aj-jid', wrapper: 'Sidekiq::ActiveJob::Wrapper')
+    @aj_seq = (@aj_seq || 0) + 1
+    data = {
+      'job_class' => job_class,
+      'job_id' => "id-#{@aj_seq}-#{rand(1 << 32)}",
+      'provider_job_id' => nil,
+      'queue_name' => queue,
+      'priority' => nil,
+      'arguments' => arguments,
+      'executions' => 0,
+      'exception_executions' => {},
+      'locale' => 'en',
+      'timezone' => 'UTC',
+      'enqueued_at' => ::Time.now.to_f.to_s,
+      'scheduled_at' => nil
+    }
+    { 'class' => wrapper, 'wrapped' => job_class, 'queue' => queue,
+      'args' => [data], 'jid' => jid }
+  end
+
+  # Install a `sidekiq_unique_context` hook on the real wrapper class for the
+  # duration of the block (that class is what `job["class"]` names on the wire).
+  def with_wrapper_context(hook)
+    wrapper = ::Sidekiq::ActiveJob::Wrapper
+    wrapper.define_singleton_method(:sidekiq_unique_context) { |job| hook.call(job) }
+    yield
+  ensure
+    wrapper.singleton_class.send(:remove_method, :sidekiq_unique_context)
+  end
+
+  def with_crypto
+    Wurk::Encryption.enable(active_version: 1) { |_v| 'k' * 32 }
+    yield
+  ensure
+    Wurk::Encryption.disable!
+    Wurk.configuration.client_middleware.remove(Wurk::Encryption::ClientMiddleware)
+    Wurk.configuration.server_middleware.remove(Wurk::Encryption::ServerMiddleware)
+  end
 
   def build_job(jid:, ttl:, until_mode: nil, klass: "UniqJob#{@suffix}", queue: 'q')
     {

--- a/test/unit/web_search_test.rb
+++ b/test/unit/web_search_test.rb
@@ -55,6 +55,17 @@ class WebSearchTest < Wurk::Test::UnitCase
     )
   end
 
+  # Regression: SortedEntry is built from the raw JSON string, and JobRecord
+  # only derived @queue from a pre-parsed Hash — so every retry/scheduled/dead
+  # search hit reported `queue: nil` to the dashboard.
+  def test_search_sorted_hit_carries_the_queue
+    %w[retry schedule dead].each { |set| push_to_zset(set, @class_a, [@needle]) }
+
+    queues = Wurk::Web::Search.new(@needle, kinds: %w[retry scheduled dead]).to_a.map { |h| h[:queue] }
+
+    assert_equal [@queue] * 3, queues
+  end
+
   def test_search_finds_scheduled_hit
     push_to_zset('schedule', @class_a, [@needle])
 


### PR DESCRIPTION
Writing the new feature documentation against the implementation (rather than against the spec) surfaced a cluster of features that **look enabled but quietly do nothing**. This PR fixes them. Every fix has a regression test that fails without it.

## The bugs

| Area | Symptom | Fix |
|---|---|---|
| **Testing** | `require "sidekiq/testing"` didn't enable fake mode, and Wurk defaults to `:disable` — a migrated suite pushed into **real Redis** while every `MyJob.jobs` assertion came back empty | Require warns once and flips to `:fake`, matching Sidekiq; never overrides an explicitly chosen mode |
| **Inline execution** | `perform_inline` bypassed both middleware chains — unique locks leaked until TTL, batch callbacks never fired | Mirrors Sidekiq 8: client chain → JSON round trip → server chain, incl. the `nil`/`true` return contract |
| **Unique + ActiveJob** | Silent no-op: args are `[job.serialize]` with a fresh `job_id`/`enqueued_at` per push, so the digest never repeated | AJ payloads narrow to wrapped class + `arguments`; retry counters excluded so a retry still matches its own lock |
| **Unique + encryption** | Which one "won" depended on initializer order; the envelope's random IV meant dedup silently never matched | Raises `Wurk::Unique::ConfigurationError` at push (stricter than Ent, which only documents it) |
| **`Unique.locked?`** | Ignored `sidekiq_unique_context`, reporting "free" for any custom-context worker | Routes through `lock_key_for` |
| **Batch `callback_class`** | Stored but never read — a `"#method"` target silently never fired | Resolves all four documented target forms |
| **Periodic jobs** | Editing a schedule left the **old loop firing forever** (`unregister` had zero callers despite its comment) | Registration prunes superseded loops, scoped by class |
| **Periodic pause** | A dashboard pause was undone on the next deploy | `paused` written with `HSETNX` |
| **Iterable jobs** | No checkpoint on graceful stop; cancelled jobs re-cycled at the queue head for 3 days | Polls `interrupted?` per iteration; cancelled jobs terminate and delete state |
| **`top_jobs(hours:)`** | Re-capped hours against `MAX_MINUTES`, so the documented 72h ceiling raised `WindowTooWide` above 8h | Each argument validated against its own cap |
| **Search / job APIs** | `SortedEntry#queue` was `nil` for every scanned entry → null `queue` in search and the retry/scheduled/dead APIs | Lazy derive from the job JSON |
| **Limiter Reset (UI)** | Deleted a bare `lmtr-b:{name}`, missing the real `:{epoch}` counter | Rebuilds the limiter and delegates to its own `reset` |

## Behavior changes to be aware of

- `perform_inline` now runs middleware, so it touches Redis and returns `true`/`nil` instead of `perform`'s value.
- **ActiveJob unique digests change.** Nothing can get permanently stuck (`unique_for` is mandatory, every key carries `EX`), but during a rolling deploy old and new processes compute different AJ keys, so dedup is split across two namespaces for the length of the deploy.
- TSTP (quiet) now interrupts an in-flight iterable job at the next iteration boundary, matching upstream.
- `unique_for` + `encrypt: true` on one worker now raises instead of silently not deduping.

## Deliberately not fixed

- A **deleted** `register` line still orphans its loop — nothing in the surviving code names that class, so no scope can see it. Manual removal is documented.
- Two registrars disagreeing about one class will flap; converges once one code version is booting. A proper fix needs an owner/generation marker in Redis, i.e. a schema change.

## Verification

- Full suite: **2597 runs, 0 failures**. The one error is pre-existing and environmental (`web_search_test` seeds an 80k-arg `ZADD` that exceeds the local Redis protocol limit — reproduces on a clean tree).
- Coverage gate green: line **96.68%**, branch **90.02%**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)