### PR TITLE
fix(swarm): fork-safety and signal correctness in the supervisor

### DIFF
--- a/lib/wurk/cli.rb
+++ b/lib/wurk/cli.rb
@@ -106,16 +106,24 @@ module Wurk
       enter_server_mode
       boot_application if boot_app
       self_read, self_write = ::IO.pipe
-      trap_signals(self_write)
-      validate_redis!
-      validate_pool_sizes!
-      @config[:identity] = identity
-      # Force lazy server-middleware chain so worker threads don't race
-      # against each other constructing it. Spec: Sidekiq::CLI line 104.
-      @config.server_middleware
-      ::Process.warmup if warmup && ::Process.respond_to?(:warmup) && ENV['RUBY_DISABLE_WARMUP'] != '1'
-      fire_event(:startup, reverse: false, reraise: true)
-      launch(self_read)
+      begin
+        trap_signals(self_write)
+        validate_redis!
+        validate_pool_sizes!
+        @config[:identity] = identity
+        # Force lazy server-middleware chain so worker threads don't race
+        # against each other constructing it. Spec: Sidekiq::CLI line 104.
+        @config.server_middleware
+        warm_up_process if warmup
+        fire_event(:startup, reverse: false, reraise: true)
+        launch(self_read)
+      ensure
+        # Every exit path — clean return, a raise out of validate/startup, and
+        # the SystemExit that `launch` unwinds on Interrupt. Embedded and test
+        # callers survive `run`, so a leaked pair is a real FD leak.
+        self_read.close
+        self_write.close
+      end
     end
 
     # Standalone multi-process boot — the `sidekiqswarm` entry point (Ent §7).
@@ -141,11 +149,18 @@ module Wurk
       validate_redis!
       validate_pool_sizes!
       @config[:identity] = identity
-      ::Process.warmup if warmup && ::Process.respond_to?(:warmup) && ENV['RUBY_DISABLE_WARMUP'] != '1'
+      warm_up_process if warmup
       @swarm = Wurk::Swarm.new(topology: @config.topology, config: @config,
                                shutdown_timeout: @config[:timeout] || Swarm::DEFAULT_SHUTDOWN_TIMEOUT)
-      @swarm.boot(install_signals: true)
-      @swarm.supervise
+      begin
+        @swarm.boot(install_signals: true)
+        @swarm.supervise
+      ensure
+        # A fork failure part-way through `boot`, or anything raising out of
+        # `supervise`, otherwise leaves live children behind with no supervisor.
+        # A no-op once the loop already drained (no children, pipe closed).
+        @swarm.shutdown
+      end
     end
 
     def handle_signal(sig)
@@ -162,6 +177,15 @@ module Wurk
 
     def enter_server_mode
       Wurk.enter_server_mode(@config)
+    end
+
+    # Pre-fault and compact the heap before workers start — in `run_swarm` that
+    # happens before the fork, so children share the warmed pages copy-on-write.
+    # RUBY_DISABLE_WARMUP=1 is the escape hatch for hosts that already warmed up.
+    def warm_up_process
+      return unless ::Process.respond_to?(:warmup) && ENV['RUBY_DISABLE_WARMUP'] != '1'
+
+      ::Process.warmup
     end
 
     def launch(self_read)
@@ -187,11 +211,21 @@ module Wurk
     # over `self_read` in `launch`. Same approach as Sidekiq.
     def trap_signals(self_write)
       signal_names.each do |sig|
-        ::Signal.trap(sig) { self_write.puts(sig) }
+        ::Signal.trap(sig) { emit_signal(self_write, sig) }
       rescue ArgumentError
         # JRuby and platforms without certain signals — log and move on.
         warn("Signal #{sig} not supported")
       end
+    end
+
+    # Non-blocking write from trap context (same shape as Swarm#emit_signal): a
+    # blocking `puts` can stall signal delivery once the pipe fills, and the
+    # traps outlive `run`'s ensure — a signal landing after the pipe is closed
+    # would otherwise raise IOError out of a trap and into the main thread.
+    def emit_signal(pipe, sig)
+      pipe.write_nonblock("#{sig}\n", exception: false)
+    rescue ::IOError, ::Errno::EPIPE, ::Errno::EBADF
+      nil
     end
 
     def signal_names

--- a/lib/wurk/rails_boot.rb
+++ b/lib/wurk/rails_boot.rb
@@ -8,6 +8,11 @@ module Wurk
   # boot policy stays pure and unit-testable without the Railtie DSL.
   # See docs/idea/03-process-model.md for the exact ordering.
   module RailsBoot
+    # What `at_exit` waits for the supervise thread on top of the swarm's own
+    # drain budget: one supervise tick to notice the request, plus slack for
+    # the final reap.
+    DRAIN_JOIN_SLACK = 1
+
     module_function
 
     # Invoked from the `wurk.server_mode` initializer, before config/initializers
@@ -103,23 +108,44 @@ module Wurk
     end
 
     def boot_swarm
-      swarm = Wurk::Swarm.new(topology: Wurk.configuration.topology,
-                              shutdown_timeout: Wurk.configuration[:timeout] || Swarm::DEFAULT_SHUTDOWN_TIMEOUT)
+      timeout = Wurk.configuration[:timeout] || Swarm::DEFAULT_SHUTDOWN_TIMEOUT
+      swarm = Wurk::Swarm.new(topology: Wurk.configuration.topology, shutdown_timeout: timeout)
+      supervisor = nil
+      # Registered BEFORE boot, which forks the children one slot at a time: a
+      # fork that raises partway through would otherwise leave the children it
+      # already spawned with nothing to drain them on host exit. Children
+      # inherit the hook — stop_swarm no-ops off the process that forked them.
+      at_exit { stop_swarm(swarm, supervisor, timeout + Swarm::SHUTDOWN_GRACE + DRAIN_JOIN_SLACK) }
       # Co-hosted in the web process (e.g. Puma single mode): the host owns the
       # process-wide TERM/INT traps. Installing the swarm's own would hijack
       # them — a deploy TERM would drain the swarm but never stop the HTTP
       # server. Let the host keep signal ownership and drain the swarm on its
       # graceful exit (same contract as boot_embedded).
       swarm.boot(install_signals: false)
-      at_exit { swarm.shutdown }
       # supervise must still run somewhere or crashed children never respawn and
       # memory checks never fire. A background thread keeps the host's main
       # thread free to serve HTTP.
-      Thread.new do
+      supervisor = Thread.new do
         swarm.supervise
       rescue StandardError => e
         logger.error { "wurk supervisor thread died: #{e.class}: #{e.message}" }
       end
+    end
+
+    # at_exit fires on the host's main thread, but the supervise thread owns the
+    # child table and two threads inside `shutdown` race on it — so request the
+    # drain and wait for the supervisor to run it. Draining here is the fallback
+    # for when no live supervisor will: it never started (boot raised) or it
+    # died early; after one that drained it finds no children and no-ops. A
+    # supervisor still alive past the join is wedged mid-drain — leave it be
+    # rather than race it; its children self-terminate (OrphanGuard) once this
+    # process is gone.
+    def stop_swarm(swarm, supervisor, drain_wait)
+      return unless swarm.owner?
+
+      swarm.request_shutdown
+      supervisor&.join(drain_wait)
+      swarm.shutdown unless supervisor&.alive?
     end
 
     # Sidekiq-embedded parity: a threads-only worker inside the web process, no

--- a/lib/wurk/swarm.rb
+++ b/lib/wurk/swarm.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'monitor'
+
 require_relative 'component'
 require_relative 'launcher'
 require_relative 'fetcher/reliable'
@@ -52,7 +54,7 @@ module Wurk
     # whole swarm.
     SWARM_SIGNALS = { 'TERM' => :term, 'INT' => :term, 'TSTP' => :tstp, 'USR1' => :usr1, 'USR2' => :usr2 }.freeze
 
-    attr_reader :topology, :children
+    attr_reader :topology
 
     def initialize(topology:, config: Wurk.configuration, memory_limit: config.memory_limit_kb,
                    shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT)
@@ -60,6 +62,14 @@ module Wurk
       @config = config
       @memory_limit = memory_limit
       @shutdown_timeout = shutdown_timeout
