### PR TITLE
fix(launcher): teardown-tail resource leaks (A2/A4/A6/A7/A8/A9/A12/F11)

### DIFF
--- a/lib/wurk/cron.rb
+++ b/lib/wurk/cron.rb
@@ -542,10 +542,14 @@ module Wurk
       # Blocks until the thread is really gone: the launcher releases the
       # cluster lock immediately after this returns, and a tick still in flight
       # would enqueue loops the next leader is about to fire itself.
+      #
+      # Cleared only on a confirmed join (Thread#join returns nil on timeout):
+      # a wedged thread must stay tracked so #start's guard returns it instead
+      # of calling @timer.reset, which would un-terminate the loop it is still
+      # inside and leave two tick threads double-enqueuing the same loops.
       def terminate
         @timer.terminate
-        @thread&.join(TimerLoop::JOIN_TIMEOUT)
-        @thread = nil
+        @thread = nil if @thread&.join(TimerLoop::JOIN_TIMEOUT)
       end
 
       # Leader-gated by the single cluster lock (Component#leader? reads

--- a/lib/wurk/cron.rb
+++ b/lib/wurk/cron.rb
@@ -6,6 +6,7 @@ require 'time'
 require_relative 'component'
 require_relative 'client'
 require_relative 'leader'
+require_relative 'timer_loop'
 
 module Wurk
   # Sidekiq Enterprise periodic jobs. Pure leader-driven cron — only the
@@ -520,34 +521,31 @@ module Wurk
 
       def initialize(config)
         @config = config
-        @done = false
-        @mutex = ::Mutex.new
-        @sleeper = ::ConditionVariable.new
         @client = Client.new(config: config)
         @thread = nil
         # Operators never need to touch this; integration tests shrink it so a
         # due loop fires within the test window instead of waiting a full minute.
         @tick_interval = config[:cron_tick_interval] || DEFAULT_TICK_SECONDS
+        @timer = TimerLoop.new(@tick_interval)
       end
 
+      # TimerLoop waits one interval before the first tick: don't fire a
+      # catch-up burst the instant we boot (the leader is barely settled), and
+      # let a short-lived process exit without ticking at all.
       def start
-        @poller_thread ||= safe_thread('cron-poller') do # rubocop:disable Naming/MemoizedInstanceVariableName
-          # Wait one interval before the first tick: don't fire a catch-up burst
-          # the instant we boot (the leader is barely settled), and let a
-          # short-lived process exit without ticking at all.
-          wait
-          until @done
-            tick
-            wait
-          end
-        end
+        return @thread if @thread
+
+        @timer.reset
+        @thread = safe_thread('cron-poller') { @timer.run { tick } }
       end
 
+      # Blocks until the thread is really gone: the launcher releases the
+      # cluster lock immediately after this returns, and a tick still in flight
+      # would enqueue loops the next leader is about to fire itself.
       def terminate
-        @mutex.synchronize do
-          @done = true
-          @sleeper.signal
-        end
+        @timer.terminate
+        @thread&.join(TimerLoop::JOIN_TIMEOUT)
+        @thread = nil
       end
 
       # Leader-gated by the single cluster lock (Component#leader? reads
@@ -589,12 +587,6 @@ module Wurk
       end
 
       private
-
-      def wait
-        @mutex.synchronize do
-          @sleeper.wait(@mutex, @tick_interval) unless @done
-        end
-      end
 
       def warn_missed_tick(loop_obj, expected, now)
         return if now - expected <= MISSED_TICK_THRESHOLD

--- a/lib/wurk/embedded.rb
+++ b/lib/wurk/embedded.rb
@@ -41,6 +41,12 @@ module Wurk
       sleep 0.2
       logger.info { "Wurk running embedded, total process thread count: #{Thread.list.size}" }
       logger.debug { Thread.list.map(&:name).to_s }
+    rescue StandardError
+      # The host is left believing Wurk never started, so anything the launcher
+      # did get up would keep fetching, beating and campaigning for the leader
+      # lock unowned for the life of the process.
+      roll_back_partial_boot
+      raise
     end
 
     # Stop fetching new work; in-flight jobs continue.
@@ -55,6 +61,13 @@ module Wurk
     end
 
     private
+
+    # Guarded so the caller sees why the boot failed, not why the rollback did.
+    def roll_back_partial_boot
+      stop
+    rescue StandardError => e
+      handle_exception(e, { context: 'embedded-boot-rollback' })
+    end
 
     # Extracted so tests can swap in a fake launcher without monkey-patching
     # Wurk::Launcher.new globally (which races other parallel tests).

--- a/lib/wurk/history.rb
+++ b/lib/wurk/history.rb
@@ -71,11 +71,19 @@ module Wurk
     end
 
     def start
-      @thread ||= safe_thread('history-snapshot') { @timer.run { tick } } # rubocop:disable Naming/MemoizedInstanceVariableName
+      return @thread if @thread
+
+      @timer.reset
+      @thread = safe_thread('history-snapshot') { @timer.run { tick } }
     end
 
+    # Blocks until the thread is really gone: the launcher releases the cluster
+    # lock immediately after this returns, and a snapshot still in flight would
+    # race the next leader's first one.
     def terminate
       @timer.terminate
+      @thread&.join(TimerLoop::JOIN_TIMEOUT)
+      @thread = nil
     end
 
     # Leader-gated: only the elected leader emits, so N workers don't each

--- a/lib/wurk/history.rb
+++ b/lib/wurk/history.rb
@@ -80,10 +80,14 @@ module Wurk
     # Blocks until the thread is really gone: the launcher releases the cluster
     # lock immediately after this returns, and a snapshot still in flight would
     # race the next leader's first one.
+    #
+    # Cleared only on a confirmed join (Thread#join returns nil on timeout): a
+    # wedged thread must stay tracked so #start's guard returns it instead of
+    # calling @timer.reset, which would un-terminate the loop it is still
+    # inside and leave two threads writing the same stream.
     def terminate
       @timer.terminate
-      @thread&.join(TimerLoop::JOIN_TIMEOUT)
-      @thread = nil
+      @thread = nil if @thread&.join(TimerLoop::JOIN_TIMEOUT)
     end
 
     # Leader-gated: only the elected leader emits, so N workers don't each

--- a/lib/wurk/launcher.rb
+++ b/lib/wurk/launcher.rb
@@ -13,6 +13,7 @@ require_relative 'metrics/rollup'
 require_relative 'metrics/queue_rollup'
 require_relative 'history'
 require_relative 'fetcher/reaper'
+require_relative 'timer_loop'
 
 module Wurk
   # Top-level supervisor inside each worker process. Owns the Manager pool
@@ -48,12 +49,12 @@ module Wurk
     def initialize(config, embedded: false)
       @config = config
       @embedded = embedded
-      # Two separate flags, deliberately. @done = "quieted" (stop fetching, stay
-      # alive, report quiet=true). @stopped = "shutting down" (terminate the
-      # heartbeat loop). Quiet must NOT stop the heartbeat — otherwise a quieted
-      # process never publishes quiet=true and expires out of the live set (#236).
+      # @done is "quieted": stop fetching, stay alive, report quiet=true. It
+      # deliberately does NOT stop the heartbeat — a quieted process that stopped
+      # beating would never publish quiet=true and would expire out of the live
+      # set (#236). Only #stop ends the beat, by terminating @beat_timer.
       @done = false
-      @stopped = false
+      @beat_timer = TimerLoop.new(BEAT_PAUSE)
       @managers = build_managers
       @poller = build_poller
       @cron_poller = build_cron_poller
@@ -249,34 +250,35 @@ module Wurk
 
     # Terminate the heartbeat loop and wait for it to exit before clear_heartbeat
     # removes us from the `processes` SET — otherwise a final in-flight beat could
-    # SADD us back right after the SREM. Wakes the thread out of its BEAT_PAUSE
-    # sleep so shutdown isn't delayed up to a full interval.
+    # SADD us back right after the SREM and the identity would linger for a full
+    # 60s TTL.
+    #
+    # The join is unbounded on purpose. This used to be `wakeup` + `join(BEAT_PAUSE)`,
+    # which lost the race whenever the beat was mid-Redis-call: `wakeup` does nothing
+    # to a thread that isn't sleeping, so the loop then slept a full interval and the
+    # bounded join returned with the thread still live — exactly the resurrect-after-
+    # SREM this ordering exists to prevent. A condvar can't be missed (terminate flips
+    # the flag inside the critical section the loop re-checks it in), so all that is
+    # left to wait out is one in-flight beat, whose Redis calls are timeout-bounded.
     def stop_heartbeat
-      @stopped = true
+      @beat_timer.terminate
       thread = @heartbeat_thread
       return unless thread
-      # Embedded dashboard-TERM runs `stop` from the beat itself; a self-join
-      # raises ThreadError. @stopped is set, so the loop exits after this beat.
+      # Embedded dashboard-TERM can run `stop` from the beat itself; a self-join
+      # raises ThreadError. The timer is terminated, so the loop exits after this beat.
       return if thread == Thread.current
 
-      begin
-        thread.wakeup
-      rescue ThreadError
-        nil
-      end
-      thread.join(BEAT_PAUSE)
+      thread.join
     end
 
-    # Heartbeat thread loop. `safe_thread` already wraps exceptions. Loops on
-    # `@stopped` — NOT `@done` — so a *quieted* process keeps beating and publishes
-    # `quiet=true` instead of vanishing from the live set (#236). Only `#stop`
-    # flips `@stopped`; its `Thread#wakeup` breaks the sleep so the loop re-checks
-    # `@stopped` and exits without waiting out the interval.
+    # Heartbeat thread loop. `safe_thread` already wraps exceptions. Beats once up
+    # front — TimerLoop#run waits before its first yield, and the dashboard has to
+    # see this process the moment it can pick up jobs — then ticks until #stop
+    # terminates the timer. Note it does NOT stop on `@done`: a *quieted* process
+    # keeps beating so it publishes `quiet=true` instead of vanishing (#236).
     def start_heartbeat
-      until @stopped
-        heartbeat
-        sleep BEAT_PAUSE
-      end
+      heartbeat
+      @beat_timer.run { heartbeat }
       logger.info('Heartbeat stopping...')
     end
 

--- a/lib/wurk/launcher.rb
+++ b/lib/wurk/launcher.rb
@@ -44,6 +44,11 @@ module Wurk
     # (Sidekiq's drop-in surface). The single source of truth is Heartbeat.
     BEAT_PAUSE = Heartbeat::BEAT_PAUSE
 
+    # Bound on how long #stop waits for the boot-time reclaim sweep before
+    # moving on — it can still be scanning a large keyspace when a fast
+    # shutdown lands right after boot; teardown must not hang on it.
+    BOOT_RECLAIM_JOIN_TIMEOUT = 5
+
     attr_accessor :managers, :poller, :cron_poller, :metrics_rollup, :queue_rollup, :history
 
     def initialize(config, embedded: false)
@@ -179,18 +184,40 @@ module Wurk
     # no tick races a follower's promotion, and the release itself happens on a
     # planned shutdown rather than waiting out the lock TTL.
     def release_components
