### PR TITLE
fix: Wurk::Engine + Sidekiq-shaped config.redis both broke the worker process only (1.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Wurk are recorded here. Format: [Keep a Changelog](https:
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-07-26
+
+Two drop-in gaps found in one production deploy, both of which only bite the worker process — so the web app looks healthy while nothing gets done. Each fix carries a regression test that fails without it.
+
+### Fixed
+- **`mount Wurk::Engine` in `config/routes.rb` crashed `wurk` / `wurkswarm` on boot** — with `uninitialized constant Wurk::Engine`, from the exact routes line the README and the migration guide tell you to write. `lib/wurk.rb` loads the engine behind a `defined?(Rails::Engine)` guard evaluated once at require time; the standalone runners require `wurk` *before* Rails exists, then boot the host app themselves, by which point `wurk` is in `$LOADED_FEATURES` and the app's own `Bundler.require` can't re-evaluate the guard. Web processes were unaffected (there `Bundler.require` runs after railties), so this reached production looking like a worker-only mystery. `Wurk::Engine` now resolves on demand behind the same guard. No `require "wurk/rails"` in routes.rb needed, and a genuinely non-Rails standalone boot still loads zero Rails code — nothing references the constant, so nothing loads.
+- **Sidekiq's `network_timeout` (and friends) killed every swarm child on boot** — `config.redis = { url:, driver:, network_timeout: 5, pool_timeout: 5 }`, an ordinary Sidekiq initializer, raised `ArgumentError: unknown keyword: :network_timeout` from redis-client. Sidekiq normalized its `config.redis` hash internally before handing it over; Wurk splatted it straight through. Because the swarm parent closes its connections *before* forking and only the children build pools, the parent stayed up and healthy — Running pod, passing liveness probe, respawn-backoff loop churning forever, zero jobs processed. `Wurk::RedisOptions` now performs Sidekiq's translation for every pool-building path:
+  - `network_timeout` / `timeout` fan out to `connect_timeout` / `read_timeout` / `write_timeout`. Not forwarded verbatim: Wurk sets all three explicitly (the split-timeout fix in 1.0.x), and redis-client lets an explicit `read_timeout` beat `timeout`, so passing the umbrella through would have silently dropped the host's value. A host-supplied split timeout still wins over the fan-out.
+  - `sentinels:` now builds the pool through `RedisClient.sentinel` — `RedisClient.config` rejects the key outright, so Sentinel deployments hit the same crash. `master_name` maps to `name`; `driver` and `role` are symbolized.
+  - `logger`, `cluster_safe` and `pool_name` are accepted and dropped, as Sidekiq did.
+  - `namespace` and `nodes` raise naming the key and its replacement, and any other key redis-client would reject raises listing the supported set — read off redis-client's own signatures, so it can't drift from the installed version.
+  - `config.redis =` validates on assignment, so a bad hash fails in the process running your initializer instead of inside a forked child nobody is watching.
+
+### Documentation
+- `docs/running.md`, `docs/configuration.md` and `docs/migrate-from-sidekiq.md` §3 promised the standalone runners "do fully boot your Rails app" while not loading the engine — true of the engine's *Rails lifecycle* (no initializers, routes or assets), but read as a guarantee that mounting the dashboard was safe, which it wasn't. The claim is now split: the engine doesn't start, but the constant resolves.
+- `docs/migrate-from-sidekiq.md` §1 implied `config.redis = {...}` was verbatim-compatible. It gains a per-key table (pass through / translated / rejected) and an upgrade note.
+
 ## [1.3.0] - 2026-07-26
 
 Error reporting. `sentry-sidekiq` is the one common add-on that cannot be installed alongside Wurk at all, and the obvious workaround — hanging a reporter off `config.error_handlers` — silently reports nothing from your jobs, because job failures never reach that hook. This release ships the integration Wurk should have had, and documents the trap for anyone rolling their own.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -325,8 +325,12 @@ contain `config/application.rb`); `concurrency` and `timeout` must both be
 logs a warning; and every capsule's pool size must be `>= its concurrency`
 (`Pool size too small for <capsule>` otherwise).
 
-Neither runner loads the Rails engine — a worker host stays lean and serves no
-dashboard — but both fully boot your app.
+Neither runner *starts* the Rails engine — no engine initializers, no dashboard
+routes, no assets, so a worker host stays lean and serves no dashboard — but both
+fully boot your app. The `Wurk::Engine` constant itself still resolves on demand,
+so an app whose `config/routes.rb` mounts the dashboard boots cleanly under
+`wurk` / `wurkswarm` too (before 1.3.1 it died there with `uninitialized constant
+Wurk::Engine`).
 
 ---
 
@@ -346,10 +350,26 @@ Wurk.configure_server do |config|
 end
 ```
 
-`config.redis =` **merges** into the existing hash. `:size` and `:name` are
-pool-structural and consumed by Wurk; everything else forwards verbatim to
-`RedisClient.config` (so `driver:`, `ssl_params:`, `username:`, `password:`,
-sentinel options, … pass through).
+`config.redis =` **merges** into the existing hash. `:size`, `:name`,
+`:pool_timeout` and `:pool_name` are pool-structural and consumed by Wurk;
+everything else forwards to redis-client (so `driver:`, `ssl_params:`,
+`username:`, `password:`, `sentinels:`, … pass through).
+
+Sidekiq-era spellings are translated rather than forwarded, so an existing
+initializer needs no edit:
+
+| You wrote | Wurk does |
+|---|---|
+| `network_timeout: 5` / `timeout: 5` | fans out to `connect_timeout` / `read_timeout` / `write_timeout` (an explicit one of those wins) |
+| `master_name: "mymaster"` | → `name:`, and `sentinels:` routes the pool through `RedisClient.sentinel` |
+| `driver: "hiredis"`, `role: "master"` | symbolized |
+| `logger:`, `cluster_safe:`, `pool_name:` | accepted and dropped, as Sidekiq does |
+| `namespace:` | raises — Wurk has no namespacing; give it its own Redis db or instance |
+| `nodes:` | raises — Redis Cluster is unsupported |
+
+Anything redis-client would reject raises on assignment, naming the key and
+listing the supported set, so a typo fails in the process running your
+initializer instead of inside a forked worker child.
 
 | Key | Default | Source |
 |---|---|---|

--- a/docs/migrate-from-sidekiq.md
+++ b/docs/migrate-from-sidekiq.md
@@ -86,7 +86,7 @@ Config options verified identical (`lib/wurk/configuration.rb`):
 |---|---|
 | `concurrency` | threads per worker process (default `5`) |
 | `queues` | ordered/weighted queue list |
-| `redis = { url:, … }` | defaults to `ENV["REDIS_URL"]` → `redis://localhost:6379/0` |
+| `redis = { url:, … }` | defaults to `ENV["REDIS_URL"]` → `redis://localhost:6379/0`; see the key notes below |
 | `logger`, `logger =` | standard `Logger` |
 | `timeout` | job + shutdown grace seconds (default `25`) |
 | `error_handlers`, `death_handlers` | arrays of callables |
@@ -94,6 +94,30 @@ Config options verified identical (`lib/wurk/configuration.rb`):
 | `on(:startup\|fork\|quiet\|shutdown\|exit\|heartbeat\|beat\|leader)` | lifecycle hooks |
 | `capsule(name) { … }` | multi-queue capsules (Sidekiq 7+) |
 | `periodic { \|mgr\| mgr.register(...) }` | cron jobs (Enterprise parity, free) |
+
+### `config.redis` keys
+
+The hash is Sidekiq's, but it isn't verbatim redis-client: Sidekiq normalized it
+internally before handing it over, and Wurk does the same translation so your existing
+initializer needs no edit.
+
+| Sidekiq key | Wurk |
+|---|---|
+| `url`, `db`, `username`, `password`, `ssl`, `ssl_params`, `driver`, `sentinels`, … | ✅ pass through |
+| `size`, `pool_timeout`, `pool_name` | ✅ pool-structural, consumed by Wurk |
+| `network_timeout` / `timeout` | ✅ fanned out to `connect_timeout` / `read_timeout` / `write_timeout` — Wurk splits them by default, and an explicitly-set one wins |
+| `master_name` | ✅ → `name`; with `sentinels:` the pool is built via `RedisClient.sentinel` |
+| `logger`, `cluster_safe` | ✅ accepted and dropped (as Sidekiq does) |
+| `namespace` | ❌ raises — Wurk has no namespacing (§4). Give it its own Redis database or instance |
+| `nodes` | ❌ raises — Redis Cluster is unsupported |
+
+Anything else redis-client would reject raises on assignment, naming the key.
+
+> ⚠️ **Upgrade note (1.3.1).** Through 1.3.0 the hash was splatted straight into
+> redis-client, so `network_timeout` (and the other Sidekiq-only spellings) raised
+> `ArgumentError: unknown keyword`. The swarm parent doesn't build a pool, so this only
+> killed the forked children — a Running pod with a passing liveness probe processing
+> zero jobs. Fixed in 1.3.1 ([#283](https://github.com/developerz-ai/wurk/issues/283)).
 
 > ℹ️ **`config.on(:fork)`** fires in each swarm child after fork — Wurk already
 > reconnects DB/Redis for you (it closes parent connections before forking and each
@@ -210,9 +234,18 @@ bundle exec wurkswarm -C config/wurk.yml -e production   # forked swarm (real pa
 bundle exec wurk      -C config/wurk.yml -e production    # single process
 ```
 
-Neither runner loads the Rails engine (the dashboard) — by design, so a worker host
-stays lean. They do fully boot your Rails app (`-r`/the environment) so your jobs and
-models are available.
+Neither runner *starts* the Rails engine (the dashboard) — by design, so a worker host
+stays lean: no engine initializers, no dashboard routes, no assets. They do fully boot
+your Rails app (`-r`/the environment) so your jobs and models are available — and that
+includes a `config/routes.rb` that mounts the dashboard, since `Wurk::Engine` resolves
+on demand.
+
+> ⚠️ **Upgrade note (1.3.1).** Through 1.3.0 that last part wasn't true: an app with
+> `mount Wurk::Engine => "/wurk"` in its routes booted fine under `rails server` but
+> died under `wurk` / `wurkswarm` with `uninitialized constant Wurk::Engine`, because
+> the runners require `wurk` before Rails exists. Fixed in 1.3.1
+> ([#282](https://github.com/developerz-ai/wurk/issues/282)) — no `require "wurk/rails"`
+> in routes.rb needed.
 
 > ✅ **ActiveJob works standalone.** If your app uses
 > `config.active_job.queue_adapter = :wurk` (or `:sidekiq`), the standalone CLI now

--- a/docs/running.md
+++ b/docs/running.md
@@ -113,13 +113,26 @@ Identical to Sidekiq:
 With no `-C`, Wurk auto-discovers `config/wurk.yml`, then `config/sidekiq.yml`
 (`.erb` variants too), relative to the required path.
 
+### Pointed at a Rails app (`-r .`)
+
+Both runners fully boot your app via `config/environment.rb`, but neither
+*starts* the engine: no engine initializers, no dashboard routes, no assets,
+nothing serving HTTP. A worker host stays lean.
+
+That's about the engine's Rails lifecycle, not the constant. `Wurk::Engine`
+resolves on demand, so an app whose `config/routes.rb` does
+`mount Wurk::Engine => "/wurk"` boots cleanly under `wurk` and `wurkswarm`
+exactly as it does under `rails server`. (Through 1.3.0 it did not — the worker
+died on boot with `uninitialized constant Wurk::Engine` while the web process was
+fine. Fixed in 1.3.1; no `require "wurk/rails"` in routes.rb needed.)
+
 ---
 
 ## Running without Rails
 
-Wurk's standalone runners never load the engine, so they work in any Ruby app —
-a Sinatra service, a plain Rack app, a CLI daemon, whatever. You point `-r` at a
-single Ruby file that loads your code and defines your jobs.
+Wurk's standalone runners pull in no Rails code of their own, so they work in any
+Ruby app — a Sinatra service, a plain Rack app, a CLI daemon, whatever. You point
+`-r` at a single Ruby file that loads your code and defines your jobs.
 
 **1. A boot file that requires your app and defines jobs:**
 

--- a/lib/wurk.rb
+++ b/lib/wurk.rb
@@ -224,6 +224,22 @@ module Wurk
     def ent?
       false
     end
+
+    # Lazily loads the Rails engine the first time something asks for
+    # `Wurk::Engine`. See the note above the `require "wurk/rails"` guard at the
+    # bottom of this file for why the guard alone isn't enough (#282), and why
+    # this loads the engine and not the railtie.
+    def const_missing(name)
+      return super unless name == :Engine
+      return super unless defined?(::Rails::Engine) && defined?(::ActionDispatch::Routing::RouteSet)
+
+      require_relative 'wurk/engine'
+      # If engine.rb somehow didn't define it, fall through to the real NameError
+      # rather than recursing back into here.
+      return super unless const_defined?(:Engine, false)
+
+      const_get(:Engine, false)
+    end
   end
 end
 
@@ -330,30 +346,18 @@ require_relative 'wurk/rails' if defined?(Rails::Engine) && defined?(::ActionDis
 # Wurk::Engine`, from the worker process only. Web processes are unaffected:
 # there Bundler.require runs after railties, so the gate passes.
 #
-# const_missing closes that window without giving up the lean standalone boot:
-# nothing loads until something actually asks for Wurk::Engine, and even then
-# only when Rails is really present. The gate is the same two-part condition as
-# above, so the ecosystem carve-out (rails/engine/railties without ActionDispatch,
-# per sidekiq-cron's test helper) still falls through to a plain NameError
-# instead of crashing on `isolate_namespace`.
+# `Wurk.const_missing` (defined in the class << self block above) closes that
+# window without giving up the lean standalone boot: nothing loads until
+# something actually asks for Wurk::Engine, and even then only when Rails is
+# really present. It reuses the same two-part condition as the guard above, so
+# the ecosystem carve-out (rails/engine/railties without ActionDispatch, per
+# sidekiq-cron's test helper) still falls through to a plain NameError instead of
+# crashing on `isolate_namespace`.
 #
-# Deliberately `wurk/engine` and not `wurk/rails`: the railtie's
+# It deliberately loads `wurk/engine`, not `wurk/rails`: the railtie's
 # `config.after_initialize` is a *global* ActiveSupport load hook registered at
 # require time, and routes are drawn before those hooks run — so dragging the
-# railtie in here would fork a swarm inside a `wurkswarm` parent that is about to
-# fork its own. The runner owns the swarm; the routes file only needs the
-# constant. `defined?(Wurk::Engine)` stays nil until then, which is what the
+# railtie in there would fork a swarm inside a `wurkswarm` parent that is about
+# to fork its own. The runner owns the swarm; the routes file only needs the
+# constant. `defined?(Wurk::Engine)` stays nil until first use, which is what the
 # "standalone stays Rails-free" tests assert.
-module Wurk
-  def self.const_missing(name)
-    return super unless name == :Engine
-    return super unless defined?(::Rails::Engine) && defined?(::ActionDispatch::Routing::RouteSet)
-
-    require_relative 'wurk/engine'
-    # Guard against recursing back into const_missing if the require somehow
-    # didn't define it (a partially-loaded engine.rb) — raise the real NameError.
-    return super unless const_defined?(:Engine, false)
-
-    const_get(:Engine, false)
-  end
-end

--- a/lib/wurk.rb
+++ b/lib/wurk.rb
@@ -318,3 +318,42 @@ require_relative 'wurk/compat'
 # real Rails host both are loaded by `rails/all` before Bundler.require, so the
 # stricter gate is invisible there.
 require_relative 'wurk/rails' if defined?(Rails::Engine) && defined?(::ActionDispatch::Routing::RouteSet)
+
+# The gate above is evaluated exactly once, when this file is first required —
+# which is too early for the standalone runners (#282). `exe/wurk` and
+# `exe/wurkswarm` require "wurk" before Rails exists (the gate is false, nothing
+# Rails-y loads), then boot the host app themselves via
+# Wurk::CLI#boot_rails_application. By then "wurk" is in $LOADED_FEATURES, so the
+# app's own `Bundler.require` is a no-op and the gate never gets a second look. A
+# host that did exactly what the README says — `mount Wurk::Engine => "/wurk"` in
+# config/routes.rb — then dies during boot with `uninitialized constant
+# Wurk::Engine`, from the worker process only. Web processes are unaffected:
+# there Bundler.require runs after railties, so the gate passes.
+#
+# const_missing closes that window without giving up the lean standalone boot:
+# nothing loads until something actually asks for Wurk::Engine, and even then
+# only when Rails is really present. The gate is the same two-part condition as
+# above, so the ecosystem carve-out (rails/engine/railties without ActionDispatch,
+# per sidekiq-cron's test helper) still falls through to a plain NameError
+# instead of crashing on `isolate_namespace`.
+#
+# Deliberately `wurk/engine` and not `wurk/rails`: the railtie's
+# `config.after_initialize` is a *global* ActiveSupport load hook registered at
+# require time, and routes are drawn before those hooks run — so dragging the
+# railtie in here would fork a swarm inside a `wurkswarm` parent that is about to
+# fork its own. The runner owns the swarm; the routes file only needs the
+# constant. `defined?(Wurk::Engine)` stays nil until then, which is what the
+# "standalone stays Rails-free" tests assert.
+module Wurk
+  def self.const_missing(name)
+    return super unless name == :Engine
+    return super unless defined?(::Rails::Engine) && defined?(::ActionDispatch::Routing::RouteSet)
+
+    require_relative 'wurk/engine'
+    # Guard against recursing back into const_missing if the require somehow
+    # didn't define it (a partially-loaded engine.rb) — raise the real NameError.
+    return super unless const_defined?(:Engine, false)
+
+    const_get(:Engine, false)
+  end
+end

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -6,6 +6,7 @@ require_relative 'middleware/chain'
 require_relative 'capsule'
 require_relative 'context'
 require_relative 'topology'
+require_relative 'redis_options'
 
 module Wurk
   # Owns runtime knobs (concurrency, queues, timeouts, lifecycle events,
@@ -169,8 +170,14 @@ module Wurk
 
     # --- Redis ------------------------------------------------------------
 
+    # Validated here, in the process running the initializer, rather than later
+    # in whichever process first builds a pool. The swarm's children are the ones
+    # that construct pools, so a bad key used to kill every child on boot while
+    # the parent stayed up and healthy — Running pod, passing probe, zero jobs
+    # processed (#283).
     def redis=(hash)
       guard_frozen!
+      RedisOptions.validate!(hash)
       @redis_config = @redis_config.merge(hash.transform_keys(&:to_sym))
     end
 

--- a/lib/wurk/redis_options.rb
+++ b/lib/wurk/redis_options.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'redis-client'
+
+module Wurk
+  # Translates a Sidekiq-shaped `config.redis` hash into the exact keyword set
+  # redis-client accepts.
+  #
+  # Sidekiq normalizes the hash itself before handing it over
+  # (`sidekiq/redis_client_adapter.rb#client_opts`), so initializers in the wild
+  # carry keys redis-client has never known. Wurk used to splat the hash straight
+  # into `RedisClient.config`, which surfaced as
+  # `ArgumentError: unknown keyword: :network_timeout` — and only inside the
+  # forked children, which build their own pools (#283). The parent booted fine,
+  # the liveness probe passed, and the swarm respawn loop churned forever
+  # processing zero jobs. Hence `validate!`, called from Configuration#redis= so
+  # a bad hash raises in the parent where someone can actually see it.
+  #
+  # Reference: sidekiq 7.3 / 8.1 `client_opts` — namespace rejected,
+  # size/pool_timeout dropped, `network_timeout` → `timeout`, `master_name` →
+  # `name`, role/driver symbolized, `reconnect_attempts ||= 1`.
+  module RedisOptions
+    # Consumed by the pool layer (RedisPool / Capsule); never a socket concern.
+    POOL_KEYS = %i[size name pool_name pool_timeout on_error].freeze
+
+    # Accepted for Sidekiq parity, then dropped: Sidekiq used `logger` for its
+    # own "connecting to Redis with options ..." line and `cluster_safe` to
+    # unlock `:nodes`. redis-client has no keyword for either.
+    IGNORED_KEYS = %i[logger cluster_safe].freeze
+
+    # Sidekiq-only spellings this module rewrites into redis-client keywords.
+    TRANSLATED_KEYS = %i[network_timeout master_name].freeze
+
+    # The umbrella socket timeout, under both its names. `network_timeout` is
+    # the redis-rb-era spelling every "widen the timeouts for a slow/remote
+    # Redis" snippet still uses; `timeout` is redis-client's own.
+    UMBRELLA_TIMEOUT_KEYS = %i[network_timeout timeout].freeze
+
+    # Wurk splits the socket timeouts (#101) and passes all three explicitly, and
+    # redis-client lets an explicit `read_timeout` win over `timeout` — so
+    # forwarding the umbrella verbatim would silently drop the host's value.
+    # Fan it out instead; a host-supplied split timeout still wins over the fan-out.
+    SPLIT_TIMEOUT_KEYS = %i[connect_timeout read_timeout write_timeout].freeze
+
+    # Symbols in redis-client, strings in plenty of YAML-sourced configs.
+    SYMBOLIZED_KEYS = %i[driver role].freeze
+
+    # Keys that mean something in Sidekiq but have no Wurk equivalent. Raise
+    # naming the key and its replacement — the alternative is an opaque
+    # `unknown keyword:` from three layers down inside a forked child.
+    REJECTED_KEYS = {
+      namespace: 'Redis namespacing was dropped in Sidekiq 7 and Wurk never implemented it ' \
+                 '(docs/migrate-from-sidekiq.md §4). Give Wurk its own Redis database ' \
+                 '(redis://host:6379/1) or its own instance instead.',
+      nodes: 'Wurk does not run on Redis Cluster. Point config.redis at a single server with ' \
+             '`url:`, or at a Sentinel set with `sentinels:`.'
+    }.freeze
+
+    # Keyword parameter kinds in Method#parameters.
+    KEYWORD_PARAMS = %i[key keyreq].freeze
+
+    class << self
+      # The keyword hash for RedisClient.config / RedisClient.sentinel.
+      # `defaults` are Wurk's own socket defaults; everything the host supplied
+      # wins over them.
+      def normalize(options, defaults: {})
+        opts = symbolize(options)
+        validate!(opts)
+        opts = translate(opts)
+
+        # A default `url` is meaningless next to a sentinel set and actively
+        # harmful: SentinelConfig derives the master name and db from it.
+        defaults = defaults.except(:url) if sentinel?(opts)
+
+        defaults.merge(split_timeouts(opts), opts.except(*UMBRELLA_TIMEOUT_KEYS))
+      end
+
+      # Raises for anything redis-client would reject. Cheap and pure, so it runs
+      # in the parent (Configuration#redis=) as well as at pool-build time.
+      def validate!(options)
+        opts = symbolize(options)
+
+        REJECTED_KEYS.each do |key, hint|
+          raise ArgumentError, "config.redis[:#{key}] is not supported. #{hint}" if opts.key?(key)
+        end
+
+        unknown = opts.keys - known_keys
+        return if unknown.empty?
+
+        raise ArgumentError,
+              "config.redis: unknown option#{'s' if unknown.size > 1} " \
+              "#{unknown.map(&:inspect).join(', ')}. Supported keys: #{known_keys.sort.join(', ')}."
+      end
+
+      # Sentinel sets go through RedisClient.sentinel — RedisClient.config
+      # rejects `sentinels:` outright. Same routing Sidekiq does.
+      def sentinel?(client_config)
+        client_config.key?(:sentinels)
+      end
+
+      # Every keyword redis-client itself accepts, read off its own signatures so
+      # the list can't drift from the installed version. Config#initialize takes
+      # a **kwargs rest and forwards to Config::Common, so both have to be walked;
+      # SentinelConfig adds the sentinel-only keys.
+      def known_keys
+        @known_keys ||= [
+          ::RedisClient::Config, ::RedisClient::Config::Common, ::RedisClient::SentinelConfig
+        ].flat_map { |mod| keyword_params(mod) }.union(POOL_KEYS, IGNORED_KEYS, TRANSLATED_KEYS)
+      end
+
+      private
+
+      # Drop what redis-client has no keyword for, then rewrite the Sidekiq
+      # spellings it does have an equivalent for.
+      def translate(opts)
+        opts = opts.except(*POOL_KEYS, *IGNORED_KEYS)
+        opts[:name] = opts.delete(:master_name) if opts.key?(:master_name)
+        SYMBOLIZED_KEYS.each { |key| opts[key] = opts[key].to_sym if opts[key] }
+        opts
+      end
+
+      def keyword_params(mod)
+        mod.instance_method(:initialize).parameters.filter_map do |kind, key|
+          key if KEYWORD_PARAMS.include?(kind)
+        end
+      end
+
+      # The umbrella timeout fanned out across the three split ones. Returns {}
+      # when the host set neither, leaving Wurk's defaults in place.
+      def split_timeouts(opts)
+        umbrella = opts.values_at(*UMBRELLA_TIMEOUT_KEYS).compact.first
+        return {} unless umbrella
+
+        SPLIT_TIMEOUT_KEYS.to_h { |key| [key, umbrella] }
+      end
+
+      def symbolize(options)
+        options.transform_keys(&:to_sym)
+      end
+    end
+  end
+end

--- a/lib/wurk/redis_pool.rb
+++ b/lib/wurk/redis_pool.rb
@@ -3,6 +3,7 @@
 require 'redis-client'
 require 'connection_pool'
 require_relative 'redis_client_adapter'
+require_relative 'redis_options'
 
 module Wurk
   # Per-process pool over redis-client + connection_pool. Never share a socket
@@ -37,6 +38,15 @@ module Wurk
     DEFAULT_WRITE_TIMEOUT      = 2.5
     DEFAULT_RECONNECT_ATTEMPTS = 1
 
+    # The floor every pool starts from; any key the host passed wins over it.
+    DEFAULT_CLIENT_CONFIG = {
+      url: DEFAULT_URL,
+      connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+      read_timeout: DEFAULT_READ_TIMEOUT,
+      write_timeout: DEFAULT_WRITE_TIMEOUT,
+      reconnect_attempts: DEFAULT_RECONNECT_ATTEMPTS
+    }.freeze
+
     # Server-side messages where the connection is closed and the block retried
     # exactly once. READONLY is itself a RedisClient::ConnectionError subclass,
     # so this message match must be tested BEFORE the generic ConnectionError
@@ -60,9 +70,12 @@ module Wurk
 
     # Takes the standard Sidekiq `config.redis` hash: `pool_timeout` tunes the
     # ConnectionPool checkout; `connect_timeout`/`read_timeout`/`write_timeout`/
-    # `reconnect_attempts` plus any other key (driver, ssl_params, …) forward
-    # verbatim to RedisClient.config. `on_error` is an optional callable fired
-    # per retry / final give-up with { error:, attempt:, retried:, pool: }.
+    # `reconnect_attempts` plus any other redis-client key (driver, ssl_params,
+    # sentinels, …) reach the client. Sidekiq-only spellings (`network_timeout`,
+    # `master_name`, `logger`, …) are translated or dropped by {RedisOptions};
+    # a key redis-client would reject raises there with the key named.
+    # `on_error` is an optional callable fired per retry / final give-up with
+    # { error:, attempt:, retried:, pool: }.
     def initialize(size:, name: DEFAULT_NAME, on_error: nil, **options)
       @size          = size
       @name          = name
@@ -112,24 +125,29 @@ module Wurk
 
     private
 
-    # Socket config forwarded to RedisClient.config. Host-supplied keys win over
-    # the defaults; `pool_timeout` is dropped (it's a pool concern, not a socket
-    # one) and unknown keys pass straight through.
+    # Socket config forwarded to redis-client. RedisOptions owns the translation
+    # of the Sidekiq-shaped hash (network_timeout, master_name, pool-only keys,
+    # …) so this class stays about pooling; host-supplied keys win over the
+    # defaults.
     def build_client_config(options)
-      {
-        url: DEFAULT_URL,
-        connect_timeout: DEFAULT_CONNECT_TIMEOUT,
-        read_timeout: DEFAULT_READ_TIMEOUT,
-        write_timeout: DEFAULT_WRITE_TIMEOUT,
-        reconnect_attempts: DEFAULT_RECONNECT_ATTEMPTS
-      }.merge(options.except(:pool_timeout)).freeze
+      RedisOptions.normalize(options, defaults: DEFAULT_CLIENT_CONFIG).freeze
     end
 
     # Wrapped in the CompatClient decorator so `Sidekiq.redis { |c| c.smembers }`
     # method-style commands work like Sidekiq 7+ (#204). Wurk's own code paths
     # use #call, which the decorator forwards.
     def build_client
-      RedisClientAdapter::CompatClient.new(RedisClient.config(**@client_config).new_client)
+      RedisClientAdapter::CompatClient.new(redis_client_config.new_client)
+    end
+
+    # A Sentinel set is a different constructor, not a different keyword:
+    # `RedisClient.config(sentinels: [...])` raises. Sidekiq routes the same way.
+    def redis_client_config
+      if RedisOptions.sentinel?(@client_config)
+        RedisClient.sentinel(**@client_config)
+      else
+        RedisClient.config(**@client_config)
+      end
     end
 
     def safe_close(conn)

--- a/lib/wurk/version.rb
+++ b/lib/wurk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wurk
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
 end

--- a/test/integration/redis_options_fork_test.rb
+++ b/test/integration/redis_options_fork_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# #283, and the reason it was so hard to see: the swarm parent never builds a
+# Redis pool. It closes the parent-side connections (step 3 of the boot ordering)
+# and forks; each child opens a fresh pool (step 5). So a `config.redis` key
+# redis-client rejects kills every child on boot —
+#
+#   ERROR swarm child #0 (12) crashed: ArgumentError: unknown keyword: :network_timeout
+#   WARN  swarm: child 12 died (status=1); respawning slot 0 in 1.0s
+#
+# — while the parent stays up and healthy: Running pod, passing liveness probe,
+# zero jobs processed, forever. A unit test on the parent's own pool would have
+# missed it, so this one runs the pool build where it actually broke.
+class RedisOptionsForkTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  CHILD_TIMEOUT = 20
+
+  # The initializer straight out of the production report.
+  SIDEKIQ_SHAPED = { driver: :ruby, network_timeout: 5, pool_timeout: 5 }.freeze
+
+  def setup
+    super
+    @config = Wurk::Configuration.new
+    @config.logger = ::Logger.new(IO::NULL)
+    @config.redis = SIDEKIQ_SHAPED.merge(url: Wurk::Test.redis_url)
+  end
+
+  def teardown
+    @config&.reset_redis_pools!
+  ensure
+    super
+  end
+
+  def test_forked_child_builds_a_working_pool_from_sidekiq_shaped_options
+    assert_equal 0, run_in_child { @config.redis_pool.with { |c| c.call('PING') } == 'PONG' },
+                 'a forked child must build its Redis pool from a Sidekiq-shaped config.redis hash'
+  end
+
+  def test_forked_child_honours_the_fanned_out_network_timeout
+    assert_equal 0, run_in_child { @config.redis_pool.client_config[:read_timeout] == 5 },
+                 'network_timeout must reach the child as the split socket timeouts'
+  end
+
+  private
+
+  # Mirrors the swarm's own pre-fork step: drop every parent-side pool, fork, and
+  # let the child build its own. Exit status is the assertion channel — that's
+  # exactly how the bug reported itself in production.
+  def run_in_child(&block)
+    @config.reset_redis_pools!
+    pid = ::Process.fork do
+      ok = begin
+        block.call
+      rescue StandardError => e
+        warn("child failed: #{e.class}: #{e.message}") if ENV['DEBUG_INVOCATION'] == '1'
+        false
+      end
+      ::Process.exit!(ok ? 0 : 1)
+    end
+    _, status = ::Process.wait2(pid)
+    status.exitstatus
+  end
+end

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -262,6 +262,20 @@ class ConfigurationTest < Wurk::Test::UnitCase
     assert_equal 'redis://example.com:6380/2', @config.redis_config[:url]
   end
 
+  def test_redis_setter_accepts_sidekiq_only_keys
+    @config.redis = { url: 'redis://example.com:6380/2', network_timeout: 5, pool_timeout: 5 }
+
+    assert_equal 5, @config.redis_config[:network_timeout]
+  end
+
+  # #283: the swarm parent never builds a pool, so an unusable key used to
+  # surface only inside the forked children. Validate where the initializer runs.
+  def test_redis_setter_rejects_an_unusable_key_in_the_calling_process
+    error = assert_raises(ArgumentError) { @config.redis = { url: 'redis://x', namespace: 'app' } }
+
+    assert_includes error.message, 'config.redis[:namespace]'
+  end
+
   def test_redis_pool_delegates_to_default_capsule
     assert_same @config.default_capsule.redis_pool, @config.redis_pool
   end

--- a/test/unit/rails_autoload_test.rb
+++ b/test/unit/rails_autoload_test.rb
@@ -65,6 +65,72 @@ class RailsAutoloadTest < Wurk::Test::UnitCase
     assert ok, 'partial Rails (rails/engine/railties without action_dispatch) must not crash `require "wurk"` (#249)'
   end
 
+  # #282: the standalone runners require "wurk" *before* Rails exists, so the
+  # load-time guard above is false and stays false — `wurk` is already in
+  # $LOADED_FEATURES by the time Wurk::CLI#boot_rails_application runs, so the
+  # host app's own Bundler.require can't re-evaluate it. Wurk::Engine must still
+  # resolve once Rails is up, or every app that follows the README and mounts the
+  # dashboard dies on boot under `wurk` / `wurkswarm`.
+  def test_engine_resolves_when_rails_arrives_after_require_wurk
+    ok = run_ruby(<<~RUBY)
+      require "wurk"
+      exit 1 if defined?(Wurk::Engine)
+
+      # ...what Wurk::CLI#boot_rails_application does next.
+      require "rails"
+      require "action_controller/railtie"
+
+      exit 1 unless Wurk::Engine < ::Rails::Engine
+      # Engine only: the runner owns the swarm, so the railtie (whose
+      # after_initialize hook forks one) must not come along for the ride.
+      exit(defined?(Wurk::Railtie) ? 1 : 0)
+    RUBY
+
+    assert ok, 'Wurk::Engine must resolve on demand once Rails is loaded, even if `require "wurk"` came first (#282)'
+  end
+
+  # The same thing end to end: a real Rails app whose config/routes.rb mounts the
+  # engine, booted in the order the standalone runners produce. Without the
+  # const_missing hook this dies exactly as production did —
+  # `config/routes.rb:2:in 'block in <top (required)>': uninitialized constant
+  # Wurk::Engine (NameError)`.
+  def test_rails_app_mounting_the_engine_boots_in_the_standalone_runner_order
+    ok = run_ruby(<<~RUBY)
+      require "tmpdir"
+      require "fileutils"
+
+      require "wurk"
+      exit 1 if defined?(Wurk::Engine)
+
+      require "rails"
+      require "action_controller/railtie"
+
+      root = Dir.mktmpdir
+      FileUtils.mkdir_p(File.join(root, "config"))
+      File.write(File.join(root, "config.ru"), "")
+      File.write(File.join(root, "config/routes.rb"), <<~ROUTES)
+        Rails.application.routes.draw do
+          mount Wurk::Engine => "/wurk"
+        end
+      ROUTES
+      Dir.chdir(root)
+
+      class HostApp < Rails::Application
+        config.load_defaults 7.1
+        config.eager_load = false
+        config.secret_key_base = "x" * 32
+        config.logger = Logger.new(IO::NULL)
+      end
+
+      HostApp.initialize!
+
+      mounted = HostApp.routes.routes.map { |r| r.path.spec.to_s }.any? { |p| p.start_with?("/wurk") }
+      exit(mounted ? 0 : 1)
+    RUBY
+
+    assert ok, '`mount Wurk::Engine` in config/routes.rb must not break app boot under wurk/wurkswarm (#282)'
+  end
+
   private
 
   def run_ruby(code)

--- a/test/unit/redis_options_test.rb
+++ b/test/unit/redis_options_test.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# #283: Sidekiq normalizes `config.redis` itself before handing it to
+# redis-client, so ordinary Sidekiq initializers carry keys redis-client has
+# never known. Wurk splatted the hash straight through and blew up with
+# `ArgumentError: unknown keyword: :network_timeout` — inside the forked
+# children only, since they're what build the pools.
+class RedisOptionsTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  DEFAULTS = Wurk::RedisPool::DEFAULT_CLIENT_CONFIG
+
+  # --- network_timeout / timeout (the reported crash) --------------------
+
+  def test_network_timeout_fans_out_to_the_split_socket_timeouts
+    config = normalize(url: 'redis://example:6379/0', network_timeout: 5)
+
+    assert_equal({ connect_timeout: 5, read_timeout: 5, write_timeout: 5 },
+                 config.slice(:connect_timeout, :read_timeout, :write_timeout))
+    refute config.key?(:network_timeout), 'network_timeout is not a redis-client keyword'
+  end
+
+  def test_timeout_fans_out_the_same_way
+    config = normalize(timeout: 4)
+
+    assert_equal({ connect_timeout: 4, read_timeout: 4, write_timeout: 4 },
+                 config.slice(:connect_timeout, :read_timeout, :write_timeout))
+    refute config.key?(:timeout)
+  end
+
+  def test_explicit_split_timeouts_win_over_the_umbrella
+    config = normalize(network_timeout: 5, read_timeout: 9)
+
+    assert_equal 9, config[:read_timeout], 'an explicit split timeout must beat the fan-out'
+    assert_equal 5, config[:connect_timeout]
+    assert_equal 5, config[:write_timeout]
+  end
+
+  def test_umbrella_absent_leaves_the_wurk_defaults_alone
+    config = normalize(url: 'redis://example:6379/0')
+
+    assert_equal DEFAULTS[:connect_timeout], config[:connect_timeout]
+    assert_equal DEFAULTS[:read_timeout], config[:read_timeout]
+  end
+
+  # --- the rest of the Sidekiq option surface ----------------------------
+
+  def test_full_sidekiq_shaped_hash_normalizes_to_redis_client_keywords
+    config = normalize(url: 'redis://example:6379/0', driver: 'hiredis',
+                       network_timeout: 5, pool_timeout: 5, size: 12, logger: ::Logger.new(IO::NULL))
+
+    assert_equal(%i[connect_timeout driver read_timeout reconnect_attempts url write_timeout], config.keys.sort)
+    assert_equal :hiredis, config[:driver], 'driver is a symbol in redis-client, a string in most YAML configs'
+  end
+
+  def test_pool_and_ignored_keys_never_reach_redis_client
+    config = normalize(size: 3, pool_timeout: 2, pool_name: 'x', name: 'y', on_error: -> {},
+                       logger: ::Logger.new(IO::NULL), cluster_safe: true)
+
+    assert_empty config.keys - DEFAULTS.keys
+  end
+
+  def test_master_name_becomes_the_sentinel_name
+    config = normalize(sentinels: [{ host: 'h', port: 26_379 }], master_name: 'mymaster', role: 'replica')
+
+    assert_equal 'mymaster', config[:name]
+    assert_equal :replica, config[:role]
+    refute config.key?(:master_name)
+  end
+
+  def test_sentinel_config_drops_the_default_url
+    config = normalize(sentinels: [{ host: 'h', port: 26_379 }], master_name: 'mymaster')
+
+    refute config.key?(:url), 'SentinelConfig derives the master name and db from :url — a default would poison it'
+    assert Wurk::RedisOptions.sentinel?(config)
+  end
+
+  def test_sentinel_predicate_is_false_for_a_plain_url_config
+    refute Wurk::RedisOptions.sentinel?(normalize(url: 'redis://example:6379/0'))
+  end
+
+  def test_string_keys_are_accepted
+    config = normalize('url' => 'redis://example:6379/0', 'network_timeout' => 7)
+
+    assert_equal 7, config[:read_timeout]
+  end
+
+  # --- rejected keys: named, with the replacement -------------------------
+
+  def test_namespace_raises_naming_the_replacement
+    error = assert_raises(ArgumentError) { Wurk::RedisOptions.validate!(namespace: 'app') }
+
+    assert_includes error.message, 'config.redis[:namespace]'
+    assert_includes error.message, 'own Redis database'
+  end
+
+  def test_cluster_nodes_raises_naming_the_replacement
+    error = assert_raises(ArgumentError) { Wurk::RedisOptions.validate!(nodes: %w[redis://a redis://b]) }
+
+    assert_includes error.message, 'config.redis[:nodes]'
+    assert_includes error.message, 'sentinels:'
+  end
+
+  def test_unknown_key_raises_naming_the_key_instead_of_dying_in_a_child
+    error = assert_raises(ArgumentError) { Wurk::RedisOptions.validate!(url: 'redis://x', conect_timeout: 1) }
+
+    assert_includes error.message, ':conect_timeout'
+    assert_includes error.message, 'connect_timeout', 'the supported-key list is the actionable half of the message'
+  end
+
+  def test_unknown_keys_are_all_reported_at_once
+    error = assert_raises(ArgumentError) { Wurk::RedisOptions.validate!(bogus: 1, alsobogus: 2) }
+
+    assert_match(/unknown options .*:bogus.*:alsobogus/, error.message)
+  end
+
+  def test_known_keys_are_read_off_redis_client_itself
+    keys = Wurk::RedisOptions.known_keys
+
+    # Config, Config::Common and SentinelConfig respectively.
+    assert_includes keys, :url
+    assert_includes keys, :reconnect_attempts
+    assert_includes keys, :sentinels
+  end
+
+  private
+
+  def normalize(options)
+    Wurk::RedisOptions.normalize(options, defaults: DEFAULTS)
+  end
+end

--- a/test/unit/redis_pool_test.rb
+++ b/test/unit/redis_pool_test.rb
@@ -106,6 +106,32 @@ class RedisPoolTest < Wurk::Test::UnitCase
     assert_equal('PONG', @pool.with { |c| c.call('PING') })
   end
 
+  # --- Sidekiq-shaped option hashes (#283) ---
+
+  # The exact initializer from the production report:
+  # `config.redis = { url:, driver:, network_timeout: 5, pool_timeout: 5 }`.
+  def test_sidekiq_shaped_options_build_a_working_pool
+    @pool = Wurk::RedisConnection.create(url: Wurk::Test.redis_url, driver: :ruby,
+                                         network_timeout: 5, pool_timeout: 5)
+
+    assert_equal 5, @pool.client_config[:read_timeout]
+    assert_in_delta 5, @pool.pool_timeout
+    assert_equal('PONG', @pool.with { |c| c.call('PING') })
+  end
+
+  def test_sentinel_options_route_through_redis_client_sentinel
+    @pool = Wurk::RedisPool.new(size: 1, sentinels: [{ host: '127.0.0.1', port: 26_379 }],
+                                master_name: 'mymaster')
+
+    assert_instance_of RedisClient::SentinelConfig, @pool.send(:redis_client_config)
+  end
+
+  def test_unsupported_option_raises_naming_the_key
+    error = assert_raises(ArgumentError) { Wurk::RedisPool.new(size: 1, namespace: 'app') }
+
+    assert_includes error.message, 'config.redis[:namespace]'
+  end
+
   def test_with_yields_a_usable_redis_connection
     @pool = build_pool
 


### PR DESCRIPTION
Two production bugs from the same deploy. Both are drop-in gaps that only bite the **worker** process, so the web app stays green while nothing gets done — which is why neither surfaced before.

## 1. `mount Wurk::Engine` crashed `wurk` / `wurkswarm` on boot

```
wurkswarm: uninitialized constant Wurk::Engine
/rails/config/routes.rb:60:in 'block in <compiled>'
```

…from the exact routes line `README.md` and `docs/migrate-from-sidekiq.md` tell you to write.

**Mechanism.** `lib/wurk.rb` ends with `require_relative "wurk/rails" if defined?(Rails::Engine) && defined?(ActionDispatch::Routing::RouteSet)`. `exe/wurk` and `exe/wurkswarm` `require "wurk"` *before* Rails exists, so the guard is false. `Wurk::CLI#boot_rails_application` then does `require "rails"` + `config/environment.rb` — but `wurk` is already in `$LOADED_FEATURES`, so the app's own `Bundler.require` is a no-op and the guard never gets a second look. Web processes are unaffected: there `Bundler.require` runs after railties.

**Fix.** `Wurk.const_missing(:Engine)` loads `wurk/engine` behind the same two-part guard.

Why this over the alternatives:

- **Lean standalone boot is preserved as a property, not a promise.** Nothing references the constant in a non-Rails worker host, so nothing loads. `defined?(Wurk::Engine)` stays `nil` until first use, which is exactly what the existing "standalone stays Rails-free" assertions check — an `autoload` would have made them vacuously true.
- **The ecosystem carve-out survives.** Same `ActionDispatch::Routing::RouteSet` half of the guard, so sidekiq-cron-style loads (`rails/engine/railties`, no ActionDispatch) still fall through to a plain `NameError` rather than crashing inside `isolate_namespace`.
- **Not `wurk/rails`.** The railtie's `config.after_initialize` is a *global* `ActiveSupport` load hook registered at require time, and routes are drawn before those hooks fire — pulling the railtie in mid-boot would fork a second swarm inside a `wurkswarm` parent that is about to fork its own. The runner owns the swarm; routes.rb only needs the constant.
- Re-evaluating the guard inside `boot_rails_application` was the other candidate and has the same double-swarm problem, plus it would have to load the engine right after `require "rails"`, before ActionDispatch is up.

**Audit of the sibling constants** (same exposure?): `Wurk::Web` — **no**, it's required unconditionally from `lib/wurk.rb:70`, and `Sidekiq::Web` / `Sidekiq::Pro::Web` are plain aliases to it. ActiveJob adapter — **no**, already closed by #253 via `Wurk::CLI#define_active_job_adapter`.

## 2. `network_timeout` killed every swarm child on boot

```
ERROR swarm child #0 (12) crashed: ArgumentError: unknown keyword: :network_timeout
WARN  swarm: child 12 died (status=1); respawning slot 0 in 1.0s
```

from an utterly ordinary initializer:

```ruby
config.redis = { url: ENV['REDIS_URL'], driver: :hiredis, network_timeout: 5, pool_timeout: 5 }
```

Sidekiq normalizes the hash itself (`sidekiq/redis_client_adapter.rb#client_opts`) before handing it to redis-client; Wurk splatted it straight through. And because the parent closes its connections *before* forking and only children build pools, the parent stayed up: Running pod, passing liveness probe, respawn-backoff loop churning forever, zero jobs processed.

New `Wurk::RedisOptions` does Sidekiq's translation for every pool-building path (capsules, web pool, `RedisConnection.create`, Limiter):

| Key | Decision |
|---|---|
| `network_timeout` / `timeout` | **translate** — fan out to `connect_timeout`/`read_timeout`/`write_timeout` |
| `sentinels` | **translate** — route through `RedisClient.sentinel` (`RedisClient.config` rejects it, so Sentinel deployments hit the same crash) |
| `master_name` | **translate** → `name` |
| `driver`, `role` | **translate** — symbolized |
| `logger`, `cluster_safe`, `pool_name` | **accept and drop**, as Sidekiq does |
| `namespace` | **raise**, naming the replacement (own Redis db/instance) |
| `nodes` | **raise** — Redis Cluster unsupported |
| anything else redis-client rejects | **raise**, naming the key + the supported set |

Two details worth calling out:

- The umbrella timeout is **fanned out, not forwarded**. Wurk sets all three split timeouts explicitly, and redis-client lets an explicit `read_timeout` beat `timeout` — so passing `timeout:` through verbatim would have silently dropped the host's value, a quieter version of the same bug. A host-supplied split timeout still wins over the fan-out.
- The accepted-key list is read off redis-client's own `initialize` signatures (`Config`, `Config::Common`, `SentinelConfig`), so it can't drift from the installed version.
- `Configuration#redis=` validates on assignment, so a bad hash raises in the process running the initializer instead of inside a forked child nobody is watching.

## Tests

- `test/unit/rails_autoload_test.rb` — two new cases in the real order: `require "wurk"` with Rails absent → boot Rails → resolve `Wurk::Engine`; and a real Rails app on disk whose `config/routes.rb` mounts the engine, booted through `initialize!`. Stashed the fix and confirmed both fail, with the production error verbatim (`config/routes.rb:2 … uninitialized constant Wurk::Engine (NameError)`).
- `test/integration/redis_options_fork_test.rb` — builds the pool **in a forked child**, since that's where it broke. Also confirmed failing without the fix.
- `test/unit/redis_options_test.rb` (15 cases, 100% line + branch on the new file), plus pool- and configuration-level cases.

Full suite: 2717 runs, 0 failures. (6 pre-existing errors locally, unrelated — the dev Redis here is Dragonfly, which enforces declared keys in Lua; identical on `main`.) Parity suite green. Coverage 96.75% line / 90.31% branch, both over the gate. RuboCop clean on every touched file.

Docs and CHANGELOG updated; version bumped to 1.3.1. Not tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787669730&installation_model_id=11168&pr_number=338&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F338&signature=632372d70ec5fbde981fc0c4b59388f79bfe42dac90396c387186b579d5ff31b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->