### PR TITLE
fix(demo): push to DOCR, build a working image, deploy on release

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,9 +1,10 @@
 name: deploy-demo
 
-# Manual-only deploy of the public demo (wurk.demo.developerz.ai).
+# Deploy of the public demo (wurk.demo.developerz.ai) — run it by hand, or let
+# release.yml call it after publishing a `v*` tag.
 #
 # DEPLOY MODEL: this workflow only BUILDS + PUSHES the image. Infra deploys it
-# via the in-cluster ArgoCD Image Updater, which watches the GHCR `:latest` tag
+# via the in-cluster ArgoCD Image Updater, which watches the DOCR `:latest` tag
 # (digest strategy) and syncs automatically — CI holds NO cluster credentials
 # (infra repo rule). There is no ArgoCD step here, and no ARGOCD_* secrets.
 #
@@ -25,17 +26,34 @@ on:
         description: Git ref (branch / tag / SHA) to build and push (Image Updater deploys it)
         required: false
         default: main
+  # release.yml calls this after a successful `v*` publish so a new gem version
+  # reaches the demo without a second manual step. Both gates still apply: the
+  # caller's actor must be in DEMO_DEPLOYERS, and `build` still enters the
+  # protected `demo` environment.
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref (branch / tag / SHA) to build and push
+        required: false
+        default: main
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 # Least privilege at the workflow level; the build job opts into packages:write.
 permissions:
   contents: read
 
 env:
-  IMAGE: ghcr.io/developerz-ai/wurk-demo
+  # DOCR is the deploy-critical registry: infra's Image Updater watches
+  # `registry.digitalocean.com/developerz-ai/wurk-demo:latest` and the demo's
+  # kustomization rewrites the manifests' ghcr.io ref onto it (infra #803 —
+  # moved off GHCR 2026-07-12 when a dead org token broke fresh pulls). GHCR
+  # stays a mirror so the manifests' literal image ref keeps resolving.
+  IMAGE: registry.digitalocean.com/developerz-ai/wurk-demo
+  MIRROR: ghcr.io/developerz-ai/wurk-demo
 
 jobs:
   authorize:
@@ -74,9 +92,22 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.inputs.ref }}
+          ref: ${{ inputs.ref }}
           persist-credentials: false
+
+      # github.sha is the SHA of the ref the WORKFLOW was loaded from (the
+      # default branch on a dispatch), not of `inputs.ref` — tagging with it
+      # mislabels the image whenever the two differ, e.g. deploying a tag.
+      - name: resolve built commit
+        id: built
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: registry.digitalocean.com
+          username: ${{ secrets.DOCR_TOKEN }}
+          password: ${{ secrets.DOCR_TOKEN }}
       - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
@@ -88,8 +119,10 @@ jobs:
           file: Dockerfile
           push: true
           tags: |
-            ${{ env.IMAGE }}:${{ github.sha }}
+            ${{ env.IMAGE }}:${{ steps.built.outputs.sha }}
             ${{ env.IMAGE }}:latest