-      [@cron_poller, @metrics_rollup, @queue_rollup, @history].each { |t| teardown_step(t.class) { t&.terminate } }
-      teardown_step('reaper') { @reaper&.stop }
-      teardown_step('leader') { @leader&.stop }
+      # Joined first, before anything below tears down the Redis pool it's
+      # still reading from: it started as a fire-and-forget thread in #run
+      # and a shutdown landing right after boot could otherwise race a
+      # pool disconnect mid-scan. Bounded: a full-keyspace scan can outlast
+      # the timeout, in which case the thread is left running rather than
+      # blocking shutdown on it — #boot_reclaim already rescues and logs on
+      # its own, so a straggler racing #reset_redis_pools! below just means
+      # a noisy log line, not a hang.
+      teardown_step('boot-reclaim-join') { @boot_reclaim_thread&.join(BOOT_RECLAIM_JOIN_TIMEOUT) }
+      stop_periodic_components
       %i[stop_heartbeat clear_heartbeat].each { |step| teardown_step(step) { send(step) } }
       # Unguarded: fire_event already reports and skips past a raising hook.
       fire_event(:exit, reverse: true)
+      # Embedded only: a swarm child or standalone process exits right after
+      # #stop anyway, so disconnecting here would just make every unit test
+      # that inspects Redis post-stop rebuild a pool for no reason. Embedded
+      # hosts (Puma, a rake task) keep running and can `run` again later —
+      # without this a stop-then-run cycle doubles the live socket set.
+      teardown_step('redis-pools') { @config.reset_redis_pools! } if @embedded
     ensure
       # In an ensure of its own, not merely a guarded step: a leaked TCPServer
       # FD survives even a non-StandardError unwind (a second TERM landing
       # mid-teardown), and kubelet would keep getting 200s from a process that
       # is already gone.
       teardown_step('health-server') { @health_server&.stop }
+    end
+
+    # Split out of #release_components to keep it under the AbcSize/
+    # CyclomaticComplexity ceilings — these three are the "periodic loop"
+    # releases, independently guarded like everything else in the tail.
+    def stop_periodic_components
+      [@cron_poller, @metrics_rollup, @queue_rollup, @history].each { |t| teardown_step(t.class) { t&.terminate } }
+      teardown_step('reaper') { @reaper&.stop }
+      teardown_step('leader') { @leader&.stop }
     end
 
     def teardown_step(label)

--- a/lib/wurk/launcher.rb
+++ b/lib/wurk/launcher.rb
@@ -54,7 +54,7 @@ module Wurk
       # process never publishes quiet=true and expires out of the live set (#236).
       @done = false
       @stopped = false
-      @managers = config.capsules.values.map { |cap| Manager.new(cap) }
+      @managers = build_managers
       @poller = build_poller
       @cron_poller = build_cron_poller
       @metrics_rollup = build_metrics_rollup
@@ -281,29 +281,40 @@ module Wurk
     end
 
     # Dashboard-queued signals must behave exactly like OS signals, so a
-    # standalone process re-delivers to itself and lets the installed trap
-    # run — that wakes the main thread (CLI self-pipe / child dispatcher)
-    # so the process actually exits instead of stopping its managers and
-    # then parking forever. Embedded mode owns no traps (and self-TERM
-    # would kill the host app), so it calls quiet/stop directly — stop on
-    # its own thread because `stop` joins the heartbeat thread we're on.
+    # standalone process re-delivers to itself and lets the installed trap run —
+    # that wakes the main thread (CLI self-pipe / child dispatcher) so the
+    # process actually exits instead of stopping its managers and then parking
+    # forever. Embedded mode owns no traps (and self-TERM would kill the host
+    # app), so quiet applies directly.
     def dispatch_signal(sig)
       case sig
-      when 'TSTP', 'TERM'
-        if @embedded
-          sig == 'TSTP' ? quiet : Thread.new { stop }
-        else
-          redeliver(sig)
-        end
+      when 'TSTP' then @embedded ? quiet : redeliver(sig)
+      when 'TERM' then request_shutdown
       else
         logger.warn { "Unknown signal in #{identity}-signals: #{sig.inspect}" }
       end
+    end
+
+    # The one way anything inside this process asks it to shut down gracefully:
+    # dashboard-queued TERM, or a Manager that can no longer hold its
+    # concurrency. Standalone hands off to the installed TERM trap; embedded
+    # owns no traps, so it drains in place — on its own thread, because callers
+    # may be a thread `stop` itself joins (the heartbeat) or kills (a Processor).
+    def request_shutdown
+      @embedded ? Thread.new { stop } : redeliver('TERM')
     end
 
     # Separate method so tests can stub it — really sending TERM/TSTP would
     # kill or suspend the test process.
     def redeliver(sig)
       ::Process.kill(sig, ::Process.pid)
+    end
+
+    # One Manager per capsule, each holding our shutdown request: a Manager
+    # that can no longer replace a dead Processor has to take the process
+    # down, and only the Launcher knows how this process exits.
+    def build_managers
+      @config.capsules.values.map { |cap| Manager.new(cap, shutdown: method(:request_shutdown)) }
     end
 
     def build_poller

--- a/lib/wurk/launcher.rb
+++ b/lib/wurk/launcher.rb
@@ -118,26 +118,18 @@ module Wurk
 
     # Graceful shutdown. Deadline is monotonic so wall-clock skew can't
     # extend it. Managers stop in parallel threads so a slow capsule
-    # doesn't block its siblings.
+    # doesn't block its siblings — and each drain is guarded, because a
+    # capsule that blows up mid-drain (Redis down during bulk_requeue) used
+    # to surface out of `join` and skip the whole teardown tail, leaving the
+    # leader lock held, the process listed as live, and its port open.
     def stop
       deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + (@config[:timeout] || 25)
       quiet
-      stoppers = @managers.map { |m| Thread.new { m.stop(deadline) } }
+      stoppers = @managers.map { |m| Thread.new { teardown_step('manager') { m.stop(deadline) } } }
       fire_event(:shutdown, reverse: true)
       stoppers.each(&:join)
-      # Full shutdown stops periodic firing (it survived #quiet); do this before
-      # releasing the lock so no tick races a follower's promotion.
-      @cron_poller&.terminate
-      @metrics_rollup&.terminate
-      @queue_rollup&.terminate
-      @history&.terminate
-      @reaper&.stop
-      # CAS-release the cluster lock now (planned shutdown) so a follower can
-      # take over immediately instead of waiting out the TTL.
-      @leader&.stop
-      stop_heartbeat
-      clear_heartbeat
-      fire_event(:exit, reverse: true)
+    ensure
+      release_components
     end
 
     def stopping?
@@ -173,6 +165,35 @@ module Wurk
     attr_reader :heartbeat_thread
 
     private
+
+    # Teardown tail, driven from #stop's ensure. Every release is guarded on
+    # its own because they are independent: a Redis blip in one (leader CAS
+    # release, heartbeat clear) must not strand the ones after it — the process
+    # is exiting either way, so the only thing worse than a failed release is a
+    # skipped one. Order matters twice over: full shutdown stops the periodic
+    # loops (they survived #quiet) before the cluster lock is CAS-released, so
+    # no tick races a follower's promotion, and the release itself happens on a
+    # planned shutdown rather than waiting out the lock TTL.
+    def release_components
+      [@cron_poller, @metrics_rollup, @queue_rollup, @history].each { |t| teardown_step(t.class) { t&.terminate } }
+      teardown_step('reaper') { @reaper&.stop }
+      teardown_step('leader') { @leader&.stop }
+      %i[stop_heartbeat clear_heartbeat].each { |step| teardown_step(step) { send(step) } }
+      # Unguarded: fire_event already reports and skips past a raising hook.
+      fire_event(:exit, reverse: true)
+    ensure
+      # In an ensure of its own, not merely a guarded step: a leaked TCPServer
+      # FD survives even a non-StandardError unwind (a second TERM landing
+      # mid-teardown), and kubelet would keep getting 200s from a process that
+      # is already gone.
+      teardown_step('health-server') { @health_server&.stop }
+    end
+
+    def teardown_step(label)
+      yield
+    rescue StandardError => e
+      handle_exception(e, { context: "launcher-stop-#{label}" })
+    end
 
     def write_stats(processed, failed, expired)
       day = Time.now.utc.strftime('%F')
@@ -217,13 +238,10 @@ module Wurk
 
     # Erase the live-process footprint. flush_stats first so we don't drop
     # the final batch of counters; then Heartbeat#stop! removes us from the
-    # `processes` SET and UNLINK-s the identity + work hashes. The probe
-    # server is closed alongside so kubelet stops getting 200s after the
-    # process is no longer healthy.
+    # `processes` SET and UNLINK-s the identity + work hashes.
     def clear_heartbeat
       flush_stats
       @heartbeat&.stop!
-      @health_server&.stop
     end
 
     # Terminate the heartbeat loop and wait for it to exit before clear_heartbeat

--- a/lib/wurk/launcher.rb
+++ b/lib/wurk/launcher.rb
@@ -87,18 +87,21 @@ module Wurk
       @config.capsules.each_value(&:prepare!)
       @config.freeze!
       @heartbeat_thread = safe_thread('heartbeat', &method(:start_heartbeat)) if async_beat
-      @poller&.start
-      @leader&.start
-      @cron_poller&.start
-      @metrics_rollup&.start
-      @queue_rollup&.start
-      @history&.start
+      [@poller, @leader, @cron_poller, @metrics_rollup, @queue_rollup, @history].compact.each(&:start)
       @managers.each(&:start)
       @reaper.start
       # Run on a background thread so /ready probe isn't delayed by a large
       # orphan sweep (reaper.reclaim! is atomic, but can scan many entries).
       @boot_reclaim_thread = safe_thread('boot-reclaim', &method(:boot_reclaim))
       @health_server&.start
+    rescue StandardError
+      # Boot is not atomic: whatever raised (a health-check port already bound,
+      # ThreadError at the OS thread limit) leaves the steps before it holding
+      # threads, sockets and a leader campaign — and the caller is about to drop
+      # its only reference to us, so nothing else can ever release them. Guarded,
+      # because the caller must see the boot failure, not a rollback failure.
+      teardown_step('boot-rollback') { stop }
+      raise
     end
 
     # Idempotent. Flips `stopping?` true, halts fetching across every

--- a/lib/wurk/manager.rb
+++ b/lib/wurk/manager.rb
@@ -24,12 +24,21 @@ module Wurk
 
     attr_reader :workers, :capsule
 
-    def initialize(capsule)
+    # `shutdown:` is the owning Launcher's process-wide shutdown request,
+    # invoked when concurrency can no longer be held (see #processor_result).
+    # Injected rather than reached for: only the entry point knows how this
+    # process exits — a swarm child / standalone CLI re-delivers TERM to itself
+    # so the installed trap drives the normal drain, while embedded mode owns
+    # no traps and must stop the launcher in place. A Manager built without an
+    # owner (Sidekiq's `Manager.new(capsule)` arity, kept for the alias) has no
+    # route to take, so it only reports.
+    def initialize(capsule, shutdown: nil)
       @config = @capsule = capsule
       @count = capsule.concurrency
       raise ArgumentError, "Concurrency of #{@count} is not supported" if @count < 1
 
       @done = false
+      @shutdown = shutdown
       @workers = Set.new
       @plock = ::Mutex.new
       @count.times do
@@ -86,8 +95,9 @@ module Wurk
     # cleanly or via raised exception. Removes the dead processor from the
     # pool and (unless we're already stopping) spawns a replacement so the
     # capsule's concurrency stays constant. If the replacement itself can't be
-    # spawned, crash the child (the swarm respawns it) rather than silently
-    # dropping concurrency. Snapshot under @plock; start the replacement — a
+    # spawned, ask the owner to shut this process down (the swarm respawns it at
+    # full concurrency) rather than silently dropping a worker for the life of
+    # the process. Snapshot under @plock; start the replacement — a
     # side effect — outside the lock.
     def processor_result(processor, _reason = nil)
       replacement = @plock.synchronize do
