### PR TITLE
chore(maintainer): lower triage.confidence_threshold 0.6→0.4

### DIFF
--- a/.maintainer.yml
+++ b/.maintainer.yml
@@ -19,6 +19,9 @@ triage:
   ask_for_repro: true
   required_fields: [steps, expected, actual, version]
   qualify_into: [bug, feature, dupe, question]
+  # Dogfood: lower than the 0.6 default so a moderately-scoped plan hands off to
+  # the coding fleet instead of escalating for review (exercises the handoff loop).
+  confidence_threshold: 0.4
 
 handoff:
   mode: webhook


### PR DESCRIPTION
Dogfood tuning: a moderately-scoped plan (e.g. #324's 0.35 was just under; 0.4 gives more headroom) hands off to the coding fleet instead of escalating for review, so the handoff loop actually exercises. Everything else unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated triage settings to allow moderately scoped tasks to proceed with less manual review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->