### PR TITLE
chore(policy): TEMPORARY auto_merge pin-off while the global babysit driver flips on

### DIFF
--- a/.maintainer.yml
+++ b/.maintainer.yml
@@ -29,7 +29,13 @@ handoff:
 
 pr:
   wait_for_other_bots: [coderabbit, copilot]
-  auto_merge: true
+  # TEMPORARY pin (2026-07-26, developerz.ai#1074): the global babysit hard driver
+  # (DZ_BABYSIT_DRIVER=1) is being enabled for the #295 dogfood on developerz.ai.
+  # This repo has no branch-protection ruleset, so until the review-absence gate
+  # (developerz-ai/developerz.ai#1080) ships, auto-merge is pinned OFF to keep the
+  # 120s review-absence hole from merging unreviewed PRs here. RESTORE auto_merge:
+  # true (this repo's deliberate dz#789 posture) once #1080 is merged.
+  auto_merge: false
 
 escalate:
   always: [security, license, cla]


### PR DESCRIPTION
## What

Pins `pr.auto_merge: false` in `.maintainer.yml`, TEMPORARILY, with the restore path in the file.

## Why

`DZ_BABYSIT_DRIVER=1` is being enabled for the #295 light-switch dogfood (developerz-ai/developerz.ai#1074). The flag is GLOBAL: every repo whose resolved policy is `auto_merge: true` gets the hard merge gate. This repo resolves true — a deliberate dz#789 dogfood posture — but unlike developerz.ai it has **no branch-protection ruleset**, so until the review-absence gate ships (developerz-ai/developerz.ai#1080) a PR here could merge with zero review after a 120s commit-age grace (Dependabot included → merge + deploy).

Ruled by ivndev001 2026-07-26: temporary pin, restore `auto_merge: true` (the declared posture) once #1080 is merged. The pin comment in the file carries the same restore instruction.

## Changes

- `.maintainer.yml`: `auto_merge: true` → `false` + TEMPORARY comment. Nothing else.

## Verification

- Policy-file-only change; wurk CI + CodeRabbit gate as usual
- Post-merge: developerz-ai/infrastructure#1072 (the flip) merges only AFTER this pin, so the radius at flip = developerz.ai only

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787642678&installation_model_id=11168&pr_number=336&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F336&signature=d3359f78f8d2ea4de73955f3c51e459fe636dbd537bf143811bcc8326ed1c24a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->