@@ -102,10 +112,15 @@ module Wurk
     rescue StandardError => e
       # Replacement spawn failed (e.g. ThreadError at the OS thread limit).
       # Silently running one Processor short for the life of the process is
-      # invisible degradation; instead report and crash the child on the main
-      # thread so the swarm respawns it at full concurrency (plan 02 §6).
+      # invisible degradation, so take the process down (the swarm respawns it
+      # at full concurrency) — but through the owner's TERM path, never
+      # `Thread.main.raise`: that raise unwound straight past Manager#stop, so
+      # the in-flight UnitsOfWork were never bulk_requeued and each one waited
+      # out a full reaper interval, and in embedded mode it killed the host's
+      # main thread instead of just the worker. Non-blocking by contract — we
+      # are on the dying Processor's own thread, which the drain will kill.
       @capsule.config.handle_exception(e, { context: 'Manager could not replace a dead Processor' })
-      main_thread.raise(e)
+      @shutdown&.call
     end
 
     # Reached when the deadline expired with workers still busy. Atomically
@@ -155,12 +170,6 @@ module Wurk
     # never ran.
     def workers_empty?
       @plock.synchronize { @workers.none? { |w| w.thread&.alive? } }
-    end
-
-    # Seam over Thread.main: lets processor_result's replacement-failure crash
-    # be unit-tested against a controlled thread instead of the live runner.
-    def main_thread
-      Thread.main
     end
 
     # Polls `condblock` until it returns true or the monotonic deadline

--- a/lib/wurk/manager.rb
+++ b/lib/wurk/manager.rb
@@ -146,8 +146,15 @@ module Wurk
       @plock.synchronize { @workers.dup }
     end
 
+    # Drained means "no processor thread is still running", not "the Set is
+    # empty": a processor removes itself from @workers from inside its own
+    # thread, so the two agree — except for a processor that was never started
+    # (a launcher that raised mid-boot and rolled back). That one holds no
+    # thread and nothing will ever remove it, so an emptiness test would make
+    # #stop poll out the entire shutdown deadline waiting on a worker that
+    # never ran.
     def workers_empty?
-      @plock.synchronize { @workers.empty? }
+      @plock.synchronize { @workers.none? { |w| w.thread&.alive? } }
     end
 
     # Seam over Thread.main: lets processor_result's replacement-failure crash

--- a/lib/wurk/metrics/queue_rollup.rb
+++ b/lib/wurk/metrics/queue_rollup.rb
@@ -51,11 +51,19 @@ module Wurk
       end
 
       def start
-        @thread ||= safe_thread('queue-metrics') { @timer.run { tick } } # rubocop:disable Naming/MemoizedInstanceVariableName
+        return @thread if @thread
+
+        @timer.reset
+        @thread = safe_thread('queue-metrics') { @timer.run { tick } }
       end
 
+      # Blocks until the thread is really gone: the launcher releases the
+      # cluster lock immediately after this returns, and a sample still in
+      # flight would write the same buckets as the next leader's first one.
       def terminate
         @timer.terminate
+        @thread&.join(TimerLoop::JOIN_TIMEOUT)
+        @thread = nil
       end
 
       # Leader-gated: only the elected leader samples, so N workers don't each

--- a/lib/wurk/metrics/queue_rollup.rb
+++ b/lib/wurk/metrics/queue_rollup.rb
@@ -60,10 +60,14 @@ module Wurk
       # Blocks until the thread is really gone: the launcher releases the
       # cluster lock immediately after this returns, and a sample still in
       # flight would write the same buckets as the next leader's first one.
+      #
+      # Cleared only on a confirmed join (Thread#join returns nil on timeout):
+      # a wedged thread must stay tracked so #start's guard returns it instead
+      # of calling @timer.reset, which would un-terminate the loop it is still
+      # inside and leave two threads HSETting the same buckets.
       def terminate
         @timer.terminate
-        @thread&.join(TimerLoop::JOIN_TIMEOUT)
-        @thread = nil
+        @thread = nil if @thread&.join(TimerLoop::JOIN_TIMEOUT)
       end
 
       # Leader-gated: only the elected leader samples, so N workers don't each

--- a/lib/wurk/metrics/rollup.rb
+++ b/lib/wurk/metrics/rollup.rb
@@ -68,10 +68,14 @@ module Wurk
       # Blocks until the thread is really gone: the launcher releases the
       # cluster lock immediately after this returns, and a roll still in flight
       # would write the same buckets as the next leader's first one.
+      #
+      # Cleared only on a confirmed join (Thread#join returns nil on timeout):
+      # a wedged thread must stay tracked so #start's guard returns it instead
+      # of calling @timer.reset, which would un-terminate the loop it is still
+      # inside and leave two threads HSETting the same buckets.
       def terminate
         @timer.terminate
-        @thread&.join(TimerLoop::JOIN_TIMEOUT)
-        @thread = nil
+        @thread = nil if @thread&.join(TimerLoop::JOIN_TIMEOUT)
       end
 
       # Leader-gated: only the elected leader writes the cluster-total series,

--- a/lib/wurk/metrics/rollup.rb
+++ b/lib/wurk/metrics/rollup.rb
@@ -59,11 +59,19 @@ module Wurk
       end
 
       def start
-        @thread ||= safe_thread('metrics-rollup') { @timer.run { tick } } # rubocop:disable Naming/MemoizedInstanceVariableName
+        return @thread if @thread
+
+        @timer.reset
+        @thread = safe_thread('metrics-rollup') { @timer.run { tick } }
       end
 
+      # Blocks until the thread is really gone: the launcher releases the
+      # cluster lock immediately after this returns, and a roll still in flight
+      # would write the same buckets as the next leader's first one.
       def terminate
         @timer.terminate
+        @thread&.join(TimerLoop::JOIN_TIMEOUT)
+        @thread = nil
       end
 
       # Leader-gated: only the elected leader writes the cluster-total series,

--- a/lib/wurk/rails_boot.rb
+++ b/lib/wurk/rails_boot.rb
@@ -151,14 +151,19 @@ module Wurk
     # Sidekiq-embedded parity: a threads-only worker inside the web process, no
     # fork. Redis validation failure keeps the host serving HTTP (log + carry
     # on). at_exit drains on the graceful shutdown the web server runs on TERM.
-    def boot_embedded
-      instance = Wurk::Embedded.new(Wurk.configuration)
-      instance.run
+    def boot_embedded(embedded = Wurk::Embedded)
+      instance = embedded.new(Wurk.configuration)
+      # Registered BEFORE run, for the reason boot_swarm registers before the
+      # fork: run brings the heartbeat, pollers, managers and health listener up
+      # one at a time, and a raise partway through would otherwise leave the ones
+      # already running with nothing to drain them on host exit.
       at_exit { instance.stop }
+      instance.run
       logger.info { 'wurk: running embedded in the web process (config.wurk.embed_in_web) — threads only, no fork' }
       instance
     rescue StandardError => e
       logger.error { "wurk: embedded boot failed: #{e.class}: #{e.message}" }
+      instance&.stop
       nil
     end
 

--- a/lib/wurk/scheduled.rb
+++ b/lib/wurk/scheduled.rb
@@ -176,14 +176,17 @@ module Wurk
       # Joins before returning — the caller (Launcher#quiet, then #stop) clears
       # the heartbeat right after, and a sweep still in flight would promote
       # jobs on behalf of a process that no longer exists.
+      #
+      # Cleared only on a confirmed join (Thread#join returns nil on timeout):
+      # a wedged sweep must stay tracked so #start's ||= guard returns it
+      # rather than spawning a second scheduler thread alongside it.
       def terminate
         @mutex.synchronize do
           @done = true
           @enq.terminate
           @sleeper.signal
         end
-        @thread&.join(TimerLoop::JOIN_TIMEOUT)
-        @thread = nil
+        @thread = nil if @thread&.join(TimerLoop::JOIN_TIMEOUT)
       end
 
       # Called on every wake. Any raise inside the Enq is reported and the

--- a/lib/wurk/scheduled.rb
+++ b/lib/wurk/scheduled.rb
@@ -6,6 +6,7 @@ require_relative 'lua'
 require_relative 'lua/loader'
 require_relative 'client'
 require_relative 'process_set'
+require_relative 'timer_loop'
 
 module Wurk
   # Promotes due jobs from the `retry` and `schedule` sorted sets back onto
@@ -169,13 +170,20 @@ module Wurk
 
       # Idempotent. Wakes the sleeping thread so it observes @done and exits.
       # Also propagates the stop signal to @enq so any in-flight drain loop
-      # short-circuits instead of running to completion.
+      # short-circuits instead of running to completion. Terminal, not a pause:
+      # @enq's stop flag is one-way, so this poller never polls again.
+      #
+      # Joins before returning — the caller (Launcher#quiet, then #stop) clears
+      # the heartbeat right after, and a sweep still in flight would promote
+      # jobs on behalf of a process that no longer exists.
       def terminate
         @mutex.synchronize do
           @done = true
           @enq.terminate
           @sleeper.signal
         end
+        @thread&.join(TimerLoop::JOIN_TIMEOUT)
+        @thread = nil
       end
 
       # Called on every wake. Any raise inside the Enq is reported and the

--- a/lib/wurk/swarm/child_boot.rb
+++ b/lib/wurk/swarm/child_boot.rb
@@ -108,6 +108,10 @@ module Wurk
         @config.reset_redis_pools!
         validate_redis!
         reconnect_active_record
+        # The dogstatsd client is memoized at the class level (Statsd.client),
+        # so without a reset every child would share the parent's UDP socket
+        # and thread-locals instead of building its own after fork.
+        Wurk::Metrics::Statsd.reset!
       end
 
       # Prove the child's fresh Redis socket reaches a live server before it

--- a/lib/wurk/timer_loop.rb
+++ b/lib/wurk/timer_loop.rb
@@ -15,6 +15,13 @@ module Wurk
   #   @thread ||= safe_thread('my-loop') { @timer.run { tick } }
   #   def terminate = @timer.terminate
   class TimerLoop
+    # Deadline every periodic component gives its loop thread when stopping.
+    # Bounded rather than an open-ended join: a tick blocked on a wedged Redis
+    # must not hold the process's whole shutdown open. Also used by
+    # Scheduled::Poller, which hand-rolls its wait (the interval is randomized
+    # per iteration) but stops on the same terms.
+    JOIN_TIMEOUT = 5
+
     def initialize(interval)
       @interval = interval
       @done = false
@@ -38,6 +45,13 @@ module Wurk
         @done = true
         @sleeper.signal
       end
+    end
+
+    # Clears a previous #terminate. Hosts call this before respawning, so a
+    # start-after-stop cycle spawns a thread that ticks instead of one that
+    # sees the stale done flag and exits immediately.
+    def reset
+      @mutex.synchronize { @done = false }
     end
 
     def wait

--- a/test/engine/railtie_test.rb
+++ b/test/engine/railtie_test.rb
@@ -226,6 +226,50 @@ class RailtieTest < Wurk::Test::EngineCase
     assert_empty swarm.drains
   end
 