+      # One reentrant lock covers the child table AND the restart machine: they
+      # are mutually recursive (Restart#advance calls back into `describe` and
+      # `spawn`, which read and write `@children`), so separate locks would be
+      # taken in opposite orders — enqueue holds children→restart, advance holds
+      # restart→children — and deadlock. Monitor's reentrancy is what lets those
+      # callbacks re-enter. Never held across a sleep: `wait_for_children` and
+      # the supervise tick sleep outside it.
+      @lock = ::Monitor.new
       @children = {}
       @assignments = []
       @owner_pid = nil
@@ -91,7 +101,14 @@ module Wurk
       install_signal_handlers if install_signals
       close_parent_sockets
       fork_children
-      @children.keys
+      child_pids
+    end
+
+    # A snapshot, not the live table. Callers read this off the supervise
+    # thread, which inserts (respawn, restart) and deletes (reap) on every tick;
+    # handing out the live Hash lets them iterate it mid-mutation.
+    def children
+      @lock.synchronize { @children.dup }
     end
 
     def supervise
@@ -102,7 +119,7 @@ module Wurk
         shutdown if @shutdown_requested && !@stopping
         reap_children
         spawn_due_respawns
-        @restart.advance unless @stopping
+        advance_restart unless @stopping
         check_memory_pressure
         sleep SUPERVISE_TICK
       end
@@ -112,7 +129,7 @@ module Wurk
       return unless owner?
 
       @stopping = true
-      @restart.abort
+      @lock.synchronize { @restart.abort }
       relay_signal('TERM')
       wait_for_children(timeout + SHUTDOWN_GRACE)
       hard_kill_stragglers
@@ -153,17 +170,33 @@ module Wurk
     # heartbeat → TERM the old child → await its drain) without blocking the
     # supervise thread, so TERM stays responsive throughout the cycle.
     def rolling_restart
-      @restart.enqueue(@children.keys)
+      @lock.synchronize { @restart.enqueue(@children.keys) }
     end
 
     private
