### PR TITLE
test: bound waitall; track BlipProxy pump threads

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -100,6 +100,8 @@ end
 desc "Run all benchmarks (enqueue, fetch+execute, bulk enqueue, swarm boot, memory)"
 task :bench do
   Dir.glob(File.join(GEM_ROOT, "bench", "*.rb")).sort.each do |script|
+    next if File.basename(script) == "support.rb"
+
     puts "\n=== #{File.basename(script)} ==="
     sh "ruby", "-Ilib", script
   end
@@ -107,6 +109,8 @@ end
 
 namespace :bench do
   Dir.glob(File.join(GEM_ROOT, "bench", "*.rb")).sort.each do |script|
+    next if File.basename(script) == "support.rb"
+
     name = File.basename(script, ".rb")
     desc "Run bench/#{name}.rb"
     task name do

--- a/bench/bulk_enqueue.rb
+++ b/bench/bulk_enqueue.rb
@@ -2,12 +2,16 @@
 
 require "benchmark/ips"
 require "wurk"
+require_relative "support"
 
 # Gate: >5% regression vs main blocks merge.
+#
+# Runs on a dedicated Redis logical DB (default 11) so this bench's DEL/LTRIM
+# of queue:default can never wipe a dev's real DB 0 data (#258/#259).
 
 BULK_SIZE = 1_000
 
-pool   = Wurk::RedisPool.new(size: 5)
+pool   = Wurk::RedisPool.new(size: 5, url: bench_redis_url("11"))
 client = Wurk::Client.new(pool: pool)
 args   = Array.new(BULK_SIZE) { [] }
 items  = { "class" => "BenchJob", "queue" => "default", "args" => args }

--- a/bench/enqueue.rb
+++ b/bench/enqueue.rb
@@ -2,10 +2,14 @@
 
 require "benchmark/ips"
 require "wurk"
+require_relative "support"
 
 # Gate: >5% regression vs main blocks merge.
+#
+# Runs on a dedicated Redis logical DB (default 10) so this bench's DEL of
+# queue:default can never wipe a dev's real DB 0 data (#258/#259).
 
-pool   = Wurk::RedisPool.new(size: 5)
+pool   = Wurk::RedisPool.new(size: 5, url: bench_redis_url("10"))
 client = Wurk::Client.new(pool: pool)
 job    = { "class" => "BenchJob", "args" => [], "queue" => "default" }
 

--- a/bench/fetch_execute.rb
+++ b/bench/fetch_execute.rb
@@ -3,6 +3,7 @@
 require "benchmark/ips"
 require "logger"
 require "wurk"
+require_relative "support"
 
 # End-to-end fetch+execute — one of the four "Faster" pillar critical paths
 # (CLAUDE.md). Each iteration enqueues one job, then drives the REAL reliable
@@ -23,12 +24,6 @@ require "wurk"
 #
 # Gate: >5% regression vs main blocks merge.
 
-def bench_redis_url
-  base = ENV["REDIS_URL"] || "redis://localhost:6379/0"
-  db = ENV.fetch("WURK_BENCH_DB", "15")
-  base.match?(%r{/\d+\z}) ? base.sub(%r{/\d+\z}, "/#{db}") : "#{base}/#{db}"
-end
-
 class BenchJob
   include Wurk::Job
 
@@ -37,7 +32,7 @@ end
 
 config = Wurk::Configuration.new
 config.logger = Logger.new(IO::NULL)
-config.redis = { url: bench_redis_url }
+config.redis = { url: bench_redis_url("15") }
 config.queues = %w[default]
 capsule = config.default_capsule
 capsule.prepare!

--- a/bench/memory.rb
+++ b/bench/memory.rb
@@ -2,6 +2,7 @@
 
 require "logger"
 require "wurk"
+require_relative "support"
 
 # Memory / allocation profile of the fetch+execute hot path — the "memory blocks
 # merge" critical path in CLAUDE.md's "Faster" pillar. Drives the REAL
@@ -20,12 +21,6 @@ require "wurk"
 # Real Redis, dedicated logical DB (default 13, mirroring fetch_execute's
 # isolation from #259). DB 0 is never touched.
 
-def bench_redis_url(default_db = "13")
-  base = ENV["REDIS_URL"] || "redis://localhost:6379/0"
-  db = ENV.fetch("WURK_BENCH_DB", default_db)
-  base.match?(%r{/\d+\z}) ? base.sub(%r{/\d+\z}, "/#{db}") : "#{base}/#{db}"
-end
-
 JOBS    = Integer(ENV.fetch("WURK_BENCH_MEM_JOBS", "2000"))
 SAMPLES = Integer(ENV.fetch("WURK_BENCH_MEM_SAMPLES", "5"))
 
@@ -37,7 +32,7 @@ end
 
 config = Wurk::Configuration.new
 config.logger = Logger.new(IO::NULL)
-config.redis = { url: bench_redis_url }
+config.redis = { url: bench_redis_url("13") }
 config.queues = %w[default]
 capsule = config.default_capsule
 capsule.prepare!

--- a/bench/scheduled_poll.rb
+++ b/bench/scheduled_poll.rb
@@ -3,6 +3,7 @@
 require "benchmark/ips"
 require "logger"
 require "wurk"
+require_relative "support"
 
 # Gate: >5% regression vs main blocks merge.
 #
@@ -11,9 +12,13 @@ require "wurk"
 # empty the sweep is two EVALSHA round-trips that return nil and re-push
 # nothing. This measures that idle sweep — the work the per-process Poller
 # repeats on every wake when there's nothing due.
+#
+# Runs on a dedicated Redis logical DB (default 12) so this bench's DEL of
+# schedule/retry can never wipe a dev's real DB 0 data (#258/#259).
 
 config = Wurk::Configuration.new
 config.logger = Logger.new(IO::NULL)