+  # --- embedded boot contract ---
+  #
+  # Same shape one layer up from the swarm: the drain hook is registered before
+  # `run` — which brings the heartbeat, pollers, managers and health listener up
+  # one at a time — so a boot that raises partway still has something to stop
+  # what it started. The rescue that keeps the host serving HTTP rolls that
+  # partial boot back rather than leaking it for the life of the web process.
+
+  def test_boot_embedded_registers_the_drain_hook_before_run
+    hooks = []
+    instance = FakeEmbedded.new(hooks)
+
+    with_at_exit(hooks) { boot_embedded_with(instance) }
+
+    assert_equal 1, instance.hooks_at_run, 'the drain hook must be registered before run'
+  end
+
+  def test_boot_embedded_returns_the_running_instance
+    hooks = []
+    instance = FakeEmbedded.new(hooks)
+
+    assert_same instance, with_at_exit(hooks) { boot_embedded_with(instance) }
+  end
+
+  def test_boot_embedded_drain_hook_stops_the_instance
+    hooks = []
+    instance = FakeEmbedded.new(hooks)
+
+    with_at_exit(hooks) { boot_embedded_with(instance) }
+    hooks.first.call
+
+    assert_equal 1, instance.stops, 'the at_exit hook must drain the embedded workers'
+  end
+
+  def test_boot_embedded_rolls_back_a_run_that_raised
+    hooks = []
+    instance = FakeEmbedded.new(hooks, boom: 'redis down at boot')
+
+    result = with_at_exit(hooks) { boot_embedded_with(instance) }
+
+    assert_nil result, 'a failed embedded boot must keep the host serving HTTP'
+    assert_equal 1, instance.stops, 'a partial boot must not outlive the boot attempt'
+  end
+
   def test_refuse_logs_actionable_guidance
     io = StringIO.new
     with_logger(::Logger.new(io)) { Wurk::RailsBoot.refuse_preforking_boot }
@@ -254,7 +298,43 @@ class RailtieTest < Wurk::Test::EngineCase
     def shutdown = @drains << Thread.current
   end
 
+  # Stand-in for Wurk::Embedded: records how many at_exit hooks were already
+  # registered when `run` ran (the ordering contract) and how often it was
+  # asked to stop.
+  class FakeEmbedded
+    attr_reader :hooks_at_run, :stops
+
+    def initialize(hooks, boom: nil)
+      @hooks = hooks
+      @boom = boom
+      @stops = 0
+    end
+
+    def run
+      @hooks_at_run = @hooks.size
+      raise @boom if @boom
+    end
+
+    def stop = @stops += 1
+  end
+
   private
+
+  # `at_exit` inside boot_embedded resolves against the module, so a singleton
+  # method intercepts it — the hook is captured instead of being registered on
+  # the test process, where it would fire long after the assertions.
+  def with_at_exit(hooks)
+    Wurk::RailsBoot.define_singleton_method(:at_exit) { |&blk| hooks << blk }
+    yield
+  ensure
+    Wurk::RailsBoot.singleton_class.send(:remove_method, :at_exit)
+  end
+
+  def boot_embedded_with(instance)
+    klass = Object.new
+    klass.define_singleton_method(:new) { |_config| instance }
+    with_logger(::Logger.new(IO::NULL)) { Wurk::RailsBoot.boot_embedded(klass) }
+  end
 
   def fake_app(embed:)
     wurk = ::ActiveSupport::OrderedOptions.new

--- a/test/unit/child_boot_test.rb
+++ b/test/unit/child_boot_test.rb
@@ -93,6 +93,19 @@ class ChildBootTest < Wurk::Test::UnitCase
     assert(present.all? { |v| v == 1 }, "post-fork boot must leave every script cached, got #{present.inspect}")
   end
 
+  # A6: the dogstatsd client is memoized at the class level, so a forked
+  # child that skipped this reset would share the parent's UDP socket and
+  # thread-locals instead of building its own after fork.
+  def test_reconnect_after_fork_resets_the_statsd_client
+    Wurk::Metrics::Statsd.instance_variable_set(:@client, :parent_client)
+
+    @boot.send(:reconnect_after_fork)
+
+    assert_nil Wurk::Metrics::Statsd.client
+  ensure
+    Wurk::Metrics::Statsd.reset!
+  end
+
   def test_validate_redis_pings_then_pipelines_every_script_load
     result = @boot.send(:validate_redis!)
 

--- a/test/unit/cron_test.rb
+++ b/test/unit/cron_test.rb
@@ -1025,9 +1025,9 @@ class CronTest < Wurk::Test::UnitCase
 
   # ---- Poller branch coverage ------------------------------------------
 
-  # 466 body + 521 (wait) loop: start spawns the tick thread; with a tiny tick
-  # interval and a non-leader gate, the `until @done { tick; wait }` body runs
-  # at least once. We count ticks, then terminate and join deterministically.
+  # start spawns the tick thread; with a tiny tick interval and a non-leader
+  # gate the loop body runs at least once. terminate joins, so the thread is
+  # already dead by the time it returns — no post-hoc join needed.
   def test_poller_start_runs_tick_loop_then_terminates
     cfg = Wurk::Configuration.new
     cfg[:cron_tick_interval] = 0.01
@@ -1036,13 +1036,34 @@ class CronTest < Wurk::Test::UnitCase
     poller.define_singleton_method(:leader?) { false }
     poller.define_singleton_method(:tick) { ticks << :t }
 
-    poller.start
-    first = ticks.pop # blocks until the loop body executes tick at least once
+    thread = poller.start
+    first = ticks.pop(timeout: 5) # waits until the loop body executes tick at least once
 
     poller.terminate
-    thread = poller.instance_variable_get(:@poller_thread)
-    assert thread.join(5), 'poller thread must exit after terminate'
+
+    refute_predicate thread, :alive?, 'terminate must join the poller thread'
+    assert_nil poller.instance_variable_get(:@thread)
     assert_equal :t, first
+  end
+
+  # A cleared @thread would be pointless if the timer stayed terminated —
+  # start has to re-arm it, not spawn a thread that exits immediately.
+  def test_poller_start_after_terminate_ticks_again
+    cfg = Wurk::Configuration.new
+    cfg[:cron_tick_interval] = 0.01
+    poller = Wurk::Cron::Poller.new(cfg)
+    ticks = Queue.new
+    poller.define_singleton_method(:leader?) { false }
+    poller.define_singleton_method(:tick) { ticks << :t }
+
+    poller.start
+    ticks.pop(timeout: 5)
+    poller.terminate
+    poller.start
+
+    assert_equal :t, ticks.pop(timeout: 5), 'start after terminate must resume ticking'
+  ensure
+    poller&.terminate
   end
 
   # 497 then: a loop whose next fire is in the future → enqueue_if_due returns

--- a/test/unit/cron_test.rb
+++ b/test/unit/cron_test.rb
@@ -1066,6 +1066,26 @@ class CronTest < Wurk::Test::UnitCase
     poller&.terminate
   end
 
+  # The flip side of re-arming: a tick wedged past JOIN_TIMEOUT (Thread#join
+  # returns nil) must keep @thread set, so the next #start returns it instead
+  # of resetting the shared timer under it and double-enqueuing every loop.
+  def test_poller_terminate_keeps_a_thread_that_outlives_the_join
+    cfg = Wurk::Configuration.new
+    cfg[:cron_tick_interval] = 0.01
+    poller = Wurk::Cron::Poller.new(cfg)
+    poller.define_singleton_method(:leader?) { false }
+
+    thread = poller.start
+    thread.define_singleton_method(:join) { |_timeout = nil| nil }
+    poller.terminate
+
+    assert_same thread, poller.instance_variable_get(:@thread), 'a wedged thread must stay tracked'
+    assert_same thread, poller.start, 'start must not spawn a second thread alongside it'
+  ensure
+    poller&.instance_variable_set(:@thread, nil)
+    thread&.kill
+  end
+
   # 497 then: a loop whose next fire is in the future → enqueue_if_due returns
   # early without enqueuing. We register a daily-4am loop and pre-seed its 'nf'
   # mark far in the future, then a leader tick must enqueue nothing.

--- a/test/unit/embedded_test.rb
+++ b/test/unit/embedded_test.rb
@@ -106,6 +106,34 @@ class EmbeddedTest < Wurk::Test::UnitCase
     assert ran
   end
 
+  # --- partial boot rollback -------------------------------------------
+
+  # A4: `run` raising leaves the host believing Wurk never started, so a
+  # launcher that came up halfway would keep fetching, beating and campaigning
+  # for the leader lock with nobody holding a reference to it.
+  def test_run_stops_a_launcher_that_raised_mid_boot
+    stopped = 0
+    embedded = embedded_with_launcher(run: -> { raise 'health port already bound' }, stop: -> { stopped += 1 })
+
+    err = assert_raises(RuntimeError) { embedded.run }
+
+    assert_equal 'health port already bound', err.message
+    assert_equal 1, stopped, 'a partial boot must be rolled back'
+  end
+
+  # The rollback is guarded so the caller sees why the boot failed.
+  def test_run_reports_a_failing_rollback_and_raises_the_boot_error
+    reported = []
+    @config.error_handlers << ->(ex, ctx, _cfg) { reported << [ex.message, ctx[:context]] }
+    embedded = embedded_with_launcher(run: -> { raise 'health port already bound' },
+                                      stop: -> { raise 'rollback exploded' })
+
+    err = assert_raises(RuntimeError) { embedded.run }
+
+    assert_equal 'health port already bound', err.message
+    assert_includes reported, ['rollback exploded', 'embedded-boot-rollback']
+  end
+
   # --- redis validation -----------------------------------------------
 
   def test_run_raises_when_redis_too_old
@@ -207,6 +235,20 @@ class EmbeddedTest < Wurk::Test::UnitCase
   end
 
   private
+
+  # Embedded over a launcher whose run/stop are the given lambdas — enough to
+  # drive the boot-failure paths without spawning manager threads.
+  def embedded_with_launcher(run:, stop:)
+    embedded = Wurk::Embedded.new(@config)
+    stub_redis!(embedded)
+    embedded.define_singleton_method(:build_launcher) do
+      fake = Object.new
+      fake.define_singleton_method(:run) { run.call }
+      fake.define_singleton_method(:stop) { stop.call }
+      fake
+    end
+    embedded
+  end
 
   # Skip redis validation AND replace the launcher build with a no-op so
   # we exercise housekeeping/startup/sleep without spawning manager threads.

--- a/test/unit/history_test.rb
+++ b/test/unit/history_test.rb
@@ -158,6 +158,37 @@ class HistoryTest < Wurk::Test::UnitCase
     assert_operator snapshotter.instance_variable_get(:@snaps).to_i, :>, 0
   end
 
+  # terminate is a barrier: the launcher releases the cluster lock right after
+  # it returns, so a snapshot still in flight would race the next leader.
+  def test_terminate_joins_and_clears_the_thread
+    snapshotter = history(interval: 0.01)
+    snapshotter.define_singleton_method(:leader?) { false }
+
+    thread = snapshotter.start
+    snapshotter.terminate
+
+    refute_predicate thread, :alive?, 'terminate must join the snapshot thread'
+    assert_nil snapshotter.instance_variable_get(:@thread)
+  end
+
+  # A cleared @thread would be pointless if the timer stayed terminated —
+  # start has to re-arm it, not spawn a thread that exits immediately.
+  def test_start_after_terminate_snapshots_again
+    snapshotter = history(interval: 0.01)
+    snapshotter.define_singleton_method(:leader?) { true }
+    snapshotter.define_singleton_method(:snapshot) { @snaps = (@snaps || 0) + 1 }
+
+    snapshotter.start
+    snapshotter.terminate
+    snapshotter.instance_variable_set(:@snaps, 0)
+    snapshotter.start
+    poll_until(2.0) { snapshotter.instance_variable_get(:@snaps).positive? }
+
+    assert_operator snapshotter.instance_variable_get(:@snaps), :>, 0
+  ensure
+    snapshotter&.terminate
+  end
+
   # --- history:metrics stream (§5.3) -----------------------------------
 
   def test_snapshot_appends_the_section_5_2_fields_to_the_stream

