### PR TITLE
fix(fetcher): pause backoff + interrupt re-push, with regression tests

### DIFF
--- a/lib/wurk/fetcher/reliable.rb
+++ b/lib/wurk/fetcher/reliable.rb
@@ -30,6 +30,13 @@ module Wurk
       # Default BLMOVE block timeout; overridable via config.fetch_poll_interval.
       TIMEOUT = 2
 
+      # Backoff for the quieted short-circuit. Manager#quiet terminates the
+      # shared fetcher before it terminates the processors, and Processor#run
+      # loops on its *own* flag — so in that window every processor would spin
+      # on an instant nil. Kept below Manager::PAUSE_TIME, which #stop sleeps
+      # immediately after #quiet, so this pause adds no drain latency.
+      QUIET_PAUSE = 0.05
+
       # Carries the public queue key, the raw (still-JSON) job payload,
       # and the capsule we use to reach Redis. ACK removes from the private
       # list; requeue pushes back to the public queue head so the job is
@@ -66,11 +73,26 @@ module Wurk
         @done = false
       end
 
+      # Every pass that yields no job has to cost wall-clock time: Processor#run
+      # drives `process_one` in a bare `until @done` loop with no pause of its
+      # own, so any nil returned instantly turns N processor threads into a hot
+      # loop. The blocking BLMOVE pays that cost on the normal empty-queue path;
+      # the two short-circuits below have to pay it themselves.
       def retrieve_work
-        return nil if @done
+        if @done
+          sleep QUIET_PAUSE
+          return nil
+        end
 
         queues = queues_cmd
-        return nil if queues.empty?
+        # Nothing fetchable — every queue paused, or none configured. Back off a
+        # full poll interval rather than re-running queues_cmd (an SMEMBERS per
+        # pass, on the main pool) as fast as the CPU allows. Mirrors Sidekiq's
+        # BasicFetch guard, upstream #4825.
+        if queues.empty?
+          sleep poll_interval
+          return nil
+        end
 
         queues.each do |public_q|
           uow = lmove(public_q)

--- a/lib/wurk/middleware/interrupt_handler.rb
+++ b/lib/wurk/middleware/interrupt_handler.rb
@@ -8,14 +8,15 @@ module Wurk
   module Middleware
     # Server middleware. Catches `Wurk::Job::Interrupted` raised by an
     # IterableJob mid-iteration (or any cooperatively-cancelled job),
-    # re-pushes the job to the head of its queue so it resumes from the
+    # re-pushes the job to the tail of its queue so it resumes from the
     # persisted cursor, and raises `Wurk::JobRetry::Skip` so the retry
     # layer treats this as a clean exit rather than an error.
     #
-    # The re-push uses LPUSH (head of queue) so the same job is the next
-    # one to be fetched after restart. The job JSON is unchanged: cursor
-    # state lives in the `it-<jid>` HASH (see IterableJob persistence),
-    # not in the payload.
+    # The re-push uses RPUSH (tail of queue) so the same job is the next
+    # one to be fetched: the fetcher's LMOVE pops from the RIGHT (tail),
+    # so this job is fetched ahead of fresh LPUSH'd enqueues. The job
+    # JSON is unchanged: cursor state lives in the `it-<jid>` HASH (see
+    # IterableJob persistence), not in the payload.
     #
     # Auto-registered at the top of the server chain when this file is
     # required. Top-of-chain is important: a downstream middleware must
@@ -36,7 +37,7 @@ module Wurk
 
       def repush(job, queue)
         payload = Wurk.dump_json(job)
-        redis_pool.with { |conn| conn.call('LPUSH', "queue:#{queue}", payload) }
+        redis_pool.with { |conn| conn.call('RPUSH', "queue:#{queue}", payload) }
       end
     end
   end

--- a/test/unit/fetcher_reliable_test.rb
+++ b/test/unit/fetcher_reliable_test.rb
@@ -64,6 +64,31 @@ class FetcherReliableTest < Wurk::Test::UnitCase
     assert_nil @fetcher.retrieve_work
   end
 
+  # Manager#quiet terminates the shared fetcher before it terminates the
+  # processors; Processor#run loops on its own flag, so the short-circuit has to
+  # pause or every processor spins for the width of that window.
+  def test_retrieve_work_pauses_on_the_quieted_short_circuit
+    @fetcher.terminate
+
+    took = elapsed { assert_nil @fetcher.retrieve_work }
+
+    assert_operator took, :>=, Wurk::Fetcher::Reliable::QUIET_PAUSE * 0.9
+  end
+
+  # Every queue paused → nothing to block on, so retrieve_work must back off a
+  # poll interval itself. Returning instantly hot-loops Processor#run and pays
+  # an SMEMBERS of the paused set on every pass (upstream Sidekiq #4825).
+  def test_retrieve_work_backs_off_a_poll_interval_when_no_queue_is_fetchable
+    @config.fetch_poll_interval = 0.2
+    Wurk::Queue.new(@queue_name).pause!
+
+    assert_empty @fetcher.queues_cmd
+
+    took = elapsed { assert_nil @fetcher.retrieve_work }
+
+    assert_operator took, :>=, 0.18
+  end
+
   # --- acknowledge / SIGKILL behavior ---------------------------------
 
   def test_acknowledge_removes_job_from_private_list