+
+    def advance_restart
+      @lock.synchronize { @restart.advance }
+    end
+
+    def child_pids
+      @lock.synchronize { @children.keys }
+    end
+
+    def child_meta(pid)
+      @lock.synchronize { @children[pid] }
+    end
+
+    def any_children?
+      @lock.synchronize { !@children.empty? }
+    end
 
     def build_restart
       Restart.new(Restart::Config.new(
                     spawn: method(:spawn_child),
                     kill: method(:safe_kill),
                     heartbeat: method(:heartbeat_seen?),
-                    describe: ->(pid) { @children[pid] },
+                    describe: ->(pid) { child_meta(pid) },
                     now: method(:monotonic),
                     logger: logger,
                     heartbeat_wait: HEARTBEAT_WAIT,
@@ -197,7 +230,7 @@ module Wurk
     # Returns the child PID; never returns in the child (ChildBoot exits).
     def spawn_child(slot, idx)
       pid = fork_child(slot, idx)
-      @children[pid] = { slot: slot, index: idx, spawned_at: monotonic }
+      @lock.synchronize { @children[pid] = { slot: slot, index: idx, spawned_at: monotonic } }
       pid
     end
 
@@ -280,14 +313,16 @@ module Wurk
     end
 
     def on_child_exit(pid, status)
-      meta = @children.delete(pid)
-      return unless meta
-      return if @restart.claim_exit(pid)
+      @lock.synchronize do
+        meta = @children.delete(pid)
+        return unless meta
+        return if @restart.claim_exit(pid)
 
-      if @stopping
-        logger.info { "swarm: child #{pid} exited (status=#{status.exitstatus})" }
-      else
-        schedule_respawn(pid, status, meta)
+        if @stopping
+          logger.info { "swarm: child #{pid} exited (status=#{status.exitstatus})" }
+        else
+          schedule_respawn(pid, status, meta)
+        end
       end
     end
 
@@ -334,7 +369,7 @@ module Wurk
       return if now - @last_memory_check < MEMORY_CHECK_INTERVAL
 
       @last_memory_check = now
-      @children.dup.each_key { |pid| recycle_if_bloated(pid) }
+      child_pids.each { |pid| recycle_if_bloated(pid) }
     end
 
     # Route a bloated child through the restart state machine (same path as a
@@ -346,7 +381,7 @@ module Wurk
       return if rss.nil? || rss < @memory_limit
 
       logger.warn { "swarm: child #{pid} RSS #{rss}KB >= #{@memory_limit}KB; recycling" }
-      @restart.enqueue([pid])
+      @lock.synchronize { @restart.enqueue([pid]) }
     end
 
     def pid_rss_kb(pid)
@@ -358,7 +393,7 @@ module Wurk
     end
 
     def relay_signal(sig)
-      @children.each_key { |pid| safe_kill(pid, sig) }
+      child_pids.each { |pid| safe_kill(pid, sig) }
     end
 
     # The one place the supervisor signals a child: relay_signal,
@@ -374,15 +409,20 @@ module Wurk
 
     def wait_for_children(timeout)
       deadline = monotonic + timeout
-      while monotonic < deadline && @children.any?
+      while monotonic < deadline && any_children?
         reap_children
         sleep 0.1
       end
     end
 
+    # Kill and forget atomically: a child landing in the table between the walk
+    # and the clear would be dropped from it without ever being signalled —
+    # untracked and still alive.
     def hard_kill_stragglers
-      @children.each_key { |pid| safe_kill(pid, 'KILL') }
-      @children.clear
+      @lock.synchronize do
+        @children.each_key { |pid| safe_kill(pid, 'KILL') }
+        @children.clear
+      end
     end
 
     # Has the child written its first heartbeat yet? One non-blocking SISMEMBER,
@@ -404,7 +444,7 @@ module Wurk
     end
 
     def done?
-      @stopping && @children.empty?
+      @stopping && !any_children?
     end
   end
 end

--- a/lib/wurk/swarm.rb
+++ b/lib/wurk/swarm.rb
@@ -62,6 +62,7 @@ module Wurk
       @shutdown_timeout = shutdown_timeout
       @children = {}
       @assignments = []
+      @owner_pid = nil
       @stopping = false
       @quieted = false
       @last_memory_check = 0
@@ -85,6 +86,7 @@ module Wurk
       raise ArgumentError, 'Topology has no slots' if @topology.empty?
 
       @assignments = @topology.assignments.freeze
+      @owner_pid = ::Process.pid
       install_signal_handlers if install_signals
       close_parent_sockets
       fork_children
@@ -92,6 +94,8 @@ module Wurk
     end
 
     def supervise
+      return unless owner?
+
       until done?
         drain_signals
         reap_children
@@ -103,6 +107,8 @@ module Wurk
     end
 
     def shutdown(timeout: @shutdown_timeout)
+      return unless owner?
+
       @stopping = true
       @restart.abort
       relay_signal('TERM')
@@ -128,6 +134,16 @@ module Wurk
     end
 
     private
+
+    # A forked child inherits this object along with the host's `at_exit` hooks
+    # — and rails_boot registers `at_exit { swarm.shutdown }`, so ChildBoot's
+    # `exit` runs a full drain inside the child. There `@children` holds the
+    # child's SIBLINGS, not its own children: unguarded, that TERMs them, stalls
+    # the whole shutdown timeout waiting on PIDs it can never reap, then SIGKILLs
+    # whatever survived. Only the process that forked them may supervise them.
+    def owner?
+      ::Process.pid == @owner_pid
+    end
 
     def build_restart
       Restart.new(Restart::Config.new(
@@ -332,7 +348,12 @@ module Wurk
       @children.each_key { |pid| safe_kill(pid, sig) }
     end
 
+    # The one place the supervisor signals a child: relay_signal,
+    # hard_kill_stragglers and the restart machine's `kill:` callback all funnel
+    # through here, so the owner check covers every path at a single choke point.
     def safe_kill(pid, sig)
+      return unless owner?
+
       ::Process.kill(sig, pid)
     rescue Errno::ESRCH, Errno::EPERM
       nil

--- a/lib/wurk/swarm.rb
+++ b/lib/wurk/swarm.rb
@@ -64,6 +64,7 @@ module Wurk
       @assignments = []
       @owner_pid = nil
       @stopping = false
+      @shutdown_requested = false
       @quieted = false
       @last_memory_check = 0
       @signal_read = nil
@@ -98,6 +99,7 @@ module Wurk
 
       until done?
         drain_signals
+        shutdown if @shutdown_requested && !@stopping
         reap_children
         spawn_due_respawns
         @restart.advance unless @stopping
@@ -114,6 +116,27 @@ module Wurk
       relay_signal('TERM')
       wait_for_children(timeout + SHUTDOWN_GRACE)
       hard_kill_stragglers
+    end
+
+    # Cross-thread drain request: raise a flag the supervise loop observes on
+    # its next tick instead of draining on the caller's thread. `shutdown`
+    # walks and clears the child table that the supervise thread is
+    # concurrently mutating (reap, respawn, restart), so two threads inside it
+    # race. Every caller that isn't the supervise thread — rails_boot's
+    # `at_exit`, which fires on the host's main thread — comes through here.
+    def request_shutdown
+      @shutdown_requested = true
+    end
+
+    # Only the process that forked the children may supervise or signal them.
+    # A forked child inherits this object along with the host's `at_exit` hooks
+    # — and rails_boot registers one that drains the swarm — so ChildBoot's
+    # `exit` reaches a full drain inside the child. There `@children` holds the
+    # child's SIBLINGS, not its own children: unguarded, that TERMs them, stalls
+    # the whole shutdown timeout waiting on PIDs it can never reap, then SIGKILLs
+    # whatever survived.
+    def owner?
+      ::Process.pid == @owner_pid
     end
 
     # TSTP quiet is one-way and GLOBAL (spec §21.3): it must survive respawns
@@ -134,16 +157,6 @@ module Wurk
     end
 
     private
-
-    # A forked child inherits this object along with the host's `at_exit` hooks
-    # — and rails_boot registers `at_exit { swarm.shutdown }`, so ChildBoot's
-    # `exit` runs a full drain inside the child. There `@children` holds the
-    # child's SIBLINGS, not its own children: unguarded, that TERMs them, stalls
-    # the whole shutdown timeout waiting on PIDs it can never reap, then SIGKILLs
-    # whatever survived. Only the process that forked them may supervise them.
-    def owner?
-      ::Process.pid == @owner_pid
-    end
 
     def build_restart
       Restart.new(Restart::Config.new(

--- a/lib/wurk/swarm.rb
+++ b/lib/wurk/swarm.rb
@@ -133,6 +133,7 @@ module Wurk
       relay_signal('TERM')
       wait_for_children(timeout + SHUTDOWN_GRACE)
       hard_kill_stragglers
+      close_signal_pipe
     end
 
     # Cross-thread drain request: raise a flag the supervise loop observes on
@@ -246,9 +247,8 @@ module Wurk
       # Drop the parent's self-pipe first: the inherited traps still write to
       # it, so a signal landing in the window before ChildBoot resets them
       # would surface in the PARENT's supervise loop (an operator TERMing one
-      # child pid would drain the whole swarm). Closed, the trap write no-ops.
-      @signal_read&.close
-      @signal_write&.close
+      # child pid would drain the whole swarm). Dropped, the trap write no-ops.
+      close_signal_pipe
       ChildBoot.new(@config, slot, idx, parent_pid: parent_pid, start_quiet: @quieted).run
       exit 0 # unreachable; ChildBoot exits explicitly
     end
@@ -266,12 +266,25 @@ module Wurk
       end
     end
 
+    # Both FDs, once. The traps stay installed and keep firing after a drain, so
+    # clear the ivars BEFORE closing: `emit_signal` then writes to nothing
+    # instead of a dead FD, and a `drain_signals` loop mid-tick (TERM handled,
+    # asking for the next buffered signal) stops instead of reading a closed
+    # pipe. Called on shutdown and, in the child, immediately after fork.
+    def close_signal_pipe
+      read = @signal_read
+      write = @signal_write
+      @signal_read = @signal_write = nil
+      read&.close
+      write&.close
+    end
+
     # Non-blocking self-pipe write from trap context: a blocking `puts` could
     # stall signal delivery if the pipe fills. `exception: false` returns
     # :wait_writable instead of raising when full (drop the coalescible
     # duplicate); a closed pipe during shutdown is ignored too.
     def emit_signal(sig)
-      @signal_write.write_nonblock("#{sig}\n", exception: false)
+      @signal_write&.write_nonblock("#{sig}\n", exception: false)
     rescue ::IOError, ::Errno::EPIPE, ::Errno::EBADF
       nil
     end
@@ -292,11 +305,14 @@ module Wurk
     end
 
     # One buffered line per pending signal, non-blocking (wait_readable(0)).
-    # nil once the pipe is drained, ending the loop for this tick.
+    # nil once the pipe is drained, ending the loop for this tick. Reads through
+    # a local because the pipe can vanish mid-drain: a buffered TERM runs
+    # `shutdown`, which closes it, and the loop then asks for the next signal.
     def read_pending_signal
-      return nil unless @signal_read.wait_readable(0)
+      read = @signal_read
+      return nil unless read&.wait_readable(0)
 
-      @signal_read.gets&.strip
+      read.gets&.strip
     end
 
     def reopen_logs

--- a/lib/wurk/swarm.rb
+++ b/lib/wurk/swarm.rb
@@ -44,6 +44,16 @@ module Wurk
     MEMORY_CHECK_INTERVAL = 10
     DEFAULT_SHUTDOWN_TIMEOUT = 25
 
+    # The supervisor's own Redis pool: one connection, disjoint from every
+    # capsule pool. Post-boot the parent's only Redis use is the heartbeat probe
+    # (`heartbeat_seen?`) — one SISMEMBER per restart tick — and routing it
+    # through the capsule main pool reopened, at capsule size (>= 10), the very
+    # sockets step 3 had just closed; the next respawn/restart fork then
+    # inherited them. Dedicated and torn down before every fork, so no child
+    # ever sees a parent socket.
+    SUPERVISOR_POOL_SIZE = 1
+    SUPERVISOR_POOL_NAME = 'swarm-supervisor'
+
     # Children each hard_shutdown after their own drain deadline (bulk_requeue
     # + a 3s ensure window + heartbeat cleanup); the parent must not SIGKILL
     # them mid-tail, so its own wait always extends past theirs by this much.
@@ -77,10 +87,9 @@ module Wurk
       @shutdown_requested = false
       @quieted = false
       @last_memory_check = 0
-      @signal_read = nil
-      @signal_write = nil
       @respawn_backoff = Backoff.new(base: RESPAWN_BACKOFF)
       @restart = build_restart
+      init_fork_unsafe_handles
     end
 
     # `install_signals:` is false in tests so the integration suite can
@@ -133,6 +142,7 @@ module Wurk
       relay_signal('TERM')
       wait_for_children(timeout + SHUTDOWN_GRACE)
       hard_kill_stragglers
+      close_supervisor_pool
       close_signal_pipe
     end
 
@@ -175,6 +185,17 @@ module Wurk
     end
 
     private
+
+    # The handles the parent must never let cross a fork: the signal self-pipe
+    # (an inherited trap would write into the PARENT's supervise loop) and the
+    # supervisor's Redis socket. Grouped because they share one rule — opened in
+    # the parent, dropped before or at every fork by `close_supervisor_pool` and
+    # `close_signal_pipe`.
+    def init_fork_unsafe_handles
+      @signal_read = nil
+      @signal_write = nil
+      @supervisor_pool = nil
+    end
 
     def advance_restart
       @lock.synchronize { @restart.advance }
@@ -239,8 +260,13 @@ module Wurk
     # from the parent, it is race-free even if the parent dies the instant
     # after fork (getppid in the child could already return the reaper). The
     # child's OrphanGuard compares live getppid against it.
+    #
+    # The supervisor pool closes here rather than in `close_parent_sockets`
+    # because that runs once, at boot: every later respawn / rolling-restart
+    # fork happens after the heartbeat probe has reopened it.
     def fork_child(slot, idx)
       parent_pid = ::Process.pid
+      close_supervisor_pool
       pid = ::Process.fork
       return pid if pid
 
@@ -459,9 +485,25 @@ module Wurk
     # forces progress.
     def heartbeat_seen?(pid)
       identity = "#{hostname}:#{pid}:#{Component::PROCESS_NONCE}"
-      @config.redis { |c| c.call('SISMEMBER', Keys::PROCESSES, identity) } == 1
+      supervisor_pool.with { |c| c.call('SISMEMBER', Keys::PROCESSES, identity) } == 1
     rescue StandardError
       false
+    end
+
+    def supervisor_pool
+      @supervisor_pool ||= @config.new_redis_pool(SUPERVISOR_POOL_SIZE, SUPERVISOR_POOL_NAME)
+    end
+
+    # ConnectionPool#shutdown is terminal, so the reference has to go with the
+    # socket — the next probe rebuilds. Cleared before disconnecting so a raise
+    # mid-teardown can't leave a shut-down pool wired up, which would make every
+    # later probe raise PoolShuttingDownError instead of reconnecting.
+    def close_supervisor_pool
+      pool = @supervisor_pool
+      @supervisor_pool = nil
+      pool&.disconnect!
+    rescue StandardError => e
+      logger.warn { "swarm: supervisor pool close failed: #{e.class}: #{e.message}" }
     end
 
     def monotonic

--- a/lib/wurk/swarm.rb
+++ b/lib/wurk/swarm.rb
@@ -284,7 +284,9 @@ module Wurk
         when :term then shutdown
         when :tstp then quiet_swarm
         when :usr1 then rolling_restart
-        when :usr2 then relay_signal('USR2')
+        when :usr2
+          reopen_logs
+          relay_signal('USR2')
         end
       end
     end
@@ -295,6 +297,13 @@ module Wurk
       return nil unless @signal_read.wait_readable(0)
 
       @signal_read.gets&.strip
+    end
+
+    def reopen_logs
+      log = @config.logger
+      log.reopen if log.respond_to?(:reopen)
+    rescue StandardError
+      nil
     end
 
     # Reap every exited child this tick (not one), so a fleet-wide death

--- a/test/engine/railtie_test.rb
+++ b/test/engine/railtie_test.rb
@@ -158,6 +158,74 @@ class RailtieTest < Wurk::Test::EngineCase
     assert_respond_to ::Rails.application.config.wurk, :embed_in_web
   end
 
+  # --- at_exit drain contract ---
+  #
+  # `boot_swarm` registers its at_exit hook BEFORE the fork, so a boot that
+  # raises partway still drains the children it already spawned. The hook then
+  # fires on the host's main thread while the supervise thread owns the child
+  # table; `stop_swarm` is its body — ask, wait, and take over only when no
+  # live supervisor will.
+
+  def test_stop_swarm_leaves_the_drain_to_a_live_supervisor
+    swarm = FakeSwarm.new
+    supervisor = Thread.new do
+      sleep 0.01 until swarm.requests.positive?
+      swarm.shutdown
+    end
+
+    Wurk::RailsBoot.stop_swarm(swarm, supervisor, 5)
+
+    assert_equal 1, swarm.requests, 'the hook must ask the supervisor to drain'
+    assert_equal supervisor, swarm.drains.first, 'the drain must run on the thread that owns the child table'
+  ensure
+    supervisor&.kill
+  end
+
+  # boot raised before the supervise thread existed: nobody else will drain the
+  # children it managed to fork.
+  def test_stop_swarm_drains_inline_without_a_supervisor
+    swarm = FakeSwarm.new
+
+    Wurk::RailsBoot.stop_swarm(swarm, nil, 5)
+
+    assert_equal [Thread.current], swarm.drains
+  end
+
+  def test_stop_swarm_drains_inline_when_the_supervisor_died
+    swarm = FakeSwarm.new
+    supervisor = Thread.new { nil }
+    supervisor.join
+
+    Wurk::RailsBoot.stop_swarm(swarm, supervisor, 5)
+
+    assert_equal [Thread.current], swarm.drains
+  end
+
+  # A supervisor still alive after the join is wedged mid-drain; draining from
+  # here too would walk the child table it is already mutating.
+  def test_stop_swarm_never_races_a_wedged_supervisor
+    swarm = FakeSwarm.new
+    supervisor = Thread.new { sleep }
+
+    Wurk::RailsBoot.stop_swarm(swarm, supervisor, 0.05)
+
+    assert_equal 1, swarm.requests
+    assert_empty swarm.drains, 'must never drain alongside a live supervisor'
+  ensure
+    supervisor&.kill
+  end
+
+  # Every forked child inherits the hook, and there `@children` lists that
+  # child's siblings — only the process that forked the fleet may act on it.
+  def test_stop_swarm_is_a_no_op_off_the_owning_process
+    swarm = FakeSwarm.new(owner: false)
+
+    Wurk::RailsBoot.stop_swarm(swarm, nil, 5)
+
+    assert_equal 0, swarm.requests
+    assert_empty swarm.drains
+  end
+
   def test_refuse_logs_actionable_guidance
     io = StringIO.new
     with_logger(::Logger.new(io)) { Wurk::RailsBoot.refuse_preforking_boot }
@@ -165,6 +233,25 @@ class RailtieTest < Wurk::Test::EngineCase
     assert_match(/wurkswarm/, io.string, 'must point the host at the standalone runner')
     assert_match(/embed_in_web/, io.string, 'must mention the embedded opt-in')
     assert_match(/WURK_DISABLED/, io.string, 'must mention the silence switch')
+  end
+
+  # Stand-in for the swarm that records which thread ran each drain, so the
+  # at_exit contract (never `shutdown` alongside a live supervisor) is
+  # assertable without forking a real fleet.
+  class FakeSwarm
+    attr_reader :requests, :drains
+
+    def initialize(owner: true)
+      @owner = owner
+      @requests = 0
+      @drains = []
+    end
+
+    def owner? = @owner
+
+    def request_shutdown = @requests += 1
+
+    def shutdown = @drains << Thread.current
   end
 
   private

--- a/test/integration/swarm_supervision_test.rb
+++ b/test/integration/swarm_supervision_test.rb
@@ -152,6 +152,33 @@ class SwarmSupervisionTest < Wurk::Test::UnitCase
     end
   end
 
+  # --- at_exit drain request ------------------------------------------------
+
+  # A Rails host's `at_exit` (rails_boot) can't drain the fleet itself: it runs
+  # on the host's main thread while the supervise thread walks the same child
+  # table. It raises a flag instead — the supervise loop must observe it on its
+  # next tick, drain the real children, and return.
+  def test_requested_shutdown_is_drained_by_the_supervise_thread
+    swarm = Wurk::Swarm.new(topology: topology_n(1), config: @config, shutdown_timeout: SHUTDOWN_TIMEOUT)
+    supervisor = nil
+
+    begin
+      children = swarm.boot(install_signals: false)
+      supervisor = Thread.new { swarm.supervise }
+
+      swarm.request_shutdown
+
+      assert_request_drained(swarm, supervisor, children)
+    ensure
+      begin
+        swarm.shutdown(timeout: SHUTDOWN_TIMEOUT)
+      rescue StandardError
+        nil
+      end
+      stop_supervisor_thread(supervisor, 10)
+    end
+  end
+
   # --- orphan self-termination ---------------------------------------------
 
   # SIGKILL'ing the supervisor must not leave the children fetching forever:
@@ -217,6 +244,12 @@ class SwarmSupervisionTest < Wurk::Test::UnitCase
     ::Process.kill('KILL', replacement)
     sleep POLL_INTERVAL * 3 # let the reaper observe the death before asserting survival
     replacement
+  end
+
+  def assert_request_drained(swarm, supervisor, children)
+    assert supervisor.join(SHUTDOWN_TIMEOUT + 5), 'supervise must return once it observes the drain request'
+    assert_empty swarm.children, 'the supervise thread must have drained the fleet'
+    assert(children.all? { |pid| wait_until_dead(pid, 5) }, "children #{children.inspect} survived the drain")
   end
 
   def assert_old_child_survives(swarm, original)

--- a/test/integration/swarm_supervision_test.rb
+++ b/test/integration/swarm_supervision_test.rb
@@ -122,6 +122,36 @@ class SwarmSupervisionTest < Wurk::Test::UnitCase
     end
   end
 
+  # --- fork safety: an exiting child must not drain the fleet ---------------
+
+  # A Rails host registers `at_exit { swarm.shutdown }` (rails_boot.rb) and
+  # every forked child inherits it, so ChildBoot's `exit` runs a full drain
+  # inside the child — where `@children` lists that child's SIBLINGS. Unguarded
+  # it TERMs them, then stalls the entire shutdown timeout on PIDs it can never
+  # reap, then SIGKILLs whatever survived. Forking the supervisor reproduces
+  # that inherited object graph exactly. No supervise thread here: its
+  # `Process.wait(-1, …)` would race us for the drainer's exit status.
+  def test_shutdown_from_a_forked_child_leaves_the_fleet_alone
+    swarm = Wurk::Swarm.new(topology: topology_n(2), config: @config, shutdown_timeout: SHUTDOWN_TIMEOUT)
+
+    begin
+      children = swarm.boot(install_signals: false)
+      elapsed = time_drain_in_a_fork(swarm)
+
+      assert_operator elapsed, :<, SHUTDOWN_TIMEOUT,
+                      "a non-owner drain must return at once, took #{elapsed.round(1)}s"
+      children.each do |pid|
+        assert pid_alive?(pid), "sibling #{pid} was killed by a forked child's inherited shutdown"
+      end
+    ensure
+      begin
+        swarm.shutdown(timeout: SHUTDOWN_TIMEOUT)
+      rescue StandardError
+        nil
+      end
+    end
+  end
+
   # --- orphan self-termination ---------------------------------------------
 
   # SIGKILL'ing the supervisor must not leave the children fetching forever:
@@ -241,6 +271,18 @@ class SwarmSupervisionTest < Wurk::Test::UnitCase
       sleep POLL_INTERVAL
     end
     nil
+  end
+
+  # `exit!` so the drainer skips this suite's at_exit hooks (Minitest reporting,
+  # SimpleCov) — the same abrupt teardown a real child gets.
+  def time_drain_in_a_fork(swarm)
+    started = monotonic_now
+    pid = ::Process.fork do
+      swarm.shutdown(timeout: SHUTDOWN_TIMEOUT)
+      exit!(0)
+    end
+    ::Process.wait(pid)
+    monotonic_now - started
   end
 
   # --- subprocess supervisor plumbing (real SIGTERM/SIGKILL delivery) ------

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -539,6 +539,64 @@ class CLITest < Wurk::Test::UnitCase
     self_write&.close
   end
 
+  # --- self-pipe lifecycle ---------------------------------------------
+
+  # `run` owns the pipe, so every exit path must close it: embedded and test
+  # callers outlive the call, and a leaked pair is two leaked FDs per boot.
+  def test_run_closes_the_self_pipe_on_the_normal_path
+    with_require_set { @cli.parse(['-q', 'default']) }
+    ends = capture_self_pipe
+
+    @cli.run(boot_app: false, warmup: false)
+
+    assert_predicate ends[:read], :closed?
+    assert_predicate ends[:write], :closed?
+  end
+
+  def test_run_closes_the_self_pipe_when_the_run_loop_raises
+    with_require_set { @cli.parse(['-q', 'default']) }
+    ends = capture_self_pipe { raise Interrupt }
+
+    assert_raises(Interrupt) { @cli.run(boot_app: false, warmup: false) }
+
+    assert_predicate ends[:read], :closed?
+    assert_predicate ends[:write], :closed?
+  end
+
+  # A step before `launch` raising still unwinds through the ensure — only the
+  # write end has been handed out by then.
+  def test_run_closes_the_self_pipe_when_a_boot_step_raises
+    with_require_set { @cli.parse(['-q', 'default']) }
+    ends = capture_self_pipe
+    @cli.define_singleton_method(:redis_info) { { 'redis_version' => '6.2.0', 'maxmemory_policy' => 'noeviction' } }
+
+    assert_raises(RuntimeError) { @cli.run(boot_app: false, warmup: false) }
+
+    assert_predicate ends[:write], :closed?
+  end
+
+  def test_emit_signal_writes_the_signal_name_to_the_pipe
+    read, write = IO.pipe
+
+    @cli.send(:emit_signal, write, 'TSTP')
+
+    assert_equal 'TSTP', read.gets.strip
+  ensure
+    read&.close
+    write&.close
+  end
+
+  # Traps outlive `run`'s ensure — a signal landing on the closed pipe must be
+  # swallowed, not raised out of trap context into the main thread.
+  def test_emit_signal_swallows_a_closed_pipe
+    read, write = IO.pipe
+    write.close
+
+    assert_nil @cli.send(:emit_signal, write, 'TERM')
+  ensure
+    read&.close
+  end
+
   # --- boot_application paths -----------------------------------------
 
   def test_boot_application_requires_single_file
@@ -711,32 +769,40 @@ class CLITest < Wurk::Test::UnitCase
 
   def test_run_swarm_preloads_then_boots_then_eager_loads
     order = []
-    @cli.define_singleton_method(:preload_bundler_groups) { order << :preload }
-    @cli.define_singleton_method(:boot_application) { order << :boot }
-    @cli.define_singleton_method(:eager_load_application) { order << :eager }
-    @cli.define_singleton_method(:validate_redis!) { nil }
-    @cli.define_singleton_method(:validate_pool_sizes!) { nil }
-    @cli.define_singleton_method(:identity) { 'host:1:abc' }
-    fake_swarm = Object.new
-    fake_swarm.define_singleton_method(:boot) { |**| nil }
-    fake_swarm.define_singleton_method(:supervise) { order << :supervise }
+    stub_swarm_preamble
+    %i[preload_bundler_groups boot_application eager_load_application].each do |m|
+      @cli.define_singleton_method(m) { order << m }
+    end
+    fake_swarm = swarm_double(boot: ->(**) {}, supervise: -> { order << :supervise },
+                              shutdown: -> { order << :shutdown })
 
     with_stub_swarm(fake_swarm) { @cli.run_swarm(boot_app: true, warmup: false) }
 
-    assert_equal %i[preload boot eager supervise], order
+    assert_equal %i[preload_bundler_groups boot_application eager_load_application supervise shutdown], order
+  end
+
+  # A11 — a fork failure partway through `boot` leaves live children with no
+  # supervisor unless the CLI drains them on the way out.
+  def test_run_swarm_drains_the_swarm_when_boot_raises
+    called = []
+    stub_swarm_preamble
+    fake_swarm = swarm_double(boot: ->(**) { raise Errno::EAGAIN },
+                              shutdown: -> { called << :shutdown })
+
+    with_stub_swarm(fake_swarm) do
+      assert_raises(Errno::EAGAIN) { @cli.run_swarm(boot_app: false, warmup: false) }
+    end
+
+    assert_equal [:shutdown], called
   end
 
   def test_run_swarm_skips_boot_steps_when_boot_app_false
     called = []
+    stub_swarm_preamble
     %i[preload_bundler_groups boot_application eager_load_application].each do |m|
       @cli.define_singleton_method(m) { called << m }
     end
-    @cli.define_singleton_method(:validate_redis!) { nil }
-    @cli.define_singleton_method(:validate_pool_sizes!) { nil }
-    @cli.define_singleton_method(:identity) { 'host:1:abc' }
-    fake_swarm = Object.new
-    fake_swarm.define_singleton_method(:boot) { |**| nil }
-    fake_swarm.define_singleton_method(:supervise) { nil }
+    fake_swarm = swarm_double(boot: ->(**) {}, supervise: -> {}, shutdown: -> {})
 
     with_stub_swarm(fake_swarm) { @cli.run_swarm(boot_app: false, warmup: false) }
 
@@ -766,6 +832,22 @@ class CLITest < Wurk::Test::UnitCase
     end
   end
 
+  # Stub `run`'s Redis/launch tail and collect the pipe ends it hands out:
+  # `trap_signals` gets the write end, `launch` the read end (never reached when
+  # an earlier step raises). The block, if given, runs in place of `launch`.
+  def capture_self_pipe(&on_launch)
+    ends = {}
+    @cli.define_singleton_method(:redis_info) { { 'redis_version' => '7.2.0', 'maxmemory_policy' => 'noeviction' } }
+    @cli.define_singleton_method(:validate_pool_sizes!) { nil }
+    @cli.define_singleton_method(:identity) { 'host:1:abc' }
+    @cli.define_singleton_method(:trap_signals) { |write| ends[:write] = write }
+    @cli.define_singleton_method(:launch) do |read|
+      ends[:read] = read
+      on_launch&.call
+    end
+    ends
+  end
+
   # `Process.warmup` is gated on RUBY_DISABLE_WARMUP != '1'; clear it so the
   # warmup branch is reachable, then restore.
   def without_warmup_disable
@@ -785,6 +867,21 @@ class CLITest < Wurk::Test::UnitCase
     yield
   ensure
     Wurk::Launcher.define_singleton_method(:new, original)
+  end
+
+  # The Redis/identity checks `run_swarm` performs before it builds the Swarm —
+  # stubbed out so the tests below only exercise the boot/supervise/drain order.
+  def stub_swarm_preamble
+    %i[validate_redis! validate_pool_sizes!].each { |m| @cli.define_singleton_method(m) { nil } }
+    @cli.define_singleton_method(:identity) { 'host:1:abc' }
+  end
+
+  # Minimal Swarm stand-in for the run_swarm tests: one entry per method the
+  # CLI calls on it.
+  def swarm_double(**bodies)
+    fake = Object.new
+    bodies.each { |name, body| fake.define_singleton_method(name, &body) }
+    fake
   end
 
   def with_stub_swarm(fake)

--- a/test/unit/swarm_concurrency_test.rb
+++ b/test/unit/swarm_concurrency_test.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Cross-thread safety of the child table and the restart machine. The supervise
+# loop inserts (respawn, rolling restart) and deletes (reap) on every tick while
+# other threads walk the same state — rails_boot's at_exit, an embedded host,
+# the integration suite — so both live under one reentrant lock. Fork-free:
+# fork_child hands back fake PIDs and safe_kill is inert, so the races run
+# without real processes or real signals.
+class SwarmConcurrencyTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  SLOTS = 4
+  CHURN_ROUNDS = 100
+  LIVE_CHILDREN = 8
+  LOCK_HOLD = 0.2
+  JOIN_WAIT = 5
+
+  Status = ::Struct.new(:exitstatus)
+
+  # A restart tick that stays in flight long enough for another thread to try
+  # to enqueue behind it.
+  class SlowRestart
+    def initialize(entered, hold)
+      @entered = entered
+      @hold = hold
+    end
+
+    def advance
+      @entered << true
+      sleep @hold
+    end
+
+    def enqueue(_pids); end
+  end
+
+  class ChurnSwarm < Wurk::Swarm
+    # Handshake queue. `safe_kill` runs once per step of a child-table walk, so
+    # pushing there wakes the churn thread *inside* the iteration rather than
+    # leaving it to chance — the insert then lands exactly where an unguarded
+    # walk breaks.
+    attr_accessor :mid_walk
+
+    def initialize(**kwargs)
+      super
+      @fake_pid = 40_000
+      @pid_lock = ::Mutex.new
+    end
+
+    private
+
+    # Both the test thread and the churn thread spawn, so the counter needs its
+    # own lock — a collision would hand back a PID already in the table and the
+    # insert under test would no longer be a new key.
+    def fork_child(_slot, _idx)
+      @pid_lock.synchronize { @fake_pid += 1 }
+    end
+
+    def safe_kill(_pid, _sig)
+      @mid_walk&.push(true)
+      ::Thread.pass
+    end
+  end
+
+  def setup
+    super
+    @config = Wurk::Configuration.new
+    @config.logger = ::Logger.new(IO::NULL)
+  end
+
+  # The public reader is handed to callers that iterate it (tests, host
+  # introspection) off the supervise thread; the live table would be mutated
+  # under them mid-walk.
+  def test_children_hands_back_a_snapshot
+    swarm = boot_swarm
+    snapshot = swarm.children
+
+    swarm.send(:spawn_child, slot(swarm), 0)
+
+    assert_equal SLOTS, snapshot.size, 'children must not alias the live child table'
+    assert_equal SLOTS + 1, swarm.children.size
+  end
+
+  # TERM/TSTP/USR2 relay walks the table while the supervise thread respawns a
+  # crashed slot into it — MRI raises on a Hash gaining a key mid-iteration.
+  def test_relay_signal_tolerates_concurrent_spawns
+    swarm = boot_swarm
+
+    with_child_churn(swarm) do
+      CHURN_ROUNDS.times { swarm.send(:relay_signal, 'TERM') }
+    end
+  end
+
+  # Same walk, from the tail of a drain — refilled each round because the kill
+  # pass clears the table behind it.
+  def test_hard_kill_stragglers_tolerates_concurrent_spawns
+    swarm = boot_swarm
+
+    with_child_churn(swarm) do
+      CHURN_ROUNDS.times do
+        LIVE_CHILDREN.times { swarm.send(:spawn_child, slot(swarm), 0) }
+        swarm.send(:hard_kill_stragglers)
+      end
+    end
+  end
+
+  # `rolling_restart` runs on whatever thread the USR1 trap or host code calls
+  # it from, while the supervise thread is inside `advance` working the same
+  # queue and child table. It must wait its turn, not interleave.
+  def test_rolling_restart_waits_for_the_supervise_tick
+    swarm = boot_swarm
+    order = ::Queue.new
+    ticker = start_slow_tick(swarm) { order << :supervise }
+    restarter = ::Thread.new do
+      swarm.rolling_restart
+      order << :rolling_restart
+    end
+
+    [ticker, restarter].each { |t| t.join(JOIN_WAIT) }
+    order.close
+
+    assert_equal %i[supervise rolling_restart], [order.pop, order.pop]
+  end
+
+  private
+
+  def topology
+    Wurk::Topology.flat(count: SLOTS, queues: ['default'], concurrency: 1)
+  end
+
+  def boot_swarm
+    swarm = ChurnSwarm.new(topology: topology, config: @config)
+    swarm.boot(install_signals: false)
+    swarm
+  end
+
+  def slot(swarm)
+    swarm.topology.assignments.first
+  end
+
+  # Spawn/reap the table from a second thread for the duration of the block,
+  # each round driven by the walk under test so the insert lands mid-iteration.
+  # The insert is what raises when the walk is unguarded, so the churn thread's
+  # own failure is the assertion.
+  def with_child_churn(swarm)
+    gate = ::Queue.new
+    failure = []
+    swarm.mid_walk = gate
+    writer = ::Thread.new { churn(swarm, gate, failure) }
+    yield
+    swarm.mid_walk = nil
+    gate.close
+    writer.join(JOIN_WAIT)
+
+    assert_empty failure, "child table was mutated mid-iteration: #{failure.first&.message}"
+  ensure
+    swarm.mid_walk = nil
+    gate&.close
+    writer&.kill
+  end
+
+  # Blocks on the gate rather than spinning: a hot loop would hold the GVL for a
+  # full thread quantum per switch and stretch the test into minutes.
+  def churn(swarm, gate, failure)
+    live = []
+    while gate.pop
+      live << swarm.send(:spawn_child, slot(swarm), 0)
+      swarm.send(:on_child_exit, live.shift, Status.new(0)) if live.size > LIVE_CHILDREN
+    end
+  rescue StandardError => e
+    failure << e
+  end
+
+  # Pin a thread inside a restart tick and return once it is in there.
+  def start_slow_tick(swarm)
+    entered = ::Queue.new
+    swarm.instance_variable_set(:@restart, SlowRestart.new(entered, LOCK_HOLD))
+    thread = ::Thread.new do
+      swarm.send(:advance_restart)
+      yield
+    end
+    entered.pop(timeout: JOIN_WAIT)
+    thread
+  end
+end

--- a/test/unit/swarm_concurrency_test.rb
+++ b/test/unit/swarm_concurrency_test.rb
@@ -22,14 +22,20 @@ class SwarmConcurrencyTest < Wurk::Test::UnitCase
   # A restart tick that stays in flight long enough for another thread to try
   # to enqueue behind it.
   class SlowRestart
-    def initialize(entered, hold)
+    def initialize(entered, hold, order)
       @entered = entered
       @hold = hold
+      @order = order
     end
 
+    # `:supervise` is recorded here, still inside the swarm's monitor, so the
+    # lock orders the two events. Recording it after `advance_restart` returns
+    # would leave a window where the restarter is scheduled first and the
+    # assertion flips on scheduler luck rather than on the guarantee under test.
     def advance
       @entered << true
       sleep @hold
+      @order << :supervise
     end
 
     def enqueue(_pids); end
@@ -111,7 +117,7 @@ class SwarmConcurrencyTest < Wurk::Test::UnitCase
   def test_rolling_restart_waits_for_the_supervise_tick
     swarm = boot_swarm
     order = ::Queue.new
-    ticker = start_slow_tick(swarm) { order << :supervise }
+    ticker = start_slow_tick(swarm, order)
     restarter = ::Thread.new do
       swarm.rolling_restart
       order << :rolling_restart
@@ -173,13 +179,10 @@ class SwarmConcurrencyTest < Wurk::Test::UnitCase
   end
 
   # Pin a thread inside a restart tick and return once it is in there.
-  def start_slow_tick(swarm)
+  def start_slow_tick(swarm, order)
     entered = ::Queue.new
-    swarm.instance_variable_set(:@restart, SlowRestart.new(entered, LOCK_HOLD))
-    thread = ::Thread.new do
-      swarm.send(:advance_restart)
-      yield
-    end
+    swarm.instance_variable_set(:@restart, SlowRestart.new(entered, LOCK_HOLD, order))
+    thread = ::Thread.new { swarm.send(:advance_restart) }
     entered.pop(timeout: JOIN_WAIT)
     thread
   end

--- a/test/unit/swarm_signals_test.rb
+++ b/test/unit/swarm_signals_test.rb
@@ -36,6 +36,25 @@ class SwarmSignalsTest < Wurk::Test::UnitCase
     end
   end
 
+  # Runs the REAL `shutdown` (SignalSpySwarm stubs it out) while staying
+  # fork-free: children are fake PIDs that are never signalled and never waited
+  # on, so the drain reaches the self-pipe teardown immediately.
+  class DrainingSwarm < Wurk::Swarm
+    private
+
+    def fork_child(_slot, _idx)
+      99_001
+    end
+
+    def safe_kill(_pid, _sig)
+      nil
+    end
+
+    def wait_for_children(_timeout)
+      nil
+    end
+  end
+
   def setup
     super
     @config = Wurk::Configuration.new
@@ -114,6 +133,49 @@ class SwarmSignalsTest < Wurk::Test::UnitCase
     end
   end
 
+  # --- self-pipe lifecycle -----------------------------------------------
+
+  def test_shutdown_closes_both_ends_of_the_self_pipe
+    swarm = draining
+    read, write = inject_pipe(swarm)
+
+    swarm.shutdown
+
+    assert_predicate read, :closed?
+    assert_predicate write, :closed?
+  end
+
+  def test_shutdown_is_idempotent_once_the_pipe_is_gone
+    swarm = draining
+    inject_pipe(swarm)
+    swarm.shutdown
+
+    swarm.shutdown
+
+    assert_nil swarm.instance_variable_get(:@signal_read)
+  end
+
+  # A TERM handled mid-drain closes the pipe under the loop, which then asks for
+  # the next buffered signal — it must stop rather than read a dead FD.
+  def test_term_mid_drain_stops_reading_the_closed_pipe
+    swarm = draining
+    feed(swarm, 'TERM', 'TSTP')
+
+    swarm.send(:drain_signals)
+
+    assert_nil swarm.instance_variable_get(:@signal_read)
+  end
+
+  # The traps stay installed after a drain; a late signal must not raise out of
+  # trap context into the supervise thread.
+  def test_emit_signal_after_shutdown_is_a_noop
+    swarm = draining
+    inject_pipe(swarm)
+    swarm.shutdown
+
+    assert_nil swarm.send(:emit_signal, 'TERM')
+  end
+
   private
 
   def topology
@@ -122,6 +184,12 @@ class SwarmSignalsTest < Wurk::Test::UnitCase
 
   def booted
     swarm = SignalSpySwarm.new(topology: topology, config: @config)
+    swarm.boot(install_signals: false)
+    swarm
+  end
+
+  def draining
+    swarm = DrainingSwarm.new(topology: topology, config: @config)
     swarm.boot(install_signals: false)
     swarm
   end

--- a/test/unit/swarm_test.rb
+++ b/test/unit/swarm_test.rb
@@ -8,6 +8,16 @@ require_relative '../test_helper'
 class SwarmTest < Wurk::Test::UnitCase
   parallelize_me!
 
+  # Fork-free swarm: `fork_child` hands back a fake PID so `boot` fills
+  # `@children` for real without spawning processes.
+  class FakeForkSwarm < Wurk::Swarm
+    private
+
+    def fork_child(_slot, _idx)
+      @fake_pid = (@fake_pid || 9000) + 1
+    end
+  end
+
   def setup
     super
     @config = Wurk::Configuration.new
@@ -60,6 +70,40 @@ class SwarmTest < Wurk::Test::UnitCase
     assert_raises(ArgumentError) { swarm.boot(install_signals: false) }
   end
 
+  # --- owner-pid guard --------------------------------------------------
+
+  # A forked child inherits the swarm object *and* the host's `at_exit` hooks —
+  # and rails_boot registers `at_exit { swarm.shutdown }` — so ChildBoot's
+  # `exit` runs a full drain inside the child, where `@children` lists the
+  # child's SIBLINGS. Every supervisory action must no-op off the process that
+  # forked them. Real-fork proof: test/integration/swarm_supervision_test.rb.
+  def test_shutdown_off_the_owning_process_never_drains
+    swarm = non_owner_swarm
+
+    swarm.shutdown(timeout: 0)
+
+    refute swarm.instance_variable_get(:@stopping), 'a non-owner must never start a drain'
+    refute_empty swarm.children, 'a non-owner reached hard_kill_stragglers and cleared the fleet'
+  end
+
+  # relay_signal, hard_kill_stragglers and the restart machine's `kill:`
+  # callback all signal through safe_kill, so that is where the owner check
+  # lives. Signal 0 sends nothing but reports delivery — 1 when the kill would
+  # have gone out, nil once the guard swallowed it.
+  def test_safe_kill_delivers_only_from_the_owning_process
+    assert_equal 1, owner_swarm.send(:safe_kill, ::Process.pid, 0)
+    assert_nil non_owner_swarm.send(:safe_kill, ::Process.pid, 0)
+  end
+
+  def test_supervise_returns_at_once_off_the_owning_process
+    swarm = non_owner_swarm
+    thread = Thread.new { swarm.supervise }
+    returned = thread.join(5)
+    thread.kill
+
+    assert returned, 'supervise must return immediately off the owning process'
+  end
+
   # --- includes -----------------------------------------------------
 
   def test_includes_component
@@ -83,5 +127,17 @@ class SwarmTest < Wurk::Test::UnitCase
 
   def topology
     Wurk::Topology.flat(count: 1, queues: ['default'], concurrency: 1)
+  end
+
+  def owner_swarm
+    swarm = FakeForkSwarm.new(topology: topology, config: @config)
+    swarm.boot(install_signals: false)
+    swarm
+  end
+
+  # A booted swarm exactly as one of its own forked children holds it: the same
+  # `@children` map, a different PID.
+  def non_owner_swarm
+    owner_swarm.tap { |swarm| swarm.instance_variable_set(:@owner_pid, ::Process.pid + 1) }
   end
 end

--- a/test/unit/swarm_test.rb
+++ b/test/unit/swarm_test.rb
@@ -22,6 +22,13 @@ class SwarmTest < Wurk::Test::UnitCase
     super
     @config = Wurk::Configuration.new
     @config.logger = ::Logger.new(IO::NULL)
+    @swarms = []
+  end
+
+  def teardown
+    @swarms.each { |swarm| swarm.send(:close_supervisor_pool) }
+  ensure
+    super
   end
 
   # --- initialization --------------------------------------------------
@@ -118,6 +125,81 @@ class SwarmTest < Wurk::Test::UnitCase
     assert returned, 'supervise must return immediately off the owning process'
   end
 
+  # --- supervisor Redis pool (boot-ordering steps 3/5) ------------------
+
+  # `boot` closes every parent-side socket before forking (step 3) and each
+  # child opens its own (step 5). The restart machine polls `heartbeat_seen?`
+  # for the life of the swarm, so running that probe on the capsule main pool
+  # reopened it — in the parent, at capsule size — right after step 3 closed it.
+  def test_heartbeat_probe_never_reopens_the_capsule_pool
+    swarm = owner_swarm
+
+    swarm.send(:heartbeat_seen?, 999_999)
+
+    assert_nil @config.default_capsule.instance_variable_get(:@redis_pool),
+               'the heartbeat probe reopened the parent capsule pool that boot had closed'
+  end
+
+  def test_supervisor_pool_is_a_dedicated_single_connection
+    swarm = bare_swarm
+    pool = swarm.send(:supervisor_pool)
+
+    assert_equal 1, pool.size, 'one SISMEMBER per tick needs exactly one connection'
+    assert_same pool, swarm.send(:supervisor_pool), 'the pool must be built once, not per probe'
+    refute_same @config.redis_pool, pool, 'the supervisor must not draw on a capsule pool'
+  end
+
+  # Every fork — boot, crash respawn, rolling restart, memory recycle — runs
+  # through `fork_child`, and the probe reopens the pool between them, so the
+  # close belongs immediately before Process.fork rather than only at boot.
+  def test_fork_closes_the_supervisor_pool_before_forking
+    swarm = bare_swarm
+    pool = swarm.send(:supervisor_pool)
+    inherited = :never_forked
+    fake_fork = lambda {
+      inherited = swarm.instance_variable_get(:@supervisor_pool)
+      9001 # a pid, so fork_child takes the parent branch and never boots a child
+    }
+
+    with_stubbed_fork(fake_fork) { swarm.send(:spawn_child, topology.assignments.first, 0) }
+
+    assert_nil inherited, 'the child inherited the parent supervisor socket'
+    assert_raises(ConnectionPool::PoolShuttingDownError) { pool.with { |c| c.call('PING') } }
+  end
+
+  # ConnectionPool#shutdown is terminal: without dropping the reference too, the
+  # first probe after a respawn would raise PoolShuttingDownError forever and
+  # every rolling restart would fall back to its heartbeat timeout.
+  def test_supervisor_pool_rebuilds_after_a_fork_closed_it
+    swarm = bare_swarm
+    closed = swarm.send(:supervisor_pool)
+    swarm.send(:close_supervisor_pool)
+    rebuilt = swarm.send(:supervisor_pool)
+
+    pong = rebuilt.with { |c| c.call('PING') }
+
+    refute_same closed, rebuilt
+    assert_equal 'PONG', pong
+  end
+
+  def test_closing_an_unbuilt_supervisor_pool_is_a_no_op
+    swarm = bare_swarm
+
+    assert_nil swarm.send(:close_supervisor_pool)
+    refute_nil swarm.send(:supervisor_pool)
+  end
+
+  def test_shutdown_closes_the_supervisor_pool
+    swarm = bare_swarm
+    swarm.instance_variable_set(:@owner_pid, ::Process.pid)
+    pool = swarm.send(:supervisor_pool)
+
+    swarm.shutdown(timeout: 0)
+
+    assert_nil swarm.instance_variable_get(:@supervisor_pool), 'the parent kept a Redis socket past the drain'
+    assert_raises(ConnectionPool::PoolShuttingDownError) { pool.with { |c| c.call('PING') } }
+  end
+
   # --- includes -----------------------------------------------------
 
   def test_includes_component
@@ -143,15 +225,31 @@ class SwarmTest < Wurk::Test::UnitCase
     Wurk::Topology.flat(count: 1, queues: ['default'], concurrency: 1)
   end
 
+  # Tracked so teardown returns the one supervisor connection a probe opens.
+  def bare_swarm(klass = Wurk::Swarm)
+    klass.new(topology: topology, config: @config).tap { |swarm| @swarms << swarm }
+  end
+
   def owner_swarm
-    swarm = FakeForkSwarm.new(topology: topology, config: @config)
-    swarm.boot(install_signals: false)
-    swarm
+    bare_swarm(FakeForkSwarm).tap { |swarm| swarm.boot(install_signals: false) }
   end
 
   # A booted swarm exactly as one of its own forked children holds it: the same
   # `@children` map, a different PID.
   def non_owner_swarm
     owner_swarm.tap { |swarm| swarm.instance_variable_set(:@owner_pid, ::Process.pid + 1) }
+  end
+
+  # Minitest 6 dropped minitest/mock; this hand-rolled stub swaps Process.fork
+  # for `replacement` so `fork_child` runs its real pre-fork work without
+  # spawning anything. Test classes get their own worker process and tests run
+  # serially inside it, so nothing else forks while this is installed.
+  def with_stubbed_fork(replacement)
+    sc = ::Process.singleton_class
+    original = ::Process.method(:fork)
+    sc.define_method(:fork) { |*args, &blk| replacement.call(*args, &blk) }
+    yield
+  ensure
+    sc.define_method(:fork) { |*a, &b| original.call(*a, &b) }
   end
 end

--- a/test/unit/swarm_test.rb
+++ b/test/unit/swarm_test.rb
@@ -95,6 +95,20 @@ class SwarmTest < Wurk::Test::UnitCase
     assert_nil non_owner_swarm.send(:safe_kill, ::Process.pid, 0)
   end
 
+  # rails_boot's `at_exit` fires on the host's main thread while the supervise
+  # thread is reaping / respawning / restarting through the same child table, so
+  # the request may only raise a flag — the drain itself belongs to the
+  # supervise loop. Real-fork proof that it observes it:
+  # test/integration/swarm_supervision_test.rb.
+  def test_request_shutdown_never_drains_on_the_calling_thread
+    swarm = owner_swarm
+
+    swarm.request_shutdown
+
+    refute swarm.instance_variable_get(:@stopping), 'request_shutdown must not drain inline'
+    refute_empty swarm.children, 'the fleet must be left to the supervise thread'
+  end
+
   def test_supervise_returns_at_once_off_the_owning_process
     swarm = non_owner_swarm
     thread = Thread.new { swarm.supervise }

--- a/test/unit/swarm_test.rb
+++ b/test/unit/swarm_test.rb
@@ -21,12 +21,20 @@ class SwarmTest < Wurk::Test::UnitCase
   def setup
     super
     @config = Wurk::Configuration.new
+    # The supervisor-pool tests open real sockets off this config, so pin it to
+    # the worker's isolated logical DB rather than inheriting whatever
+    # REDIS_URL happens to hold — the class runs under parallelize_me!.
+    @config.redis = { url: Wurk::Test.redis_url }
     @config.logger = ::Logger.new(IO::NULL)
     @swarms = []
   end
 
+  # The supervisor pool is the swarm's own; `redis_pool` assertions build a
+  # capsule pool on top of it. Both are returned here or the class leaks a
+  # connection per test.
   def teardown
     @swarms.each { |swarm| swarm.send(:close_supervisor_pool) }
+    @config.reset_redis_pools!
   ensure
     super
   end


### PR DESCRIPTION
Swarm parent-process fixes from the leak/logic audit (`docs/plans/2026/07/31/101-leak-logic-perf-fixes/01-swarm-launcher-teardown.md`, items A1/A3/A5/A10/A11/A13).

- **A1 (critical)** — a forked child inherits the swarm object *and* rails_boot's `at_exit { swarm.shutdown }`, so `ChildBoot`'s `exit` ran a full drain inside the child, where `@children` holds its *siblings*: TERM to all of them, a 30s stall waiting on PIDs it can never reap, then SIGKILL. `boot` now captures `@owner_pid` and `shutdown`/`supervise`/`safe_kill` no-op off it; `at_exit` registers before `boot` and only sets a flag the supervise thread observes.
- **A3** — `@children` and the restart machine are serialized behind one reentrant `Monitor` (they are mutually recursive, so separate locks deadlock); readers walk snapshots, `hard_kill_stragglers` kills and clears atomically. Fixes `can't add a new key into hash during iteration`.
- **A5/A10/A11** — the parent reopens its own logs on USR2 instead of only relaying it; `shutdown` closes both self-pipe ends and `emit_signal`/`read_pending_signal` tolerate the pipe vanishing mid-drain; `CLI#run` closes its pipe on every exit path and always drains the swarm.
- **A13** — `heartbeat_seen?` ran on the capsule main pool, reopening in the parent (at capsule size ≥ 10) the sockets `close_parent_sockets` had just shut, and every later respawn/restart fork inherited them. It now uses a dedicated 1-connection pool disconnected immediately before every `Process.fork`, restoring boot-ordering steps 3/5.

Suite 2755 runs / 0 failures / 0 errors, parity 23/0, coverage line 96.71% / branch 90.5% (gate holds), rubocop clean, swarm-boot bench flat. Each fix ships with tests confirmed to fail without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788160812&installation_model_id=11168&pr_number=344&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F344&signature=b6167b5d4ec45f8bbc813580708eada8873135b2d14e9ebda8516b0671556013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved process startup reliability with runtime capability checks.
  - Ensured clean shutdowns across normal exits, errors, timeouts, and hosted Rails environments.
  - Prevented shutdowns in one process from affecting sibling workers.
  - Improved handling of signals, restarts, child processes, and resource cleanup.
  - Made concurrent worker management more stable and predictable.

- **Tests**
  - Added comprehensive coverage for shutdown behavior, signal handling, fork safety, concurrency, restarts, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->