--- a/test/unit/history_test.rb
+++ b/test/unit/history_test.rb
@@ -189,6 +189,24 @@ class HistoryTest < Wurk::Test::UnitCase
     snapshotter&.terminate
   end
 
+  # The flip side of re-arming: a snapshot wedged past JOIN_TIMEOUT (Thread#join
+  # returns nil) must keep @thread set, so the next #start returns it instead of
+  # resetting the shared timer under it and double-writing the stream.
+  def test_terminate_keeps_a_thread_that_outlives_the_join
+    snapshotter = history(interval: 0.01)
+    snapshotter.define_singleton_method(:leader?) { false }
+
+    thread = snapshotter.start
+    thread.define_singleton_method(:join) { |_timeout = nil| nil }
+    snapshotter.terminate
+
+    assert_same thread, snapshotter.instance_variable_get(:@thread), 'a wedged thread must stay tracked'
+    assert_same thread, snapshotter.start, 'start must not spawn a second thread alongside it'
+  ensure
+    snapshotter&.instance_variable_set(:@thread, nil)
+    thread&.kill
+  end
+
   # --- history:metrics stream (§5.3) -----------------------------------
 
   def test_snapshot_appends_the_section_5_2_fields_to_the_stream

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -820,6 +820,44 @@ class LauncherTest < Wurk::Test::UnitCase
     assert stopped.pop(timeout: 5), 'a queued TERM must invoke #stop (async thread)'
   end
 
+  # --- shutdown request (A7) -------------------------------------------
+
+  # A Manager that can no longer replace a dead Processor has to take the
+  # process down. It holds the Launcher's request rather than raising into
+  # Thread.main, which skipped the drain (no bulk_requeue) and, embedded, took
+  # the host's main thread with it.
+  def test_managers_hold_the_launcher_shutdown_request
+    launcher = Wurk::Launcher.new(@config)
+
+    routes = launcher.managers.map { |m| m.instance_variable_get(:@shutdown) }
+
+    assert_equal [launcher], routes.map(&:receiver).uniq
+    assert_equal [:request_shutdown], routes.map(&:name).uniq
+  end
+
+  def test_manager_shutdown_request_redelivers_term_standalone
+    launcher = build_isolated_launcher
+    redelivered = []
+    launcher.define_singleton_method(:redeliver) { |s| redelivered << s }
+
+    launcher.managers.first.instance_variable_get(:@shutdown).call
+
+    assert_equal ['TERM'], redelivered
+    refute_predicate launcher, :stopping?, 'the trap, not the request, owns the state change'
+  end
+
+  # Embedded owns no traps, so it drains in place — off the caller's thread,
+  # which is the dying Processor's and gets killed by that very drain.
+  def test_manager_shutdown_request_drains_off_thread_when_embedded
+    launcher = build_isolated_launcher(embedded: true)
+    stopped = Queue.new
+    launcher.define_singleton_method(:stop) { stopped << Thread.current }
+
+    launcher.managers.first.instance_variable_get(:@shutdown).call
+
+    refute_same Thread.current, stopped.pop(timeout: 5)
+  end
+
   # Branch coverage: an unrecognized signal must be logged, not dispatched.
   # Exercises the `else` arm of dispatch_signal (line 227).
   def test_heartbeat_logs_unknown_signal

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -445,6 +445,63 @@ class LauncherTest < Wurk::Test::UnitCase
     assert_predicate launcher, :stopping?
   end
 
+  # A2: a Manager that raised mid-drain surfaced out of `stoppers.each(&:join)`
+  # and skipped the whole teardown tail — leader lock still held, process still
+  # listed as live, health-server socket still open. The tail now runs from
+  # #stop's ensure, and each stopper thread swallows (and reports) its own
+  # failure so one bad capsule can't cancel its siblings' joins either.
+  def test_stop_completes_teardown_when_a_manager_stop_raises
+    @config[:timeout] = 0
+    launcher = Wurk::Launcher.new(@config)
+    managers_raising_on_stop(launcher, 'redis down mid-drain')
+    seen = record_teardown(launcher)
+
+    launcher.stop
+
+    assert_equal %i[cron_poller metrics_rollup queue_rollup reaper leader heartbeat exit health], seen
+  end
+
+  def test_stop_reports_a_manager_that_raises_mid_drain
+    @config[:timeout] = 0
+    reported = []
+    @config.error_handlers << ->(ex, ctx, _cfg) { reported << [ex.message, ctx[:context]] }
+    launcher = Wurk::Launcher.new(@config)
+    managers_raising_on_stop(launcher, 'redis down mid-drain')
+    record_teardown(launcher)
+
+    launcher.stop
+
+    assert_includes reported, ['redis down mid-drain', 'launcher-stop-manager']
+  end
+
+  # A Redis blip in one release must not strand the ones after it: the leader
+  # CAS release is the likeliest to fail, and it sits right before the heartbeat
+  # clear that takes us out of the live `processes` SET.
+  def test_stop_releases_heartbeat_and_health_server_when_leader_release_raises
+    @config[:timeout] = 0
+    launcher = Wurk::Launcher.new(@config)
+    silence_managers(launcher)
+    seen = record_teardown(launcher)
+    launcher.instance_variable_get(:@leader).define_singleton_method(:stop) { raise 'CAS release failed' }
+
+    launcher.stop
+
+    assert_equal %i[cron_poller metrics_rollup queue_rollup reaper heartbeat exit health], seen
+  end
+
+  def test_stop_closes_the_health_server_when_clearing_the_heartbeat_raises
+    @config[:timeout] = 0
+    launcher = Wurk::Launcher.new(@config)
+    silence_managers(launcher)
+    seen = record_teardown(launcher)
+    launcher.instance_variable_get(:@heartbeat).define_singleton_method(:stop!) { raise 'redis down' }
+
+    launcher.stop
+
+    assert_includes seen, :health, 'a failed heartbeat clear must not leak the probe listener'
+    assert_includes seen, :exit
+  end
+
   def test_stop_fires_shutdown_then_exit_in_reverse
     order = []
     @config.on(:shutdown) { order << :shutdown_first }
@@ -487,7 +544,7 @@ class LauncherTest < Wurk::Test::UnitCase
     launcher.stop
 
     assert hb_stopped, 'clear_heartbeat must stop! a live heartbeat'
-    assert health_stopped, 'clear_heartbeat must stop a present health server'
+    assert health_stopped, 'stop must close a present health server'
   end
 
   # --- flush_stats -----------------------------------------------------
@@ -859,6 +916,40 @@ class LauncherTest < Wurk::Test::UnitCase
     launcher.instance_variable_get(:@leader).define_singleton_method(:start) { nil }
     # Don't spawn the real cron tick thread (it would poll Redis on a timer).
     launcher.cron_poller.define_singleton_method(:start) { nil }
+  end
+
+  # Stubs every collaborator #stop's teardown tail touches and records, in
+  # order, the ones that actually ran — so a test can assert the tail completed
+  # end to end under an injected failure. @history stays nil (history is opt-in),
+  # which also covers the safe-nav else branch in the timer-loop sweep.
+  def record_teardown(launcher)
+    seen = []
+    %i[cron_poller metrics_rollup queue_rollup].each do |name|
+      record_stop(launcher.public_send(name), :terminate, seen, name)
+    end
+    record_stop(launcher.instance_variable_get(:@reaper), :stop, seen, :reaper)
+    record_stop(launcher.instance_variable_get(:@leader), :stop, seen, :leader)
+    record_heartbeat_and_health(launcher, seen)
+    @config.on(:exit) { seen << :exit }
+    seen
+  end
+
+  def record_heartbeat_and_health(launcher, seen)
+    launcher.define_singleton_method(:flush_stats) { nil }
+    launcher.instance_variable_set(:@heartbeat, record_stop(Object.new, :stop!, seen, :heartbeat))
+    launcher.instance_variable_set(:@health_server, record_stop(Object.new, :stop, seen, :health))
+  end
+
+  def record_stop(target, message, seen, label)
+    target.define_singleton_method(message) { seen << label }
+    target
+  end
+
+  def managers_raising_on_stop(launcher, message)
+    launcher.managers.each do |m|
+      m.define_singleton_method(:quiet) { nil }
+      m.define_singleton_method(:stop) { |_d| raise message }
+    end
   end
 
   def silence_managers(launcher)

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -10,6 +10,10 @@ require_relative '../test_helper'
 class LauncherTest < Wurk::Test::UnitCase
   parallelize_me!
 
+  # BOOT_RECLAIM_JOIN_TIMEOUT is process-global; the two tests that depend on
+  # its value (one shortens it) must not overlap under the parallel runner.
+  BOOT_RECLAIM_TIMEOUT_LOCK = ::Mutex.new
+
   def setup
     super
     @ns = "lt-#{Process.pid}-#{object_id}"
@@ -501,49 +505,47 @@ class LauncherTest < Wurk::Test::UnitCase
   # A9: the boot-time reclaim sweep started as a fire-and-forget thread in
   # #run — #stop must join it before returning so a straggling scan doesn't
   # keep running (and touching Redis) after the launcher is torn down.
+  #
+  # Serialized against the test below: this class is parallelize_me!, and that
+  # test shortens the process-global BOOT_RECLAIM_JOIN_TIMEOUT — under which
+  # this test's 0.05s reclaim thread would race its own join bound.
   def test_stop_joins_the_boot_reclaim_thread
-    @config[:timeout] = 0
-    launcher = Wurk::Launcher.new(@config)
-    silence_managers(launcher)
-    finished = false
-    launcher.instance_variable_set(:@boot_reclaim_thread, Thread.new do
-      sleep 0.05
-      finished = true
-    end)
+    with_boot_reclaim_join_timeout do
+      @config[:timeout] = 0
+      launcher = Wurk::Launcher.new(@config)
+      silence_managers(launcher)
+      finished = false
+      launcher.instance_variable_set(:@boot_reclaim_thread, Thread.new do
+        sleep 0.05
+        finished = true
+      end)
 
-    launcher.stop
+      launcher.stop
 
-    assert finished, '#stop must join the boot-reclaim thread before returning'
+      assert finished, '#stop must join the boot-reclaim thread before returning'
+    end
   end
 
   # A9: bounded so a still-scanning full-keyspace sweep can't hang shutdown
   # forever — the join gives up after BOOT_RECLAIM_JOIN_TIMEOUT and lets
   # teardown continue.
   def test_stop_does_not_hang_when_boot_reclaim_outlives_the_join_timeout
-    @config[:timeout] = 0
-    launcher = Wurk::Launcher.new(@config)
-    silence_managers(launcher)
+    thread = nil
     gate = Queue.new
-    thread = Thread.new { gate.pop }
-    launcher.instance_variable_set(:@boot_reclaim_thread, thread)
-    original = Wurk::Launcher::BOOT_RECLAIM_JOIN_TIMEOUT
-    with_warnings(nil) { Wurk::Launcher.const_set(:BOOT_RECLAIM_JOIN_TIMEOUT, 0.05) }
+    with_boot_reclaim_join_timeout(0.05) do
+      @config[:timeout] = 0
+      launcher = Wurk::Launcher.new(@config)
+      silence_managers(launcher)
+      thread = Thread.new { gate.pop }
+      launcher.instance_variable_set(:@boot_reclaim_thread, thread)
 
-    launcher.stop
+      launcher.stop
 