@@ -276,6 +301,13 @@ class FetcherReliableTest < Wurk::Test::UnitCase
     end
     @capsule.define_singleton_method(:fetch_redis) { |&blk| blk.call(conn) }
     box
+  end
+
+  # Monotonic wall-clock cost of the block, in seconds.
+  def elapsed
+    started = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+    yield
+    ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) - started
   end
 
   def private_queue

--- a/test/unit/interrupt_handler_test.rb
+++ b/test/unit/interrupt_handler_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Wurk::Middleware::InterruptHandler against real Redis and the real reliable
+# fetcher. MiddlewareBuiltinsTest already pins the wire shape (RPUSH cmd/key/
+# payload) against a fake pool; this proves the ordering effect that shape is
+# for: F7 regressed when the repush used LPUSH (head of queue) instead of
+# RPUSH (tail) — the interrupted job landed *behind* whatever backlog was
+# already sitting in the queue instead of being the very next fetch, since
+# the fetcher's LMOVE pops from the tail (RIGHT).
+#
+# Spec: docs/target/sidekiq-free.md §10.3 (IterableJob interrupt/resume).
+class InterruptHandlerTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @ns      = "irqh-#{Process.pid}-#{object_id}"
+    @qname   = "irqh-#{@ns}"
+    @rqname  = "queue:#{@qname}"
+    @config  = Wurk::Configuration.new
+    @capsule = Wurk::Capsule.new('test', @config)
+    @capsule.queues = [@qname]
+    @fetcher = Wurk::Fetcher::Reliable.new(@capsule)
+    @pool    = @capsule.redis_pool
+    @handler = Wurk::Middleware::InterruptHandler.new
+    @handler.config = @capsule
+  end
+
+  def teardown
+    @pool.with { |c| c.call('DEL', @rqname, private_queue) }
+  ensure
+    super
+  end
+
+  def test_repushed_job_is_fetched_before_older_backlog
+    seed_backlog('older-1', 'older-2')
+    interrupted_job = { 'class' => 'X', 'jid' => 'irqh-jid-1', 'args' => [] }
+
+    assert_raises(Wurk::JobRetry::Skip) do
+      @handler.call(nil, interrupted_job, @qname) { raise Wurk::Job::Interrupted }
+    end
+
+    uow = @fetcher.retrieve_work
+
+    refute_nil uow
+    assert_equal interrupted_job, ::JSON.parse(uow.job)
+  end
+
+  def test_older_backlog_is_still_fetched_after_the_repushed_job
+    seed_backlog('older-1')
+    interrupted_job = { 'class' => 'X', 'jid' => 'irqh-jid-2', 'args' => [] }
+
+    assert_raises(Wurk::JobRetry::Skip) do
+      @handler.call(nil, interrupted_job, @qname) { raise Wurk::Job::Interrupted }
+    end
+
+    first  = @fetcher.retrieve_work
+    second = @fetcher.retrieve_work
+
+    assert_equal interrupted_job, ::JSON.parse(first.job)
+    assert_equal 'older-1', ::JSON.parse(second.job)['args'].first
+  end
+
+  # A cooperatively-cancelled job raised while a fresh (non-interrupted)
+  # backlog job was LPUSH'd after it must still resume ahead of that fresh
+  # enqueue too, not just ahead of pre-existing backlog.
+  def test_repushed_job_is_fetched_before_a_fresh_enqueue_made_afterward
+    interrupted_job = { 'class' => 'X', 'jid' => 'irqh-jid-3', 'args' => [] }
+
+    assert_raises(Wurk::JobRetry::Skip) do
+      @handler.call(nil, interrupted_job, @qname) { raise Wurk::Job::Interrupted }
+    end
+    seed_backlog('fresh-after-repush')
+
+    uow = @fetcher.retrieve_work
+
+    refute_nil uow
+    assert_equal interrupted_job, ::JSON.parse(uow.job)
+  end
+
+  private
+
+  def seed_backlog(*payloads)
+    @pool.with do |c|
+      payloads.each do |p|
+        c.call('LPUSH', @rqname, ::Wurk.dump_json({ 'class' => 'Old', 'args' => [p] }))
+      end
+    end
+  end
+
+  def private_queue
+    Wurk::Fetcher::Reliable.private_queue_name(@rqname)
+  end
+end

--- a/test/unit/middleware_builtins_test.rb
+++ b/test/unit/middleware_builtins_test.rb
@@ -385,7 +385,7 @@ class MiddlewareBuiltinsTest < Wurk::Test::UnitCase
     assert_equal 1, calls.size
     cmd, key, payload = calls.first
 
-    assert_equal 'LPUSH', cmd
+    assert_equal 'RPUSH', cmd
     assert_equal 'queue:mine', key
     assert_equal job, ::JSON.parse(payload)
   end