+config.redis = { url: bench_redis_url("12") }
 pool = config.default_capsule.redis_pool
 pool.with { |c| Wurk::Lua::Loader.script_load_all(c) }
 

--- a/bench/support.rb
+++ b/bench/support.rb
@@ -1,11 +1,24 @@
 # frozen_string_literal: true
 
+require "uri"
+
 # Shared Redis DB-isolation helper for bench/*.rb. Every bench hits a dedicated
 # logical DB (never DB 0) so a stray dev/CI Redis with real data can't be read,
 # drained, or FLUSHDB'd by a benchmark run (#258/#259). `WURK_BENCH_DB`
 # overrides the per-bench default when a caller needs to point at a specific DB.
+#
+# The override is rejected unless it is a positive integer: `0`, a negative, or
+# a typo would otherwise silently aim a FLUSHDB at the developer's real data.
+# The DB is swapped through `URI#path` rather than by string surgery so a
+# query-bearing URL (`redis://host/0?timeout=1`) keeps its query instead of
+# growing a `/10` suffix after it.
 def bench_redis_url(default_db)
-  base = ENV["REDIS_URL"] || "redis://localhost:6379/0"
-  db = ENV.fetch("WURK_BENCH_DB", default_db)
-  base.match?(%r{/\d+\z}) ? base.sub(%r{/\d+\z}, "/#{db}") : "#{base}/#{db}"
+  db = ENV.fetch("WURK_BENCH_DB", default_db).to_s
+  unless db.match?(/\A[1-9][0-9]*\z/)
+    raise ArgumentError, "WURK_BENCH_DB must be a positive integer (DB 0 is never safe to flush), got #{db.inspect}"
+  end
+
+  uri = URI.parse(ENV["REDIS_URL"] || "redis://localhost:6379/0")
+  uri.path = "/#{db}"
+  uri.to_s
 end

