### PR TITLE
FE: frontend leak fixes (slice 09)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { Router, Route } from '@solidjs/router';
 import { QueryClient, QueryClientProvider } from '@tanstack/solid-query';
-import { Suspense, lazy, createSignal, type ParentProps } from 'solid-js';
+import { Suspense, lazy, createSignal, createEffect, onCleanup, type ParentProps } from 'solid-js';
 import { Show } from 'solid-js';
 import { useMeta } from './hooks/useMeta';
 import { basePath } from './basePath';
@@ -64,13 +64,6 @@ export function ReadOnlyBanner() {
 
 const NAV_COLLAPSED_KEY = 'wurk-nav-collapsed';
 
-function prefersReducedMotion() {
-  return (
-    typeof window !== 'undefined' &&
-    window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true
-  );
-}
-
 // Root layout: the persistent shell (hamburger, main content, nav) that wraps
 // every route. Solid Router renders the matched route into `props.children`,
 // which lives inside the <Suspense> so lazy chunks fall back to the skeleton.
@@ -89,6 +82,22 @@ function Layout(props: ParentProps) {
       }
     })(),
   );
+
+  // Track prefers-reduced-motion reactively; subscribe to changes and clean up
+  // on unmount to avoid a dangling listener.
+  const [prefersReducedMotion, setPrefersReducedMotion] = createSignal(
+    typeof window !== 'undefined' &&
+      window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true,
+  );
+
+  createEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mq = window.matchMedia?.('(prefers-reduced-motion: reduce)');
+    if (!mq) return;
+    const handler = () => setPrefersReducedMotion(mq.matches);
+    mq.addEventListener('change', handler);
+    onCleanup(() => mq.removeEventListener('change', handler));
+  });
   const toggleCollapsed = () =>
     setCollapsed((c) => {
       const next = !c;

--- a/frontend/src/components/Modal.test.tsx
+++ b/frontend/src/components/Modal.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createSignal, Show, onMount, onCleanup } from 'solid-js';
+import { render, screen } from '@solidjs/testing-library';
+import Modal from './Modal';
+
+// jsdom has no <dialog> top-layer support; the modal's content visibility is
+// signal-driven, so stubbing these is enough for showModal()/close().
+HTMLDialogElement.prototype.showModal = vi.fn();
+HTMLDialogElement.prototype.close = vi.fn();
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('Modal', () => {
+  it('renders the title and children while open', () => {
+    render(() => (
+      <Modal open onClose={() => {}} title="Detail">
+        <div>payload</div>
+      </Modal>
+    ));
+    expect(screen.getByText('Detail')).toBeInTheDocument();
+    expect(screen.getByText('payload')).toBeInTheDocument();
+  });
+
+  it('resolves dynamic (e.g. <Show>-gated) children without losing them while open', () => {
+    const [proc, setProc] = createSignal<{ pid: number } | null>({ pid: 1 });
+    render(() => (
+      <Modal open onClose={() => {}} title="Detail">
+        <Show when={proc()}>{(p) => <div>pid {p().pid}</div>}</Show>
+      </Modal>
+    ));
+    expect(screen.getByText('pid 1')).toBeInTheDocument();
+
+    setProc({ pid: 2 });
+    expect(screen.getByText('pid 2')).toBeInTheDocument();
+  });
+
+  it('keeps the last content on screen immediately after close, for the exit transition to animate', () => {
+    const [open, setOpen] = createSignal(true);
+    render(() => (
+      <Modal open={open()} onClose={() => {}} title="Detail">
+        <div>payload</div>
+      </Modal>
+    ));
+
+    setOpen(false);
+    expect(screen.getByText('payload')).toBeInTheDocument();
+  });
+
+  it('releases the held subtree 240ms after close (matches --dur-slow)', () => {
+    vi.useFakeTimers();
+    const [open, setOpen] = createSignal(true);
+    render(() => (
+      <Modal open={open()} onClose={() => {}} title="Detail">
+        <div>payload</div>
+      </Modal>
+    ));
+
+    setOpen(false);
+    expect(screen.queryByText('payload')).not.toBeNull();
+
+    vi.advanceTimersByTime(239);
+    expect(screen.queryByText('payload')).not.toBeNull();
+
+    vi.advanceTimersByTime(1);
+    expect(screen.queryByText('payload')).toBeNull();
+  });
+
+  it('disposes children owned by the consumer (e.g. a <Show>) the moment its own condition flips, independent of the release timer', () => {
+    vi.useFakeTimers();
+    const disposed = vi.fn();
+    function Tracked(props: { pid: number }) {
+      onCleanup(disposed);
+      return <div>payload {props.pid}</div>;
+    }
+    const [open, setOpen] = createSignal(true);
+    const [proc, setProc] = createSignal<{ pid: number } | null>({ pid: 1 });
+    render(() => (
+      <Modal open={open()} onClose={() => {}} title="Detail">
+        <Show when={proc()}>{(p) => <Tracked pid={p().pid} />}</Show>
+      </Modal>
+    ));
+
+    // Consumers typically clear their data the instant `open` flips false —
+    // Modal's held/release timer only governs how long the already-resolved
+    // DOM stays visible, not when the consumer's own reactive tree disposes.
+    setOpen(false);
+    setProc(null);
+    expect(disposed).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(240);
+    expect(screen.queryByText('payload')).toBeNull();
+  });
+
+  it('reopening before the release timer fires cancels the pending release', () => {
+    vi.useFakeTimers();
+    const [open, setOpen] = createSignal(true);
+    render(() => (
+      <Modal open={open()} onClose={() => {}} title="Detail">
+        <div>payload</div>
+      </Modal>
+    ));
+
+    setOpen(false);
+    vi.advanceTimersByTime(100);
+    setOpen(true);
+    vi.advanceTimersByTime(200);
+
+    expect(screen.queryByText('payload')).not.toBeNull();
+  });
+
+  it('clears the pending release timer on unmount instead of leaking it', () => {
+    vi.useFakeTimers();
+    const clearSpy = vi.spyOn(window, 'clearTimeout');
+    const [open, setOpen] = createSignal(true);
+    const { unmount } = render(() => (
+      <Modal open={open()} onClose={() => {}} title="Detail">
+        <div>payload</div>
+      </Modal>
+    ));
+
+    setOpen(false);
+    unmount();
+
+    expect(clearSpy).toHaveBeenCalled();
+  });
+
+  it('does not remount the children subtree on every reactive read of an unrelated signal', () => {
+    const mounts = vi.fn();
+    function Tracked() {
+      onMount(mounts);
+      return <div>payload</div>;
+    }
+    const [tick, setTick] = createSignal(0);
+    render(() => {
+      tick();
+      return (
+        <Modal open onClose={() => {}} title="Detail">
+          <Tracked />
+        </Modal>
+      );
+    });
+
+    setTick((t) => t + 1);
+    setTick((t) => t + 1);
+
+    expect(mounts).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,4 +1,7 @@
-import { createEffect, createSignal, onCleanup, onMount, Show, type JSX } from 'solid-js';
+import { children, createEffect, createSignal, onCleanup, onMount, Show, type JSX } from 'solid-js';
+
+// Matches --dur-slow (styles/abstracts/_variables.scss) — the modal's exit transition.
+const EXIT_DURATION_MS = 240;
 
 interface ModalProps {
   open: boolean;
@@ -20,16 +23,30 @@ export default function Modal(props: ModalProps) {
   let dlg!: HTMLDialogElement;
   const titleId = `modal-title-${Math.random().toString(36).slice(2)}`;
 
+  // Resolve once via the `children` helper so repeated reads (below, and in the
+  // `held` effect) don't re-run the consumer's JSX-producing function on every
+  // reactive read — without it, a parent that re-renders on a poll interval
+  // would rebuild (and remount) the whole subtree each tick even though `open`
+  // never changed.
+  const resolvedChildren = children(() => props.children);
+
   // Hold the last content + title so the panel isn't blank while it animates out
-  // (consumers typically clear their data the moment `open` flips false).
-  const [held, setHeld] = createSignal<{ title: JSX.Element; children: JSX.Element }>({
+  // (consumers typically clear their data the moment `open` flips false), then
+  // release it once the exit transition finishes so the held subtree doesn't
+  // stay mounted (and subscribed) forever.
+  const [held, setHeld] = createSignal<{ title: JSX.Element; children: JSX.Element } | null>({
     title: props.title,
-    children: props.children,
+    children: resolvedChildren(),
   });
   createEffect(() => {
-    if (props.open) setHeld({ title: props.title, children: props.children });
+    if (props.open) {
+      setHeld({ title: props.title, children: resolvedChildren() });
+    } else {
+      const timer = setTimeout(() => setHeld(null), EXIT_DURATION_MS);
+      onCleanup(() => clearTimeout(timer));
+    }
   });
-  const shown = () => (props.open ? { title: props.title, children: props.children } : held());
+  const shown = () => (props.open ? { title: props.title, children: resolvedChildren() } : held());
 
   createEffect(() => {
     if (props.open && !dlg.open) dlg.showModal();
@@ -60,12 +77,12 @@ export default function Modal(props: ModalProps) {
     >
       <div class="modal-panel" style={{ 'max-width': `${props.width ?? 640}px` }}>
         <div class="modal-header">
-          <h2 id={titleId} class="modal-title">{shown().title}</h2>
+          <h2 id={titleId} class="modal-title">{shown()?.title}</h2>
           <button class="modal-close" onClick={() => props.onClose()} aria-label="Close">
             <i class="fa-solid fa-xmark" />
           </button>
         </div>
-        <div class="modal-body">{shown().children}</div>
+        <div class="modal-body">{shown()?.children}</div>
         <Show when={props.footer}>
           <div class="modal-footer">{props.footer}</div>
         </Show>

--- a/frontend/src/hooks/useSSE.test.ts
+++ b/frontend/src/hooks/useSSE.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { renderHook, waitFor } from '@solidjs/testing-library';
-import { useSSE, type StatsSnapshot } from './useSSE';
+import { renderHook, waitFor, cleanup } from '@solidjs/testing-library';
+import { useSSE, __resetSSE, type StatsSnapshot } from './useSSE';
 
 // Minimal EventSource stand-in that records every instance opened so tests can
 // reach in and fire onopen/onerror/message the way a real SSE stream would.
@@ -49,6 +49,14 @@ const SNAPSHOT: StatsSnapshot = {
 
 describe('useSSE', () => {
   afterEach(() => {
+    // cleanup() disposes any still-mounted reactive root first (running
+    // useSSE's onCleanup, which decrements refs the normal way); __resetSSE()
+    // then forces module state to zero regardless of whether that dispose
+    // ran at all — belt-and-braces for a test that threw before reaching its
+    // own cleanup() call. Order matters: resetting first would let a
+    // still-pending onCleanup decrement refs to -1 instead of 0.
+    cleanup();
+    __resetSSE();
     vi.unstubAllGlobals();
     StubEventSource.instances = [];
   });
@@ -114,5 +122,28 @@ describe('useSSE', () => {
     renderHook(() => useSSE(false));
     await new Promise((r) => setTimeout(r, 0));
     expect(StubEventSource.instances).toHaveLength(0);
+  });
+
+  it('does not leak refs/source into the next test when a mid-test assertion throws', async () => {
+    vi.stubGlobal('EventSource', StubEventSource);
+    renderHook(() => useSSE());
+    await waitFor(() => expect(StubEventSource.instances).toHaveLength(1));
+
+    // Simulates a failing assertion (or any thrown error) partway through a
+    // test, before its cleanup() would normally run and decrement refs.
+    // __resetSSE() in afterEach must still bring module state back to zero.
+    expect(() => {
+      throw new Error('simulated mid-test failure before cleanup() runs');
+    }).toThrow();
+    // Deliberately no cleanup() call here — mirrors a real thrown failure.
+  });
+
+  it('opens exactly one fresh connection after a prior test threw without cleanup', async () => {
+    vi.stubGlobal('EventSource', StubEventSource);
+    const { result } = renderHook(() => useSSE());
+
+    await waitFor(() => expect(StubEventSource.instances).toHaveLength(1));
+    expect(result.connected()).toBe(false);
+    expect(result.stats()).toBeNull();
   });
 });

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -47,6 +47,19 @@ function closeStream() {
   setStats(null);
 }
 
+// Test-only: module state (source/refs/signals) survives across test cases
+// since the SSE stream is a singleton, not per-component. A test that throws
+// mid-run can skip its onCleanup and leak refs/source into the next test —
+// call this in afterEach to force a clean slate regardless of how the
+// previous test exited.
+export function __resetSSE(): void {
+  source?.close();
+  source = null;
+  refs = 0;
+  setConnected(false);
+  setStats(null);
+}
+
 // Live stats over Server-Sent Events. Returns signal accessors — read them as
 // `stats()` / `connected()` inside JSX or a memo so they track reactively.
 export function useSSE(

--- a/frontend/src/pages/Extension.test.tsx
+++ b/frontend/src/pages/Extension.test.tsx
@@ -69,4 +69,43 @@ describe('Extension', () => {
     await waitFor(() => expect(screen.getByTitle('Legacy')).toBeTruthy());
     expect(screen.getByTitle('Legacy').getAttribute('src')).toBe('/wurk/legacy?wurk_ext_embed=1');
   });
+
+  it('aborts the in-flight extension fetch on unmount and never resolves state after', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    let resolveExt: (res: Response) => void = () => {};
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/api/meta')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            read_only: false,
+            read_only_message: null,
+            custom_tabs: [{ name: 'Demo Locks', path: 'locks/', ext_name: 'demo_locks' }],
+          }),
+          text: async () => '',
+        } as Response;
+      }
+      capturedSignal = init?.signal ?? undefined;
+      return new Promise<Response>((resolve) => {
+        resolveExt = resolve;
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { unmount } = renderAt('/ext/locks');
+
+    await waitFor(() => expect(capturedSignal).toBeInstanceOf(AbortSignal));
+    expect(capturedSignal!.aborted).toBe(false);
+
+    unmount();
+
+    expect(capturedSignal!.aborted).toBe(true);
+
+    // Resolving the stale fetch after unmount must not throw or update state.
+    resolveExt({ ok: true, status: 200, json: async () => ({}), text: async () => '<h2>Late</h2>' } as Response);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.queryByText('Late')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/Extension.tsx
+++ b/frontend/src/pages/Extension.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createEffect, Show } from 'solid-js';
+import { createSignal, createEffect, onCleanup, Show } from 'solid-js';
 import { useParams } from '@solidjs/router';
 import { PageHeader } from '../components/PageHeader';
 import { Skeleton, SkeletonTable } from '../components/Skeleton';
@@ -41,19 +41,26 @@ function NativeExtension(props: { extName: string; indexPath: string; title: str
   // Monotonic request id: a response only lands if it's still the latest, so
   // rapid link clicks can't resolve out of order and show stale HTML.
   let seq = 0;
+  // Aborts the in-flight fetch on unmount so a slow response can't call
+  // setHtml/setError after the component is gone.
+  let controller: AbortController | undefined;
 
   const load = async (path: string, init?: RequestInit) => {
     const id = ++seq;
+    controller = new AbortController();
     try {
-      const res = await fetch(base + path, init);
+      const res = await fetch(base + path, { ...init, signal: controller.signal });
       const text = await res.text();
       if (id !== seq) return;
       setError(!res.ok && res.status !== 404);
       setHtml(text);
-    } catch {
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
       if (id === seq) setError(true);
     }
   };
+
+  onCleanup(() => controller?.abort());
 
   createEffect(() => {
     void load(props.indexPath.replace(/\/+$/, ''));

--- a/frontend/src/toast.test.tsx
+++ b/frontend/src/toast.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@solidjs/testing-library';
 import { Toasts, notifyError, pushToast, dismissToast, toasts } from './toast';
 import { RequestError } from './http';
@@ -47,5 +47,34 @@ describe('Toasts', () => {
 
     fireEvent.click(screen.getByRole('button', { name: t('toast.dismiss') }));
     expect(screen.queryByText('boom happened')).toBeNull();
+  });
+});
+
+describe('toast timers', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('clears the auto-dismiss timer when dismissed early', () => {
+    vi.useFakeTimers();
+    const clearSpy = vi.spyOn(window, 'clearTimeout');
+
+    const id = pushToast('early dismiss', 'error');
+    dismissToast(id);
+
+    expect(clearSpy).toHaveBeenCalled();
+    // Advancing past the TTL must not re-dismiss (list stays empty, no throw).
+    vi.advanceTimersByTime(10_000);
+    expect(toasts()).toHaveLength(0);
+  });
+
+  it('caps the visible list at 5, dropping the oldest', () => {
+    vi.useFakeTimers();
+
+    for (let i = 0; i < 20; i += 1) pushToast(`toast ${i}`, 'error');
+
+    const current = toasts();
+    expect(current).toHaveLength(5);
+    expect(current.map((toast) => toast.message)).toEqual(['toast 15', 'toast 16', 'toast 17', 'toast 18', 'toast 19']);
   });
 });

--- a/frontend/src/toast.tsx
+++ b/frontend/src/toast.tsx
@@ -8,6 +8,7 @@ export interface Toast {
   id: number;
   kind: ToastKind;
   message: string;
+  timer?: number;
 }
 
 // Module-level signal: a toast can be raised by any mutation on any page, so
@@ -18,18 +19,33 @@ const [toasts, setToasts] = createSignal<Toast[]>([]);
 export { toasts };
 
 const TTL_MS = 6000;
+const MAX_TOASTS = 5;
 let seq = 0;
 
 export function pushToast(message: string, kind: ToastKind = 'error'): number {
   const id = (seq += 1);
-  setToasts((list) => [...list, { id, kind, message }]);
   // Auto-dismiss after the TTL; guarded for the non-DOM (unit) path with no timer.
-  if (typeof window !== 'undefined') window.setTimeout(() => dismissToast(id), TTL_MS);
+  const timer = typeof window !== 'undefined' ? window.setTimeout(() => dismissToast(id), TTL_MS) : undefined;
+  setToasts((list) => {
+    const next = [...list, { id, kind, message, timer }];
+    // Cap the visible/pending list so a burst of failures can't grow it unbounded;
+    // dropped toasts' timers are cleared since dismissToast will never see them.
+    if (next.length <= MAX_TOASTS) return next;
+    const overflow = next.slice(0, next.length - MAX_TOASTS);
+    for (const toast of overflow) {
+      if (toast.timer !== undefined) window.clearTimeout(toast.timer);
+    }
+    return next.slice(next.length - MAX_TOASTS);
+  });
   return id;
 }
 
 export function dismissToast(id: number): void {
-  setToasts((list) => list.filter((toast) => toast.id !== id));
+  setToasts((list) => {
+    const toast = list.find((item) => item.id === id);
+    if (toast?.timer !== undefined) window.clearTimeout(toast.timer);
+    return list.filter((item) => item.id !== id);
+  });
 }
 
 // Maps a failed mutation to a status-aware toast: 403 = read-only mode, 404 =


### PR DESCRIPTION
## Summary
- **FE6:** abort in-flight Extension fetches on dispose
- **FE7:** clear toast timers and cap the list
- **FE8:** memoize Modal children and release held subtree
- **FE10:** export a test-only SSE reset
- **FE9:** make prefersReducedMotion reactive

## Test plan
- hooks test: useCountUp snaps under prefers-reduced-motion (stub + dynamic listener)
- hooks test: useCountUp snaps on non-finite target (no stub, finite guard)
- Extension test: unmount-mid-fetch aborts, setter not called after unmount
- Modal test: children resolved once, released after close
- Toasts test: dismiss clears timer, cap evicts oldest
- `tsc --noEmit` clean
- All 119 frontend tests pass

🤖 Generated with Claude Code

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/351"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788200528&installation_model_id=11168&pr_number=351&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F351&signature=8a34c007ef4f4f2489c5350da0063c5036dd34cc30c0a048cf19156b4f8c2541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->