--- a/test/unit/queue_pause_test.rb
+++ b/test/unit/queue_pause_test.rb
@@ -112,6 +112,28 @@ class QueuePauseTest < Wurk::Test::UnitCase
     capsule&.stop
   end
 
+  # F1 regression: with every queue paused, retrieve_work has nothing to
+  # BLMOVE on, so it must back off a full poll interval per pass rather than
+  # returning nil instantly. A caller that drives retrieve_work in a bare loop
+  # (Processor#run has no pause of its own) would otherwise turn this into a
+  # hot spin issuing one SMEMBERS per iteration as fast as the CPU allows —
+  # thousands of Redis round trips per second instead of a handful.
+  def test_fetcher_backs_off_with_bounded_redis_commands_when_all_paused
+    fetcher, capsule, counter = build_paused_fetcher_with_counter
+
+    results = drain_for_one_second(fetcher)
+
+    # Backed off at 0.05s/pass, ~1s of wall clock caps this well under 40
+    # passes; a hot spin (no backoff) would blow past this by orders of
+    # magnitude. One SMEMBERS per retrieve_work pass, so the Redis command
+    # count tracks 1:1 with the loop iteration count.
+    assert(results.all?(&:nil?))
+    assert_operator results.size, :<=, 40
+    assert_operator counter.count, :<=, 40
+  ensure
+    capsule&.stop
+  end
+
   def test_fetcher_skips_paused_queue_on_retrieve_work
     fetcher, capsule = build_fetcher(%W[#{@qname} #{@other}])
     @pool.with do |c|
@@ -164,6 +186,44 @@ class QueuePauseTest < Wurk::Test::UnitCase
       private_q = Wurk::Fetcher::Reliable.private_queue_name(@rqname)
       private_other = Wurk::Fetcher::Reliable.private_queue_name(@rotherq)
       c.call('DEL', private_q, private_other)
+    end
+  end
+
+  def monotonic_now
+    ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+  end
+
+  def drain_for_one_second(fetcher)
+    deadline = monotonic_now + 1.0
+    results = []
+    results << fetcher.retrieve_work while monotonic_now < deadline
+    results
+  end
+
+  def build_paused_fetcher_with_counter
+    fetcher, capsule = build_fetcher(%W[#{@qname} #{@other}])
+    capsule.config.fetch_poll_interval = 0.05
+    Wurk::Queue.new(@qname).pause!
+    Wurk::Queue.new(@other).pause!
+    counter = RedisCallCounter.new(capsule.redis_pool)
+    capsule.instance_variable_set(:@redis_pool, counter)
+    [fetcher, capsule, counter]
+  end
+
+  # Delegating pool that counts checkouts (one per `config.redis` block),
+  # swapped in for the capsule's real pool so a test can measure Redis round
+  # trips without a global monkeypatch. Mirrors WebSearchTest::RoundTripCounter.
+  class RedisCallCounter
+    attr_reader :count
+
+    def initialize(pool)
+      @pool = pool
+      @count = 0
+    end
+
+    def with(&)
+      @count += 1
+      @pool.with(&)
     end
   end
 end


### PR DESCRIPTION
## Summary
- **F1**: `Fetcher::Reliable#retrieve_work` sleeps a full poll interval when every queue is paused/unfetchable, instead of hot-spinning an SMEMBERS per pass as fast as the CPU allows (Processor#run has no pause of its own).
- **F7**: `InterruptHandler` re-pushes an interrupted job via `RPUSH` (tail) instead of `LPUSH` (head), so the fetcher's tail-popping LMOVE fetches it next — ahead of any existing backlog.
- **Regression tests** (this PR's task): bound the Redis command count over 1s of real wall clock when all queues are paused (`queue_pause_test.rb`), and a new `interrupt_handler_test.rb` proving the re-pushed job is fetched before older backlog *and* before a fresh enqueue made afterward, against real Redis + the real reliable fetcher.

## Test plan
- [x] `bin/rake test TEST=test/unit/queue_pause_test.rb` — 15 runs, 0 failures (×3)
- [x] `bin/rake test TEST=test/unit/interrupt_handler_test.rb` — 3 runs, 0 failures (×3)
- [x] Fail-first verified: reverting each fix reproduces the exact regression (2981 Redis calls/s spin; interrupted job fetched after backlog)
- [x] `bin/rake test` full suite — 2800 runs, 0 failures/errors, 7 skips
- [x] `bundle exec rubocop` — 609 offenses, unchanged from main (0 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788171230&installation_model_id=11168&pr_number=348&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F348&signature=3142966267e5fee1c5d3f8028bd548c3ddcd214c1ba593bcb4152084d0591e7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interrupted jobs now resume in the correct queue order, ahead of older backlog and newly enqueued work.
  * The system now pauses appropriately when work is unavailable or processing is terminated, reducing unnecessary polling and resource usage.

* **Tests**
  * Added coverage for interrupted-job ordering, paused queues, termination behavior, and continued backlog processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->