### PR TITLE
fix: Reaper liveness across PID namespaces (private-list nonce)

### DIFF
--- a/docs/idea/parity-divergences.md
+++ b/docs/idea/parity-divergences.md
@@ -123,3 +123,37 @@ cycling, which the in-process state machine does (verified by
 
 **Anchor:** `lib/wurk/swarm.rb:104-108`, PR3 (`fix/swarm-supervision`), Ent
 §8.
+
+## Reaper liveness has a residual local pid-reuse blind spot — shared with `super_fetch`, not fixed
+
+**Wurk:** `Fetcher::Reaper#owner_alive?` fast-paths same-boot-generation
+private lists (host **and** `Component::PROCESS_NONCE` match) straight to
+`Process.kill(0, pid)` (`lib/wurk/fetcher/reaper.rb:270-284`). The nonce is
+minted once per process image and inherited unchanged across `fork`
+(`lib/wurk/component.rb:19-21`), so this group is every process forked from
+the current swarm boot, not a single pid. If the OS hands a *replacement*
+child, forked from that same boot, the exact pid a just-reaped sibling held,
+`kill(0)` reads the new occupant as the old one — alive. Every other owner
+(different nonce, pre-nonce key, or different host) is checked against the
+namespace-blind heartbeat instead, which doesn't have this gap.
+
+**Spec:** Pro §3.2's `super_fetch` decides local liveness the same way —
+`Process.kill(0, pid)` against the owning pid, with no generation counter to
+distinguish a reused pid from its original holder. The spec neither claims
+nor tests a stronger guarantee here.
+
+**Why:** closing this would require tracking pid *generation* — something
+the OS doesn't expose (Linux pid reuse is opaque past `/proc` disappearing;
+there is no monotonic "this is generation N of pid 4711" primitive to key
+against). Doing it via Redis bookkeeping (e.g. a per-pid generation counter
+written at fork time) would add a write on every child spawn to close a gap
+that, per the swarm's own respawn ordering, doesn't arise in practice: a
+replacement child is forked and reaches its own boot heartbeat before its
+predecessor's pid becomes eligible for OS reuse, so the collision window is
+theoretical, not observed. Since Sidekiq Pro's `super_fetch` — the spec this
+component is bug-compatible with — carries the identical limitation, this is
+recorded as a deliberate, matched-parity gap rather than an intentional
+"improvement" left undone.
+
+**Anchor:** `lib/wurk/fetcher/reaper.rb:270-284`, `lib/wurk/component.rb:19-21`,
+`docs/reliability.md` (Reliable fetch → How "dead" is decided), Pro §3.2.

--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -55,13 +55,32 @@ LMOVE  queue:default  queue:default|web-1|4711|0  RIGHT LEFT
 The destination is the **private list** — one per (public queue, process):
 
 ```
-queue:<public queue name>|<host>|<pid>|<index>
+queue:<public queue name>|<host>|<pid>|<nonce>|<index>
 ```
 
 - `<host>` is `ENV["DYNO"]` when set, otherwise `Socket.gethostname`.
+- `<nonce>` is `Wurk::Component::PROCESS_NONCE` — 12 hex chars
+  (`SecureRandom.hex(6)`), minted once when the process image loads and
+  inherited unchanged across `fork`. It disambiguates two process
+  *generations* that land on the same `<host>|<pid>` — a quick restart that
+  gets pid-recycled by the OS, or a container that restarts under a fixed
+  hostname into a fresh pid namespace. Without it, a reaper could match the
+  new process's private list against the old (dead) process's identity, or
+  vice versa.
 - `<index>` is currently always `0` — one fetcher per capsule.
 - Pipe separators, matching Sidekiq Pro's `super_fetch` naming byte-for-byte, so
   third-party tooling that parses these keys keeps working.