-    assert_predicate launcher, :stopping?
+      assert_predicate launcher, :stopping?
+    end
   ensure
     gate << true
     thread&.join(1)
-    with_warnings(nil) { Wurk::Launcher.const_set(:BOOT_RECLAIM_JOIN_TIMEOUT, original) } if original
-  end
-
-  def with_warnings(level)
-    prev = $VERBOSE
-    $VERBOSE = level
-    yield
-  ensure
-    $VERBOSE = prev
   end
 
   # A8: an embedded host (Puma, a rake task) keeps running after #stop and may
@@ -1073,6 +1075,36 @@ class LauncherTest < Wurk::Test::UnitCase
   end
 
   private
+
+  # Takes the lock for every test whose outcome depends on the process-global
+  # BOOT_RECLAIM_JOIN_TIMEOUT, and (when `seconds` is given) shortens it for
+  # the duration of the block. Without the lock a shortened bound would leak
+  # into the sibling test running concurrently under parallelize_me!.
+  def with_boot_reclaim_join_timeout(seconds = nil)
+    BOOT_RECLAIM_TIMEOUT_LOCK.synchronize do
+      return yield unless seconds
+
+      original = Wurk::Launcher::BOOT_RECLAIM_JOIN_TIMEOUT
+      begin
+        swap_boot_reclaim_join_timeout(seconds)
+        yield
+      ensure
+        swap_boot_reclaim_join_timeout(original)
+      end
+    end
+  end
+
+  def swap_boot_reclaim_join_timeout(seconds)
+    with_warnings(nil) { Wurk::Launcher.const_set(:BOOT_RECLAIM_JOIN_TIMEOUT, seconds) }
+  end
+
+  def with_warnings(level)
+    prev = $VERBOSE
+    $VERBOSE = level
+    yield
+  ensure
+    $VERBOSE = prev
+  end
 
   # Builds a Launcher with an identity unique to this test, so parallel
   # tests can't collide on the global `processes` SET.

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -22,9 +22,13 @@ class LauncherTest < Wurk::Test::UnitCase
     @config[:tag] = @ns
     @pool = cap.redis_pool
     @cleanup_keys = []
+    @threads = []
   end
 
   def teardown
+    # Before the key sweep, not after: a heartbeat thread left running would
+    # SADD its identity back in behind us.
+    @threads.each(&:kill)
     @pool.with do |c|
       @cleanup_keys.each do |k|
         c.call('SREM', Wurk::Keys::PROCESSES, k) if k.start_with?("host-#{@ns}")
@@ -243,7 +247,6 @@ class LauncherTest < Wurk::Test::UnitCase
     assert_kind_of Thread, thread
     assert_equal 'heartbeat', thread.name
   ensure
-    launcher.instance_variable_set(:@done, true)
     thread&.kill
   end
 
@@ -376,21 +379,12 @@ class LauncherTest < Wurk::Test::UnitCase
   end
 
   # Regression #236: the heartbeat survives quiet, so #stop is now what tears the
-  # thread down — via stop_heartbeat (flip @stopped + wake the sleeping loop).
+  # thread down — via stop_heartbeat (terminate the beat timer, then join).
   def test_stop_terminates_the_heartbeat_thread
     @config[:timeout] = 0
     launcher = build_isolated_launcher
-    launcher.managers.each do |m|
-      m.define_singleton_method(:start) { nil }
-      m.define_singleton_method(:quiet) { nil }
-      m.define_singleton_method(:stop) { |_d| nil }
-    end
+    silence_boot(launcher)
     silence_beat(launcher)
-    launcher.poller = launcher.cron_poller = launcher.metrics_rollup = launcher.queue_rollup = launcher.history = nil
-    launcher.instance_variable_set(:@leader, nil)
-    reaper = launcher.instance_variable_get(:@reaper)
-    reaper.define_singleton_method(:start) { nil }
-    reaper.define_singleton_method(:stop) { nil }
     track(launcher_identity(launcher))
 
     launcher.run(async_beat: true)
@@ -401,6 +395,53 @@ class LauncherTest < Wurk::Test::UnitCase
     launcher.stop
 
     refute_predicate thread, :alive?, 'stop must terminate the heartbeat thread (#236)'
+  end
+
+  # TimerLoop#run waits before its first yield; the heartbeat deliberately does
+  # not inherit that. A process the dashboard cannot see for a whole BEAT_PAUSE
+  # after boot is a process that looks dead while it is already taking jobs.
+  def test_first_beat_does_not_wait_out_the_interval
+    launcher = build_isolated_launcher
+    silence_boot(launcher)
+    beats = Queue.new
+    launcher.define_singleton_method(:heartbeat) { beats << true }
+    track(launcher_identity(launcher))
+
+    launcher.run(async_beat: true)
+
+    assert beats.pop(timeout: 5), "the first beat must not wait out BEAT_PAUSE (#{Wurk::Launcher::BEAT_PAUSE}s)"
+  ensure
+    launcher&.send(:stop_heartbeat)
+  end
+
+  # F11: `Thread#wakeup` does nothing to a thread that isn't sleeping, so a beat
+  # caught mid-Redis-call swallowed the wake, slept a full interval, and outlived
+  # the bounded join. stop_heartbeat must not return while the loop is still live.
+  def test_stop_heartbeat_waits_out_a_beat_that_is_already_running
+    launcher, thread, gate = boot_with_a_beat_in_flight
+
+    stopper = track_thread(Thread.new { launcher.send(:stop_heartbeat) })
+    sleep 0.1 # the stop signal now lands on a beat in flight, not on a sleeping thread
+    gate << true
+
+    assert stopper.join(2), 'stop_heartbeat must not wait out a whole beat interval'
+    refute_predicate thread, :alive?, 'stop_heartbeat must not return with the beat loop still live'
+  end
+
+  # The reason the ordering exists: a beat that lands mid-shutdown must finish
+  # before clear_heartbeat SREMs us, or the SADD wins and the dead process haunts
+  # the `processes` SET until its 60s TTL expires.
+  def test_stop_does_not_let_an_in_flight_beat_resurrect_the_identity
+    @config[:timeout] = 0
+    launcher, _thread, gate = boot_with_a_beat_in_flight
+
+    stopper = track_thread(Thread.new { launcher.stop })
+    sleep 0.1
+    gate << true # the released beat SADDs the identity while #stop is tearing down
+
+    assert stopper.join(5), 'stop must not outlive the heartbeat thread'
+    assert_equal 0, listed?(launcher_identity(launcher)),
+                 'a beat landing during shutdown must not resurrect the identity'
   end
 
   # --- stop ------------------------------------------------------------
@@ -980,6 +1021,11 @@ class LauncherTest < Wurk::Test::UnitCase
     @cleanup_keys << key
   end
 
+  def track_thread(thread)
+    @threads << thread
+    thread
+  end
+
   def stub_managers(launcher)
     launcher.managers.each { |m| m.define_singleton_method(:start) { nil } }
     # Don't campaign for the global `dear-leader` lock during unit run-tests.
@@ -1032,6 +1078,46 @@ class LauncherTest < Wurk::Test::UnitCase
 
   def silence_beat(launcher)
     launcher.define_singleton_method(:heartbeat) { nil }
+  end
+
+  # Boots an isolated launcher whose first beat blocks partway through, and
+  # returns it with its live heartbeat thread and the gate that releases the
+  # beat. This is the state `Thread#wakeup` was lost in: the thread sits inside
+  # a beat rather than sleeping between two of them.
+  def boot_with_a_beat_in_flight
+    launcher = build_isolated_launcher
+    silence_boot(launcher)
+    track(launcher_identity(launcher))
+    entered = Queue.new
+    gate = Queue.new
+    beat = launcher.method(:heartbeat)
+    launcher.define_singleton_method(:heartbeat) do
+      entered << true
+      gate.pop
+      beat.call
+    end
+    launcher.run(async_beat: true)
+
+    assert entered.pop(timeout: 5), 'the heartbeat thread should have entered its first beat'
+
+    [launcher, track_thread(launcher.heartbeat_thread), gate]
+  end
+
+  # Neuters every collaborator #run starts and #stop tears down, so a test can
+  # drive the real boot/shutdown path with the heartbeat thread as the only
+  # live moving part.
+  def silence_boot(launcher)
+    launcher.managers.each do |m|
+      m.define_singleton_method(:start) { nil }
+      m.define_singleton_method(:quiet) { nil }
+      m.define_singleton_method(:stop) { |_d| nil }
+    end
+    launcher.poller = launcher.cron_poller = launcher.metrics_rollup = launcher.queue_rollup = launcher.history = nil
+    launcher.instance_variable_set(:@leader, nil)
+    reaper = launcher.instance_variable_get(:@reaper)
+    reaper.define_singleton_method(:start) { nil }
+    reaper.define_singleton_method(:stop) { nil }
+    reaper.define_singleton_method(:reclaim!) { nil }
   end
 
   # The poller is the first thing #run starts, so nothing else comes up before

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -498,6 +498,85 @@ class LauncherTest < Wurk::Test::UnitCase
     assert stopped, 'stop should halt the reaper thread'
   end
 
+  # A9: the boot-time reclaim sweep started as a fire-and-forget thread in
+  # #run — #stop must join it before returning so a straggling scan doesn't
+  # keep running (and touching Redis) after the launcher is torn down.
+  def test_stop_joins_the_boot_reclaim_thread
+    @config[:timeout] = 0
+    launcher = Wurk::Launcher.new(@config)
+    silence_managers(launcher)
+    finished = false
+    launcher.instance_variable_set(:@boot_reclaim_thread, Thread.new do
+      sleep 0.05
+      finished = true
+    end)
+
+    launcher.stop
+
+    assert finished, '#stop must join the boot-reclaim thread before returning'
+  end
+
+  # A9: bounded so a still-scanning full-keyspace sweep can't hang shutdown
+  # forever — the join gives up after BOOT_RECLAIM_JOIN_TIMEOUT and lets
+  # teardown continue.
+  def test_stop_does_not_hang_when_boot_reclaim_outlives_the_join_timeout
+    @config[:timeout] = 0
+    launcher = Wurk::Launcher.new(@config)
+    silence_managers(launcher)
+    gate = Queue.new
+    thread = Thread.new { gate.pop }
+    launcher.instance_variable_set(:@boot_reclaim_thread, thread)
+    original = Wurk::Launcher::BOOT_RECLAIM_JOIN_TIMEOUT
+    with_warnings(nil) { Wurk::Launcher.const_set(:BOOT_RECLAIM_JOIN_TIMEOUT, 0.05) }
+
+    launcher.stop
+
+    assert_predicate launcher, :stopping?
+  ensure
+    gate << true
+    thread&.join(1)
+    with_warnings(nil) { Wurk::Launcher.const_set(:BOOT_RECLAIM_JOIN_TIMEOUT, original) } if original
+  end
+
+  def with_warnings(level)
+    prev = $VERBOSE
+    $VERBOSE = level
+    yield
+  ensure
+    $VERBOSE = prev
+  end
+
+  # A8: an embedded host (Puma, a rake task) keeps running after #stop and may
+  # `run` again later — without disconnecting here a stop-then-run cycle
+  # doubles the live socket set.
+  def test_stop_disconnects_redis_pools_when_embedded
+    @config[:timeout] = 0
+    launcher = build_isolated_launcher(embedded: true)
+    silence_managers(launcher)
+    track(launcher_identity(launcher))
+    reset = false
+    @config.define_singleton_method(:reset_redis_pools!) { reset = true }
+
+    launcher.stop
+
+    assert reset, 'embedded #stop must disconnect the Redis pools'
+  end
+
+  # A8: a swarm child or standalone process exits right after #stop anyway —
+  # disconnecting here would just force every subsequent Redis touch (this
+  # test's own teardown included) to silently rebuild a pool for nothing.
+  def test_stop_leaves_redis_pools_connected_when_not_embedded
+    @config[:timeout] = 0
+    launcher = Wurk::Launcher.new(@config)
+    silence_managers(launcher)
+    reset = false
+    @config.define_singleton_method(:reset_redis_pools!) { reset = true }
+
+    launcher.stop
+
+    refute reset, 'non-embedded #stop must not disconnect the Redis pools'
+  end
+
   # Branch coverage: #stop's safe-nav teardown of the cron poller, metrics
   # rollup, reaper, and leader must each tolerate a nil collaborator.
   # Exercises the else side of lines 115–117 and 120.

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -264,6 +264,38 @@ class LauncherTest < Wurk::Test::UnitCase
     assert_predicate @config, :frozen?
   end
 