+            ${{ env.MIRROR }}:${{ steps.built.outputs.sha }}
+            ${{ env.MIRROR }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -117,10 +150,14 @@ jobs:
       # (and children) from GHCR without pulling layers, so this fails the run
       # loudly if the deploy-critical :latest or the just-pushed :sha stopped
       # resolving. Not continue-on-error: a broken :latest breaks the Image
-      # Updater deploy, so it must surface.
+      # Updater deploy, so it must surface. DOCR is checked first and for the
+      # same reason — it is the registry Image Updater actually watches.
       - name: verify retained images still resolve
+        env:
+          SHA: ${{ steps.built.outputs.sha }}
         run: |
-          for ref in "${IMAGE}:latest" "${IMAGE}:${{ github.sha }}"; do
+          for ref in "${IMAGE}:latest" "${IMAGE}:${SHA}" \
+                     "${MIRROR}:latest" "${MIRROR}:${SHA}"; do
             echo "==> inspecting $ref"
             docker buildx imagetools inspect "$ref" >/dev/null
           done

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,7 +24,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   deploy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,17 @@ on:
 
 # Least privilege: contents:write to cut the GitHub Release; id-token:write for
 # RubyGems trusted publishing (OIDC). No long-lived GEM_HOST_API_KEY anywhere.
+# packages:write is for the called deploy-demo workflow — a reusable workflow's
+# job permissions are capped by the caller's, so without it the demo's GHCR
+# mirror push is denied.
 permissions:
   contents: write
   id-token: write
+  packages: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -89,3 +93,16 @@ jobs:
             flags+=(--prerelease)
           fi
           gh release create "${GITHUB_REF_NAME}" "${flags[@]}" "pkg/wurk-${version}.gem"
+
+  # Ship the released tag to wurk.demo.developerz.ai. Runs only after the gem is
+  # published, so the demo never advertises a version RubyGems does not have.
+  # deploy-demo keeps both of its gates (DEMO_DEPLOYERS actor allowlist + the
+  # protected `demo` environment), so this queues the deploy rather than forcing
+  # it — an unapproved release still publishes the gem and just leaves the demo
+  # on the previous image.
+  demo:
+    needs: release
+    uses: ./.github/workflows/deploy-demo.yml
+    with:
+      ref: ${{ github.ref_name }}
+    secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,11 @@ FROM ruby:3.4-slim-bookworm
 ENV RAILS_ENV=production \
     WURK_DEMO=1 \
     WURK_WEB_READ_ONLY=1
+# libffi-dev is for the `fiddle` gem: it left Ruby's default gems in 4.0, so
+# wurk depends on it explicitly (swarm PR_SET_PDEATHSIG) and it builds a native
+# extension here — without the headers `bundle install` dies in extconf.
 RUN apt-get update -qq && apt-get install -y --no-install-recommends \
-      build-essential libsqlite3-dev libyaml-dev curl git && \
+      build-essential libsqlite3-dev libyaml-dev libffi-dev curl git && \
     rm -rf /var/lib/apt/lists/* && \
     useradd --create-home --shell /bin/bash wurk
 

--- a/docs/demo-deploy.md
+++ b/docs/demo-deploy.md
@@ -34,12 +34,14 @@ internet ──►│                                                     ├─
 
 `.github/workflows/deploy-demo.yml` **builds and pushes the image only** — it
 holds no cluster credentials. The in-cluster **ArgoCD Image Updater** watches the
-GHCR `:latest` digest and syncs the deployment automatically; the pushed digest
-*is* the deploy trigger. The workflow is **manual only** (`workflow_dispatch`) and
-gated three ways so only the org can ship an image:
+DOCR `:latest` digest and syncs the deployment automatically; the pushed digest
+*is* the deploy trigger. It runs two ways — `workflow_dispatch` by hand, or
+called by `release.yml` after a `v*` tag publishes — and is gated three ways so
+only the org can ship an image:
 
 1. **Public repo + `workflow_dispatch`** → only users with *write* access (org
-   members) can trigger it; external forks cannot.
+   members) can trigger it; external forks cannot. A release-triggered run is
+   attributed to whoever pushed the tag, so gate 2 still applies to it.
 2. **`DEMO_DEPLOYERS` repo variable** (comma-separated GitHub usernames) → the
    `authorize` job rejects anyone not listed.
 3. **Protected `demo` environment** → add Required Reviewers. The gate sits on the
@@ -53,30 +55,49 @@ gated three ways so only the org can ship an image:
 - **Settings → Environments → `demo`:** create it, add the deployer(s) as
   *Required reviewers*, and (optionally) restrict the deployment branch to `main`.
 
-No `ARGOCD_*` secrets are needed — CI never talks to the cluster. The image push
-uses the built-in `GITHUB_TOKEN` (GHCR), so no registry secret is required either.
+- **Settings → Environments → `demo` → Environment secrets:** add `DOCR_TOKEN`
+  (a DigitalOcean token with registry write). It lives on the environment, not
+  the repo, so only the reviewer-gated `build` job can read it — this repo is
+  public.
 
-## ✅ Infra requirements (for the infra team)
+No `ARGOCD_*` secrets are needed — CI never talks to the cluster.
 
-What's needed to make `https://wurk.demo.developerz.ai` go live. Items marked
-**(app)** are in this repo / done; the rest are infra.
+### Registries
 
-- [x] **(app)** Containerized demo (`Dockerfile`, `bin/demo-entrypoint`) — web + worker roles. *Build still needs one verification pass.*
+The image is pushed to **two** registries from one build:
+
+| Registry | Tag | Role |
+|---|---|---|
+| `registry.digitalocean.com/developerz-ai/wurk-demo` | `latest` + `<sha>` | **Deploy-critical.** Image Updater watches this digest. |
+| `ghcr.io/developerz-ai/wurk-demo` | `latest` + `<sha>` | Mirror, so the manifests' literal `ghcr.io` image ref still resolves. |
+
+Infra moved the demo to DOCR on 2026-07-12 (infra #803) after a dead GHCR org
+token broke fresh pulls; `stacks/apps/wurk-demo/manifests/kustomization.yml`
+rewrites the `ghcr.io` name onto DOCR. **Pushing only to GHCR is a silent
+no-op** — the build succeeds and the demo never changes.
+
+## ✅ Infra requirements
+
+All live as of 2026-07-21 — the stack is at
+`../infrastructure/stacks/apps/wurk-demo/`. Kept as a checklist because it is
+also the rebuild recipe. Items marked **(app)** live in this repo.
+
+- [x] **(app)** Containerized demo (`Dockerfile`, `bin/demo-entrypoint`) — web + worker roles.
 - [x] **(app)** Gated deploy workflow (`deploy-demo.yml`).
 - [x] **(app)** Read-only dashboard (`WURK_WEB_READ_ONLY=1`) + live data generator.
-- [ ] **Redis** — a small managed/in-cluster Redis (7.x) reachable from both pods, exposed as `REDIS_URL`. Demo data only; safe to flush.
-- [ ] **`SECRET_KEY_BASE`** — a strong random value injected at runtime (k8s secret) so the Rails app boots in production. Not baked into the image.
-- [ ] **GHCR pull access** — an `imagePullSecret` (or public package) so the cluster can pull `ghcr.io/developerz-ai/wurk-demo`.
-- [ ] **ArgoCD Application `wurk-demo`** in `../infrastructure` — Deployments for `web` (cmd `web`) and `worker` (cmd `worker`), a Service, and the Redis dependency.
-- [ ] **ArgoCD Image Updater** watching `ghcr.io/developerz-ai/wurk-demo:latest` (digest strategy) so a pushed image auto-syncs. CI holds no cluster credentials, so there are no `ARGOCD_*` secrets.
-- [ ] **DNS** — `wurk.demo.developerz.ai` → the cluster ingress / Traefik.
-- [ ] **Ingress (Traefik) + TLS** — route the host to the `web` Service, Let's Encrypt cert.
-- [ ] **Public rate-limit** — a Traefik rate-limit middleware on the ingress to discourage abuse.
-- [ ] **Hourly reset `CronJob`** — apply [`demo/k8s/demo-reset-cronjob.yaml`](../demo/k8s/demo-reset-cronjob.yaml) (`demo:reset` → FLUSHDB) so queue latency doesn't creep up over hours. Without it the demo stays alive but the `high`/`low` queues accumulate a multi-hour backlog.
-- [ ] **Resource limits + restart policy** — modest CPU/mem requests; pods must recover on restart with no manual step (the generator self-heals; no persistent state outside Redis).
+- [x] **Redis** — a small managed/in-cluster Redis (7.x) reachable from both pods, exposed as `REDIS_URL`. Demo data only; safe to flush.
+- [x] **`SECRET_KEY_BASE`** — a strong random value injected at runtime (k8s secret) so the Rails app boots in production. Not baked into the image.
+- [x] **Registry pull access** — sealed `docr-pull` / `ghcr-pull` imagePullSecrets in ns `wurk-demo`.
+- [x] **ArgoCD Application `wurk-demo`** in `../infrastructure` — Deployments for `web` (cmd `web`) and `worker` (cmd `worker`), a Service, and the Redis dependency.
+- [x] **ArgoCD Image Updater** watching `registry.digitalocean.com/developerz-ai/wurk-demo:latest` (digest strategy) so a pushed image auto-syncs. CI holds no cluster credentials, so there are no `ARGOCD_*` secrets.
+- [x] **DNS** — `wurk.demo.developerz.ai` → the cluster ingress / Traefik.
+- [x] **Ingress (Traefik) + TLS** — route the host to the `web` Service, Let's Encrypt cert.
+- [x] **Public rate-limit** — a Traefik rate-limit middleware on the ingress to discourage abuse.
+- [x] **Hourly reset `CronJob`** — apply [`demo/k8s/demo-reset-cronjob.yaml`](../demo/k8s/demo-reset-cronjob.yaml) (`demo:reset` → FLUSHDB) so queue latency doesn't creep up over hours. Without it the demo stays alive but the `high`/`low` queues accumulate a multi-hour backlog.
+- [x] **Resource limits + restart policy** — modest CPU/mem requests; pods must recover on restart with no manual step (the generator self-heals; no persistent state outside Redis).
 
-### Decisions to confirm with infra
+### Settled decisions
 
-- **Redis sizing / persistence:** demo can run on an ephemeral Redis (a restart
-  just empties it; the generator refills). Confirm whether infra wants
-  persistence at all.
+- **Redis sizing / persistence:** ephemeral, no persistence — an in-cluster
+  Dragonfly (`manifests/dragonfly.yml`). A restart just empties it and the
+  generator refills within a tick, which is also what the hourly reset relies on.


### PR DESCRIPTION
The demo at wurk.demo.developerz.ai has been stale since 2026-07-01. Three independent breakages, each of which alone was enough to stop it updating.

## 1. Pushing to a registry nobody watches

`deploy-demo.yml` pushed only to `ghcr.io/developerz-ai/wurk-demo`. Infra **#803** moved the demo to DOCR on 2026-07-12 after a dead GHCR org token broke fresh pulls — `application.yml`'s Image Updater now watches `registry.digitalocean.com/developerz-ai/wurk-demo:latest`, and `kustomization.yml` rewrites the manifests' `ghcr.io` name onto DOCR.

Only the infra half of that migration was done. A GHCR-only push is a **silent no-op**: the build goes green and the demo never changes.

Now pushes both, DOCR first, and the verify step checks all four tags resolve. GHCR stays a mirror so the manifests' literal image ref keeps resolving.

## 2. The image did not build

```
checking for ffi.h... no
missing libffi. Please install libffi
An error occurred while installing fiddle (1.1.8)
```

`wurk` 1.2.0 depends on `fiddle` — it left Ruby's default gems in 4.0 and the swarm needs it for `PR_SET_PDEATHSIG`. It compiles a native extension, and the runtime stage installed no libffi headers. Added `libffi-dev`.

## 3. A release did not reach the demo

`release.yml` now calls `deploy-demo.yml` with the tag after the gem publishes. **Both gates survive** — the caller's actor must still be in `DEMO_DEPLOYERS`, and `build` still enters the protected `demo` environment — so this *queues* a deploy rather than forcing one. An unapproved release still publishes the gem and leaves the demo on the previous image.

The caller gained `packages: write`: a reusable workflow's job permissions are capped by its caller's, so without it the mirror push would be denied.

## Found along the way

- **Image tagged with the wrong SHA.** `${{ github.sha }}` on `workflow_dispatch` is the SHA of the branch the *workflow file* came from, not of `inputs.ref` — so deploying a tag mislabelled the image. Resolves `HEAD` after checkout instead.
- **`cancel-in-progress: true` on deploy-demo, pages and release.** `CLAUDE.md`'s CI standard names those three as never-auto-cancel. Cancelling a half-finished registry push or gem publish is the exact case that rule exists for.
- **`docs/demo-deploy.md` was badly stale** — documented the GHCR deploy model and listed nine infra prerequisites as outstanding that have all been live for weeks (Dragonfly, sealed `SECRET_KEY_BASE`, the Application, ingress + TLS, the Traefik rate-limit, the reset CronJob).

## Secret

`DOCR_TOKEN` is set as an **environment** secret on `demo`, not a repo secret — this repo is public, so only the reviewer-gated `build` job can read it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)