### PR TITLE
perf(ci): skip Ruby work on changes that cannot affect it

### DIFF
--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -9,13 +9,47 @@ on:
 
 permissions:
   contents: read
+  # paths-filter reads the PR's changed-file list on pull_request events.
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # 45 minutes of third-party suites is far too much to pay for a docs edit.
+  # Gate it — but on pull requests ONLY: push-to-main keeps main verifiable, and
+  # the weekly schedule has no base commit to diff against, so filtering there
+  # would silently skip the run it exists for.
+  detect:
+    name: detect changed paths
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 5
+    outputs:
+      ruby: ${{ steps.filter.outputs.ruby }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          filters: |
+            ruby:
+              - 'lib/**'
+              - 'app/**'
+              - 'exe/**'
+              - 'test/**'
+              - 'tasks/**'
+              - 'Gemfile'
+              - 'Gemfile.lock'
+              - 'Rakefile'
+              - '*.gemspec'
+              - '.github/workflows/ecosystem.yml'
+
   ecosystem:
+    needs: detect
+    if: github.event_name != 'pull_request' || needs.detect.outputs.ruby == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 45
     services:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,16 +6,62 @@ on:
   pull_request:
 
 # Least privilege: every job here only reads the repo (artifact upload doesn't
-# need a broader GITHUB_TOKEN scope).
+# need a broader GITHUB_TOKEN scope). pull-requests:read is for the `detect`
+# gate — paths-filter reads the PR's changed-file list on pull_request events.
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Which parts of the repo does this change touch? Everything below keys off
+  # these outputs, so a docs-only PR stops paying for the full Ruby matrix.
+  #
+  # PULL REQUESTS ONLY. On push-to-main every job runs unconditionally: main is
+  # what `release:check` and the tag build trust, so its history stays fully
+  # verified regardless of what a given commit touched.
+  detect:
+    name: detect changed paths
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 5
+    outputs:
+      ruby: ${{ steps.filter.outputs.ruby }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      specdocs: ${{ steps.filter.outputs.specdocs }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          filters: |
+            ruby:
+              - 'lib/**'
+              - 'app/**'
+              - 'exe/**'
+              - 'bin/**'
+              - 'test/**'
+              - 'tasks/**'
+              - 'config/**'
+              - 'frontend/**'
+              - 'Gemfile'
+              - 'Gemfile.lock'
+              - 'Rakefile'
+              - '*.gemspec'
+              - '.github/workflows/test.yml'
+            frontend:
+              - 'frontend/**'
+              - '.github/workflows/test.yml'
+            specdocs:
+              - 'docs/target/**'
+              - '.github/workflows/test.yml'
+
   test:
+    needs: detect
     # No explicit `name:` — GitHub's default matrix naming emits
     # "test (<ruby>, <rails>)", which branch protection (strict: true) requires
     # byte-identical for "test (3.4, 7.2)" and "test (4.0, 8.0)" (merge-gated).
@@ -46,17 +92,25 @@ jobs:
       BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile
       RAILS_VERSION: ${{ matrix.rails }}
       REDIS_URL: redis://localhost:6379/0
+      # Gated per STEP, not per job. "test (3.4, 7.2)" and "test (4.0, 8.0)" are
+      # required checks under branch protection, and GitHub does not count a
+      # skipped required check as satisfied — a job-level `if:` would park every
+      # docs-only PR on "Expected — waiting for status" forever. So the job always
+      # runs and reports success; on an irrelevant change it just does nothing.
+      RUN: ${{ github.event_name != 'pull_request' || needs.detect.outputs.ruby == 'true' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
           persist-credentials: false
       - uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1
+        if: env.RUN == 'true'
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
           # Each Rails leg resolves a different lock; isolate the gem cache.
           cache-version: rails-${{ matrix.rails }}
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        if: env.RUN == 'true'
         with:
           bun-version: "1.3.14"
       # Cache Bun's global download cache so `bun install --frozen-lockfile`
@@ -67,6 +121,7 @@ jobs:
       # frontend lockfile; the shared key is intentional so every matrix leg and
       # job reuses one cache.
       - name: cache bun install cache
+        if: env.RUN == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.bun/install/cache
@@ -74,13 +129,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
       - name: build dashboard SPA
+        if: env.RUN == 'true'
         run: bundle exec rake frontend:build
       - name: dummy app setup
+        if: env.RUN == 'true'
         run: |
           cd test/dummy
           bundle install
           bin/rails db:prepare
       - name: rake test
+        if: env.RUN == 'true'
         run: bundle exec rake test
 
   # Oracle suite lifted from upstream Sidekiq (SHA-pinned in
@@ -89,6 +147,8 @@ jobs:
   # it tests a matrix Rails line rather than floating to newest.
   parity:
     name: parity (oracle)
+    needs: detect
+    if: github.event_name != 'pull_request' || needs.detect.outputs.ruby == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     services:
@@ -121,6 +181,8 @@ jobs:
   # gated numbers stay deterministic.
   coverage:
     name: coverage (line + branch >= 90%)
+    needs: detect
+    if: github.event_name != 'pull_request' || needs.detect.outputs.ruby == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     services:
@@ -184,6 +246,8 @@ jobs:
   # parity). This is a quick, standalone check that doesn't require Redis or Ruby.
   spec-docs:
     name: spec docs (exist + non-empty)
+    needs: detect
+    if: github.event_name != 'pull_request' || needs.detect.outputs.specdocs == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
@@ -211,6 +275,8 @@ jobs:
   # (no Ruby/Redis needed; the suite is fast). Closes #273.
   frontend:
     name: frontend (vitest)
+    needs: detect
+    if: github.event_name != 'pull_request' || needs.detect.outputs.frontend == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:

--- a/test/integration/redis_outage_recovery_test.rb
+++ b/test/integration/redis_outage_recovery_test.rb
@@ -87,7 +87,14 @@ class RedisOutageRecoveryTest < Wurk::Test::UnitCase
     assert_equal 0, @observer.call('ZCARD', Wurk::Keys::RETRY).to_i, 'no job should have failed into the retry set'
     assert_equal 0, @observer.call('ZCARD', Wurk::Keys::DEAD).to_i, 'no job should have failed into the dead set'
     assert_equal 0, @observer.call('LLEN', "queue:#{@queue_name}").to_i, 'public queue must fully drain'
-    assert_equal 0, @observer.call('LLEN', private_queue_key).to_i, 'private list must fully drain (every job acked)'
+
+    # The ack (LREM) runs in Processor#process's ensure, *after* perform
+    # returns, and goes through the blipped pool's retry+backoff — while the
+    # sentinel records its execution over a direct connection that bypasses the
+    # proxy. So "all jobs executed" strictly precedes "all jobs acked"; poll for
+    # the drain rather than sampling it the instant the last job runs.
+    assert wait_until?(timeout: POLL_TIMEOUT) { private_queue_depth.zero? },
+           "private list must fully drain (every job acked), still holding #{private_queue_depth}"
 
     refute_predicate @manager, :stopped?, 'the manager must self-heal in place — no restart'
 
@@ -150,6 +157,10 @@ class RedisOutageRecoveryTest < Wurk::Test::UnitCase
 
   def private_queue_key
     Wurk::Fetcher::Reliable.private_queue_name("queue:#{@queue_name}")
+  end
+
+  def private_queue_depth
+    @observer.call('LLEN', private_queue_key).to_i
   end
 
   def wait_until?(timeout: 5.0)


### PR DESCRIPTION
Every PR ran the full Ruby matrix, parity, coverage, the 45-minute ecosystem suite and vitest — including the docs- and workflow-only PRs that are most of what lands here. #322 changed five files, **none of them Ruby**, and still paid for all of it.

Adds a `detect` job using `dorny/paths-filter` — the pattern already in use in `tesote.ai`'s CI — and keys the rest off its outputs.

## The required-check trap

Branch protection requires `test (3.4, 7.2)` and `test (4.0, 8.0)` byte-for-byte:

```json
{"required_checks":["test (3.4, 7.2)","test (4.0, 8.0)"],"strict":true}
```

**GitHub does not count a skipped required check as satisfied.** A job-level `if:` on those would park every docs-only PR on "Expected — waiting for status" forever.

So the `test` job always runs and gates its **steps** instead — on an irrelevant change it checks out and finishes green in seconds. `parity`, `coverage`, `spec-docs`, `frontend` and `ecosystem` are not required, so they take a job-level `if:` and skip outright.

## Scope of the gate

| Event | Behavior |
|---|---|
| `pull_request` | Gated. |
| `push` to main | Everything runs — main is what `release:check` and the tag build trust. |
| `schedule` (ecosystem, weekly) | Everything runs — there is no base commit to diff against, so filtering would silently skip the run that exists to catch upstream drift. |

`frontend/**` deliberately sits **inside** the `ruby` filter: the matrix legs run `rake frontend:build`, so a frontend change can break them and nothing else would catch that. A frontend-only PR still pays full price; the win is docs-only PRs.

## Also: the flake that failed #322

`RedisOutageRecoveryTest` failed on the Ruby 4.0 leg and passed on rerun with identical code. Not random — a real ordering assumption:

```ruby
assert_equal 0, @observer.call('LLEN', private_queue_key).to_i, 'private list must fully drain'
```

It sampled `LLEN` the instant the last job *executed*. But the ack (`LREM`) runs in `Processor#process`'s `ensure` — after `perform` returns, and through the blipped pool's retry+backoff — while the sentinel records execution over a direct connection that **bypasses the proxy**. Execution strictly precedes the ack, so under load the sample lands in the gap.

Now polls for the drain like the sibling assertions in the same test already do. Verified locally: `1 runs, 13 assertions, 0 failures`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)