+  # A4: boot is not atomic. A step that raises leaves everything before it
+  # holding threads, sockets and a leader campaign — and the caller is about to
+  # drop its only reference to the launcher, so #run unwinds on the way out.
+  def test_run_rolls_back_the_partial_boot_when_a_component_start_raises
+    @config[:timeout] = 0
+    launcher = Wurk::Launcher.new(@config)
+    silence_managers(launcher)
+    silence_beat(launcher)
+    seen = record_teardown(launcher)
+    fail_first_boot_step(launcher, 'redis down at boot')
+
+    err = assert_raises(RuntimeError) { launcher.run(async_beat: false) }
+
+    assert_equal 'redis down at boot', err.message, 'the boot failure must still reach the caller'
+    assert_equal %i[cron_poller metrics_rollup queue_rollup reaper leader heartbeat exit health], seen
+  end
+
+  # The rollback is guarded: a launcher that cannot tear itself down must still
+  # raise why the boot failed, not why the cleanup did.
+  def test_run_reports_a_failing_rollback_and_raises_the_boot_error
+    @config[:timeout] = 0
+    launcher = Wurk::Launcher.new(@config)
+    reported = capture_reported_errors
+    fail_first_boot_step(launcher, 'redis down at boot')
+    launcher.define_singleton_method(:stop) { raise 'rollback exploded' }
+
+    err = assert_raises(RuntimeError) { launcher.run(async_beat: false) }
+
+    assert_equal 'redis down at boot', err.message
+    assert_includes reported, ['rollback exploded', 'launcher-stop-boot-rollback']
+  end
+
   # --- quiet -----------------------------------------------------------
 
   def test_quiet_flips_stopping_and_quiets_managers
@@ -962,6 +994,18 @@ class LauncherTest < Wurk::Test::UnitCase
 
   def silence_beat(launcher)
     launcher.define_singleton_method(:heartbeat) { nil }
+  end
+
+  # The poller is the first thing #run starts, so nothing else comes up before
+  # the boot fails — the rollback is asserted against a known-small partial boot.
+  def fail_first_boot_step(launcher, message)
+    launcher.poller.define_singleton_method(:start) { raise message }
+  end
+
+  def capture_reported_errors
+    reported = []
+    @config.error_handlers << ->(ex, ctx, _cfg) { reported << [ex.message, ctx[:context]] }
+    reported
   end
 
   # redis-client returns HGETALL as either a Hash or a flat Array

--- a/test/unit/manager_test.rb
+++ b/test/unit/manager_test.rb
@@ -204,48 +204,63 @@ class ManagerTest < Wurk::Test::UnitCase
   end
 
   # A replacement that can't be spawned (Processor.new raising) must escalate
-  # to a visible crash on the main thread — not silently drop concurrency.
-  def test_processor_result_crashes_child_when_replacement_cannot_spawn # rubocop:disable Minitest/MultipleAssertions,Metrics/AbcSize
-    mgr = Wurk::Manager.new(@capsule)
+  # through the owner's shutdown request — not silently drop concurrency.
+  def test_processor_result_requests_shutdown_when_replacement_cannot_spawn # rubocop:disable Minitest/MultipleAssertions,Metrics/AbcSize
+    requested = 0
+    mgr = Wurk::Manager.new(@capsule, shutdown: -> { requested += 1 })
     silence_processors(mgr)
     victim = mgr.workers.first
-    target, crashes = crash_target
-    mgr.define_singleton_method(:main_thread) { target }
     reported = capture_error_handler
 
     boom = ThreadError.new('cannot create thread')
     with_processor_new_raising(boom) { mgr.processor_result(victim) }
 
-    assert_same boom, crashes.pop, 'must escalate to a crash on the main thread'
+    assert_equal 1, requested, 'must ask the owner to shut the process down'
     assert_equal [boom], reported.map(&:first), 'must report via handle_exception'
     refute_includes mgr.workers, victim
     assert_equal 2, mgr.workers.size, 'no silent replacement on failure'
-  ensure
-    target&.kill
   end
 
   # Same escalation when the replacement is built but its thread won't start.
-  def test_processor_result_crashes_child_when_replacement_start_raises # rubocop:disable Metrics/AbcSize
-    mgr = Wurk::Manager.new(@capsule)
+  def test_processor_result_requests_shutdown_when_replacement_start_raises
+    requested = 0
+    mgr = Wurk::Manager.new(@capsule, shutdown: -> { requested += 1 })
     silence_processors(mgr)
     victim = mgr.workers.first
-    target, crashes = crash_target
-    mgr.define_singleton_method(:main_thread) { target }
 
     boom = ThreadError.new('start failed')
     exploding = Object.new.tap { |p| p.define_singleton_method(:start) { raise boom } }
     with_processor_new(exploding) { mgr.processor_result(victim) }
 
-    assert_same boom, crashes.pop
+    assert_equal 1, requested
     refute_includes mgr.workers, victim
-  ensure
-    target&.kill
   end
 
-  def test_main_thread_seam_targets_the_process_main_thread
-    mgr = Wurk::Manager.new(@capsule)
+  # A7: the escalation used to be `Thread.main.raise`, which unwound past #stop
+  # (nothing bulk_requeued) and killed the host's main thread when embedded. It
+  # must stay a plain call on the dying Processor's own thread.
+  def test_processor_result_escalation_does_not_raise_to_the_caller
+    mgr = Wurk::Manager.new(@capsule, shutdown: -> {})
+    silence_processors(mgr)
+    victim = mgr.workers.first
 
-    assert_same Thread.main, mgr.send(:main_thread)
+    with_processor_new_raising(ThreadError.new('nope')) do
+      assert_nil mgr.processor_result(victim)
+    end
+  end
+
+  # Sidekiq's `Manager.new(capsule)` arity stays valid (the Sidekiq::Manager
+  # alias). With no owner there is no route to take — report and carry on.
+  def test_processor_result_without_a_shutdown_route_only_reports
+    mgr = Wurk::Manager.new(@capsule)
+    silence_processors(mgr)
+    victim = mgr.workers.first
+    reported = capture_error_handler
+
+    boom = ThreadError.new('cannot create thread')
+    with_processor_new_raising(boom) { mgr.processor_result(victim) }
+
+    assert_equal [boom], reported.map(&:first)
   end
 
   # --- stop / hard_shutdown -------------------------------------------
@@ -427,21 +442,6 @@ class ManagerTest < Wurk::Test::UnitCase
     yield
   ensure
     sc.define_method(:new) { |*a, &b| original.call(*a, &b) }
-  end
-
-  # A parked thread standing in for the process main thread, so a crash
-  # escalation (`main_thread.raise`) can be observed instead of taking down
-  # the test runner. Returns [thread, queue-of-caught-exceptions].
-  def crash_target
-    caught = Queue.new
-    t = Thread.new do
-      Thread.current.report_on_exception = false
-      sleep 5
-    rescue StandardError => e
-      caught << e
-    end
-    Thread.pass until t.status == 'sleep'
-    [t, caught]
   end
 
   # Register a recording error handler and return the array it appends to.

--- a/test/unit/manager_test.rb
+++ b/test/unit/manager_test.rb
@@ -270,6 +270,7 @@ class ManagerTest < Wurk::Test::UnitCase
   def test_stop_returns_after_drain_without_hard_shutdown
     mgr = Wurk::Manager.new(@capsule)
     silence_processors(mgr)
+    live = pretend_running(mgr)
     # Simulate workers draining during the poll.
     mgr.define_singleton_method(:wait_for) { |_deadline| @workers.clear }
 
@@ -281,13 +282,18 @@ class ManagerTest < Wurk::Test::UnitCase
 
     refute hard_shutdown_ran, 'hard_shutdown must be skipped when workers drained'
     assert_empty mgr.workers
+  ensure
+    live&.kill
   end
 
+  # The workers have to look *running* to reach hard_shutdown: a processor with
+  # no thread was never started, and #stop no longer waits on those at all.
   def test_stop_calls_capsule_stop_even_when_hard_shutdown_runs
     mgr = Wurk::Manager.new(@capsule)
     silence_processors(mgr)
+    live = pretend_running(mgr)
     mgr.workers.each do |w|
-      w.define_singleton_method(:kill) { nil }
+      w.define_singleton_method(:kill) { live.kill }
       w.define_singleton_method(:job) { nil }
     end
     capsule_stopped = false
@@ -296,6 +302,24 @@ class ManagerTest < Wurk::Test::UnitCase
     mgr.stop(::Process.clock_gettime(::Process::CLOCK_MONOTONIC) - 5)
 
     assert capsule_stopped
+  ensure
+    live&.kill
+  end
+
+  # A4: a launcher that raises mid-boot rolls back before Manager#start ever
+  # ran. Those processors hold no thread, so they never run the callback that
+  # removes them from @workers — polling for the Set to empty would burn the
+  # whole shutdown deadline inside a web process's after_initialize.
+  def test_stop_does_not_wait_out_the_deadline_for_processors_that_never_started
+    mgr = Wurk::Manager.new(@capsule)
+    silence_processors(mgr)
+    @capsule.define_singleton_method(:stop) { nil }
+    started = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+
+    mgr.stop(started + 10)
+    elapsed = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) - started
+
+    assert_operator elapsed, :<, 5, "stop waited #{elapsed.round(1)}s on processors that were never started"
   end
 
   def test_hard_shutdown_bulk_requeues_inflight_jobs_then_kills_threads # rubocop:disable Metrics/AbcSize
@@ -371,6 +395,15 @@ class ManagerTest < Wurk::Test::UnitCase
   # kill real (un-started) threads.
   def silence_processors(mgr)
     mgr.workers.each { |w| w.define_singleton_method(:terminate) { nil } }
+  end
+
+  # #stop only waits on processors that hold a live thread — a never-started
+  # one is nothing to drain. Hand every worker the same stand-in so the drain
+  # poll behaves as if the manager really booted; returns it for the teardown.
+  def pretend_running(mgr)
+    live = Thread.new { sleep }
+    mgr.workers.each { |w| w.define_singleton_method(:thread) { live } }
+    live
   end
 
   # Minitest 6 dropped minitest/mock; this hand-rolled stub temporarily

--- a/test/unit/metrics_queue_rollup_test.rb
+++ b/test/unit/metrics_queue_rollup_test.rb
@@ -169,6 +169,24 @@ class MetricsQueueRollupTest < Wurk::Test::UnitCase
     qr&.terminate
   end
 