--- a/bench/support.rb
+++ b/bench/support.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Shared Redis DB-isolation helper for bench/*.rb. Every bench hits a dedicated
+# logical DB (never DB 0) so a stray dev/CI Redis with real data can't be read,
+# drained, or FLUSHDB'd by a benchmark run (#258/#259). `WURK_BENCH_DB`
+# overrides the per-bench default when a caller needs to point at a specific DB.
+def bench_redis_url(default_db)
+  base = ENV["REDIS_URL"] || "redis://localhost:6379/0"
+  db = ENV.fetch("WURK_BENCH_DB", default_db)
+  base.match?(%r{/\d+\z}) ? base.sub(%r{/\d+\z}, "/#{db}") : "#{base}/#{db}"
+end

--- a/bench/swarm_boot.rb
+++ b/bench/swarm_boot.rb
@@ -2,6 +2,7 @@
 
 require "logger"
 require "wurk"
+require_relative "support"
 
 # Swarm boot — one of the "Faster" pillar critical paths (CLAUDE.md). Measures
 # the REAL fork + reconnect + first-heartbeat latency: each sample boots a small
@@ -22,15 +23,9 @@ require "wurk"
 # isolated-DB approach from #259) so a stray worker on the default DB can't
 # perturb the boot. DB 0 is never touched.
 
-def bench_redis_url(default_db = "14")
-  base = ENV["REDIS_URL"] || "redis://localhost:6379/0"
-  db = ENV.fetch("WURK_BENCH_DB", default_db)
-  base.match?(%r{/\d+\z}) ? base.sub(%r{/\d+\z}, "/#{db}") : "#{base}/#{db}"
-end
-
 def monotonic = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
 
-REDIS_URL    = bench_redis_url
+REDIS_URL    = bench_redis_url("14")
 CHILDREN     = Integer(ENV.fetch("WURK_BENCH_SWARM_CHILDREN", "2"))
 SAMPLES      = Integer(ENV.fetch("WURK_BENCH_SWARM_SAMPLES", "8"))
 BOOT_MARKER  = "wurk-bench:swarm-boot-log"

--- a/test/integration/batch_nested_callbacks_test.rb
+++ b/test/integration/batch_nested_callbacks_test.rb
@@ -115,7 +115,7 @@ class BatchNestedCallbacksTest < Wurk::Test::UnitCase
       rescue StandardError
         nil
       end
-      supervisor&.join(10) || supervisor&.kill
+      stop_supervisor_thread(supervisor, 10)
     end
   end
 

--- a/test/integration/batch_nested_callbacks_test.rb
+++ b/test/integration/batch_nested_callbacks_test.rb
@@ -76,10 +76,10 @@ class BatchNestedCallbacksTest < Wurk::Test::UnitCase
   def test_parent_callbacks_wait_for_running_child_batch_under_real_forks # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Minitest/MultipleAssertions
     parent, child = enqueue_nested_batches
     swarm = Wurk::Swarm.new(topology: topology, config: @config, shutdown_timeout: 5)
-    swarm.boot(install_signals: false)
     supervisor = nil
 
     begin
+      swarm.boot(install_signals: false)
       supervisor = Thread.new { swarm.supervise }
 
       assert wait_until { window_open?(parent, child) },
@@ -110,8 +110,12 @@ class BatchNestedCallbacksTest < Wurk::Test::UnitCase
                       'child :success must precede parent :success (spec §2.4)'
     ensure
       @observer.call('SET', @release_key, '1', 'EX', 60) # never strand the gated worker
-      swarm.shutdown(timeout: 5)
-      supervisor&.join(10)
+      begin
+        swarm.shutdown(timeout: 5)
+      rescue StandardError
+        nil
+      end
+      supervisor&.join(10) || supervisor&.kill
     end
   end
 

--- a/test/integration/batch_retry_roundtrip_test.rb
+++ b/test/integration/batch_retry_roundtrip_test.rb
@@ -328,7 +328,7 @@ class BatchRetryRoundtripTest < Wurk::Test::UnitCase
       rescue StandardError
         nil
       end
-      supervisor&.join(10) || supervisor&.kill
+      stop_supervisor_thread(supervisor, 10)
     end
   end
 

--- a/test/integration/batch_retry_roundtrip_test.rb
+++ b/test/integration/batch_retry_roundtrip_test.rb
@@ -316,12 +316,20 @@ class BatchRetryRoundtripTest < Wurk::Test::UnitCase
 
   def with_swarm(topo)
     swarm = Wurk::Swarm.new(topology: topo, config: @config, shutdown_timeout: 5)
-    swarm.boot(install_signals: false)
-    supervisor = Thread.new { swarm.supervise }
-    yield
-  ensure
-    swarm&.shutdown(timeout: 5)
-    supervisor&.join(10)
+    supervisor = nil
+
+    begin
+      swarm.boot(install_signals: false)
+      supervisor = Thread.new { swarm.supervise }
+      yield
+    ensure
+      begin
+        swarm.shutdown(timeout: 5)
+      rescue StandardError
+        nil
+      end
+      supervisor&.join(10) || supervisor&.kill
+    end
   end
 
   # Finds the due-set member belonging to `needle` (a Redis key baked into

--- a/test/integration/liveness_probe_test.rb
+++ b/test/integration/liveness_probe_test.rb
@@ -22,7 +22,9 @@ class LivenessProbeTest < Wurk::Test::UnitCase
     @config.logger = ::Logger.new(IO::NULL)
     @config[:tag] = @ns
     cap = @config.default_capsule
-    cap.queues = ['default']
+    # Unique per-test queue: a leaked Launcher from a prior run/test must
+    # never be able to steal work off the shared `queue:default` list.
+    cap.queues = [@ns]
     cap.concurrency = 1
     cap.fetcher = Wurk::Fetcher::Reliable.new(cap)
     # Materialize lazy ivars before Launcher.run freezes the capsule —
@@ -38,11 +40,15 @@ class LivenessProbeTest < Wurk::Test::UnitCase
   end
 
   def teardown
-    if @launcher
-      @launcher.instance_variable_set(:@done, true)
-      @launcher.instance_variable_get(:@health_server)&.stop
-      @launcher.instance_variable_get(:@heartbeat)&.stop! rescue nil
+    # Full teardown (not just health-server/heartbeat) so managers, poller,
+    # reaper and leader threads don't outlive the test — a leaked Launcher
+    # here would otherwise keep fetching from later tests' queues.
+    begin
+      @launcher&.stop
+    rescue StandardError
+      nil
     end
+    @launcher&.instance_variable_get(:@boot_reclaim_thread)&.join(2)
   ensure
     super
   end

--- a/test/integration/liveness_probe_test.rb
+++ b/test/integration/liveness_probe_test.rb
@@ -48,9 +48,15 @@ class LivenessProbeTest < Wurk::Test::UnitCase
     rescue StandardError
       nil
     end
-    @launcher&.instance_variable_get(:@boot_reclaim_thread)&.join(2)
+    # Launcher#stop doesn't own the boot-reclaim thread and offers no kill
+    # fallback, so teardown has to confirm the join actually landed — a
+    # surviving thread keeps sweeping Redis into the next test.
+    reclaim = @launcher&.instance_variable_get(:@boot_reclaim_thread)
+    stuck = !reclaim.nil? && reclaim.join(2).nil?
+    reclaim.kill if stuck
   ensure
     super
+    raise 'boot-reclaim thread still alive 2s after Launcher#stop' if stuck
   end
 
   def test_live_returns_200_when_launcher_running

--- a/test/integration/periodic_leader_test.rb
+++ b/test/integration/periodic_leader_test.rb
@@ -67,10 +67,10 @@ class PeriodicLeaderTest < Wurk::Test::UnitCase
     @lid = register_loop
 
     swarm = Wurk::Swarm.new(topology: topology_n(2), config: @config, shutdown_timeout: 5)
-    swarm.boot(install_signals: false)
     supervisor = nil
 
     begin
+      swarm.boot(install_signals: false)
       supervisor = Thread.new { swarm.supervise }
 
       assert wait_for_history, "loop #{@lid} never fired within #{POLL_TIMEOUT}s — " \
@@ -78,8 +78,12 @@ class PeriodicLeaderTest < Wurk::Test::UnitCase
       assert_equal 1, history_len,
                    'two workers + one loop must enqueue exactly once per tick (no follower double-fire)'
     ensure
-      swarm.shutdown(timeout: 5)
-      supervisor&.join(10)
+      begin
+        swarm.shutdown(timeout: 5)
+      rescue StandardError
+        nil
+      end
+      supervisor&.join(10) || supervisor&.kill
     end
   end
 

--- a/test/integration/periodic_leader_test.rb
+++ b/test/integration/periodic_leader_test.rb
@@ -83,7 +83,7 @@ class PeriodicLeaderTest < Wurk::Test::UnitCase
       rescue StandardError
         nil
       end
-      supervisor&.join(10) || supervisor&.kill
+      stop_supervisor_thread(supervisor, 10)
     end
   end
 

--- a/test/integration/reaper_kill9_test.rb
+++ b/test/integration/reaper_kill9_test.rb
@@ -93,7 +93,7 @@ class ReaperKill9Test < Wurk::Test::UnitCase
       rescue StandardError
         nil
       end
-      supervisor&.join(15) || supervisor&.kill
+      stop_supervisor_thread(supervisor, 15)
     end
   end
 

--- a/test/integration/reaper_kill9_test.rb
+++ b/test/integration/reaper_kill9_test.rb
@@ -69,10 +69,12 @@ class ReaperKill9Test < Wurk::Test::UnitCase
   def test_kill_9_storm_loses_no_jobs_and_never_loops_forever # rubocop:disable Metrics/AbcSize
     enqueue_jobs
     swarm = Wurk::Swarm.new(topology: topology, config: @config, shutdown_timeout: 5)
-    swarm.boot(install_signals: false)
-    supervisor = Thread.new { swarm.supervise }
+    supervisor = nil
 
     begin
+      swarm.boot(install_signals: false)
+      supervisor = Thread.new { swarm.supervise }
+
       kill_random_children(swarm)
       completed = wait_for_drain
 
@@ -86,8 +88,12 @@ class ReaperKill9Test < Wurk::Test::UnitCase
 
       assert_operator exec_count, :<=, ceiling, 'executions unbounded — reclaim is looping'
     ensure
-      swarm.shutdown(timeout: 5)
-      supervisor&.join(15)
+      begin
+        swarm.shutdown(timeout: 5)
+      rescue StandardError
+        nil
+      end
+      supervisor&.join(15) || supervisor&.kill
     end
   end
 

--- a/test/integration/redis_outage_recovery_test.rb
+++ b/test/integration/redis_outage_recovery_test.rb
@@ -201,6 +201,7 @@ class RedisOutageRecoveryTest < Wurk::Test::UnitCase
       @server = TCPServer.new('127.0.0.1', 0)
       @port = @server.addr(false)[1]
       @outage = false
+      @stopped = false
       @mutex = ::Mutex.new
       @sockets = []
       @pump_threads = []
@@ -227,12 +228,22 @@ class RedisOutageRecoveryTest < Wurk::Test::UnitCase
     rescue IOError, Errno::EBADF
       nil
     ensure
-      @mutex.synchronize do
-        drop_tracked_sockets
-        @pump_threads.each(&:kill)
-        @pump_threads.each { |t| t.join(1) }
+      # Flip `@stopped` in the same critical section that takes the snapshot, so
+      # a relay racing this shutdown either lands in the snapshot or is refused
+      # outright — never registers into a list nobody will drain again.
+      sockets, pumps = @mutex.synchronize do
+        @stopped = true
+        snapshot = [@sockets.dup, @pump_threads.dup]
+        @sockets.clear
         @pump_threads.clear
+        snapshot
       end
+      # Outside the mutex: a killed pump's `ensure` calls untrack, which wants
+      # the same mutex, so holding it here would make every join burn its
+      # full 1s timeout and then leave the thread alive anyway.
+      sockets.each { |s| close_quietly(s) }
+      pumps.each(&:kill)
+      pumps.each { |t| t.join(1) }
     end
 
     private
@@ -255,24 +266,41 @@ class RedisOutageRecoveryTest < Wurk::Test::UnitCase
     end
 
     def relay(client)
-      @mutex.synchronize { @sockets.push(client) }
+      return close_quietly(client) unless track(client)
+
       upstream = TCPSocket.new(@upstream_host, @upstream_port)
-      @mutex.synchronize { @sockets.push(upstream) }
+      return close_quietly(upstream) unless track(upstream)
+
       pump(client, upstream)
       pump(upstream, client)
     end
 
-    def pump(from, dest)
-      thread = Thread.new do
-        IO.copy_stream(from, dest)
-      rescue StandardError
-        nil
-      ensure
-        untrack(from)
-        untrack(dest)
+    def track(sock)
+      @mutex.synchronize do
+        return false if @stopped
+
+        @sockets.push(sock)
+        true
       end
-      @mutex.synchronize { @pump_threads.push(thread) }
-      thread
+    end
+
+    # Spawn under the mutex so creation and registration are one step: a thread
+    # created after stop! took its snapshot would never be killed or joined.
+    def pump(from, dest)
+      @mutex.synchronize do
+        return nil if @stopped
+
+        thread = Thread.new do
+          IO.copy_stream(from, dest)
+        rescue StandardError
+          nil
+        ensure
+          untrack(from)
+          untrack(dest)
+        end
+        @pump_threads.push(thread)
+        thread
+      end
     end
 
     def untrack(sock)

--- a/test/integration/redis_outage_recovery_test.rb
+++ b/test/integration/redis_outage_recovery_test.rb
@@ -203,6 +203,7 @@ class RedisOutageRecoveryTest < Wurk::Test::UnitCase
       @outage = false
       @mutex = ::Mutex.new
       @sockets = []
+      @pump_threads = []
       @accept_thread = Thread.new { accept_loop }
     end
 
@@ -226,7 +227,12 @@ class RedisOutageRecoveryTest < Wurk::Test::UnitCase
     rescue IOError, Errno::EBADF
       nil
     ensure
-      @mutex.synchronize { drop_tracked_sockets }
+      @mutex.synchronize do
+        drop_tracked_sockets
+        @pump_threads.each(&:kill)
+        @pump_threads.each { |t| t.join(1) }
+        @pump_threads.clear
+      end
     end
 
     private
@@ -249,14 +255,15 @@ class RedisOutageRecoveryTest < Wurk::Test::UnitCase
     end
 
     def relay(client)
+      @mutex.synchronize { @sockets.push(client) }
       upstream = TCPSocket.new(@upstream_host, @upstream_port)
-      @mutex.synchronize { @sockets.push(client, upstream) }
+      @mutex.synchronize { @sockets.push(upstream) }
       pump(client, upstream)
       pump(upstream, client)
     end
 
     def pump(from, dest)
-      Thread.new do
+      thread = Thread.new do
         IO.copy_stream(from, dest)
       rescue StandardError
         nil
@@ -264,6 +271,8 @@ class RedisOutageRecoveryTest < Wurk::Test::UnitCase
         untrack(from)
         untrack(dest)
       end
+      @mutex.synchronize { @pump_threads.push(thread) }
+      thread
     end
 
     def untrack(sock)

--- a/test/integration/scheduled_promotion_test.rb
+++ b/test/integration/scheduled_promotion_test.rb
@@ -107,7 +107,7 @@ class ScheduledPromotionTest < Wurk::Test::UnitCase
       rescue StandardError
         nil
       end
-      supervisor&.join(10) || supervisor&.kill
+      stop_supervisor_thread(supervisor, 10)
     end
   end
 

--- a/test/integration/scheduled_promotion_test.rb
+++ b/test/integration/scheduled_promotion_test.rb
@@ -83,10 +83,10 @@ class ScheduledPromotionTest < Wurk::Test::UnitCase
   def test_due_scheduled_job_is_promoted_and_runs # rubocop:disable Metrics/AbcSize,Minitest/MultipleAssertions
     target_at = schedule_sentinel_job(SCHEDULE_DELAY)
     swarm = Wurk::Swarm.new(topology: topology_n(1), config: @config, shutdown_timeout: 5)
-    swarm.boot(install_signals: false)
     supervisor = nil
 
     begin
+      swarm.boot(install_signals: false)
       supervisor = Thread.new { swarm.supervise }
       result = wait_for_sentinel
 
@@ -102,8 +102,12 @@ class ScheduledPromotionTest < Wurk::Test::UnitCase
       assert_operator lateness, :<=, MAX_LATENESS,
                       "job ran #{lateness.round(2)}s after target; expected within #{MAX_LATENESS}s"
     ensure
-      swarm.shutdown(timeout: 5)
-      supervisor&.join(10)
+      begin
+        swarm.shutdown(timeout: 5)
+      rescue StandardError
+        nil
+      end
+      supervisor&.join(10) || supervisor&.kill
     end
   end
 

--- a/test/integration/swarm_boot_test.rb
+++ b/test/integration/swarm_boot_test.rb
@@ -54,10 +54,11 @@ class SwarmBootTest < Wurk::Test::UnitCase
   def test_swarm_boots_forks_and_runs_a_job_in_a_child # rubocop:disable Metrics/AbcSize,Minitest/MultipleAssertions
     push_sentinel_job
     swarm = Wurk::Swarm.new(topology: topology_n(2), config: @config, shutdown_timeout: 5)
-
-    pids = swarm.boot(install_signals: false)
+    supervisor = nil
 
     begin
+      pids = swarm.boot(install_signals: false)
+
       assert_equal 2, pids.size, 'boot should return one PID per slot assignment'
       pids.each { |pid| assert pid_alive?(pid), "expected child #{pid} to be alive after boot" }
 
@@ -70,8 +71,12 @@ class SwarmBootTest < Wurk::Test::UnitCase
       assert_includes pids.map(&:to_s), sentinel_pid,
                       "sentinel writer #{sentinel_pid} should be one of the spawned children #{pids}"
     ensure
-      swarm.shutdown(timeout: 5)
-      supervisor&.join(10)
+      begin
+        swarm.shutdown(timeout: 5)
+      rescue StandardError
+        nil
+      end
+      supervisor&.join(10) || supervisor&.kill
     end
   end
 
@@ -87,9 +92,11 @@ class SwarmBootTest < Wurk::Test::UnitCase
     log_boot_pids
     @config.memory_limit_mb = 1
     swarm = Wurk::Swarm.new(topology: topology_n(1), config: @config, shutdown_timeout: 5)
+    supervisor = nil
 
-    original = swarm.boot(install_signals: false).first
     begin
+      original = swarm.boot(install_signals: false).first
+
       assert_equal original.to_s, wait_for_boot_count(1)&.first,
                    "first child #{original} never finished booting"
 
@@ -101,8 +108,12 @@ class SwarmBootTest < Wurk::Test::UnitCase
       assert wait_until_dead(original),
              'the original (bloated) child should be TERMed once its replacement took over'
     ensure
-      swarm.shutdown(timeout: 5)
-      supervisor&.join(10)
+      begin
+        swarm.shutdown(timeout: 5)
+      rescue StandardError
+        nil
+      end
+      supervisor&.join(10) || supervisor&.kill
     end
   end
 
@@ -113,11 +124,16 @@ class SwarmBootTest < Wurk::Test::UnitCase
 
   def test_boot_is_not_re_entrant
     swarm = Wurk::Swarm.new(topology: topology_n(1), config: @config, shutdown_timeout: 5)
-    swarm.boot(install_signals: false)
+
     begin
+      swarm.boot(install_signals: false)
       assert_raises(RuntimeError) { swarm.boot(install_signals: false) }
     ensure
-      swarm.shutdown(timeout: 5)
+      begin
+        swarm.shutdown(timeout: 5)
+      rescue StandardError
+        nil
+      end
     end
   end
 

--- a/test/integration/swarm_boot_test.rb
+++ b/test/integration/swarm_boot_test.rb
@@ -76,7 +76,7 @@ class SwarmBootTest < Wurk::Test::UnitCase
       rescue StandardError
         nil
       end
-      supervisor&.join(10) || supervisor&.kill
+      stop_supervisor_thread(supervisor, 10)
     end
   end
 
@@ -113,7 +113,7 @@ class SwarmBootTest < Wurk::Test::UnitCase
       rescue StandardError
         nil
       end
-      supervisor&.join(10) || supervisor&.kill
+      stop_supervisor_thread(supervisor, 10)
     end
   end
 

--- a/test/integration/swarm_supervision_test.rb
+++ b/test/integration/swarm_supervision_test.rb
@@ -61,7 +61,7 @@ class SwarmSupervisionTest < Wurk::Test::UnitCase
       rescue StandardError
         nil
       end
-      supervisor&.join(10) || supervisor&.kill
+      stop_supervisor_thread(supervisor, 10)
     end
   end
 
@@ -92,7 +92,7 @@ class SwarmSupervisionTest < Wurk::Test::UnitCase
       rescue StandardError
         nil
       end
-      supervisor&.join(10) || supervisor&.kill
+      stop_supervisor_thread(supervisor, 10)
     end
   end
 

--- a/test/integration/swarm_supervision_test.rb
+++ b/test/integration/swarm_supervision_test.rb
@@ -45,17 +45,23 @@ class SwarmSupervisionTest < Wurk::Test::UnitCase
     key = "#{@ns}-crash-log"
     install_crash_on_startup(key)
     swarm = Wurk::Swarm.new(topology: topology_n(1), config: @config, shutdown_timeout: SHUTDOWN_TIMEOUT)
-    swarm.boot(install_signals: false)
-    supervisor = Thread.new { swarm.supervise }
+    supervisor = nil
 
     begin
+      swarm.boot(install_signals: false)
+      supervisor = Thread.new { swarm.supervise }
+
       assert_growing_backoff(key)
       assert_drains_promptly_while_backoff_pending(swarm)
     ensure
       # A failed assertion must not leave the crash-loop respawning forever;
       # shutdown is idempotent so the happy path's drain isn't double-counted.
-      swarm.shutdown(timeout: SHUTDOWN_TIMEOUT)
-      supervisor&.join(10)
+      begin
+        swarm.shutdown(timeout: SHUTDOWN_TIMEOUT)
+      rescue StandardError
+        nil
+      end
+      supervisor&.join(10) || supervisor&.kill
     end
   end
 
@@ -66,10 +72,12 @@ class SwarmSupervisionTest < Wurk::Test::UnitCase
   # (a fresh replacement spawned) once the restart's own backoff elapses.
   def test_kill_replacement_mid_restart_keeps_old_child_and_retries_slot
     swarm = Wurk::Swarm.new(topology: topology_n(1), config: @config, shutdown_timeout: SHUTDOWN_TIMEOUT)
-    original = swarm.boot(install_signals: false).first
-    supervisor = Thread.new { swarm.supervise }
+    supervisor = nil
 
     begin
+      original = swarm.boot(install_signals: false).first
+      supervisor = Thread.new { swarm.supervise }
+
       swarm.rolling_restart
       replacement = kill_the_replacement(swarm, original)
 
@@ -79,8 +87,12 @@ class SwarmSupervisionTest < Wurk::Test::UnitCase
 
       assert retried, 'the slot must be retried with a fresh replacement after backoff'
     ensure
-      swarm.shutdown(timeout: SHUTDOWN_TIMEOUT)
-      supervisor&.join(10)
+      begin
+        swarm.shutdown(timeout: SHUTDOWN_TIMEOUT)
+      rescue StandardError
+        nil
+      end
+      supervisor&.join(10) || supervisor&.kill
     end
   end
 

--- a/test/support/swarm_teardown.rb
+++ b/test/support/swarm_teardown.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'English'
+
+# Cleanup for the `Thread.new { swarm.supervise }` pattern every real-fork
+# integration test uses. `Wurk::Swarm#shutdown` never joins the supervise loop
+# and `Thread#kill` is asynchronous, so a plain `join(t) || kill` can return
+# while the supervisor is still parked in `Process.wait(-1, …)` — where it
+# steals the exit status of the *next* test's children.
+module SwarmTeardown
+  KILL_GRACE = 5
+
+  def stop_supervisor_thread(supervisor, timeout)
+    return if supervisor.nil?
+    return if supervisor.join(timeout)
+
+    supervisor.kill
+    return if supervisor.join(KILL_GRACE)
+
+    message = "supervisor thread survived shutdown + kill + #{KILL_GRACE}s join; " \
+              'it is still reaping children and will corrupt later tests'
+    # Called from an `ensure`: $ERROR_INFO is the exception already on its way
+    # out, and replacing a real assertion failure with this one hides the cause.
+    raise message if $ERROR_INFO.nil?
+
+    warn message
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -112,7 +112,34 @@ if Minitest.respond_to?(:after_parallel_fork)
     ActiveRecord::Base.connection_handler.clear_all_connections! if defined?(ActiveRecord::Base)
     SimpleCov.at_fork.call("worker-#{worker}") if ENV["COVERAGE"] && defined?(SimpleCov)
   end
-  Minitest.after_run { Process.waitall } if ENV["COVERAGE"] && defined?(SimpleCov)
+  Minitest.after_run do
+    if ENV["COVERAGE"] && defined?(SimpleCov)
+      deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + 10.0
+      orphans = []
+      loop do
+        pid, status = ::Process.waitpid2(-1, ::Process::WNOHANG)
+        break if pid.nil?
+
+        raise "Unexpected child status: #{status.inspect} pid=#{pid}" unless status&.success?
+      end
+      loop do
+        if ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) >= deadline
+          break
+        end
+
+        begin
+          pid, _status = ::Process.waitpid2(-1, ::Process::WNOHANG)
+          break if pid.nil?
+
+          orphans.push(pid)
+        rescue Errno::ECHILD
+          break
+        end
+        sleep 0.01
+      end
+      raise "Unreapable children after 10s deadline: #{orphans.inspect}" if orphans.any?
+    end
+  end
 end
 
 require_relative "support/redis_namespace"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -112,37 +112,37 @@ if Minitest.respond_to?(:after_parallel_fork)
     ActiveRecord::Base.connection_handler.clear_all_connections! if defined?(ActiveRecord::Base)
     SimpleCov.at_fork.call("worker-#{worker}") if ENV["COVERAGE"] && defined?(SimpleCov)
   end
+  # Reap every worker before the parent's at-exit SimpleCov merge, without the
+  # unbounded Process.waitall that would hang the suite on a stuck child.
+  # waitpid2(-1, WNOHANG) returns nil while a child is still running and raises
+  # ECHILD once none remain, so nil means "poll again", not "done" — only ECHILD
+  # ends the loop, and only a blown deadline is an error.
   Minitest.after_run do
     if ENV["COVERAGE"] && defined?(SimpleCov)
-      deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + 10.0
-      orphans = []
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 10.0
       loop do
-        pid, status = ::Process.waitpid2(-1, ::Process::WNOHANG)
-        break if pid.nil?
-
-        raise "Unexpected child status: #{status.inspect} pid=#{pid}" unless status&.success?
-      end
-      loop do
-        if ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) >= deadline
-          break
-        end
-
         begin
-          pid, _status = ::Process.waitpid2(-1, ::Process::WNOHANG)
-          break if pid.nil?
-
-          orphans.push(pid)
+          pid, status = Process.waitpid2(-1, Process::WNOHANG)
         rescue Errno::ECHILD
           break
         end
+
+        if pid
+          raise "Unexpected child status: #{status.inspect} pid=#{pid}" unless status.success?
+
+          next
+        end
+
+        raise "Children still running after 10s deadline" if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+
         sleep 0.01
       end
-      raise "Unreapable children after 10s deadline: #{orphans.inspect}" if orphans.any?
     end
   end
 end
 
 require_relative "support/redis_namespace"
+require_relative "support/swarm_teardown"
 
 module Wurk
   module Test
@@ -169,6 +169,7 @@ module Wurk
     # Base class for non-engine tests.
     class UnitCase < ::Minitest::Test
       include RedisNamespace
+      include SwarmTeardown
 
       def self.parallelize_me!
         # Hook for Minitest's parallel runner.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -105,6 +105,11 @@ if Minitest.respond_to?(:after_parallel_fork)
     Wurk.configuration.redis = { url: Wurk::Test.redis_url }
     Wurk.configuration.reset_redis_pools!
     Wurk.redis { |c| c.call("FLUSHDB") }
+    # engine_test_helper boots the dummy app (opening test/dummy/db/test.sqlite3)
+    # in the parent before this fork; each worker inherits that connection and
+    # must drop it, mirroring Swarm#close_parent_sockets, or workers corrupt
+    # each other's queries on the shared SQLite handle.
+    ActiveRecord::Base.connection_handler.clear_all_connections! if defined?(ActiveRecord::Base)
     SimpleCov.at_fork.call("worker-#{worker}") if ENV["COVERAGE"] && defined?(SimpleCov)
   end
   Minitest.after_run { Process.waitall } if ENV["COVERAGE"] && defined?(SimpleCov)

--- a/test/unit/bench_support_test.rb
+++ b/test/unit/bench_support_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require_relative '../../bench/support'
+
+# `bench_redis_url` is the only thing standing between a benchmark's FLUSHDB
+# and a developer's real DB 0, so its two failure modes are pinned here: a
+# bogus `WURK_BENCH_DB` must raise rather than fall back, and a query-bearing
+# `REDIS_URL` must keep its query when the DB is swapped.
+class BenchSupportTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def test_uses_the_per_bench_default_database
+    with_env('REDIS_URL' => 'redis://localhost:6379/0', 'WURK_BENCH_DB' => nil) do
+      assert_equal 'redis://localhost:6379/10', bench_redis_url('10')
+    end
+  end
+
+  def test_override_replaces_the_default_database
+    with_env('REDIS_URL' => 'redis://localhost:6379/0', 'WURK_BENCH_DB' => '11') do
+      assert_equal 'redis://localhost:6379/11', bench_redis_url('10')
+    end
+  end
+
+  def test_preserves_query_and_credentials_when_swapping_the_database
+    with_env('REDIS_URL' => 'rediss://:pw@host:6380/0?ssl=true', 'WURK_BENCH_DB' => '12') do
+      assert_equal 'rediss://:pw@host:6380/12?ssl=true', bench_redis_url('10')
+    end
+  end
+
+  def test_appends_the_database_to_a_url_without_one
+    with_env('REDIS_URL' => 'redis://host?timeout=1', 'WURK_BENCH_DB' => '13') do
+      assert_equal 'redis://host/13?timeout=1', bench_redis_url('10')
+    end
+  end
+
+  def test_rejects_database_zero
+    assert_invalid_override '0'
+  end
+
+  def test_rejects_negative_database
+    assert_invalid_override '-1'
+  end
+
+  def test_rejects_non_numeric_database
+    assert_invalid_override 'abc'
+  end
+
+  private
+
+  def assert_invalid_override(value)
+    with_env('REDIS_URL' => 'redis://localhost:6379/0', 'WURK_BENCH_DB' => value) do
+      error = assert_raises(ArgumentError) { bench_redis_url('10') }
+
+      assert_match(/positive integer/, error.message)
+    end
+  end
+
+  # ENV is process-global and the whole suite reads REDIS_URL for its per-worker
+  # DB isolation, so every key touched here is restored even on failure.
+  def with_env(vars)
+    saved = vars.keys.to_h { |key| [key, ENV.fetch(key, nil)] }
+    vars.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+    yield
+  ensure
+    saved.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+  end
+end

--- a/test/unit/processor_test.rb
+++ b/test/unit/processor_test.rb
@@ -434,20 +434,27 @@ class ProcessorTest < Wurk::Test::UnitCase
     Wurk::Processor.new(@capsule, &block).tap { |p| @processors << p }
   end
 
-  # A few tests deliberately drive their processor's thread to die with
-  # FatalBoom (a non-StandardError); #kill's `@thread.value` — and any later
-  # #join — re-raises that stored exception every time it's called on the
-  # already-dead thread, so both calls here must rescue broadly.
+  # `kill(true)` would block in `@thread.value` with no timeout, so teardown
+  # asks for the raise only and does its own bounded wait below.
   def stop_processor(processor)
-    processor.kill(true)
+    processor.kill(false)
   rescue Exception # rubocop:disable Lint/RescueException
     nil
   ensure
     join_quietly(processor.thread)
   end
 
+  # A few tests deliberately drive their processor's thread to die with
+  # FatalBoom (a non-StandardError); #join re-raises that stored exception
+  # every time it's called on the already-dead thread, so this rescues broadly
+  # — a raising join still means the thread is gone. Only a join that times out
+  # needs the Thread#kill fallback.
   def join_quietly(thread)
-    thread&.join(2)
+    return if thread.nil?
+    return if thread.join(2)
+
+    thread.kill
+    thread.join(1)
   rescue Exception # rubocop:disable Lint/RescueException
     nil
   end

--- a/test/unit/processor_test.rb
+++ b/test/unit/processor_test.rb
@@ -22,11 +22,13 @@ class ProcessorTest < Wurk::Test::UnitCase
     @capsule.queues = [@queue_name]
     @capsule.fetcher = Wurk::Fetcher::Reliable.new(@capsule)
     @pool = @capsule.redis_pool
-    @processor = Wurk::Processor.new(@capsule)
+    @processors = []
+    @processor = new_processor
     @dead_members = []
   end
 
   def teardown
+    @processors.each { |p| stop_processor(p) }
     @pool.with do |conn|
       conn.call('DEL', @public_queue, private_queue)
       conn.call('ZREM', Wurk::Keys::DEAD, *@dead_members) unless @dead_members.empty?
@@ -106,7 +108,7 @@ class ProcessorTest < Wurk::Test::UnitCase
 
   def test_run_invokes_callback_on_clean_exit
     called = []
-    processor = Wurk::Processor.new(@capsule) { |p| called << p }
+    processor = new_processor { |p| called << p }
     processor.start
     processor.terminate(true)
 
@@ -114,7 +116,7 @@ class ProcessorTest < Wurk::Test::UnitCase
   end
 
   def test_run_without_callback_exits_cleanly
-    processor = Wurk::Processor.new(@capsule) # nil callback => &. short-circuits
+    processor = new_processor # nil callback => &. short-circuits
     processor.start
     processor.terminate(true)
 
@@ -128,7 +130,7 @@ class ProcessorTest < Wurk::Test::UnitCase
 
   def test_run_invokes_callback_on_shutdown
     called = []
-    processor = Wurk::Processor.new(@capsule) { |_p| called << :shutdown }
+    processor = new_processor { |_p| called << :shutdown }
     processor.define_singleton_method(:process_one) { raise Wurk::Shutdown }
     processor.start
     processor.thread.join(2)
@@ -138,7 +140,7 @@ class ProcessorTest < Wurk::Test::UnitCase
   end
 
   def test_run_without_callback_on_shutdown_exits_cleanly
-    processor = Wurk::Processor.new(@capsule) # nil callback in Shutdown rescue
+    processor = new_processor # nil callback in Shutdown rescue
     processor.define_singleton_method(:process_one) { raise Wurk::Shutdown }
     processor.start
     processor.thread.join(2)
@@ -165,7 +167,7 @@ class ProcessorTest < Wurk::Test::UnitCase
 
   def test_run_invokes_callback_then_reraises_on_fatal_error
     called = []
-    processor = Wurk::Processor.new(@capsule) { |_p| called << :fatal }
+    processor = new_processor { |_p| called << :fatal }
     processor.define_singleton_method(:fetch) { raise FatalBoom, 'fatal' }
     processor.start
     # run re-raises (line 146); Thread#join propagates it to the caller.
@@ -176,7 +178,7 @@ class ProcessorTest < Wurk::Test::UnitCase
   end
 
   def test_run_without_callback_reraises_on_fatal_error
-    processor = Wurk::Processor.new(@capsule) # nil callback in Exception rescue
+    processor = new_processor # nil callback in Exception rescue
     processor.define_singleton_method(:fetch) { raise FatalBoom, 'fatal' }
     processor.start
     assert_raises(FatalBoom) { processor.thread.join(2) }
@@ -427,6 +429,28 @@ class ProcessorTest < Wurk::Test::UnitCase
   end
 
   private
+
+  def new_processor(&block)
+    Wurk::Processor.new(@capsule, &block).tap { |p| @processors << p }
+  end
+
+  # A few tests deliberately drive their processor's thread to die with
+  # FatalBoom (a non-StandardError); #kill's `@thread.value` — and any later
+  # #join — re-raises that stored exception every time it's called on the
+  # already-dead thread, so both calls here must rescue broadly.
+  def stop_processor(processor)
+    processor.kill(true)
+  rescue Exception # rubocop:disable Lint/RescueException
+    nil
+  ensure
+    join_quietly(processor.thread)
+  end
+
+  def join_quietly(thread)
+    thread&.join(2)
+  rescue Exception # rubocop:disable Lint/RescueException
+    nil
+  end
 
   def private_queue
     Wurk::Fetcher::Reliable.private_queue_name(@public_queue)


### PR DESCRIPTION
## Summary
- Replace unbounded `Process.waitall` in coverage-mode teardown with WNOHANG poll loop (10s deadline); fail loudly with unreapable PIDs
- Track pump threads spawned by BlipProxy relay and join them in `stop!`
- Ensure client socket pushed into `@sockets` before upstream connection (fail-safe on partial init)

## Test plan
- `bin/rake test` — 2717 runs, 0 failures/errors
- `bin/rake test TEST=test/integration/redis_outage_recovery_test.rb` ×3
- Follows established fork/thread resource-leak teardown pattern from prior sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788153850&installation_model_id=11168&pr_number=343&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F343&signature=ebe147e9fbf8cda3d632db88390e2adaefa3a7b4312d7d1484639d4b42a3f8bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark isolation by assigning separate Redis databases to each benchmark.
  * Prevented benchmark support files from being run as standalone benchmarks.
  * Improved cleanup when integration tests encounter startup or shutdown failures.
  * Reduced resource leaks from lingering supervisor, processor, relay, and worker threads.
  * Improved test reliability around database connections, child processes, and concurrent shutdowns.

* **Tests**
  * Added stronger teardown handling, including timeouts and forced termination for stuck processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->