+
+> **Migration window.** Keys written before the nonce existed have the
+> 3-segment tail `<host>|<pid>|<index>` (no nonce). The reaper's parser
+> (`Fetcher::Reaper#parse_owner`/`#parse_full_key`, right-anchored via
+> `owner_tails`) accepts both the 4-segment and 3-segment tail shapes, trying
+> the wider (nonce-bearing) reading first and falling back to the narrow one.
+> A pre-nonce key stays reclaimable indefinitely — nothing writes that shape
+> anymore, but a list created by a not-yet-upgraded process can still hold
+> in-flight jobs across a rolling upgrade, and dropping the narrow parse
+> would strand it. See [How "dead" is decided](#how-dead-is-decided) for how
+> liveness is checked differently for nonce-bearing vs. pre-nonce keys.
 
 The job stays in that private list for the entire duration of `perform`. Only
 when the Processor finishes does it ACK:
@@ -157,21 +176,39 @@ end
 
 ### How "dead" is decided
 
-Per private-list owner, and the answer differs by host:
+Per private-list owner, and the answer now turns on nonce, not just host:
 
-- **Same host** — the OS is authoritative: `Process.kill(0, pid)`. Instant. A
-  `kill -9`ed sibling is reclaimed the moment the supervisor reaps it, without
-  waiting out any TTL. (`EPERM` is treated as alive.)
-- **Other host** — we can't ping the pid, so we trust the heartbeat: the owner
-  is alive iff some member of the `processes` set whose `info` hash still exists
-  shares its `<host>:<pid>` prefix. The heartbeat hash has a **60s TTL**, so
-  **cross-host reclaim can lag up to ~60 seconds.** Bare set membership isn't
-  enough — a member lingers after its hash expires, and that window must count
-  as dead.
+- **Our own host *and* nonce** — a key's `<host>|<pid>|<nonce>` tail matches
+  this process's own `hostname` and `Component::PROCESS_NONCE`. Because the
+  nonce is minted once per process image and inherited unchanged across
+  `fork` (`component.rb:19-21`), this group is every process forked from the
+  same swarm boot — the pid was minted in *our* pid namespace, so the OS is
+  authoritative: `Process.kill(0, pid)`. Instant. It ignores a stale
+  `processes` SET entry whose 60s TTL hasn't lapsed yet, so a `kill -9`ed
+  sibling is reclaimed the moment the supervisor reaps it, not up to 60s
+  later. (`EPERM` is treated as alive.)
+- **Any other incarnation** — different nonce (a different boot generation),
+  a pre-nonce key, or a different host — its pid means nothing in our
+  namespace, so we trust the heartbeat instead: the owner is alive iff its
+  identity is a live `processes` member (one whose `info` hash still
+  exists). Match is on the full `<host>:<pid>:<nonce>` for a nonce-bearing
+  key, or just the `<host>:<pid>` prefix for a pre-nonce one — see the
+  [migration window](#reliable-fetch) note above. The heartbeat hash has a
+  **60s TTL**, so **this path can lag reclaim up to ~60 seconds.** Bare set
+  membership isn't enough — a member lingers after its hash expires, and that
+  window must count as dead.
 
-The one blind spot is local pid reuse: if an unrelated process grabs the dead
-worker's pid, the private list looks alive. In practice the supervisor respawns
-with a fresh pid, so it doesn't arise.
+**The remaining blind spot, unchanged by the nonce:** pid reuse *within* the
+same boot generation. If the swarm respawns a replacement and the OS hands it
+the exact pid a just-reaped sibling held — same host, same inherited
+nonce — the new occupant reads as the old one, alive. In practice the
+supervisor's own bookkeeping means this doesn't arise (a respawned child
+gets a fresh pid before its predecessor's is even eligible for reuse), so it
+stays a theoretical gap rather than an operational one. This is the same
+class of weakness Sidekiq Pro's `super_fetch` has never closed — see
+[Parity Divergences](idea/parity-divergences.md) — recorded there as
+deliberate rather than fixed, since eliminating it would mean tracking pid
+generation numbers the OS doesn't expose.
 
 ### What reclaim actually does
 

--- a/lib/wurk/fetcher/reaper.rb
+++ b/lib/wurk/fetcher/reaper.rb
@@ -17,15 +17,16 @@ module Wurk
     # moves their jobs back to the public queue so a live worker re-runs them.
     #
     # Liveness is decided per owner:
-    #   * same host — the OS is authoritative: `Process.kill(0, pid)`. This
-    #     is instant and ignores a stale `processes` SET entry whose 60s TTL
-    #     hasn't lapsed yet, so a `kill -9`ed sibling is reclaimed the moment
-    #     the supervisor reaps it rather than 60s later. (Pid reuse by an
-    #     unrelated local process is the one blind spot — the supervisor
-    #     respawns with a fresh pid, so it does not arise in practice.)
-    #   * other host — we cannot ping the pid, so we trust the heartbeat:
-    #     the owner is alive iff some live `processes` member (one whose
-    #     `info` hash still exists) shares its `host:pid`. Cross-host reclaim
+    #   * our own host and nonce — the pid was minted in our PID namespace, so
+    #     the OS is authoritative: `Process.kill(0, pid)`. This is instant and
+    #     ignores a stale `processes` SET entry whose 60s TTL hasn't lapsed
+    #     yet, so a `kill -9`ed sibling is reclaimed the moment the supervisor
+    #     reaps it rather than 60s later. (Pid reuse by an unrelated process in
+    #     the same tree is the one blind spot — the supervisor respawns with a
+    #     fresh pid, so it does not arise in practice.)
+    #   * any other incarnation — its pid means nothing in our namespace, so we
+    #     trust the heartbeat: the owner is alive iff its identity is a live
+    #     `processes` member (one whose `info` hash still exists). Such reclaim
     #     therefore waits out the 60s heartbeat TTL, exactly as the spec says.
     #
     # Re-pushed jobs run through Wurk::Middleware::PoisonPill, which caps a
@@ -116,8 +117,8 @@ module Wurk
       # jobs reclaimed (re-queued or killed). Public so boot paths and tests
       # can drive a deterministic pass without the cluster lock.
       def reclaim!
-        prefixes = live_process_prefixes
-        served_queues.sum { |public_q| reclaim_queue(public_q, prefixes) }
+        owners = live_owners
+        served_queues.sum { |public_q| reclaim_queue(public_q, owners) }
       end
 
       # One unguarded full-keyspace sweep: every `queue:*|*` private list, even
@@ -125,10 +126,10 @@ module Wurk
       # of jobs reclaimed. Public so boot paths and tests can drive it without
       # the hourly lock.
       def reclaim_full!
-        prefixes = live_process_prefixes
+        owners = live_owners
         reclaimed = 0
-        each_full_private_list do |key, public_q, host, pid|
-          next if owner_alive?(host, pid, prefixes)
+        each_full_private_list do |key, public_q, host, pid, nonce|
+          next if owner_alive?(host, pid, nonce, owners)
 
           reclaimed += drain(key, public_q)
         end
@@ -148,17 +149,17 @@ module Wurk
       end
 
       # SCAN for this public queue's private lists, reclaim the orphaned ones.
-      def reclaim_queue(public_q, prefixes)
+      def reclaim_queue(public_q, owners)
         reclaimed = 0
-        each_private_list(public_q) do |key, host, pid|
-          next if owner_alive?(host, pid, prefixes)
+        each_private_list(public_q) do |key, host, pid, nonce|
+          next if owner_alive?(host, pid, nonce, owners)
 
           reclaimed += drain(key, public_q)
         end
         reclaimed
       end
 
-      # Yields [private_list_key, host, pid] for each private list of
+      # Yields [private_list_key, host, pid, nonce] for each private list of
       # `public_q`. MATCH `<public_q>|*` matches only this queue's private
       # lists (public queue keys carry no `|`).
       def each_private_list(public_q)
@@ -166,14 +167,14 @@ module Wurk
         loop do
           cursor, keys = redis { |c| c.call('SCAN', cursor, 'MATCH', "#{public_q}|*", 'COUNT', SCAN_COUNT) }
           keys.each do |key|
-            host, pid = parse_owner(public_q, key)
-            yield key, host, pid if pid
+            host, pid, nonce = parse_owner(public_q, key)
+            yield key, host, pid, nonce if pid
           end
           break if cursor == '0'
         end
       end
 
-      # Yields [private_list_key, public_q, host, pid] for every private list in
+      # Yields [private_list_key, public_q, host, pid, nonce] for every list in
       # the keyspace. MATCH `queue:*|*` matches only private lists (public queue
       # keys carry no `|`); parse_full_key drops anything that isn't a
       # well-formed `queue:<public>|<host>|<pid>|<nonce>|<idx>`.
@@ -189,9 +190,9 @@ module Wurk
         end
       end
 
-      # `queue:<public>|<host>|<pid>|<nonce>|<idx>` → [public_q, host, pid],
-      # parsed from the right so a `|` inside the queue name is tolerated. nil
-      # when the key isn't a well-formed private list.
+      # `queue:<public>|<host>|<pid>|<nonce>|<idx>` → [public_q, host, pid,
+      # nonce], parsed from the right so a `|` inside the queue name is
+      # tolerated. nil when the key isn't a well-formed private list.
       #
       # With no known prefix to split on, both owner shapes are tried in
       # preference order and the first one leaving a real public queue behind
@@ -200,34 +201,34 @@ module Wurk
       # hex chars): read wide, its host segment eats the whole queue name.
       def parse_full_key(key)
         parts = key.split('|')
-        owner_tails(parts).each do |host, pid, width|
+        owner_tails(parts).each do |host, pid, nonce, width|
           public_q = parts[0...-width].join('|')
           next unless public_q.start_with?(Keys::QUEUE_PREFIX) && public_q != Keys::QUEUE_PREFIX
 
-          return [public_q, host, pid]
+          return [public_q, host, pid, nonce]
         end
         nil
       end
 
-      # `<public_q>|<host>|<pid>|<nonce>|<idx>` → [host, pid] (pid as Integer),
-      # or [nil, nil] when the suffix isn't a well-formed owner tail. Splitting
-      # the suffix off the known public-queue prefix tolerates a `|` inside the
-      # queue name itself, and leaves the tail unambiguous: exactly 4 segments
-      # for the current shape, exactly 3 for the pre-nonce one.
+      # `<public_q>|<host>|<pid>|<nonce>|<idx>` → [host, pid, nonce] (pid as
+      # Integer), or all-nil when the suffix isn't a well-formed owner tail.
+      # Splitting the suffix off the known public-queue prefix tolerates a `|`
+      # inside the queue name itself, and leaves the tail unambiguous: exactly
+      # 4 segments for the current shape, exactly 3 for the pre-nonce one.
       def parse_owner(public_q, key)
         suffix = key.delete_prefix("#{public_q}|")
-        return [nil, nil] if suffix == key
+        return [nil, nil, nil] if suffix == key
 
-        host, pid = owner_tails(suffix.split('|')).first
-        [host, pid]
+        host, pid, nonce = owner_tails(suffix.split('|')).first
+        [host, pid, nonce]
       end
 
       # Owner segments of a private-list key, taken from the right, as
-      # [host, pid, segment_count] readings in preference order (empty when
-      # nothing parses). The wide shape is preferred: an all-digit nonce is rare
-      # but reachable, and reading such a key narrow would take the pid for the
-      # host and the nonce for the pid — draining a live owner's list out from
-      # under it.
+      # [host, pid, nonce, segment_count] readings in preference order (empty
+      # when nothing parses). The wide shape is preferred: an all-digit nonce is
+      # rare but reachable, and reading such a key narrow would take the pid for
+      # the host and the nonce for the pid — draining a live owner's list out
+      # from under it.
       def owner_tails(parts)
         return [] unless parts.size >= 3 && integer?(parts[-1])
 
@@ -236,24 +237,41 @@ module Wurk
 
       # `<host>|<pid>|<nonce>|<idx>` — the shape every current process writes.
       def wide_tail(parts)
-        [parts[-4], parts[-3].to_i, 4] if parts.size >= 4 && integer?(parts[-3])
+        [parts[-4], parts[-3].to_i, parts[-2], 4] if parts.size >= 4 && integer?(parts[-3])
       end
 
       # `<host>|<pid>|<idx>` — written before the nonce existed. Such a list can
       # still hold a pre-upgrade process's in-flight jobs across a rolling
       # upgrade, so it stays reclaimable even though nothing writes it anymore.
       def narrow_tail(parts)
-        [parts[-3], parts[-2].to_i, 3] if integer?(parts[-2])
+        [parts[-3], parts[-2].to_i, nil, 3] if integer?(parts[-2])
       end
 
       def integer?(str)
         str.is_a?(String) && str.match?(/\A\d+\z/)
       end
 
-      def owner_alive?(host, pid, prefixes)
-        return local_pid_alive?(pid) if host == hostname
+      # `Process.kill(0, pid)` answers "does this pid exist *in my PID
+      # namespace*", which is the question we're actually asking only when the
+      # key was written from that same namespace. A shared hostname does not
+      # imply it: a container restarting under a fixed hostname comes back in a
+      # fresh namespace where the dead owner's pid is likely taken again (list
+      # read as live, jobs stranded forever), and two containers sharing a
+      # host's network namespace but not its pid namespace each hold pids the
+      # other lacks (live owner read as dead, list drained mid-job, duplicate
+      # run). So kill(0) can serve as neither a positive nor a negative signal
+      # off our own namespace.
+      #
+      # The nonce settles it: minted once per process image and inherited across
+      # fork, so a key carrying ours provably came from this very process tree.
+      # Every other owner goes through the namespace-blind heartbeat — alive iff
+      # its identity is a live `processes` member. A pre-nonce key can only be
+      # matched on the `<host>:<pid>` prefix of that identity.
+      def owner_alive?(host, pid, nonce, owners)
+        return local_pid_alive?(pid) if nonce == process_nonce && host == hostname
+        return owners.include?("#{host}:#{pid}:#{nonce}") if nonce
 
-        prefixes.include?("#{host}:#{pid}")
+        owners.include?("#{host}:#{pid}")
       end
 
       def local_pid_alive?(pid)
@@ -265,18 +283,21 @@ module Wurk
         true
       end
 
-      # `host:pid` of every live process — a member of `processes` whose
-      # `info` hash still exists. A bare SET membership isn't enough: the
-      # member lingers after its 60s hash TTL until ProcessSet#cleanup prunes
-      # it, and we must treat that window as dead for cross-host reclaim.
-      def live_process_prefixes
+      # Every live process indexed both ways: the full `<host>:<pid>:<nonce>`
+      # identity a nonce-bearing private list is matched on, and the
+      # `<host>:<pid>` prefix a pre-nonce one has to settle for. Live means a
+      # member of `processes` whose `info` hash still exists — a bare SET
+      # membership isn't enough, since the member lingers after its 60s hash
+      # TTL until ProcessSet#cleanup prunes it and that window must read as
+      # dead or the owner's jobs are never reclaimed.
+      def live_owners
         redis do |conn|
           members = conn.call('SMEMBERS', Keys::PROCESSES)
           next ::Set.new if members.empty?
 
           infos = conn.pipelined { |pipe| members.each { |m| pipe.call('HGET', m, 'info') } }
           members.zip(infos).each_with_object(::Set.new) do |(member, info), set|
-            set << host_pid(member) if info
+            set << member << host_pid(member) if info
           end
         end
       end

--- a/lib/wurk/fetcher/reaper.rb
+++ b/lib/wurk/fetcher/reaper.rb
@@ -9,7 +9,7 @@ module Wurk
     # Orphan reclamation for the reliable fetcher (Pro super_fetch §3.2).
     #
     # The Reliable fetcher moves each job from a public queue into a
-    # per-process private list (`queue:<public>|<host>|<pid>|<idx>`) and
+    # per-process private list (`queue:<public>|<host>|<pid>|<nonce>|<idx>`) and
     # leaves it there until the Processor ACKs. A SIGKILLed or crashed
     # worker therefore strands its in-flight jobs in private lists that
     # nobody will ever ACK. The Reaper is the recovery half: it periodically
@@ -176,7 +176,7 @@ module Wurk
       # Yields [private_list_key, public_q, host, pid] for every private list in
       # the keyspace. MATCH `queue:*|*` matches only private lists (public queue
       # keys carry no `|`); parse_full_key drops anything that isn't a
-      # well-formed `queue:<public>|<host>|<pid>|<idx>`.
+      # well-formed `queue:<public>|<host>|<pid>|<nonce>|<idx>`.
       def each_full_private_list
         cursor = '0'
         loop do
@@ -189,35 +189,48 @@ module Wurk
         end
       end
 
-      # `queue:<public>|<host>|<pid>|<idx>` → [public_q, host, pid], parsed from
-      # the right (pid + idx are integers, host precedes them) so a `|` inside
-      # the queue name is tolerated. nil when the key isn't a well-formed
-      # private list.
+      # `queue:<public>|<host>|<pid>|<nonce>|<idx>` → [public_q, host, pid],
+      # parsed from the right so a `|` inside the queue name is tolerated. nil
+      # when the key isn't a well-formed private list.
       def parse_full_key(key)
         parts = key.split('|')
-        return nil if parts.size < 4
+        host, pid, width = parse_owner_tail(parts)
+        return nil unless host
 
-        host, pid, idx = parts.last(3)
-        return nil unless integer?(pid) && integer?(idx)
-
-        public_q = parts[0...-3].join('|')
+        public_q = parts[0...-width].join('|')
         return nil unless public_q.start_with?(Keys::QUEUE_PREFIX) && public_q != Keys::QUEUE_PREFIX
 
-        [public_q, host, pid.to_i]
+        [public_q, host, pid]
       end
 
-      # `<public_q>|<host>|<pid>|<idx>` → [host, pid] (pid as Integer), or
-      # [nil, nil] when the suffix isn't a well-formed `host|pid|idx` triple.
-      # Splitting the suffix off the known public-queue prefix tolerates a
-      # `|` inside the queue name itself.
+      # `<public_q>|<host>|<pid>|<nonce>|<idx>` → [host, pid] (pid as Integer),
+      # or [nil, nil] when the suffix isn't a well-formed owner tail. Splitting
+      # the suffix off the known public-queue prefix tolerates a `|` inside the
+      # queue name itself.
       def parse_owner(public_q, key)
         suffix = key.delete_prefix("#{public_q}|")
         return [nil, nil] if suffix == key
 
-        host, pid, idx = suffix.split('|')
-        return [nil, nil] unless host && integer?(pid) && integer?(idx)
+        host, pid = parse_owner_tail(suffix.split('|'))
+        [host, pid]
+      end
 
-        [host, pid.to_i]
+      # Owner segments of a private-list key, taken from the right:
+      # [host, pid, segment_count], or nil when they don't parse. Two shapes
+      # are accepted — `<host>|<pid>|<nonce>|<idx>` (current) and
+      # `<host>|<pid>|<idx>` (written before the nonce existed; such lists can
+      # still hold in-flight jobs across a rolling upgrade, so they must stay
+      # reclaimable). The 4-segment shape is tried first: an all-digit nonce is
+      # rare but reachable, and reading such a key as the 3-segment shape would
+      # take the pid for the host and the nonce for the pid.
+      def parse_owner_tail(parts)
+        return nil unless parts.size >= 3 && integer?(parts[-1])
+
+        if parts.size >= 4 && integer?(parts[-3])
+          [parts[-4], parts[-3].to_i, 4]
+        elsif integer?(parts[-2])
+          [parts[-3], parts[-2].to_i, 3]
+        end
       end
 
       def integer?(str)

--- a/lib/wurk/fetcher/reaper.rb
+++ b/lib/wurk/fetcher/reaper.rb
@@ -192,45 +192,58 @@ module Wurk
       # `queue:<public>|<host>|<pid>|<nonce>|<idx>` → [public_q, host, pid],
       # parsed from the right so a `|` inside the queue name is tolerated. nil
       # when the key isn't a well-formed private list.
+      #
+      # With no known prefix to split on, both owner shapes are tried in
+      # preference order and the first one leaving a real public queue behind
+      # wins. The narrow reading is what saves a pre-nonce key from an all-digit
+      # host (`queue:q|123456789012|<pid>|<idx>` — a bare Docker hostname is 12
+      # hex chars): read wide, its host segment eats the whole queue name.
       def parse_full_key(key)
         parts = key.split('|')
-        host, pid, width = parse_owner_tail(parts)
-        return nil unless host
+        owner_tails(parts).each do |host, pid, width|
+          public_q = parts[0...-width].join('|')
+          next unless public_q.start_with?(Keys::QUEUE_PREFIX) && public_q != Keys::QUEUE_PREFIX
 
-        public_q = parts[0...-width].join('|')
-        return nil unless public_q.start_with?(Keys::QUEUE_PREFIX) && public_q != Keys::QUEUE_PREFIX
-
-        [public_q, host, pid]
+          return [public_q, host, pid]
+        end
+        nil
       end
 
       # `<public_q>|<host>|<pid>|<nonce>|<idx>` → [host, pid] (pid as Integer),
       # or [nil, nil] when the suffix isn't a well-formed owner tail. Splitting
       # the suffix off the known public-queue prefix tolerates a `|` inside the
-      # queue name itself.
+      # queue name itself, and leaves the tail unambiguous: exactly 4 segments
+      # for the current shape, exactly 3 for the pre-nonce one.
       def parse_owner(public_q, key)
         suffix = key.delete_prefix("#{public_q}|")
         return [nil, nil] if suffix == key
 
-        host, pid = parse_owner_tail(suffix.split('|'))
+        host, pid = owner_tails(suffix.split('|')).first
         [host, pid]
       end
 
-      # Owner segments of a private-list key, taken from the right:
-      # [host, pid, segment_count], or nil when they don't parse. Two shapes
-      # are accepted — `<host>|<pid>|<nonce>|<idx>` (current) and
-      # `<host>|<pid>|<idx>` (written before the nonce existed; such lists can
-      # still hold in-flight jobs across a rolling upgrade, so they must stay
-      # reclaimable). The 4-segment shape is tried first: an all-digit nonce is
-      # rare but reachable, and reading such a key as the 3-segment shape would
-      # take the pid for the host and the nonce for the pid.
-      def parse_owner_tail(parts)
-        return nil unless parts.size >= 3 && integer?(parts[-1])
+      # Owner segments of a private-list key, taken from the right, as
+      # [host, pid, segment_count] readings in preference order (empty when
+      # nothing parses). The wide shape is preferred: an all-digit nonce is rare
+      # but reachable, and reading such a key narrow would take the pid for the
+      # host and the nonce for the pid — draining a live owner's list out from
+      # under it.
+      def owner_tails(parts)
+        return [] unless parts.size >= 3 && integer?(parts[-1])
 
-        if parts.size >= 4 && integer?(parts[-3])
-          [parts[-4], parts[-3].to_i, 4]
-        elsif integer?(parts[-2])
-          [parts[-3], parts[-2].to_i, 3]
-        end
+        [wide_tail(parts), narrow_tail(parts)].compact
+      end
+
+      # `<host>|<pid>|<nonce>|<idx>` — the shape every current process writes.
+      def wide_tail(parts)
+        [parts[-4], parts[-3].to_i, 4] if parts.size >= 4 && integer?(parts[-3])
+      end
+
+      # `<host>|<pid>|<idx>` — written before the nonce existed. Such a list can
+      # still hold a pre-upgrade process's in-flight jobs across a rolling
+      # upgrade, so it stays reclaimable even though nothing writes it anymore.
+      def narrow_tail(parts)
+        [parts[-3], parts[-2].to_i, 3] if integer?(parts[-2])
       end
 
       def integer?(str)

--- a/lib/wurk/fetcher/reliable.rb
+++ b/lib/wurk/fetcher/reliable.rb
@@ -9,7 +9,7 @@ require_relative '../fetcher'
 module Wurk
   class Fetcher
     # Default fetcher. Each public queue is paired with a per-process
-    # private list (`queue:<name>|<host>|<pid>|<idx>`); a job is moved
+    # private list (`queue:<name>|<host>|<pid>|<nonce>|<idx>`); a job is moved
     # atomically from the public tail to the private head via LMOVE, and
     # stays there until the Processor explicitly ACKs (LREM). SIGKILL
     # between fetch and ack leaves the job in the private list, where the
@@ -62,9 +62,16 @@ module Wurk
       # carrying a back-reference to its parent fetcher. Index defaults to
       # 0 — we run one fetcher per capsule today. Multi-processor topology
       # (one private list per processor slot) is a future Manager concern.
+      #
+      # The nonce marks the incarnation. host+pid alone is ambiguous once PID
+      # namespaces are in play: a restarted container reuses both, so the
+      # reaper's `kill(0)` liveness check would read a dead owner's list as
+      # live (jobs stranded) or a live owner's as dead (job run twice). Keys
+      # written before the nonce existed stay reclaimable — Reaper#parse_owner
+      # accepts both shapes.
       def self.private_queue_name(public_queue, index = 0)
         host = ENV['DYNO'] || Socket.gethostname
-        "#{public_queue}|#{host}|#{::Process.pid}|#{index}"
+        "#{public_queue}|#{host}|#{::Process.pid}|#{Component::PROCESS_NONCE}|#{index}"
       end
 
       def initialize(capsule)

--- a/test/integration/graceful_shutdown_test.rb
+++ b/test/integration/graceful_shutdown_test.rb
@@ -253,7 +253,7 @@ class GracefulShutdownTest < Wurk::Test::UnitCase
     "#{Wurk::Keys::QUEUE_PREFIX}#{@queue_name}"
   end
 
-  # Private lists are named `<public_queue>|<host>|<pid>|<idx>` (Reliable
+  # Private lists are named `<public_queue>|<host>|<pid>|<nonce>|<idx>` (Reliable
   # .private_queue_name) — the pid belongs to the forked swarm child, which the
   # test never learns directly, so SCAN by prefix instead. Redis deletes a list
   # key outright once its last element is LREM'd/ACK'd, so "no matching keys"

--- a/test/integration/reaper_full_sweep_test.rb
+++ b/test/integration/reaper_full_sweep_test.rb
@@ -11,6 +11,8 @@ require_relative '../test_helper'
 class ReaperFullSweepTest < Wurk::Test::UnitCase
   parallelize_me!
 
+  DEAD_PID = 999_999 # never a running pid in CI/dev
+
   def setup
     super
     @ns        = "reapfull-#{Process.pid}-#{object_id}"
@@ -50,6 +52,22 @@ class ReaperFullSweepTest < Wurk::Test::UnitCase
     assert_equal 1, @observer.call('LLEN', @orphan_q), 'job re-queued onto its public queue'
   end
   # rubocop:enable Minitest/MultipleAssertions, Metrics/AbcSize
+
+  # Migration window: a private list written before the PROCESS_NONCE upgrade
+  # (`<host>|<pid>|<idx>`, no nonce segment) must stay reclaimable by the full
+  # sweep. No fork needed here — the owner pid is simply gone, exactly like a
+  # pre-upgrade process that crashed and was never replaced under that pid.
+  # rubocop:disable Minitest/MultipleAssertions
+  def test_full_sweep_reclaims_a_legacy_pre_nonce_orphan_in_an_unserved_queue
+    legacy_priv = "#{@orphan_q}|#{Socket.gethostname}|#{DEAD_PID}|0"
+    @observer.call('RPUSH', legacy_priv, payload('job-legacy'))
+
+    assert_equal 0, @reaper.reclaim!, 'scoped sweep ignores an unserved queue'
+    assert_equal 1, @reaper.reclaim_full!, 'full sweep recovers the pre-nonce orphan'
+    assert_equal 0, @observer.call('LLEN', legacy_priv), 'private list drained'
+    assert_equal 1, @observer.call('LLEN', @orphan_q), 'job re-queued onto its public queue'
+  end
+  # rubocop:enable Minitest/MultipleAssertions
 
   private
 

--- a/test/unit/fetcher_reaper_test.rb
+++ b/test/unit/fetcher_reaper_test.rb
@@ -214,6 +214,27 @@ class FetcherReaperTest < Wurk::Test::UnitCase
     assert_equal 0, @reaper.reclaim!, 'non-numeric pid/idx suffixes are not reclaimable'
   end
 
+  # The shape every current process writes. The pre-nonce shape the other
+  # cases seed must keep reclaiming too — that is the rolling-upgrade window.
+  def test_reclaims_a_nonce_keyed_private_list
+    key = "#{@public_queue}|#{@host}|#{DEAD_PID}|#{Wurk::Component::PROCESS_NONCE}|0"
+    @pool.with { |c| c.call('RPUSH', key, payload('n1'), payload('n2')) }
+
+    assert_equal 2, @reaper.reclaim!, 'a nonce-keyed orphan is reclaimed'
+    assert_equal 0, llen(key), 'private list drained'
+  end
+
+  # SecureRandom.hex can emit an all-digit nonce. Read as the pre-nonce shape
+  # such a key yields the pid as the host and the nonce as the pid, so a *live*
+  # owner looks remote-and-dead and gets drained out from under itself.
+  def test_all_digit_nonce_still_resolves_the_live_owner
+    key = "#{@public_queue}|#{@host}|#{Process.pid}|123456789012|0"
+    @pool.with { |c| c.call('RPUSH', key, payload('live')) }
+
+    assert_equal 0, @reaper.reclaim!, 'a live owner is never reclaimed'
+    assert_equal 1, llen(key), 'in-flight job left alone'
+  end
+
   # --- cluster lock ------------------------------------------------------
 
   def test_reap_is_a_noop_when_both_locks_are_held_elsewhere
@@ -285,8 +306,20 @@ class FetcherReaperTest < Wurk::Test::UnitCase
     assert_equal 0, @reaper.reclaim_full!
   end
 
-  # A `|` inside the queue name must still parse: the owner triple is taken from
-  # the right, so the public queue is everything before host|pid|idx.
+  # The full sweep has its own parser (no known public-queue prefix to split
+  # on), so the nonce shape needs its own case there.
+  def test_reclaim_full_reclaims_a_nonce_keyed_orphan
+    foreign_q = Wurk::Keys.queue("#{@ns}-nonced")
+    private_key = "#{foreign_q}|#{@host}|#{DEAD_PID}|#{Wurk::Component::PROCESS_NONCE}|0"
+    @extra_keys.push(foreign_q, private_key)
+    @pool.with { |c| c.call('RPUSH', private_key, payload('x')) }
+
+    assert_equal 1, @reaper.reclaim_full!
+    assert_equal 1, llen(foreign_q), 'reclaimed onto the correctly-parsed public queue'
+  end
+
+  # A `|` inside the queue name must still parse: the owner segments are taken
+  # from the right, so the public queue is everything before host|pid|nonce|idx.
   def test_reclaim_full_tolerates_a_pipe_in_the_queue_name
     foreign_q = Wurk::Keys.queue("#{@ns}|piped")
     private_key = "#{foreign_q}|#{@host}|#{DEAD_PID}|0"

--- a/test/unit/fetcher_reaper_test.rb
+++ b/test/unit/fetcher_reaper_test.rb
@@ -181,8 +181,8 @@ class FetcherReaperTest < Wurk::Test::UnitCase
 
   def test_cross_host_owner_with_live_heartbeat_is_skipped
     other_host = 'other-host.example'
-    register_process(other_host, DEAD_PID, info: true)
-    seed_private_list(DEAD_PID, %w[remote], host: other_host)
+    nonce = register_process(other_host, DEAD_PID, info: true)
+    seed_private_list(DEAD_PID, %w[remote], host: other_host, nonce: nonce)
 
     reclaimed = @reaper.reclaim!
 
@@ -193,14 +193,87 @@ class FetcherReaperTest < Wurk::Test::UnitCase
 
   def test_cross_host_owner_without_info_hash_is_reclaimed
     other_host = 'other-host.example'
-    register_process(other_host, DEAD_PID, info: false) # SET member, expired hash
-    seed_private_list(DEAD_PID, %w[remote], host: other_host)
+    nonce = register_process(other_host, DEAD_PID, info: false) # SET member, expired hash
+    seed_private_list(DEAD_PID, %w[remote], host: other_host, nonce: nonce)
 
     reclaimed = @reaper.reclaim!
 
     assert_equal 1, reclaimed, 'a SET member whose heartbeat lapsed is dead'
   ensure
     unregister_process(other_host, DEAD_PID)
+  end
+
+  # A heartbeat under the same host:pid but a *different* incarnation is not
+  # this list's owner: that process died, and its successor happens to occupy
+  # the pid it used to hold.
+  def test_cross_host_owner_with_a_heartbeat_from_another_incarnation_is_reclaimed
+    other_host = 'other-host.example'
+    register_process(other_host, DEAD_PID, info: true)
+    seed_private_list(DEAD_PID, %w[remote], host: other_host, nonce: SecureRandom.hex(6))
+
+    assert_equal 1, @reaper.reclaim!, 'the heartbeat has to match the full identity, not just host:pid'
+  ensure
+    unregister_process(other_host, DEAD_PID)
+  end
+
+  # --- liveness: same host, foreign PID namespace ------------------------
+
+  # F2(a): a container restarting under a fixed hostname comes back in a fresh
+  # pid namespace, where the dead owner's pid is likely taken again — here by
+  # this very process. Trusting kill(0) on a hostname match alone strands those
+  # jobs forever; the incarnation nonce is what tells the two apart.
+  def test_same_host_dead_incarnation_is_reclaimed_even_when_its_pid_is_live
+    seed_private_list(Process.pid, %w[stranded], nonce: SecureRandom.hex(6))
+
+    assert_equal 1, @reaper.reclaim!, 'a foreign incarnation is not vouched for by a live local pid'
+    assert_equal 1, llen(@public_queue)
+  end
+
+  # F2(b): two containers share the host's network namespace but not its pid
+  # namespace, so the live owner's pid does not exist here. kill(0) would call
+  # it dead and drain the list out from under a job that is still running.
+  def test_same_host_foreign_incarnation_with_a_live_heartbeat_is_left_alone
+    nonce = register_process(@host, unowned_pid, info: true)
+    key = seed_private_list(unowned_pid, %w[in-flight], nonce: nonce)
+
+    assert_equal 0, @reaper.reclaim!, 'a beating owner keeps its jobs whatever our pid namespace says'
+    assert_equal 1, llen(key)
+  ensure
+    unregister_process(@host, unowned_pid)
+  end
+
+  # The fast path earns its keep: for our own incarnation the OS is
+  # authoritative and outranks the heartbeat, so a SIGKILLed sibling is
+  # reclaimed the moment the supervisor reaps it instead of 60s later when its
+  # `info` hash finally lapses.
+  def test_own_incarnation_is_reclaimed_on_a_dead_pid_despite_a_live_heartbeat
+    register_process(@host, unowned_pid, info: true, nonce: Wurk::Component::PROCESS_NONCE)
+    seed_private_list(unowned_pid, %w[sibling])
+
+    assert_equal 1, @reaper.reclaim!, 'kill(0) decides for our own process tree'
+  ensure
+    unregister_process(@host, unowned_pid)
+  end
+
+  # Our nonce under someone else's host segment: whatever wrote that key, our
+  # pid table has no standing to vouch for it, so the heartbeat decides — and
+  # with none on record the list is an orphan however live the pid looks here.
+  def test_own_nonce_under_a_foreign_host_still_goes_through_the_heartbeat
+    seed_private_list(Process.pid, %w[elsewhere], host: 'other-host.example')
+
+    assert_equal 1, @reaper.reclaim!, 'the fast path needs the host to match too, not just the nonce'
+  end
+
+  # A pre-nonce key names no incarnation, so the heartbeat is all there is to
+  # go on and it can only be matched on the host:pid prefix of an identity.
+  def test_pre_nonce_key_with_a_live_heartbeat_is_skipped
+    register_process(@host, unowned_pid, info: true)
+    key = seed_private_list(unowned_pid, %w[legacy], nonce: nil)
+
+    assert_equal 0, @reaper.reclaim!, 'a beating pre-upgrade owner keeps its jobs'
+    assert_equal 1, llen(key)
+  ensure
+    unregister_process(@host, unowned_pid)
   end
 
   # --- key parsing -------------------------------------------------------
@@ -225,14 +298,17 @@ class FetcherReaperTest < Wurk::Test::UnitCase
   end
 
   # SecureRandom.hex can emit an all-digit nonce. Read as the pre-nonce shape
-  # such a key yields the pid as the host and the nonce as the pid, so a *live*
-  # owner looks remote-and-dead and gets drained out from under itself.
+  # such a key yields the pid as the host and the nonce as the pid, so its
+  # owner's heartbeat is looked up under an identity nobody registered and a
+  # *live* owner gets drained out from under itself.
   def test_all_digit_nonce_still_resolves_the_live_owner
-    key = "#{@public_queue}|#{@host}|#{Process.pid}|123456789012|0"
-    @pool.with { |c| c.call('RPUSH', key, payload('live')) }
+    register_process(@host, unowned_pid, info: true, nonce: '123456789012')
+    key = seed_private_list(unowned_pid, %w[live], nonce: '123456789012')
 
     assert_equal 0, @reaper.reclaim!, 'a live owner is never reclaimed'
     assert_equal 1, llen(key), 'in-flight job left alone'
+  ensure
+    unregister_process(@host, unowned_pid)
   end
 
   # A bare Docker hostname is 12 hex chars, so ~1 in 175 hosts is all digits.
@@ -299,7 +375,8 @@ class FetcherReaperTest < Wurk::Test::UnitCase
 
   def test_reclaim_full_leaves_a_live_owners_list_untouched
     foreign_q = Wurk::Keys.queue("#{@ns}-live")
-    private_key = "#{foreign_q}|#{@host}|#{Process.pid}|0" # this very process — alive
+    # This very process — same incarnation, alive.
+    private_key = "#{foreign_q}|#{@host}|#{Process.pid}|#{Wurk::Component::PROCESS_NONCE}|0"
     @extra_keys.push(foreign_q, private_key)
     @pool.with { |c| c.call('RPUSH', private_key, payload('z')) }
 
@@ -488,6 +565,13 @@ class FetcherReaperTest < Wurk::Test::UnitCase
 
   private
 
+  # A pid this process can be sure is not running, distinct per test so the
+  # heartbeat one test registers under it can never make a peer's orphan read
+  # as live (the `processes` SET is global to the worker's Redis DB).
+  def unowned_pid
+    @unowned_pid ||= 990_000 + (object_id % 9_000)
+  end
+
   def wait_until(timeout: 5.0)
     deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
     sleep(0.005) until yield || Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
@@ -510,14 +594,18 @@ class FetcherReaperTest < Wurk::Test::UnitCase
     @pool.with { |c| c.call('KEYS', "#{private_list(Process.pid)}:*").size }
   end
 
-  def seed_private_list(pid, tokens, host: @host)
-    key = "#{@public_queue}|#{host}|#{pid}|0"
+  def seed_private_list(pid, tokens, host: @host, nonce: Wurk::Component::PROCESS_NONCE)
+    key = private_list(pid, host: host, nonce: nonce)
     @pool.with { |c| tokens.each { |t| c.call('RPUSH', key, payload(t)) } }
     key
   end
 
-  def private_list(pid, host: @host)
-    "#{@public_queue}|#{host}|#{pid}|0"
+  # `nonce: nil` yields the pre-nonce shape a process running the previous
+  # release would have written.
+  def private_list(pid, host: @host, nonce: Wurk::Component::PROCESS_NONCE)
+    return "#{@public_queue}|#{host}|#{pid}|0" if nonce.nil?
+
+    "#{@public_queue}|#{host}|#{pid}|#{nonce}|0"
   end
 
   def payload(token, jid: nil)
@@ -529,14 +617,17 @@ class FetcherReaperTest < Wurk::Test::UnitCase
     "#{Wurk::Middleware::PoisonPill::KEY_PREFIX}#{jid}"
   end
 
-  def register_process(host, pid, info:)
-    identity = "#{host}:#{pid}:#{SecureRandom.hex(6)}"
+  # Returns the nonce of the registered identity so a caller can key a private
+  # list to the very process it just gave a heartbeat to.
+  def register_process(host, pid, info:, nonce: SecureRandom.hex(6))
+    identity = "#{host}:#{pid}:#{nonce}"
     @registered ||= {}
     @registered[[host, pid]] = identity
     Wurk.redis do |c|
       c.call('SADD', Wurk::Keys::PROCESSES, identity)
       c.call('HSET', identity, 'info', '{}') if info
     end
+    nonce
   end
 
   def unregister_process(host, pid)

--- a/test/unit/fetcher_reaper_test.rb
+++ b/test/unit/fetcher_reaper_test.rb
@@ -235,6 +235,17 @@ class FetcherReaperTest < Wurk::Test::UnitCase
     assert_equal 1, llen(key), 'in-flight job left alone'
   end
 
+  # A bare Docker hostname is 12 hex chars, so ~1 in 175 hosts is all digits.
+  # The scoped sweep splits the tail off a known public-queue prefix, so the
+  # pre-nonce shape stays unambiguous even then.
+  def test_reclaims_a_pre_nonce_private_list_from_an_all_digit_host
+    key = "#{@public_queue}|123456789012|#{DEAD_PID}|0"
+    @pool.with { |c| c.call('RPUSH', key, payload('legacy')) }
+
+    assert_equal 1, @reaper.reclaim!, 'a pre-nonce orphan is reclaimable during the upgrade window'
+    assert_equal 1, llen(@public_queue)
+  end
+
   # --- cluster lock ------------------------------------------------------
 
   def test_reap_is_a_noop_when_both_locks_are_held_elsewhere
@@ -316,6 +327,32 @@ class FetcherReaperTest < Wurk::Test::UnitCase
 
     assert_equal 1, @reaper.reclaim_full!
     assert_equal 1, llen(foreign_q), 'reclaimed onto the correctly-parsed public queue'
+  end
+
+  # The full sweep has no prefix to split on, so an all-digit host makes the
+  # pre-nonce shape look like the nonce shape: read wide, `123456789012` is the
+  # queue name's last segment and the queue name itself is gone. Such a list
+  # holds a pre-upgrade process's in-flight jobs — it has to stay reclaimable.
+  def test_reclaim_full_reclaims_a_pre_nonce_orphan_from_an_all_digit_host
+    foreign_q = Wurk::Keys.queue("#{@ns}-legacy")
+    private_key = "#{foreign_q}|123456789012|#{DEAD_PID}|0"
+    @extra_keys.push(foreign_q, private_key)
+    @pool.with { |c| c.call('RPUSH', private_key, payload('legacy')) }
+
+    assert_equal 1, @reaper.reclaim_full!
+    assert_equal 1, llen(foreign_q), 'reclaimed onto the queue the narrow reading recovers'
+  end
+
+  # Same host, current shape: the wide reading is the right one and must stay
+  # preferred — read narrow, the job lands on `<queue>|123456789012`.
+  def test_reclaim_full_reclaims_a_nonce_keyed_orphan_from_an_all_digit_host
+    foreign_q = Wurk::Keys.queue("#{@ns}-digits")
+    private_key = "#{foreign_q}|123456789012|#{DEAD_PID}|#{Wurk::Component::PROCESS_NONCE}|0"
+    @extra_keys.push(foreign_q, private_key, "#{foreign_q}|123456789012")
+    @pool.with { |c| c.call('RPUSH', private_key, payload('nonced')) }
+
+    assert_equal 1, @reaper.reclaim_full!
+    assert_equal 1, llen(foreign_q), 'reclaimed onto the queue the wide reading recovers'
   end
 
   # A `|` inside the queue name must still parse: the owner segments are taken

--- a/test/unit/fetcher_reliable_test.rb
+++ b/test/unit/fetcher_reliable_test.rb
@@ -235,9 +235,20 @@ class FetcherReliableTest < Wurk::Test::UnitCase
   def test_private_queue_name_uses_pipe_separators_and_encodes_identity
     parts = Wurk::Fetcher::Reliable.private_queue_name(@public_queue).split('|')
 
-    # [public_queue, hostname, pid, index] — assert as a single tuple so the
-    # whole shape is one expectation rather than four.
-    assert_equal [@public_queue, parts[1], Process.pid.to_s, '0'], parts
+    # [public_queue, hostname, pid, nonce, index] — assert as a single tuple so
+    # the whole shape is one expectation rather than five.
+    assert_equal [@public_queue, parts[1], Process.pid.to_s, Wurk::Component::PROCESS_NONCE, '0'], parts
+  end
+
+  # The nonce is what distinguishes two incarnations that share host+pid (a
+  # container restarted into a fresh PID namespace), so it must be the
+  # process-wide one the heartbeat publishes in `identity`, not a fresh value
+  # per call.
+  def test_private_queue_name_carries_the_process_nonce_from_identity
+    nonce = Wurk::Fetcher::Reliable.private_queue_name(@public_queue).split('|')[3]
+
+    assert_equal @fetcher.identity.split(':').last, nonce
+    assert_equal nonce, Wurk::Fetcher::Reliable.private_queue_name(@public_queue).split('|')[3]
   end
 
   def test_private_queue_name_honors_dyno_env_when_set


### PR DESCRIPTION
## Summary
- Add `Component::PROCESS_NONCE` to the private-list key (`queue:<q>|<host>|<pid>|<nonce>|<idx>`) so the reaper can tell apart same-host/same-pid owners from different process incarnations (container restart in a fresh PID namespace, or hostNetwork sharing without pid-namespace sharing).
- Reaper parses both the new 5-part and legacy 4-part (pre-nonce) key shapes — required in the same change so upgrading doesn't strand in-flight jobs written by not-yet-upgraded processes.
- Gate the fast `kill(0)` liveness check on the key's nonce matching our own; every other incarnation falls through to the namespace-blind heartbeat (`processes` SET membership).
- Document the key extension and the deliberate pid-reuse blind spot (parity with Sidekiq Pro's `super_fetch`).
- This PR: add integration coverage for a legacy pre-nonce private list reclaimed via the full-keyspace sweep (unit-level coverage for both F2 failure scenarios — dead nonce falls to heartbeat and reclaims; live owner is left alone — already landed in a prior commit on this branch).

## Test plan
- [x] `bin/rake test TEST=test/unit/fetcher_reaper_test.rb` — 39 runs, 0 failures (×3)
- [x] `bin/rake test TEST=test/integration/reaper_full_sweep_test.rb` — 2 runs, 0 failures (×3)
- [x] `bin/rake test` — 2814 runs, 0 failures/errors, 7 skips
- [x] `bin/rake test:parity` — 23 runs, 0 failures
- [x] `bundle exec rubocop` on touched files — clean

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/349"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788173909&installation_model_id=11168&pr_number=349&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F349&signature=a9047635137d5f3f3f1bb0b1805ac50ef0b74fc7264e0e16eefb7a20822f7eb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->