+  # The flip side of re-arming: a sample wedged past JOIN_TIMEOUT (Thread#join
+  # returns nil) must keep @thread set, so the next #start returns it instead of
+  # resetting the shared timer under it and double-writing the same buckets.
+  def test_terminate_keeps_a_thread_that_outlives_the_join
+    qr = loop_queue_rollup
+    qr.define_singleton_method(:leader?) { false }
+
+    thread = qr.start
+    thread.define_singleton_method(:join) { |_timeout = nil| nil }
+    qr.terminate
+
+    assert_same thread, qr.instance_variable_get(:@thread), 'a wedged thread must stay tracked'
+    assert_same thread, qr.start, 'start must not spawn a second thread alongside it'
+  ensure
+    qr&.instance_variable_set(:@thread, nil)
+    thread&.kill
+  end
+
   private
 
   # A QueueRollup on a throwaway config with a tick interval short enough that

--- a/test/unit/metrics_queue_rollup_test.rb
+++ b/test/unit/metrics_queue_rollup_test.rb
@@ -137,7 +137,48 @@ class MetricsQueueRollupTest < Wurk::Test::UnitCase
   end
   # rubocop:enable Metrics/AbcSize
 
+  # terminate is a barrier: the launcher releases the cluster lock right after
+  # it returns, so a sample still in flight would write the same buckets as the
+  # next leader's first one.
+  def test_terminate_joins_and_clears_the_thread
+    qr = loop_queue_rollup
+    qr.define_singleton_method(:leader?) { false }
+
+    thread = qr.start
+    qr.terminate
+
+    refute_predicate thread, :alive?, 'terminate must join the sampling thread'
+    assert_nil qr.instance_variable_get(:@thread)
+  end
+
+  # A cleared @thread would be pointless if the timer stayed terminated —
+  # start has to re-arm it, not spawn a thread that exits immediately.
+  def test_start_after_terminate_samples_again
+    qr = loop_queue_rollup
+    qr.define_singleton_method(:leader?) { true }
+    qr.define_singleton_method(:sample) { |_now = ::Time.now| @ticks = (@ticks || 0) + 1 }
+
+    qr.start
+    qr.terminate
+    qr.instance_variable_set(:@ticks, 0)
+    qr.start
+    poll_until(2.0) { qr.instance_variable_get(:@ticks).positive? }
+
+    assert_operator qr.instance_variable_get(:@ticks), :>, 0
+  ensure
+    qr&.terminate
+  end
+
   private
+
+  # A QueueRollup on a throwaway config with a tick interval short enough that
+  # the spawned loop body runs within the test window.
+  def loop_queue_rollup
+    config = Wurk::Configuration.new
+    config.logger = ::Logger.new(IO::NULL)
+    config[:metrics_rollup_interval] = 0.01
+    Wurk::Metrics::QueueRollup.new(config)
+  end
 
   def poll_until(timeout)
     deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + timeout

--- a/test/unit/metrics_rollup_test.rb
+++ b/test/unit/metrics_rollup_test.rb
@@ -121,6 +121,38 @@ class MetricsRollupTest < Wurk::Test::UnitCase
   end
   # rubocop:enable Metrics/AbcSize
 
+  # terminate is a barrier: the launcher releases the cluster lock right after
+  # it returns, so a roll still in flight would write the same buckets as the
+  # next leader's first one.
+  def test_terminate_joins_and_clears_the_thread
+    rollup = loop_rollup
+    rollup.define_singleton_method(:leader?) { false }
+
+    thread = rollup.start
+    rollup.terminate
+
+    refute_predicate thread, :alive?, 'terminate must join the rollup thread'
+    assert_nil rollup.instance_variable_get(:@thread)
+  end
+
+  # A cleared @thread would be pointless if the timer stayed terminated —
+  # start has to re-arm it, not spawn a thread that exits immediately.
+  def test_start_after_terminate_rolls_again
+    rollup = loop_rollup
+    rollup.define_singleton_method(:leader?) { true }
+    rollup.define_singleton_method(:roll) { |_now = ::Time.now| @ticks = (@ticks || 0) + 1 }
+
+    rollup.start
+    rollup.terminate
+    rollup.instance_variable_set(:@ticks, 0)
+    rollup.start
+    poll_until(2.0) { rollup.instance_variable_get(:@ticks).positive? }
+
+    assert_operator rollup.instance_variable_get(:@ticks), :>, 0
+  ensure
+    rollup&.terminate
+  end
+
   # `TimerLoop#wait` short-circuits the ConditionVariable wait once terminated
   # (the `unless @done` else branch) so terminate-then-wait returns at once.
   # Mutex/CV mechanics live in Wurk::TimerLoop now (test/unit/timer_loop_test.rb);
@@ -180,6 +212,15 @@ class MetricsRollupTest < Wurk::Test::UnitCase
   end
 
   private
+
+  # A Rollup on a throwaway config with a tick interval short enough that the
+  # spawned loop body runs within the test window.
+  def loop_rollup
+    config = Wurk::Configuration.new
+    config.logger = ::Logger.new(IO::NULL)
+    config[:metrics_rollup_interval] = 0.01
+    Wurk::Metrics::Rollup.new(config)
+  end
 
   def poll_until(timeout)
     deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + timeout

--- a/test/unit/metrics_rollup_test.rb
+++ b/test/unit/metrics_rollup_test.rb
@@ -153,6 +153,24 @@ class MetricsRollupTest < Wurk::Test::UnitCase
     rollup&.terminate
   end
 
+  # The flip side of re-arming: a roll wedged past JOIN_TIMEOUT (Thread#join
+  # returns nil) must keep @thread set, so the next #start returns it instead of
+  # resetting the shared timer under it and double-writing the same buckets.
+  def test_terminate_keeps_a_thread_that_outlives_the_join
+    rollup = loop_rollup
+    rollup.define_singleton_method(:leader?) { false }
+
+    thread = rollup.start
+    thread.define_singleton_method(:join) { |_timeout = nil| nil }
+    rollup.terminate
+
+    assert_same thread, rollup.instance_variable_get(:@thread), 'a wedged thread must stay tracked'
+    assert_same thread, rollup.start, 'start must not spawn a second thread alongside it'
+  ensure
+    rollup&.instance_variable_set(:@thread, nil)
+    thread&.kill
+  end
+
   # `TimerLoop#wait` short-circuits the ConditionVariable wait once terminated
   # (the `unless @done` else branch) so terminate-then-wait returns at once.
   # Mutex/CV mechanics live in Wurk::TimerLoop now (test/unit/timer_loop_test.rb);

--- a/test/unit/scheduled_poller_test.rb
+++ b/test/unit/scheduled_poller_test.rb
@@ -303,6 +303,24 @@ class ScheduledPollerTest < Wurk::Test::UnitCase
     assert completed
   end
 
+  # terminate is a barrier: Launcher#stop clears the heartbeat right after, so
+  # a sweep still in flight would promote jobs for a process that is gone.
+  def test_terminate_joins_and_clears_the_thread
+    @config[:scheduler_initial_wait] = 0.01
+    poller = Wurk::Scheduled::Poller.new(@config)
+    sweeps = Queue.new
+    poller.define_singleton_method(:enqueue) { sweeps << :s }
+
+    thread = poller.start
+    sweeps.pop(timeout: 5)
+    poller.terminate
+
+    refute_predicate thread, :alive?, 'terminate must join the scheduler thread'
+    assert_nil poller.instance_variable_get(:@thread)
+  ensure
+    thread&.kill
+  end
+
   private
 
   def build_poller_with_rng_and_count(rand_value:, process_count:)

--- a/test/unit/scheduled_poller_test.rb
+++ b/test/unit/scheduled_poller_test.rb
@@ -321,6 +321,27 @@ class ScheduledPollerTest < Wurk::Test::UnitCase
     thread&.kill
   end
 
+  # A sweep wedged past JOIN_TIMEOUT (Thread#join returns nil) must keep @thread
+  # set, so the next #start returns it rather than spawning a second scheduler
+  # thread alongside the one still promoting.
+  def test_terminate_keeps_a_thread_that_outlives_the_join
+    @config[:scheduler_initial_wait] = 0.01
+    poller = Wurk::Scheduled::Poller.new(@config)
+    sweeps = Queue.new
+    poller.define_singleton_method(:enqueue) { sweeps << :s }
+
+    thread = poller.start
+    sweeps.pop(timeout: 5)
+    thread.define_singleton_method(:join) { |_timeout = nil| nil }
+    poller.terminate
+
+    assert_same thread, poller.instance_variable_get(:@thread), 'a wedged thread must stay tracked'
+    assert_same thread, poller.start, 'start must not spawn a second thread alongside it'
+  ensure
+    poller&.instance_variable_set(:@thread, nil)
+    thread&.kill
+  end
+
   private
 
   def build_poller_with_rng_and_count(rand_value:, process_count:)

--- a/test/unit/timer_loop_test.rb
+++ b/test/unit/timer_loop_test.rb
@@ -88,6 +88,24 @@ class TimerLoopTest < Wurk::Test::UnitCase
     refute ticked, 'run must not tick if already terminated before the first wait'
   end
 
+  # Without #reset a host that stops then starts again would spawn a thread
+  # that sees the stale done flag and exits without ever ticking.
+  def test_reset_re_arms_a_terminated_loop
+    timer = Wurk::TimerLoop.new(0.01)
+    timer.terminate
+    timer.reset
+
+    ticks = 0
+    thread = Thread.new { timer.run { ticks += 1 } }
+    poll_until(2.0) { ticks.positive? }
+    timer.terminate
+    thread.join(2.0)
+
+    assert_operator ticks, :>, 0, 'reset must let run tick again'
+  ensure
+    thread&.kill
+  end
+
   private
 
   def poll_until(timeout)


### PR DESCRIPTION
## Summary
- `Launcher#stop`'s teardown tail runs fully under `ensure`; every release step is independently guarded (A2).
- Embedded partial boot rolls back; `at_exit` registers before `run` (A4).
- Manager spawn failure routes through the child TERM path instead of `Thread.main` (A7).
- TimerLoop components (`History`, `Metrics::Rollup`/`QueueRollup`, `Scheduled::Poller`, `Cron::Poller`) join + clear `@thread` on terminate (A12).
- Heartbeat stop uses Mutex+ConditionVariable instead of a lost `Thread#wakeup` (F11).
- `Launcher#stop` joins the boot-time reclaim thread (bounded) before the rest of teardown touches Redis (A9).
- Embedded `#stop` disconnects the config's Redis pools so a stop-then-run cycle in a long-lived host doesn't double the socket set; scoped to embedded only (A8).
- `ChildBoot#reconnect_after_fork` resets the memoized dogstatsd client so a forked child doesn't inherit the parent's UDP socket (A6).

## Test plan
- [x] `bin/rake test` — 2789 runs / 0 failures / 0 errors / 7 skips (x3 for targeted files)
- [x] `bundle exec rubocop` — 609/609 offenses (zero new)
- [x] `COVERAGE=1 bin/rake test` — line 96.81% / branch 90.4% (gate holds)
- [x] New unit tests confirmed failing before each fix, passing after

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788167550&installation_model_id=11168&pr_number=346&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F346&signature=af3bf7ec5a3a2b38126e15c2e5b28011c344e62ee70fe1d9475182cc75b93d1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown handling so background work stops cleanly within a bounded timeout.
  * Added recovery when embedded startup fails, preserving the original error while cleaning up partial launches.
  * Improved worker failure handling to request shutdown without unexpectedly raising errors.
  * Ensured forked workers use independent metrics connections.
* **Reliability**
  * Background polling, history, scheduling, and metrics tasks can now restart safely after termination.
  * Enhanced shutdown sequencing so cleanup continues even when individual components encounter errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->