### PR TITLE
fix(redis-pool): retry idempotency policy split (04)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -405,14 +405,34 @@ Redis connections are **never shared across forks**: the swarm parent calls
 
 ### Transient-failure handling
 
-`RedisPool#with` absorbs blips before raising:
+`RedisPool#with` absorbs blips before raising — but only where replaying the
+caller's block cannot change what the server already did. The block is arbitrary
+Ruby, so a retry re-issues every command in it:
 
 - `READONLY` / `NOREPLICAS` / `UNBLOCKED` — a failover; close and retry once
   immediately.
-- `RedisClient::ConnectionError` — close, sleep `(0.5 × 2ⁿ) + rand×0.25`, retry
-  up to 3 attempts total, then raise.
+- `CannotConnectError` / `FailoverError` — raised while dialing, before any byte
+  reached a server, so nothing can have applied: close, sleep
+  `(0.5 × 2ⁿ) + rand×0.25`, retry up to 3 attempts total, then raise.
+- `ReadTimeoutError` / `WriteTimeoutError` / bare `ConnectionError` — the command
+  may already have applied server-side, so these raise rather than double-push a
+  job or double-count a stat.
 - `ConnectionPool::TimeoutError` — one retry after `0.1–0.3s`, then raise.
   Sustained checkout starvation is a sizing bug; fix the size.
+
+A block that is safe to re-run opts back into the full backoff with
+`idempotent: true`, forwarded by every wrapper (`Wurk.redis`, `Sidekiq.redis`,
+`Capsule#redis` / `#fetch_redis`, `Component#redis`, …):
+
+```ruby
+Wurk.redis(idempotent: true) { |conn| conn.call("LLEN", "queue:default") }
+```
+
+Wurk claims it for its own replay-safe paths — the fetcher's `LMOVE`/`BLMOVE` and
+paused-queue lookup, the reaper's SCAN and liveness sweep, `Stats`, `Queue`,
+`ProcessSet`, and the dashboard's search and limits reads. A host-supplied pool
+that doesn't understand the keyword keeps the conservative default; the zero-arg
+`Sidekiq.redis { … }` shape never changes.
 
 Every retry and final give-up is reported to `config.on_redis_error`:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -411,14 +411,21 @@ Ruby, so a retry re-issues every command in it:
 
 - `READONLY` / `NOREPLICAS` / `UNBLOCKED` — a failover; close and retry once
   immediately.
-- `CannotConnectError` / `FailoverError` — raised while dialing, before any byte
-  reached a server, so nothing can have applied: close, sleep
+- `CannotConnectError` / `FailoverError` — raised while dialing, so the command
+  that hit one never reached a server and cannot have applied: close, sleep
   `(0.5 × 2ⁿ) + rand×0.25`, retry up to 3 attempts total, then raise.
 - `ReadTimeoutError` / `WriteTimeoutError` / bare `ConnectionError` — the command
   may already have applied server-side, so these raise rather than double-push a
   job or double-count a stat.
 - `ConnectionPool::TimeoutError` — one retry after `0.1–0.3s`, then raise.
   Sustained checkout starvation is a sizing bug; fix the size.
+
+Those proofs cover the command that raised, not the block around it. A block is
+several round trips and redis-client re-dials mid-block, so a
+`CannotConnectError` can surface on the second pipeline of a push whose first
+one already landed. The pool counts completed round trips per connection and
+refuses to replay a block that has any, so a write Redis already took is never
+re-applied — however provably the failing command missed the server.
 
 A block that is safe to re-run opts back into the full backoff with
 `idempotent: true`, forwarded by every wrapper (`Wurk.redis`, `Sidekiq.redis`,

--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -327,9 +327,13 @@ Wurk::Client.reliable_push! unless Rails.env.test?
 | `Wurk::Client.reliable_push?` | — | Is it installed |
 | `Wurk::Client::Buffered.buffer_size` | — | Current depth |
 
-What gets caught: `RedisClient::ConnectionError` (after `Wurk::RedisPool`'s own
-retries — 3 attempts with exponential backoff) and `ConnectionPool::TimeoutError`
-(checkout starvation).
+What gets caught: `RedisClient::ConnectionError` and
+`ConnectionPool::TimeoutError` (checkout starvation). `Wurk::RedisPool` retries
+first, but only where a replay is provably safe: a connect-phase failure
+(`CannotConnectError` / `FailoverError`) gets 3 attempts with exponential
+backoff, while a read/write timeout — where the push may already have applied —
+raises on the first error rather than risk a duplicate job, and lands in the
+buffer straight away.
 
 **Flush behavior.** Every subsequent `push` / `push_bulk` drains the buffer
 oldest-first *before* pushing the new job. Draining stops at the first transient

--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -333,7 +333,10 @@ first, but only where a replay is provably safe: a connect-phase failure
 (`CannotConnectError` / `FailoverError`) gets 3 attempts with exponential
 backoff, while a read/write timeout — where the push may already have applied —
 raises on the first error rather than risk a duplicate job, and lands in the
-buffer straight away.
+buffer straight away. That backoff only runs while the push has landed nothing:
+once a queue group is acknowledged the pool stops replaying the block whatever
+the error, so a push that dies partway can never double the group it already
+delivered.
 
 **Flush behavior.** Every subsequent `push` / `push_bulk` drains the buffer
 oldest-first *before* pushing the new job. Draining stops at the first transient

--- a/lib/wurk.rb
+++ b/lib/wurk.rb
@@ -8,6 +8,7 @@
 require_relative 'wurk/version'
 require_relative 'wurk/keys'
 require_relative 'wurk/redis_pool'
+require_relative 'wurk/pool_checkout'
 require_relative 'wurk/redis_connection'
 require_relative 'wurk/middleware'
 require_relative 'wurk/middleware/chain'
@@ -126,8 +127,15 @@ module Wurk
     end
     alias default_configuration configuration
 
-    def redis(&)
-      redis_pool.with(&)
+    # `idempotent: true` asserts the block is safe to re-run after a command may
+    # already have applied server-side, buying back the full connection backoff
+    # (see RedisPool#with). Every wrapper down the chain — Capsule,
+    # Configuration, Component, middleware, Sidekiq.redis — forwards it, so a
+    # caller can claim apply-safety wherever it holds; PoolCheckout drops the
+    # claim for a host-supplied pool that wouldn't understand it. The zero-arg
+    # shape is the drop-in contract: `Sidekiq.redis { |c| ... }` never changes.
+    def redis(idempotent: false, &)
+      PoolCheckout.with(redis_pool, idempotent, &)
     end
 
     # Capsule-aware pool lookup. Thread-local override wins so per-capsule

--- a/lib/wurk/capsule.rb
+++ b/lib/wurk/capsule.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'redis_pool'
+require_relative 'pool_checkout'
 require_relative 'middleware/chain'
 require_relative 'fetcher/reliable'
 
@@ -120,14 +121,14 @@ module Wurk
       @fetch_redis_pool = nil
     end
 
-    def redis(&)
-      redis_pool.with(&)
+    def redis(idempotent: false, &)
+      PoolCheckout.with(redis_pool, idempotent, &)
     end
 
     # Checkout from the dedicated fetch pool. Only the reliable fetcher's
     # blocking BLMOVE uses this, so a parked fetch never holds a main-pool slot.
-    def fetch_redis(&)
-      fetch_redis_pool.with(&)
+    def fetch_redis(idempotent: false, &)
+      PoolCheckout.with(fetch_redis_pool, idempotent, &)
     end
 
     def lookup(name)

--- a/lib/wurk/client.rb
+++ b/lib/wurk/client.rb
@@ -248,6 +248,11 @@ module Wurk
       buffer = Thread.current[Wurk::Batch::BUFFER_KEY]
       return buffer_add(buffer, payloads) if buffer && payloads.all? { |p| p['bid'] && !p['at'] }
 
+      # No apply-safety claim: every command below appends (LPUSH, ZADD, the
+      # batch Lua's counters), so a block replayed after a lost reply is a
+      # second copy of the job. A post-write timeout raises out of here instead
+      # — {Client::Buffered} turns that into an outage-buffer entry, and a plain
+      # Client hands it to whoever called `perform_async`.
       pool.with { |conn| atomic_push(conn, payloads) }
       nil
     end
@@ -407,11 +412,12 @@ module Wurk
     end
 
     # Record a write Redis has acknowledged, for {Client::Buffered} to subtract
-    # from what it re-buffers. RedisPool#with replays the caller block on a
-    # transient error, so the ledger accumulates across attempts and is never
-    # pruned: a group applied on an earlier attempt stays marked, and the
-    # payload can't end up both retried by the pool and replayed from the
-    # buffer.
+    # from what it re-buffers: one push spans several pipelines (plain vs
+    # batched, immediate vs scheduled), and the ledger is what keeps a group
+    # that already landed out of the buffer when a later group fails. It
+    # accumulates across pool attempts and is never pruned — #raw_push claims no
+    # apply-safety, so the only replay left is a pre-apply one, where nothing
+    # was acknowledged and the ledger is still empty anyway.
     def mark_delivered(payloads)
       Thread.current[DELIVERED_KEY]&.concat(payloads)
     end

--- a/lib/wurk/client.rb
+++ b/lib/wurk/client.rb
@@ -252,7 +252,9 @@ module Wurk
       # batch Lua's counters), so a block replayed after a lost reply is a
       # second copy of the job. A post-write timeout raises out of here instead
       # — {Client::Buffered} turns that into an outage-buffer entry, and a plain
-      # Client hands it to whoever called `perform_async`.
+      # Client hands it to whoever called `perform_async`. The pool's pre-apply
+      # retry only fires while this block has landed nothing, so a queue group
+      # that already went out is never re-pushed by a replay.
       pool.with { |conn| atomic_push(conn, payloads) }
       nil
     end
@@ -416,8 +418,9 @@ module Wurk
     # batched, immediate vs scheduled), and the ledger is what keeps a group
     # that already landed out of the buffer when a later group fails. It
     # accumulates across pool attempts and is never pruned — #raw_push claims no
-    # apply-safety, so the only replay left is a pre-apply one, where nothing
-    # was acknowledged and the ledger is still empty anyway.
+    # apply-safety, and RedisPool refuses to replay such a block once one of its
+    # round trips has completed, so the only replay left starts from an empty
+    # ledger.
     def mark_delivered(payloads)
       Thread.current[DELIVERED_KEY]&.concat(payloads)
     end

--- a/lib/wurk/compat.rb
+++ b/lib/wurk/compat.rb
@@ -170,7 +170,7 @@ module Sidekiq
     def configure_client(&) = Wurk.configure_client(&)
     def configure_embed(&) = Wurk.configure_embed(&)
     def default_configuration = Wurk.default_configuration
-    def redis(&) = Wurk.redis(&)
+    def redis(idempotent: false, &) = Wurk.redis(idempotent:, &)
     def redis_pool = Wurk.redis_pool
     def logger = Wurk.logger
 

--- a/lib/wurk/component.rb
+++ b/lib/wurk/component.rb
@@ -63,8 +63,8 @@ module Wurk
       config.logger
     end
 
-    def redis(&)
-      config.redis(&)
+    def redis(idempotent: false, &)
+      config.redis(idempotent:, &)
     end
 
     def handle_exception(ex, ctx = {})

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -4,6 +4,7 @@ require 'etc'
 require 'logger'
 require_relative 'middleware/chain'
 require_relative 'capsule'
+require_relative 'pool_checkout'
 require_relative 'context'
 require_relative 'topology'
 require_relative 'redis_options'
@@ -198,8 +199,8 @@ module Wurk
       build_redis_pool(size: size, name: name)
     end
 
-    def redis(&)
-      redis_pool.with(&)
+    def redis(idempotent: false, &)
+      PoolCheckout.with(redis_pool, idempotent, &)
     end
 
     # --- Web dashboard Redis pool ----------------------------------------

--- a/lib/wurk/cron.rb
+++ b/lib/wurk/cron.rb
@@ -478,8 +478,8 @@ module Wurk
 
       private
 
-      def redis(&)
-        @config ? @config.redis(&) : Wurk.redis(&)
+      def redis(idempotent: false, &)
+        @config ? @config.redis(idempotent:, &) : Wurk.redis(idempotent:, &)
       end
     end
 

--- a/lib/wurk/deploy.rb
+++ b/lib/wurk/deploy.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'pool_checkout'
+
 module Wurk
   # Records deploy markers into Redis so the history pane can overlay
   # "deployed at" lines onto job-throughput charts. Wire-compatible with
@@ -84,11 +86,11 @@ module Wurk
       nil
     end
 
-    def with_redis(&)
+    def with_redis(idempotent: false, &)
       if @pool
-        @pool.with(&)
+        PoolCheckout.with(@pool, idempotent, &)
       else
-        Wurk.redis(&)
+        Wurk.redis(idempotent:, &)
       end
     end
   end

--- a/lib/wurk/fetcher/reaper.rb
+++ b/lib/wurk/fetcher/reaper.rb
@@ -165,7 +165,9 @@ module Wurk
       def each_private_list(public_q)
         cursor = '0'
         loop do
-          cursor, keys = redis { |c| c.call('SCAN', cursor, 'MATCH', "#{public_q}|*", 'COUNT', SCAN_COUNT) }
+          cursor, keys = redis(idempotent: true) do |c|
+            c.call('SCAN', cursor, 'MATCH', "#{public_q}|*", 'COUNT', SCAN_COUNT)
+          end
           keys.each do |key|
             host, pid, nonce = parse_owner(public_q, key)
             yield key, host, pid, nonce if pid
@@ -181,7 +183,9 @@ module Wurk
       def each_full_private_list
         cursor = '0'
         loop do
-          cursor, keys = redis { |c| c.call('SCAN', cursor, 'MATCH', "#{Keys::QUEUE_PREFIX}*|*", 'COUNT', SCAN_COUNT) }
+          cursor, keys = redis(idempotent: true) do |c|
+            c.call('SCAN', cursor, 'MATCH', "#{Keys::QUEUE_PREFIX}*|*", 'COUNT', SCAN_COUNT)
+          end
           keys.each do |key|
             parsed = parse_full_key(key)
             yield key, *parsed if parsed
@@ -291,7 +295,7 @@ module Wurk
       # TTL until ProcessSet#cleanup prunes it and that window must read as
       # dead or the owner's jobs are never reclaimed.
       def live_owners
-        redis do |conn|
+        redis(idempotent: true) do |conn|
           members = conn.call('SMEMBERS', Keys::PROCESSES)
           next ::Set.new if members.empty?
 
@@ -312,6 +316,12 @@ module Wurk
       # poison check, so a crash mid-drain leaves the job safely in the public
       # queue (at-least-once), never lost. Poison jobs are killed to the dead
       # set by PoisonPill.track! and then LREM'd out of the public queue.
+      #
+      # Unlike the fetcher's LMOVE, this one does *not* claim apply-safety: a
+      # replay after a lost reply moves the next job and never poison-checks the
+      # one already on the public tail, so a job that kills its worker every time
+      # would get a free recovery past the cap. A raise instead lands in the
+      # rescue below, and the next sweep re-drains what's left.
       def drain(private_list, public_q)
         queue_name = public_q.delete_prefix(Keys::QUEUE_PREFIX)
         count = 0

--- a/lib/wurk/fetcher/reliable.rb
+++ b/lib/wurk/fetcher/reliable.rb
@@ -177,12 +177,19 @@ module Wurk
       # is dominated by the BLMOVE that follows. Returns a Set for O(1)
       # lookup against the (often weighted-expanded) queue list.
       def paused_names
-        config.redis { |conn| conn.call('SMEMBERS', Keys::PAUSED_SET) }.to_set
+        config.redis(idempotent: true) { |conn| conn.call('SMEMBERS', Keys::PAUSED_SET) }.to_set
       end
 
+      # Both LMOVE forms claim apply-safety, so fetch keeps the full
+      # connection-blip backoff the F5 split otherwise takes away: a move that
+      # applied but whose reply was lost leaves the job in *this* process's
+      # private list, un-ACKed — byte-for-byte the state a SIGKILL between fetch
+      # and ack leaves behind, which the next boot's Reaper already reclaims. The
+      # replay then pulls a different job; nothing duplicates and nothing is
+      # lost, at worst one job waits out this process's lifetime.
       def lmove(public_q)
         priv = self.class.private_queue_name(public_q)
-        job = config.redis { |conn| conn.call('LMOVE', public_q, priv, 'RIGHT', 'LEFT') }
+        job = config.redis(idempotent: true) { |conn| conn.call('LMOVE', public_q, priv, 'RIGHT', 'LEFT') }
         job ? UnitOfWork.new(queue: public_q, job: job, config: config) : nil
       end
 
@@ -194,7 +201,7 @@ module Wurk
         # starving the main pool's background loops (#101). Extend the socket
         # read-timeout one second past BLMOVE's own server-side timeout so the
         # connection's read timeout can't fire while BLMOVE is legitimately blocked.
-        job = config.fetch_redis do |conn|
+        job = config.fetch_redis(idempotent: true) do |conn|
           conn.blocking_call(timeout + 1, 'BLMOVE', public_q, priv, 'RIGHT', 'LEFT', timeout)
         end
         job ? UnitOfWork.new(queue: public_q, job: job, config: config) : nil

--- a/lib/wurk/heartbeat.rb
+++ b/lib/wurk/heartbeat.rb
@@ -11,14 +11,17 @@ module Wurk
   # Wurk::Launcher so the launcher can stay focused on lifecycle and so the
   # heartbeat schema lives in one place readers can grep for.
   #
-  # Each beat is one pipelined round-trip:
+  # Each beat is two pipelined round-trips. The identity write:
   #   SADD   processes <identity>
   #   HSET   <identity>          info concurrency busy beat quiet rss rtt_us
   #   EXPIRE <identity>          60
   #   UNLINK <identity>:work
   #   HSET   <identity>:work     <tid> <json> ...    (only if WORK_STATE non-empty)
   #   EXPIRE <identity>:work     60                  (only if WORK_STATE non-empty)
+  # then the signal drain:
   #   LPOP   <identity>-signals  × BEAT_PAUSE
+  # Two rather than one because only the first is safe to replay — see
+  # #pipelined_beat and #drain_signals.
   #
   # The work hash is UNLINK-then-rewritten on every beat — a dropped beat
   # momentarily empties it, and ProcessSet#cleanup compensates by SREM-ing
@@ -90,16 +93,17 @@ module Wurk
 
     private
 
-    # Two extra writes (HSET + EXPIRE for the work mirror) when WORK_STATE
-    # has entries, so `lead` shifts to skip them when slicing signals out
-    # of the pipeline result.
+    # Every command in #write_beat converges on the state this snapshot
+    # describes however many times it lands, so the beat claims apply-safety and
+    # rides out a blip the way it did before the pool started splitting replay
+    # by it. `rtt_us` measures this write alone — the signal drain that follows
+    # is a separate checkout and deliberately not part of the gauge.
     def pipelined_beat
       work_snapshot = Processor::WORK_STATE.dup
-      lead = 4 + (work_snapshot.empty? ? 0 : 2)
       t0 = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC, :microsecond)
-      results = redis { |conn| conn.pipelined { |pipe| write_beat(pipe, work_snapshot) } }
+      redis(idempotent: true) { |conn| conn.pipelined { |pipe| write_beat(pipe, work_snapshot) } }
       rtt = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC, :microsecond) - t0
-      [results[lead, BEAT_PAUSE] || [], rtt]
+      [drain_signals, rtt]
     end
 
     def write_beat(pipe, work_snapshot)
@@ -107,7 +111,6 @@ module Wurk
       pipe.call('HSET', @identity, *beat_hash_args(work_snapshot.size))
       pipe.call('EXPIRE', @identity, TTL_SECONDS)
       write_work_hash(pipe, work_snapshot)
-      drain_signals(pipe)
     end
 
     def beat_hash_args(busy)
@@ -132,10 +135,19 @@ module Wurk
       pipe.call('EXPIRE', work_key, TTL_SECONDS)
     end
 
+    # Its own checkout, and never an idempotent one: LPOP is destructive and
+    # carries its result in the reply, so a replay after a lost reply discards
+    # whatever the first attempt already popped — and a discarded entry is a
+    # dashboard TERM or TSTP this process never acts on. Fused into the beat
+    # pipeline it would have dragged those writes down to the same no-replay
+    # default, or worse, invited a later sweep to claim the LPOPs alongside
+    # them. Runs after the beat so a signal only leaves Redis once the write
+    # that reports us alive has landed.
+    #
     # LPOP one entry per second of cadence so a flood of queued signals
     # can't stall the beat; anything older drains on the next beat.
-    def drain_signals(pipe)
-      BEAT_PAUSE.times { pipe.call('LPOP', "#{@identity}-signals") }
+    def drain_signals
+      redis { |conn| conn.pipelined { |pipe| BEAT_PAUSE.times { pipe.call('LPOP', "#{@identity}-signals") } } }
     end
 
     def info_hash

--- a/lib/wurk/launcher.rb
+++ b/lib/wurk/launcher.rb
@@ -163,9 +163,12 @@ module Wurk
 
       write_stats(processed, failed, expired)
     rescue StandardError => e
-      # Replay-safety: counters were reset above, so a Redis blip would
-      # otherwise drop stats. We log and accept — the per-job at-least-once
-      # semantics don't apply to *counters*, and the next beat resets again.
+      # The counters were reset above, so a raise here drops this window's stats
+      # for good: #write_stats cannot claim apply-safety and the pool no longer
+      # replays it through a blip. Accepted deliberately — adding them back
+      # would double-count the case where the INCRBYs did land and only the
+      # reply was lost, and the per-job at-least-once semantics don't apply to
+      # *counters*. The next beat resets again.
       handle_exception(e, { context: 'flush_stats' })
     end
 
@@ -226,6 +229,9 @@ module Wurk
       handle_exception(e, { context: "launcher-stop-#{label}" })
     end
 
+    # INCRBY is additive, so a pipeline replayed after a lost reply counts this
+    # window twice on every `stat:` key it touches — no apply-safety claim. (The
+    # EXPIREs riding along are harmless to repeat; the INCRBYs pin the block.)
     def write_stats(processed, failed, expired)
       day = Time.now.utc.strftime('%F')
       @config.redis do |conn|

--- a/lib/wurk/leader.rb
+++ b/lib/wurk/leader.rb
@@ -3,6 +3,7 @@
 require 'securerandom'
 require 'socket'
 require_relative 'component'
+require_relative 'pool_checkout'
 
 module Wurk
   # Cluster leader election via Redis `SET NX EX`. Single-leader-per-cluster
@@ -175,13 +176,13 @@ module Wurk
       @config.handle_exception(e, event: :leader) if @config.respond_to?(:handle_exception)
     end
 
-    def redis_call(&)
+    def redis_call(idempotent: false, &)
       if @pool
-        @pool.with(&)
+        PoolCheckout.with(@pool, idempotent, &)
       elsif @config
-        @config.redis(&)
+        @config.redis(idempotent:, &)
       else
-        Wurk.redis(&)
+        Wurk.redis(idempotent:, &)
       end
     end
 

--- a/lib/wurk/limiter.rb
+++ b/lib/wurk/limiter.rb
@@ -4,6 +4,7 @@ require 'json'
 require 'digest'
 require 'securerandom'
 require_relative 'lua'
+require_relative 'pool_checkout'
 
 module Wurk
   # Sidekiq Enterprise rate limiters: concurrent, bucket, window, leaky,
@@ -146,9 +147,8 @@ module Wurk
       # Redis access: caller-supplied pool (Limiter.configure.redis = …) wins,
       # else fall back to the default Wurk pool. This is the same hierarchy
       # Sidekiq Ent documents — dedicated rate-limiter pool is opt-in.
-      def redis(&)
-        pool = config.pool || Wurk.redis_pool
-        pool.with(&)
+      def redis(idempotent: false, &)
+        PoolCheckout.with(config.pool || Wurk.redis_pool, idempotent, &)
       end
 
       # `ZRANGE key 0 0 WITHSCORES` yields a single [member, score] pair, but the

--- a/lib/wurk/metrics/history.rb
+++ b/lib/wurk/metrics/history.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../middleware'
+require_relative '../pool_checkout'
 
 module Wurk
   module Metrics
@@ -124,11 +125,11 @@ module Wurk
         cfg.handle_exception(err, context: 'Wurk::Metrics::History')
       end
 
-      def self.with_pool(pool, &)
+      def self.with_pool(pool, idempotent: false, &)
         if pool
-          pool.with(&)
+          PoolCheckout.with(pool, idempotent, &)
         else
-          Wurk.redis(&)
+          Wurk.redis(idempotent:, &)
         end
       end
       private_class_method :with_pool

--- a/lib/wurk/middleware.rb
+++ b/lib/wurk/middleware.rb
@@ -24,8 +24,8 @@ module Wurk
         config.logger
       end
 
-      def redis(&)
-        config.redis(&)
+      def redis(idempotent: false, &)
+        config.redis(idempotent:, &)
       end
     end
 

--- a/lib/wurk/middleware/poison_pill.rb
+++ b/lib/wurk/middleware/poison_pill.rb
@@ -124,6 +124,11 @@ module Wurk
         end
       end
 
+      # No apply-safety claim: INCR is additive, so a block replayed after a
+      # lost reply bumps twice and can carry a healthy job past
+      # RECOVERY_THRESHOLD into the dead set. Raising instead only leaves the
+      # count short — Reaper#drain rescues, and the job is already back on its
+      # public queue, so it just misses one poison check.
       def bump_counter(jid)
         key = "#{KEY_PREFIX}#{jid}"
         Wurk.redis do |conn|

--- a/lib/wurk/pool_checkout.rb
+++ b/lib/wurk/pool_checkout.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative 'redis_pool'
+
+module Wurk
+  # The seam every `#redis`-style wrapper checks out through.
+  #
+  # `idempotent:` is a {Wurk::RedisPool} concept — it re-enables block replay
+  # after a command may already have applied server-side (see RedisPool#with).
+  # The object behind a wrapper is not always ours, though: the Sidekiq surface
+  # Wurk drops into lets a host supply any ConnectionPool-shaped object
+  # (`Sidekiq::Client#redis_pool=`, `Sidekiq::Web.redis_pool=`, the `pool:`
+  # kwarg on Stats::History / Deploy / Leader / Profiler / Metrics::History),
+  # and a bare `def with; yield conn; end` decorator — the shape people reach
+  # for to count or trace round trips — is a legal implementation of it. Handing
+  # that an unknown keyword is an ArgumentError, so the claim goes only to a pool
+  # that understands it.
+  #
+  # Dropping the claim is always sound: the pool falls back to the conservative
+  # no-replay default, which is exactly what a foreign pool did before the
+  # keyword existed. Apply-safety is an optimization, never a correctness input.
+  module PoolCheckout
+    def self.with(pool, idempotent, &)
+      return pool.with(&) unless idempotent && pool.is_a?(RedisPool)
+
+      pool.with(idempotent: true, &)
+    end
+  end
+end

--- a/lib/wurk/process_set.rb
+++ b/lib/wurk/process_set.rb
@@ -32,7 +32,7 @@ module Wurk
     # absence (process never registered) and expiry (heartbeat lapsed,
     # info field gone) both return nil.
     def self.[](identity)
-      exists, fields = Wurk.redis do |conn|
+      exists, fields = Wurk.redis(idempotent: true) do |conn|
         conn.pipelined do |pipe|
           pipe.call('SISMEMBER', Keys::PROCESSES, identity)
           pipe.call('HMGET', identity, *LOOKUP_FIELDS)
@@ -47,6 +47,11 @@ module Wurk
     # globally to 1/min via SET NX EX so concurrent dashboards / API calls
     # don't dogpile the prune. Returns the number of identities removed
     # (or 0 when the lock was held by someone else).
+    #
+    # No apply-safety claim, unlike the reads around it: a replay re-decides
+    # which identities are dead, so it could prune one that registered in
+    # between and hasn't written `info` yet. A blip here just skips one prune —
+    # the next caller a minute later does it.
     #
     # Spec: docs/target/sidekiq-free.md §31.17.
     def cleanup
@@ -84,7 +89,7 @@ module Wurk
     # SCARD over `processes`. Not pruned — may include identities whose
     # heartbeat has lapsed. Use `each` for the accurate count.
     def size
-      Wurk.redis { |conn| conn.call('SCARD', Keys::PROCESSES) }
+      Wurk.redis(idempotent: true) { |conn| conn.call('SCARD', Keys::PROCESSES) }
     end
 
     # Sum of `concurrency` across live processes. Iterates `each` so dead
@@ -104,7 +109,7 @@ module Wurk
     # `||=` with empty-string fallback distinguishes "leader is unset" from
     # "memoization not yet computed".
     def leader
-      @leader ||= Wurk.redis { |c| c.call('GET', 'dear-leader') } || ''
+      @leader ||= Wurk.redis(idempotent: true) { |c| c.call('GET', 'dear-leader') } || ''
     end
 
     class << self
@@ -134,7 +139,7 @@ module Wurk
     private
 
     def fetch_each_rows
-      Wurk.redis do |conn|
+      Wurk.redis(idempotent: true) do |conn|
         procs = conn.call('SMEMBERS', Keys::PROCESSES).sort
         next [] if procs.empty?
 
@@ -223,7 +228,7 @@ module Wurk
     # Compares identity against the `dear-leader` STRING. Ent-only;
     # always false in OSS/free.
     def leader?
-      Wurk.redis { |c| c.call('GET', 'dear-leader') == identity }
+      Wurk.redis(idempotent: true) { |c| c.call('GET', 'dear-leader') == identity }
     end
 
     private

--- a/lib/wurk/profiler.rb
+++ b/lib/wurk/profiler.rb
@@ -5,6 +5,7 @@ require 'zlib'
 require 'stringio'
 require 'tempfile'
 require_relative 'keys'
+require_relative 'pool_checkout'
 
 module Wurk
   # Job profiling (Sidekiq 8.0+, OSS). When a job is pushed with a `profile`
@@ -113,8 +114,8 @@ module Wurk
         end
       end
 
-      def with_pool(pool, &)
-        pool ? pool.with(&) : Wurk.redis(&)
+      def with_pool(pool, idempotent: false, &)
+        pool ? PoolCheckout.with(pool, idempotent, &) : Wurk.redis(idempotent:, &)
       end
 
       def now

--- a/lib/wurk/queue.rb
+++ b/lib/wurk/queue.rb
@@ -25,7 +25,7 @@ module Wurk
 
     # @return [Array<Queue>] one per known queue, sorted by name.
     def self.all
-      names = Wurk.redis { |conn| conn.call('SMEMBERS', Keys::QUEUES_SET) }
+      names = Wurk.redis(idempotent: true) { |conn| conn.call('SMEMBERS', Keys::QUEUES_SET) }
       names.sort.map { |n| new(n) }
     end
 
@@ -35,12 +35,12 @@ module Wurk
     end
 
     def size
-      Wurk.redis { |conn| conn.call('LLEN', @rname) }
+      Wurk.redis(idempotent: true) { |conn| conn.call('LLEN', @rname) }
     end
 
     # Seconds since the oldest job (tail of LIST) was enqueued. 0.0 when empty.
     def latency
-      payload = Wurk.redis { |conn| conn.call('LRANGE', @rname, -1, -1).first }
+      payload = Wurk.redis(idempotent: true) { |conn| conn.call('LRANGE', @rname, -1, -1).first }
       return 0.0 if payload.nil?
 
       JobRecord.latency_from(Wurk.load_json(payload)['enqueued_at'])
@@ -51,19 +51,19 @@ module Wurk
     # True iff this queue's name is a member of the `paused` SET. Wurk
     # implements the Pro contract for free; fetchers consult the same set.
     def paused?
-      Wurk.redis { |conn| conn.call('SISMEMBER', Keys::PAUSED_SET, @name) } == 1
+      Wurk.redis(idempotent: true) { |conn| conn.call('SISMEMBER', Keys::PAUSED_SET, @name) } == 1
     end
 
     # Pause new fetches against this queue. Idempotent — `SADD` returns
     # 0 when the name was already present. In-flight jobs are untouched.
     def pause! # rubocop:disable Naming/PredicateMethod
-      Wurk.redis { |conn| conn.call('SADD', Keys::PAUSED_SET, @name) }
+      Wurk.redis(idempotent: true) { |conn| conn.call('SADD', Keys::PAUSED_SET, @name) }
       true
     end
 
     # Resume fetches. Idempotent.
     def unpause! # rubocop:disable Naming/PredicateMethod
-      Wurk.redis { |conn| conn.call('SREM', Keys::PAUSED_SET, @name) }
+      Wurk.redis(idempotent: true) { |conn| conn.call('SREM', Keys::PAUSED_SET, @name) }
       true
     end
 
@@ -74,7 +74,7 @@ module Wurk
       loop do
         start  = page * PAGE_SIZE
         stop   = start + PAGE_SIZE - 1
-        slice  = Wurk.redis { |conn| conn.call('LRANGE', @rname, start, stop) }
+        slice  = Wurk.redis(idempotent: true) { |conn| conn.call('LRANGE', @rname, start, stop) }
         slice.each { |value| yield JobRecord.new(value, @name) }
         break if slice.size < PAGE_SIZE
 
@@ -91,6 +91,9 @@ module Wurk
     # UNLINK the list + drop the queue from the `queues` set. Pipelined
     # so a partial failure leaves at most one of the two ops applied.
     # Method name is Sidekiq wire-compat — `clear?` would break the alias.
+    #
+    # Unlike pause!/unpause!, this one can't claim apply-safety: a replay after
+    # a lost reply would UNLINK whatever a producer enqueued in between.
     def clear # rubocop:disable Naming/PredicateMethod
       Wurk.redis do |conn|
         conn.pipelined do |pipe|

--- a/lib/wurk/redis_client_adapter.rb
+++ b/lib/wurk/redis_client_adapter.rb
@@ -21,13 +21,18 @@ module Wurk
 
     DEPRECATED_COMMANDS = %i[rpoplpush zrangebyscore zrevrange zrevrangebyscore getset hmset setex setnx].to_set
 
+    # Every method here dispatches through `call` rather than `@client.call` so
+    # the round-trip odometer below sees method-style commands too — a host
+    # block doing `conn.sadd(...)` then `conn.lpush(...)` has to be as
+    # replay-protected as one written with `conn.call`. On the pipeline
+    # decorator `call` is the same buffered forward it always was.
     module CompatMethods
       def info
-        @client.call('INFO') { |i| i.lines(chomp: true).map { |l| l.split(':', 2) }.select { |l| l.size == 2 }.to_h }
+        call('INFO') { |i| i.lines(chomp: true).map { |l| l.split(':', 2) }.select { |l| l.size == 2 }.to_h }
       end
 
       def evalsha(sha, keys, argv)
-        @client.call('EVALSHA', sha, keys.size, *keys, *argv)
+        call('EVALSHA', sha, keys.size, *keys, *argv)
       end
 
       # The Redis commands Sidekiq itself uses — defined eagerly so the
@@ -41,7 +46,7 @@ module Wurk
 
       USED_COMMANDS.each do |name|
         define_method(name) do |*args, **kwargs|
-          @client.call(name, *args, **kwargs)
+          call(name, *args, **kwargs)
         end
       end
 
@@ -52,7 +57,7 @@ module Wurk
         if DEPRECATED_COMMANDS.include?(args.first)
           warn("[sidekiq#5788] Redis has deprecated the `#{args.first}` command, called at #{caller(1..1)}")
         end
-        @client.call(*args, &)
+        call(*args, &)
       end
       ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
 
@@ -64,8 +69,47 @@ module Wurk
     CompatClient = RedisClient::Decorator.create(CompatMethods)
 
     class CompatClient
+      # Dispatch methods that put commands on the wire and wait for the reply.
+      # SCAN and friends are left out on purpose: they are pure reads, so
+      # re-running one applies nothing and cannot make a replay unsafe.
+      DISPATCH_METHODS = %i[call call_v call_once call_once_v
+                            blocking_call blocking_call_v pipelined multi].freeze
+
+      # Round trips this connection has completed, monotonic for its whole life.
+      #
+      # {Wurk::RedisPool} replays a failed block only while it can prove nothing
+      # in it applied, and a connect-phase error proves that for the command
+      # that raised — never for the ones before it. redis-client re-dials a
+      # dropped socket mid-block, so `CannotConnectError` surfaces on the second
+      # pipeline of a block whose first one already landed. The pool snapshots
+      # this counter around the block and refuses the replay once it has moved.
+      attr_reader :round_trips
+
+      def initialize(client)
+        super
+        @round_trips = 0
+      end
+
       def config
         @client.config
+      end
+
+      # Counted *after* the call returns: a command that never reached a server
+      # leaves the odometer where it was, which is what keeps the pre-apply
+      # backoff alive for blocks that failed on their very first round trip.
+      DISPATCH_METHODS.each do |name|
+        class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
+          # def call(...)
+          #   result = super
+          #   @round_trips += 1
+          #   result
+          # end
+          def #{name}(...)
+            result = super
+            @round_trips += 1
+            result
+          end
+        RUBY
       end
     end
   end

--- a/lib/wurk/redis_pool.rb
+++ b/lib/wurk/redis_pool.rb
@@ -10,17 +10,23 @@ module Wurk
   # across forks: the parent closes the pool before fork, each child opens a
   # fresh one (see docs/idea/03-process-model.md, steps 3 and 5).
   #
-  # #with absorbs transient Redis failures (production incident #101):
+  # #with absorbs transient Redis failures (production incident #101), but only
+  # where replaying the caller's block cannot change what the server already
+  # did — the block is arbitrary Ruby, so a replay re-issues every command in it:
   #   * READONLY / NOREPLICAS / UNBLOCKED — a failover happened; close and retry
   #     once immediately so redis-client redials the new primary (spec §26).
-  #   * ConnectionError (incl. CannotConnect / Read- / WriteTimeout) — a blip;
-  #     close and retry with exponential backoff up to CONN_MAX_ATTEMPTS, then
-  #     raise. At-least-once tolerates the rare duplicate and JobRetry re-runs
-  #     the job anyway, so retrying at the pool layer is strictly better.
+  #   * CannotConnect / Failover — raised while dialing, before any byte of the
+  #     block reached a server, so nothing can have applied; close and retry with
+  #     exponential backoff up to CONN_MAX_ATTEMPTS, then raise.
+  #   * Read-/WriteTimeout and bare ConnectionError — the command may already
+  #     have applied server-side, so these raise. Replaying would double-push a
+  #     job, double-count a stat, or drop a member ZPOPed by the lost reply.
+  #     Blocks that are safe to re-run (pure reads, an LMOVE the reaper reclaims,
+  #     owner-CAS scripts) opt back into the backoff with `with(idempotent: true)`.
   #   * ConnectionPool::TimeoutError — checkout starved; retry once after a
   #     short jittered pause, then raise (sizing is the fix, not queuing).
-  # Every retry and final give-up is reported through the injected `on_error`
-  # telemetry hook (Wurk::Configuration#on_redis_error).
+  # Every retry, refused replay, and final give-up is reported through the
+  # injected `on_error` telemetry hook (Wurk::Configuration#on_redis_error).
   class RedisPool
     DEFAULT_URL  = ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')
     DEFAULT_NAME = 'default'
@@ -32,7 +38,9 @@ module Wurk
     # wait above. read/write are deliberately wider than connect so a briefly-
     # slow-but-alive Redis (RDB fork pause, a large BLMOVE payload) doesn't
     # spuriously ReadTimeout — the production incident (#101) the single
-    # dual-use timeout caused. reconnect_attempts re-dials a dropped socket once.
+    # dual-use timeout caused. reconnect_attempts re-dials a dropped socket once;
+    # note that redis-client's re-dial also re-sends the one in-flight command,
+    # so the apply-safety split below bounds block replay, not command replay.
     DEFAULT_CONNECT_TIMEOUT    = 1.0
     DEFAULT_READ_TIMEOUT       = 2.5
     DEFAULT_WRITE_TIMEOUT      = 2.5
@@ -52,6 +60,17 @@ module Wurk
     # so this message match must be tested BEFORE the generic ConnectionError
     # backoff below (otherwise a failover would sleep instead of redialing).
     RETRYABLE_MSG = /\A(READONLY|NOREPLICAS|UNBLOCKED)/
+
+    # ConnectionErrors that can only be raised while dialing, so the block
+    # provably never applied and replaying it is safe whatever it contains.
+    # CannotConnect covers every connect-phase failure (redis-client converts a
+    # stalled handshake into it); Failover is the Sentinel resolver rejecting a
+    # server whose role changed. Any other ConnectionError — Read-/WriteTimeout
+    # or a reset mid-command — leaves the outcome unknown.
+    PRE_APPLY_ERRORS = [RedisClient::CannotConnectError, RedisClient::FailoverError].freeze
+
+    # The two retry_plan verdicts that re-run the block; the rest raise.
+    REPLAY_PLANS = %i[failover backoff].freeze
 
     # ConnectionError backoff: CONN_MAX_ATTEMPTS total tries, sleeping
     # (BASE * 2**attempt) + rand*JITTER before each retry. The 1.0s + 2.0s pair
@@ -89,10 +108,14 @@ module Wurk
     # Checkout a connection and run the block. ConnectionPool::TimeoutError is
     # raised by @pool.with *before* the block runs, so it is caught out here
     # (the in-block #run rescue never sees it) — one retry, then raise.
-    def with(&block)
+    #
+    # `idempotent: true` asserts the block can be re-run after a command may
+    # already have applied server-side, which buys back the full ConnectionError
+    # backoff. Only claim it for pure reads or writes whose repeat is a no-op.
+    def with(idempotent: false, &block)
       checkout_retried = false
       begin
-        @pool.with { |conn| run(conn, &block) }
+        @pool.with { |conn| run(conn, idempotent, &block) }
       rescue ConnectionPool::TimeoutError => e
         if checkout_retried
           notify_error(e, attempt: 2, retried: false)
@@ -113,7 +136,7 @@ module Wurk
     # slot counts merged in — one call gives a heartbeat both Redis health and
     # local pool saturation. (Real Redis INFO has no `size`/`available` field.)
     def info
-      with { |conn| parse_info(conn.call('INFO')) }
+      with(idempotent: true) { |conn| parse_info(conn.call('INFO')) }
         .merge('size' => @size, 'available' => available)
     end
 
@@ -159,17 +182,18 @@ module Wurk
     # Runs the block on the checked-out `conn`, retrying transient RedisClient
     # errors in place: the same slot is reused across retries (redis-client
     # redials a closed socket lazily), so a busy fetcher can't leak checkouts.
-    def run(conn)
+    def run(conn, idempotent)
       attempts = 0
       begin
         attempts += 1
         yield conn
       rescue RedisClient::Error => e
-        plan = retry_plan(e, attempts)
+        plan = retry_plan(e, attempts, idempotent)
         raise if plan == :propagate
 
-        notify_error(e, attempt: attempts, retried: plan != :exhausted)
-        raise if plan == :exhausted
+        replaying = REPLAY_PLANS.include?(plan)
+        notify_error(e, attempt: attempts, retried: replaying)
+        raise unless replaying
 
         safe_close(conn)
         sleep(backoff_delay(attempts)) if plan == :backoff
@@ -177,19 +201,27 @@ module Wurk
       end
     end
 
-    # Pure classification of a RedisClient error against the attempt count:
+    # Pure classification of a RedisClient error against the attempt count and
+    # the caller's apply-safety claim:
     #   :failover  → close + immediate retry (a primary swap)
     #   :backoff   → close + sleep + retry (a connection blip)
-    #   :exhausted → ConnectionError past the cap; report and give up
+    #   :unsafe    → the command may have applied; report the blip, then raise
+    #   :exhausted → replayable ConnectionError past the cap; report and give up
     #   :propagate → not transient (or a spent failover); raise as-is
-    def retry_plan(err, attempts)
+    def retry_plan(err, attempts, idempotent)
       if RETRYABLE_MSG.match?(err.message.to_s)
         attempts > 1 ? :propagate : :failover
-      elsif err.is_a?(RedisClient::ConnectionError)
-        attempts >= CONN_MAX_ATTEMPTS ? :exhausted : :backoff
-      else
+      elsif !err.is_a?(RedisClient::ConnectionError)
         :propagate
+      elsif !replayable?(err, idempotent)
+        :unsafe
+      else
+        attempts >= CONN_MAX_ATTEMPTS ? :exhausted : :backoff
       end
+    end
+
+    def replayable?(err, idempotent)
+      idempotent || PRE_APPLY_ERRORS.any? { |klass| err.is_a?(klass) }
     end
 
     def notify_error(error, attempt:, retried:)

--- a/lib/wurk/redis_pool.rb
+++ b/lib/wurk/redis_pool.rb
@@ -15,8 +15,8 @@ module Wurk
   # did — the block is arbitrary Ruby, so a replay re-issues every command in it:
   #   * READONLY / NOREPLICAS / UNBLOCKED — a failover happened; close and retry
   #     once immediately so redis-client redials the new primary (spec §26).
-  #   * CannotConnect / Failover — raised while dialing, before any byte of the
-  #     block reached a server, so nothing can have applied; close and retry with
+  #   * CannotConnect / Failover — raised while dialing, so the command that hit
+  #     one never reached a server and cannot have applied; close and retry with
   #     exponential backoff up to CONN_MAX_ATTEMPTS, then raise.
   #   * Read-/WriteTimeout and bare ConnectionError — the command may already
   #     have applied server-side, so these raise. Replaying would double-push a
@@ -25,6 +25,12 @@ module Wurk
   #     owner-CAS scripts) opt back into the backoff with `with(idempotent: true)`.
   #   * ConnectionPool::TimeoutError — checkout starved; retry once after a
   #     short jittered pause, then raise (sizing is the fix, not queuing).
+  # Those proofs are about the command that raised, not the block around it: a
+  # block is several round trips, and redis-client re-dials mid-block, so a
+  # CannotConnect can surface on the second pipeline of a block whose first one
+  # already landed. So the pool also watches the connection's round-trip
+  # odometer (RedisClientAdapter::CompatClient#round_trips) and refuses to
+  # replay a non-idempotent block that has already completed one.
   # Every retry, refused replay, and final give-up is reported through the
   # injected `on_error` telemetry hook (Wurk::Configuration#on_redis_error).
   class RedisPool
@@ -186,9 +192,10 @@ module Wurk
       attempts = 0
       begin
         attempts += 1
+        odometer = conn.round_trips
         yield conn
       rescue RedisClient::Error => e
-        plan = retry_plan(e, attempts, idempotent)
+        plan = retry_plan(e, attempts, idempotent, conn.round_trips != odometer)
         raise if plan == :propagate
 
         replaying = REPLAY_PLANS.include?(plan)
@@ -201,27 +208,33 @@ module Wurk
       end
     end
 
-    # Pure classification of a RedisClient error against the attempt count and
-    # the caller's apply-safety claim:
+    # Pure classification of a RedisClient error against the attempt count, the
+    # caller's apply-safety claim, and whether this attempt already completed a
+    # round trip (`dirty`):
     #   :failover  → close + immediate retry (a primary swap)
     #   :backoff   → close + sleep + retry (a connection blip)
-    #   :unsafe    → the command may have applied; report the blip, then raise
+    #   :unsafe    → something may have applied; report the blip, then raise
     #   :exhausted → replayable ConnectionError past the cap; report and give up
     #   :propagate → not transient (or a spent failover); raise as-is
-    def retry_plan(err, attempts, idempotent)
-      if RETRYABLE_MSG.match?(err.message.to_s)
-        attempts > 1 ? :propagate : :failover
-      elsif !err.is_a?(RedisClient::ConnectionError)
-        :propagate
-      elsif !replayable?(err, idempotent)
-        :unsafe
-      else
-        attempts >= CONN_MAX_ATTEMPTS ? :exhausted : :backoff
-      end
+    def retry_plan(err, attempts, idempotent, dirty)
+      failover = RETRYABLE_MSG.match?(err.message.to_s)
+      return :propagate unless failover || err.is_a?(RedisClient::ConnectionError)
+      return :unsafe unless replayable?(err, idempotent, dirty, failover)
+      return attempts > 1 ? :propagate : :failover if failover
+
+      attempts >= CONN_MAX_ATTEMPTS ? :exhausted : :backoff
     end
 
-    def replayable?(err, idempotent)
-      idempotent || PRE_APPLY_ERRORS.any? { |klass| err.is_a?(klass) }
+    # A replay re-issues the whole block, so one completed round trip voids
+    # every pre-apply proof: however provably the *failing* command missed the
+    # server, the ones ahead of it in the block did not. On a still-clean block
+    # a failover reply is proof enough by itself (the command was rejected
+    # outright); a bare ConnectionError needs one of the connect-phase classes.
+    def replayable?(err, idempotent, dirty, failover)
+      return true if idempotent
+      return false if dirty
+
+      failover || PRE_APPLY_ERRORS.any? { |klass| err.is_a?(klass) }
     end
 
     def notify_error(error, attempt:, retried:)

--- a/lib/wurk/scheduled.rb
+++ b/lib/wurk/scheduled.rb
@@ -58,11 +58,28 @@ module Wurk
         loop do
           break if @done
 
-          jobstr = @config.redis { |conn| Wurk::Lua::Loader.eval_cached(conn, :zpopbyscore, keys: [sset], argv: [now]) }
+          jobstr = pop_due(sset, now)
           break unless jobstr
 
           push_promoted(jobstr, sset)
         end
+      end
+
+      # ZPOPBYSCORE is destructive and carries its result in the reply, so this
+      # block never claims apply-safety: a replay discards whatever the lost
+      # reply already removed. The pool therefore raises on a Read-/WriteTimeout,
+      # which leaves the outcome of *this* pop unknown — a due job may or may not
+      # have come off the ZSET. Report it and end this set's drain (the nil makes
+      # #drain_set break) rather than pop again blind; a job caught in that window
+      # falls into the same pop→push loss the default scheduler already documents
+      # on #push_promoted, and `reliable_scheduler!` (ReliableEnq) is the loss-free
+      # fix. Rescuing here rather than around #drain_set keeps the sibling set
+      # draining on this tick.
+      def pop_due(sset, now)
+        @config.redis { |conn| Wurk::Lua::Loader.eval_cached(conn, :zpopbyscore, keys: [sset], argv: [now]) }
+      rescue RedisClient::ConnectionError => e
+        handle_exception(e, { context: 'scheduler_pop', set: sset })
+        nil
       end
 
       # A raising `@client.push` (bad payload, transient Redis error) must not

--- a/lib/wurk/stats.rb
+++ b/lib/wurk/stats.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'date'
+require_relative 'pool_checkout'
 
 module Wurk
   # Read-only inspector for cluster state in Redis. The cheap counters are
@@ -185,11 +186,11 @@ module Wurk
         keys.zip(values.map(&:to_i)).to_h
       end
 
-      def with_redis(&)
+      def with_redis(idempotent: false, &)
         if @pool
-          @pool.with(&)
+          PoolCheckout.with(@pool, idempotent, &)
         else
-          Wurk.redis(&)
+          Wurk.redis(idempotent:, &)
         end
       end
     end

--- a/lib/wurk/stats.rb
+++ b/lib/wurk/stats.rb
@@ -39,7 +39,7 @@ module Wurk
     # Sum of the `busy` HASH field across every live process identity.
     # Pipelined but unbounded by process count.
     def workers_size
-      Wurk.redis do |conn|
+      Wurk.redis(idempotent: true) do |conn|
         identities = conn.call('SMEMBERS', Keys::PROCESSES)
         next 0 if identities.empty?
 
@@ -56,7 +56,7 @@ module Wurk
     # and dashboards reading this rely on that order. Match it exactly with
     # `sort_by { |_, size| -size }`.
     def queues
-      Wurk.redis do |conn|
+      Wurk.redis(idempotent: true) do |conn|
         names = conn.call('SMEMBERS', Keys::QUEUES_SET)
         next {} if names.empty?
 
@@ -72,7 +72,7 @@ module Wurk
     # (`queue_summaries.sort_by { |qd| -qd.size }`) — this feeds the
     # dashboard's queue table (api_controller#queues).
     def queue_summaries
-      Wurk.redis do |conn|
+      Wurk.redis(idempotent: true) do |conn|
         names = conn.call('SMEMBERS', Keys::QUEUES_SET)
         next [] if names.empty?
 
@@ -90,13 +90,17 @@ module Wurk
     # Latency (secs) of the `default` queue — the most-asked-about gauge.
     def default_queue_latency
       now_ms = ::Process.clock_gettime(::Process::CLOCK_REALTIME, :millisecond)
-      payload = Wurk.redis { |c| c.call('LRANGE', Keys.queue('default'), -1, -1) }.first
+      payload = Wurk.redis(idempotent: true) { |c| c.call('LRANGE', Keys.queue('default'), -1, -1) }.first
       compute_latency(payload, now_ms)
     end
 
     # Resets the named global counters. With no args, clears `processed`,
     # `failed`, and `expired`. SET … 0 (not DEL — keeps the key around so
     # reads stay `Integer` not `nil`).
+    #
+    # The only write here, and the only block in this class that can't claim
+    # apply-safety: a replay after a lost reply would re-zero the counters,
+    # discarding whatever the fleet counted in between.
     def reset(*stats)
       all      = %w[failed processed expired]
       to_clear = stats.empty? ? all : all & stats.flatten.map(&:to_s)
@@ -124,7 +128,7 @@ module Wurk
     private_constant :FAST_QUERIES, :FAST_KEYS
 
     def fetch_stats_fast!
-      raw = Wurk.redis do |conn|
+      raw = Wurk.redis(idempotent: true) do |conn|
         conn.pipelined { |pipe| FAST_QUERIES.each { |args| pipe.call(*args) } }
       end
       @stats = FAST_KEYS.zip(raw.map(&:to_i)).to_h
@@ -180,7 +184,7 @@ module Wurk
 
       def date_stat_hash(stat)
         keys = (0...@days_previous).map { |i| (@start_date - i).strftime('%Y-%m-%d') }
-        values = with_redis do |conn|
+        values = with_redis(idempotent: true) do |conn|
           conn.pipelined { |pipe| keys.each { |d| pipe.call('GET', "stat:#{stat}:#{d}") } }
         end
         keys.zip(values.map(&:to_i)).to_h

--- a/lib/wurk/web/enterprise.rb
+++ b/lib/wurk/web/enterprise.rb
@@ -25,7 +25,7 @@ module Wurk
         # @return [Array<String>] limiter names, optionally filtered to those
         #   whose name contains the case-insensitive substring `filter`.
         def list(filter: nil)
-          names = Wurk.redis { |c| c.call('SMEMBERS', Wurk::Limiter::LIST_KEY) }.sort
+          names = Wurk.redis(idempotent: true) { |c| c.call('SMEMBERS', Wurk::Limiter::LIST_KEY) }.sort
           return names if filter.nil? || filter.to_s.empty?
 
           needle = filter.to_s.downcase
@@ -33,7 +33,7 @@ module Wurk
         end
 
         def metadata(name)
-          raw = Wurk.redis { |c| c.call('HGETALL', "lmtr:#{name}") }
+          raw = Wurk.redis(idempotent: true) { |c| c.call('HGETALL', "lmtr:#{name}") }
           raw.is_a?(Array) ? raw.each_slice(2).to_h : raw
         end
 

--- a/lib/wurk/web/extension.rb
+++ b/lib/wurk/web/extension.rb
@@ -148,7 +148,7 @@ module Wurk
           %(<time class="ltr" dir="ltr" title="#{iso}" datetime="#{iso}">#{iso}</time>)
         end
 
-        def redis(&) = ::Wurk.redis(&)
+        def redis(idempotent: false, &) = ::Wurk.redis(idempotent:, &)
         def product_version = ::Wurk::VERSION
         def number_with_delimiter(num) = num.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse
       end

--- a/lib/wurk/web/search.rb
+++ b/lib/wurk/web/search.rb
@@ -103,10 +103,12 @@ module Wurk
       # we scan a bounded prefix and never full-walk the LIST from a keystroke.
       def scan_queue_list(queue_name, &)
         key = Keys.queue(queue_name)
-        stop_at = queue_scan_stop(Wurk.redis { |c| c.call('LLEN', key) })
+        stop_at = queue_scan_stop(Wurk.redis(idempotent: true) { |c| c.call('LLEN', key) })
         start = 0
         while start < stop_at
-          slice = Wurk.redis { |c| c.call('LRANGE', key, start, [start + QUEUE_PAGE, stop_at].min - 1) }
+          slice = Wurk.redis(idempotent: true) do |c|
+            c.call('LRANGE', key, start, [start + QUEUE_PAGE, stop_at].min - 1)
+          end
           break if slice.empty?
 
           slice.each(&)
@@ -134,7 +136,7 @@ module Wurk
         set = sorted_set_for(kind)
         cursor = '0'
         loop do
-          cursor, page = Wurk.redis { |c| c.call('ZSCAN', set.name, cursor, 'COUNT', ZSCAN_PAGE) }
+          cursor, page = Wurk.redis(idempotent: true) { |c| c.call('ZSCAN', set.name, cursor, 'COUNT', ZSCAN_PAGE) }
           emit_sorted_hits(kind, set, page, &)
           @scanned += page.size / 2
           break if cursor == '0'

--- a/test/integration/redis_outage_recovery_test.rb
+++ b/test/integration/redis_outage_recovery_test.rb
@@ -107,6 +107,37 @@ class RedisOutageRecoveryTest < Wurk::Test::UnitCase
   end
   # rubocop:enable Metrics/AbcSize, Minitest/MultipleAssertions
 
+  # 04-redis-retry-idempotency, F5 regression: Heartbeat#drain_signals is
+  # deliberately excluded from `idempotent: true` (LPOP is destructive — see
+  # heartbeat.rb's comment above the method) so it never replays a reply lost
+  # to a blip. That is only safe because the retry that lets a heartbeat
+  # survive the blip at all comes from RedisPool's always-retryable
+  # PRE_APPLY_ERRORS (CannotConnectError et al.) — errors raised before any
+  # command reached the wire — which is exactly what a real TCP outage in
+  # front of a fresh connection attempt produces. Seed a signal directly
+  # against real Redis (bypassing the proxy, same as the sentinel worker
+  # above), blip the pool the heartbeat itself is behind, and assert the
+  # signal comes back exactly once: not dropped by the outage, not
+  # duplicated by the retry.
+  def test_heartbeat_retry_survives_a_blip_without_dropping_a_seeded_signal
+    identity = "#{@ns}-hb"
+    signals_key = "#{identity}-signals"
+    @observer.call('LPUSH', signals_key, 'TERM')
+    heartbeat = Wurk::Heartbeat.new(identity: identity, config: @config)
+
+    blip = Thread.new { @proxy.blip!(BLIP_SECONDS) }
+    sleep 0.2 # let the outage start before the beat's first connection attempt hits it
+
+    sigs = heartbeat.beat!
+    blip.join
+
+    assert_equal ['TERM'], sigs, 'the seeded signal must survive the blip exactly once'
+    assert_equal 0, @observer.call('LLEN', signals_key).to_i, 'the signal must be drained, not left behind'
+  ensure
+    @observer.call('DEL', identity, "#{identity}:work", signals_key)
+    @observer.call('SREM', Wurk::Keys::PROCESSES, identity)
+  end
+
   private
 
   def build_config

--- a/test/unit/client_partial_delivery_test.rb
+++ b/test/unit/client_partial_delivery_test.rb
@@ -118,6 +118,20 @@ class ClientPartialDeliveryTest < Wurk::Test::UnitCase
     assert_empty queued_args(@queue)
   end
 
+  # Plan 04/F5 follow-up, through a real RedisPool this time. CannotConnectError
+  # is the pool's "provably nothing applied" case — true of the command that
+  # raised, false of the pipeline before it. Replaying the block would put the
+  # delivered group in `queue:` a second time.
+  def test_the_pool_does_not_replay_a_push_that_already_delivered_a_queue_group
+    client = Wurk::Client.new(pool: retrying_pool(deliver: 1, kind: RedisClient::CannotConnectError))
+
+    client.send(:raw_push, [item(args: ['a'], jid: 'j-a'),
+                            item(args: ['b'], jid: 'j-b', queue: @other_queue)])
+
+    assert_equal [['a']], queued_args(@queue), 'the delivered group must not be re-pushed'
+    assert_equal [['b']], buffered_args
+  end
+
   # Plan 03/S14. raw_push hands back exactly what it diverted into the buffer,
   # and Client#push subtracts that from the enqueued metric. The delivered
   # group must not be in the set — it reached Redis and has to keep counting.
@@ -178,14 +192,36 @@ class ClientPartialDeliveryTest < Wurk::Test::UnitCase
   # like a dropped socket. Reproduces the only failure mode that matters here:
   # writes Redis already applied, followed by a ConnectionError.
   #
-  # Deliberately not a RedisPool: #with there replays the block up to
-  # CONN_MAX_ATTEMPTS with backoff, which would both re-apply the delivered
-  # group (plan 04's F5, fixed separately) and add seconds of sleep per test.
+  # Deliberately not a RedisPool: these cases are about the delivery ledger, not
+  # the retry policy, and a bare pool keeps them free of both.
   def dropping_pool(deliver:)
     conn = MidPushDropConn.new(raw_conn, deliver: deliver)
     pool = Object.new
     pool.define_singleton_method(:with) { |&blk| blk.call(conn) }
     pool
+  end
+
+  # The same connection behind a real RedisPool, so the block runs under the
+  # actual retry policy. Its own ConnectionPool is swapped out rather than
+  # opened, exactly like the pool unit tests do.
+  def retrying_pool(deliver:, kind:)
+    conn = MidPushDropConn.new(raw_conn, deliver: deliver, kind: kind)
+    pool = Wurk::RedisPool.new(size: 1, url: Wurk::Test.redis_url, name: 'partial')
+    pool.instance_variable_set(:@pool, SingleConnPool.new(conn))
+    pool
+  end
+
+  # Stand-in ConnectionPool that always yields the one faulted connection.
+  class SingleConnPool
+    def initialize(conn)
+      @conn = conn
+    end
+
+    def with
+      yield @conn
+    end
+
+    def shutdown(&); end
   end
 
   # Bare connection, built the way RedisPool#build_client builds one, against
@@ -196,22 +232,33 @@ class ClientPartialDeliveryTest < Wurk::Test::UnitCase
     )
   end
 
+  # Lands `deliver` pipelines for real, drops the socket on the next one, then
+  # recovers — what redis-client's mid-block re-dial looks like from above. A
+  # block that replays after the drop therefore re-applies what it already sent,
+  # which is the duplicate the pool has to refuse.
   class MidPushDropConn
-    def initialize(real, deliver:)
+    def initialize(real, deliver:, kind: RedisClient::ConnectionError)
       @real = real
       @deliver = deliver
+      @kind = kind
       @seen = 0
     end
 
     def pipelined(&)
       @seen += 1
-      raise RedisClient::ConnectionError, 'simulated mid-push drop' if @seen > @deliver
+      raise @kind, 'simulated mid-push drop' if @seen == @deliver + 1
 
       @real.pipelined(&)
     end
 
     def call(*, &)
       @real.call(*, &)
+    end
+
+    # Pass-through, so the odometer RedisPool's replay guard reads is the real
+    # connection's count of what actually landed.
+    def round_trips
+      @real.round_trips
     end
   end
 end

--- a/test/unit/fetcher_reliable_test.rb
+++ b/test/unit/fetcher_reliable_test.rb
@@ -290,8 +290,14 @@ class FetcherReliableTest < Wurk::Test::UnitCase
     used = nil
     conn = Object.new
     conn.define_singleton_method(:blocking_call) { |*_| nil }
-    @capsule.define_singleton_method(:fetch_redis) { |&blk| used = :fetch; blk.call(conn) }
-    @capsule.define_singleton_method(:redis) { |&blk| used = :main; blk.call(conn) }
+    @capsule.define_singleton_method(:fetch_redis) do |**_opts, &blk|
+      used = :fetch
+      blk.call(conn)
+    end
+    @capsule.define_singleton_method(:redis) do |**_opts, &blk|
+      used = :main
+      blk.call(conn)
+    end
 
     @fetcher.send(:blmove, @public_queue)
 
@@ -310,7 +316,7 @@ class FetcherReliableTest < Wurk::Test::UnitCase
       box.replace(a)
       nil
     end
-    @capsule.define_singleton_method(:fetch_redis) { |&blk| blk.call(conn) }
+    @capsule.define_singleton_method(:fetch_redis) { |**_opts, &blk| blk.call(conn) }
     box
   end
 

--- a/test/unit/heartbeat_test.rb
+++ b/test/unit/heartbeat_test.rb
@@ -280,6 +280,24 @@ class HeartbeatTest < Wurk::Test::UnitCase
     assert_equal [], sigs
   end
 
+  # The drain is a second checkout that runs only after the identity write
+  # returns, so a failed beat leaves every queued signal in Redis for the next
+  # one. Popping first would swallow a dashboard TERM into the beat! rescue.
+  def test_failed_identity_write_leaves_signals_queued
+    sig_key = "#{@identity}-signals"
+    @pool.with { |c| c.call('LPUSH', sig_key, 'TERM') }
+    hb = build_heartbeat
+
+    # Minitest 6 dropped minitest/mock; a singleton override is the stub.
+    hb.define_singleton_method(:write_beat) { |*| raise 'beat write failed' }
+
+    sigs = hb.beat!
+    remaining = @pool.with { |c| c.call('LLEN', sig_key) }
+
+    assert_nil sigs
+    assert_equal 1, remaining.to_i
+  end
+
   # --- stop! -----------------------------------------------------------
 
   def test_stop_removes_identity_from_processes_set

--- a/test/unit/middleware_chain_ops_test.rb
+++ b/test/unit/middleware_chain_ops_test.rb
@@ -13,15 +13,19 @@ class MiddlewareChainOpsTest < Wurk::Test::UnitCase
   # care about. Returning sentinel objects lets the assertions identity-check
   # to prove the delegation is unwrapped (no caching/copying).
   class FakeConfig
-    attr_reader :redis_pool, :logger, :redis_block
+    attr_reader :redis_pool, :logger, :redis_block, :idempotent
 
     def initialize(redis_pool: Object.new, logger: Object.new)
       @redis_pool = redis_pool
       @logger = logger
     end
 
-    def redis
+    # `config` is always a Wurk::Configuration or Wurk::Capsule, both of which
+    # take the apply-safety claim, so the double takes it too — a middleware
+    # that opts a read back into retry must reach the pool with the claim intact.
+    def redis(idempotent: false)
       @redis_block = true
+      @idempotent = idempotent
       yield :conn
     end
   end

--- a/test/unit/redis_client_adapter_test.rb
+++ b/test/unit/redis_client_adapter_test.rb
@@ -86,6 +86,43 @@ class RedisClientAdapterTest < Wurk::Test::UnitCase
     end
   end
 
+  # --- round-trip odometer (RedisPool's replay guard reads this) ---
+
+  def test_round_trips_counts_call_and_pipelined
+    @pool.with do |conn|
+      before = conn.round_trips
+      conn.call('PING')
+      conn.pipelined { |pipe| pipe.call('PING') }
+
+      assert_equal before + 2, conn.round_trips, 'a pipeline is one round trip'
+    end
+  end
+
+  # Method-style commands route through CompatMethods, which would otherwise
+  # dispatch straight at the wrapped client and slip past the odometer.
+  def test_round_trips_counts_method_style_commands
+    @pool.with do |conn|
+      before = conn.round_trips
+      conn.set(@key, 'v')
+      conn.echo('hi')
+      conn.info
+
+      assert_equal before + 3, conn.round_trips
+    end
+  end
+
+  # The odometer only moves for a command that came back clean: a raise means
+  # nothing applied — rejected by the server or never sent — which is the state
+  # the pool's pre-apply backoff stays available for.
+  def test_round_trips_holds_when_a_command_raises
+    @pool.with do |conn|
+      before = conn.round_trips
+
+      assert_raises(RedisClient::CommandError) { conn.call('NOSUCHCOMMAND') }
+      assert_equal before, conn.round_trips
+    end
+  end
+
   def test_pipelined_yields_compat_pipeline
     @pool.with do |conn|
       conn.pipelined do |pipe|

--- a/test/unit/redis_idempotent_call_sites_test.rb
+++ b/test/unit/redis_idempotent_call_sites_test.rb
@@ -211,6 +211,36 @@ class RedisIdempotentCallSitesTest < Wurk::Test::UnitCase
     assert_equal [false], @main.claims_for('SET')
   end
 
+  # --- web ----------------------------------------------------------------
+
+  # A dashboard keystroke pages a queue LIST. Both round trips are reads, and
+  # the scan budget is counted in Ruby, so a replayed page double-counts nothing.
+  def test_web_search_queue_scan_claims_apply_safety
+    on_default_pool do
+      register_queue(%({"jid":"#{@ns}","class":"SearchHit"}))
+      Wurk::Web::Search.new('SearchHit', kinds: %w[queues]).to_a
+    end
+
+    assert_equal [true], @main.claims_for('LLEN')
+    assert_equal [true], @main.claims_for('LRANGE')
+  end
+
+  def test_web_search_sorted_set_scan_claims_apply_safety
+    on_default_pool { Wurk::Web::Search.new('SearchHit', kinds: %w[retry]).to_a }
+
+    assert_equal [true], @main.claims_for('ZSCAN')
+  end
+
+  def test_web_limits_read_paths_claim_apply_safety
+    on_default_pool do
+      Wurk::Web::Enterprise::Limits.list
+      Wurk::Web::Enterprise::Limits.metadata("#{@ns}-lmtr")
+    end
+
+    assert_equal [true], @main.claims_for('SMEMBERS')
+    assert_equal [true], @main.claims_for('HGETALL')
+  end
+
   private
 
   def on_default_pool
@@ -247,6 +277,15 @@ class RedisIdempotentCallSitesTest < Wurk::Test::UnitCase
 
   def enqueue(payload)
     @main.with { |conn| conn.call('LPUSH', @public_queue, payload) }
+  end
+
+  # Search walks `Queue.all`, so the queue has to be a `queues` SET member too,
+  # not just a non-empty LIST.
+  def register_queue(payload)
+    @main.with do |conn|
+      conn.call('SADD', Wurk::Keys::QUEUES_SET, @queue_name)
+      conn.call('LPUSH', @public_queue, payload)
+    end
   end
 
   # A private list owned by a dead pid in this process's own namespace, which the

--- a/test/unit/redis_idempotent_call_sites_test.rb
+++ b/test/unit/redis_idempotent_call_sites_test.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# F5 sweep. `RedisPool#with` now defaults to "the command may already have
+# applied — do not replay the block", so a path that used to ride out a
+# connection blip raises unless it claims apply-safety with `idempotent: true`.
+#
+# That claim is invisible to any test that only asserts returned data, and it is
+# wrong in both directions: dropped from a read path in a refactor, a fetch loop
+# stops surviving a failover it used to absorb; added to a path that moves,
+# pushes or increments, a blip silently duplicates work. So every swept call site
+# is pinned here — including the neighbours that must stay unclaimed.
+class RedisIdempotentCallSitesTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  DEAD_PID = 999_999 # never a running pid in CI/dev
+
+  # One checkout: the apply-safety claim it carried, plus the Redis command verbs
+  # its block actually issued.
+  Checkout = Struct.new(:idempotent, :commands)
+
+  # Pairs each checkout's claim with the commands issued inside it, so a test can
+  # say "the SCAN claimed, the LMOVE didn't" instead of asserting a positional
+  # sequence that any unrelated new round trip would break.
+  #
+  # Subclasses the real pool because PoolCheckout dispatches on the RedisPool
+  # type — a bare double would take the foreign-pool branch and prove nothing —
+  # and delegates to a real connection, so the paths under test run their normal
+  # logic against real Redis.
+  class ClaimRecordingPool < Wurk::RedisPool
+    def initialize(size: 2)
+      super(size: size, name: 'claim-recording', url: Wurk::Test.redis_url)
+      @checkouts = []
+    end
+
+    def with(idempotent: false, &block)
+      log = []
+      @checkouts << Checkout.new(idempotent, log)
+      super { |conn| block.call(RecordingConn.new(conn, log)) }
+    end
+
+    # The claim of every checkout that issued `command`, in call order. Empty
+    # when the command was never issued — assert on it and a call site that
+    # silently stopped running shows up as a failure too.
+    def claims_for(command)
+      @checkouts.select { |c| c.commands.include?(command) }.map(&:idempotent)
+    end
+
+    def commands
+      @checkouts.flat_map(&:commands)
+    end
+  end
+
+  # Connection decorator that logs each command verb into its checkout's log.
+  # Only the three entry points Wurk's own code uses are intercepted; anything
+  # else a block reaches for is forwarded untouched.
+  class RecordingConn
+    def initialize(conn, log)
+      @conn = conn
+      @log = log
+    end
+
+    def call(*args, **, &)
+      @log << args.first.to_s
+      @conn.call(*args, **, &)
+    end
+
+    def blocking_call(timeout, *args, **, &)
+      @log << args.first.to_s
+      @conn.blocking_call(timeout, *args, **, &)
+    end
+
+    def pipelined
+      @conn.pipelined { |pipe| yield RecordingConn.new(pipe, @log) }
+    end
+
+    def respond_to_missing?(name, include_private = false)
+      @conn.respond_to?(name, include_private) || super
+    end
+
+    def method_missing(name, ...)
+      @conn.public_send(name, ...)
+    end
+  end
+
+  def setup
+    super
+    @ns = "ics-#{Process.pid}-#{object_id}"
+    @queue_name = "#{@ns}-q"
+    @public_queue = Wurk::Keys.queue(@queue_name)
+    @main = ClaimRecordingPool.new
+    @config = Wurk::Configuration.new
+    @config.logger = ::Logger.new(IO::NULL)
+    on_recording_pools(@config)
+  end
+
+  def teardown
+    @main.with do |conn|
+      keys = conn.call('KEYS', "#{@public_queue}*")
+      conn.call('DEL', *keys) unless keys.empty?
+    end
+    @main.disconnect!
+    @fetch&.disconnect!
+  ensure
+    super
+  end
+
+  # --- fetcher ------------------------------------------------------------
+
+  # An empty-poll SMEMBERS and the LMOVE that follows it are the two hottest
+  # round trips in the process; both keep the connection backoff.
+  def test_fetch_read_and_move_paths_claim_apply_safety
+    enqueue('{"jid":"a"}')
+
+    refute_nil fetcher.retrieve_work
+
+    assert_equal [true], @main.claims_for('SMEMBERS')
+    assert_equal [true], @main.claims_for('LMOVE')
+  end
+
+  # BLMOVE draws from the dedicated fetch pool, a separate checkout path, so its
+  # claim is asserted on that pool — not the main one.
+  def test_blmove_claims_apply_safety_on_the_fetch_pool
+    @config.fetch_poll_interval = 0.05
+
+    assert_nil fetcher.send(:blmove, @public_queue)
+
+    assert_equal [true], @fetch.claims_for('BLMOVE')
+    assert_empty @main.commands
+  end
+
+  # The ACK and the shutdown re-push are the other side of the same fetcher: an
+  # RPUSH replayed after a lost reply is a duplicate job, so neither may claim.
+  def test_ack_and_requeue_do_not_claim_apply_safety
+    enqueue('{"jid":"b"}')
+    uow = fetcher.retrieve_work
+    uow.requeue
+    uow.acknowledge
+
+    assert_equal [false], @main.claims_for('RPUSH')
+    assert_equal [false], @main.claims_for('LREM')
+  end
+
+  # --- reaper -------------------------------------------------------------
+
+  # The sweep is all reads until it finds an orphan: SMEMBERS + HGET for
+  # liveness, SCAN for the private lists.
+  def test_reaper_read_paths_claim_apply_safety
+    seed_processes_member
+    seed_private_list([%({"jid":"#{@ns}-c"})])
+    reaper.reclaim!
+
+    assert_equal [true], @main.claims_for('SMEMBERS')
+    assert_equal [true], @main.claims_for('HGET')
+    assert_equal [true], @main.claims_for('SCAN').uniq
+  end
+
+  # Drain moves a job then poison-checks it. A replay would move the next job
+  # and leave the moved one unchecked, so it stays unclaimed on purpose.
+  def test_reaper_drain_does_not_claim_apply_safety
+    seed_private_list([%({"jid":"#{@ns}-d"}), %({"jid":"#{@ns}-e"})])
+
+    assert_equal 2, reaper.reclaim!
+
+    assert_equal [false], @main.claims_for('LMOVE').uniq
+  end
+
+  private
+
+  # Points every pool a subsystem can reach at a recorder: the default capsule's
+  # main + fetch pools (Capsule#redis / #fetch_redis) and, through
+  # Configuration#redis_pool, Component#redis and Wurk.redis.
+  def on_recording_pools(config)
+    @fetch = ClaimRecordingPool.new
+    main = @main
+    fetch = @fetch
+    capsule = config.default_capsule
+    capsule.define_singleton_method(:redis_pool) { main }
+    capsule.define_singleton_method(:fetch_redis_pool) { fetch }
+  end
+
+  def fetcher
+    @fetcher ||= begin
+      @config.default_capsule.queues = [@queue_name]
+      Wurk::Fetcher::Reliable.new(@config.default_capsule)
+    end
+  end
+
+  def reaper
+    @config.default_capsule.queues = [@queue_name]
+    Wurk::Fetcher::Reaper.new(@config, interval: 1, lock_key: "#{@ns}-lock", full_lock_key: "#{@ns}-full")
+  end
+
+  def enqueue(payload)
+    @main.with { |conn| conn.call('LPUSH', @public_queue, payload) }
+  end
+
+  # A private list owned by a dead pid in this process's own namespace, which the
+  # reaper reads as an orphan via kill(0) without waiting out a heartbeat TTL.
+  def seed_private_list(payloads)
+    host = ENV['DYNO'] || Socket.gethostname
+    key = "#{@public_queue}|#{host}|#{DEAD_PID}|#{Wurk::Component::PROCESS_NONCE}|0"
+    @main.with { |conn| conn.call('LPUSH', key, *payloads) }
+    key
+  end
+
+  # `live_owners` only pipelines the HGET liveness probe when `processes` has at
+  # least one member, so the HGET claim needs a member to exist.
+  def seed_processes_member
+    identity = "#{@ns}:1:nonce"
+    @main.with do |conn|
+      conn.call('SADD', Wurk::Keys::PROCESSES, identity)
+      conn.call('HSET', identity, 'info', '{}')
+    end
+  end
+end

--- a/test/unit/redis_idempotent_call_sites_test.rb
+++ b/test/unit/redis_idempotent_call_sites_test.rb
@@ -20,6 +20,10 @@ class RedisIdempotentCallSitesTest < Wurk::Test::UnitCase
   # its block actually issued.
   Checkout = Struct.new(:idempotent, :commands)
 
+  # The capsule duck type `Wurk.redis_pool` resolves through, so a class that
+  # reaches for the process-wide pool lands on the recorder instead.
+  Handle = Struct.new(:redis_pool)
+
   # Pairs each checkout's claim with the commands issued inside it, so a test can
   # say "the SCAN claimed, the LMOVE didn't" instead of asserting a positional
   # sequence that any unrelated new round trip would break.
@@ -166,7 +170,56 @@ class RedisIdempotentCallSitesTest < Wurk::Test::UnitCase
     assert_equal [false], @main.claims_for('LMOVE').uniq
   end
 
+  # --- data API (Stats / Queue / ProcessSet) ------------------------------
+
+  # Everything the dashboard and third-party gems poll: counters, queue sizes,
+  # latency, the process list. All pure reads, so all replayable.
+  def test_data_api_read_paths_claim_apply_safety
+    on_default_pool do
+      Wurk::Stats.new.queues
+      Wurk::Queue.new(@queue_name).size
+      Wurk::ProcessSet.new(false).size
+    end
+
+    assert_equal [true], @main.claims_for('GET').uniq
+    assert_equal [true], @main.claims_for('LLEN').uniq
+    assert_equal [true], @main.claims_for('SCARD').uniq
+  end
+
+  # Pause/unpause converge on the membership the caller asked for, so a replay
+  # after a lost reply lands on the same state — the claim documented on both.
+  def test_queue_pause_and_unpause_claim_apply_safety
+    queue = Wurk::Queue.new(@queue_name)
+    on_default_pool do
+      queue.pause!
+      queue.unpause!
+    end
+
+    assert_equal [true], @main.claims_for('SADD')
+    assert_equal [true], @main.claims_for('SREM')
+  end
+
+  # The writes among those reads: clearing a queue and zeroing the global
+  # counters both wipe a container other writers append to.
+  def test_data_api_writes_do_not_claim_apply_safety
+    on_default_pool do
+      Wurk::Queue.new(@queue_name).clear
+      Wurk::Stats.new.reset
+    end
+
+    assert_equal [false], @main.claims_for('UNLINK')
+    assert_equal [false], @main.claims_for('SET')
+  end
+
   private
+
+  def on_default_pool
+    prev = Thread.current[:wurk_capsule]
+    Thread.current[:wurk_capsule] = Handle.new(@main)
+    yield
+  ensure
+    Thread.current[:wurk_capsule] = prev
+  end
 
   # Points every pool a subsystem can reach at a recorder: the default capsule's
   # main + fetch pools (Capsule#redis / #fetch_redis) and, through

--- a/test/unit/redis_idempotent_call_sites_test.rb
+++ b/test/unit/redis_idempotent_call_sites_test.rb
@@ -101,8 +101,9 @@ class RedisIdempotentCallSitesTest < Wurk::Test::UnitCase
 
   def teardown
     @main.with do |conn|
-      keys = conn.call('KEYS', "#{@public_queue}*")
+      keys = conn.call('KEYS', "*#{@ns}*")
       conn.call('DEL', *keys) unless keys.empty?
+      conn.call('SREM', Wurk::Keys::PROCESSES, "#{@ns}:1:x")
     end
     @main.disconnect!
     @fetch&.disconnect!
@@ -239,6 +240,56 @@ class RedisIdempotentCallSitesTest < Wurk::Test::UnitCase
 
     assert_equal [true], @main.claims_for('SMEMBERS')
     assert_equal [true], @main.claims_for('HGETALL')
+  end
+
+  # --- the five the audit named ------------------------------------------
+
+  # Enqueue. Every command the push issues appends, so a replay is a second
+  # copy of the job — the outage buffer, not the pool, is what retries here.
+  def test_client_push_does_not_claim_apply_safety
+    Wurk::Client.new(config: @config).push('class' => 'HardJob', 'args' => [], 'queue' => @queue_name)
+
+    assert_equal [false], @main.claims_for('LPUSH')
+  end
+
+  # Scheduler promotion, both halves: the destructive ZPOPBYSCORE and the LPUSH
+  # that re-queues what it popped.
+  def test_scheduler_pop_and_promote_do_not_claim_apply_safety
+    sset = "#{@ns}-schedule"
+    @main.with { |c| c.call('ZADD', sset, '0', %({"class":"HardJob","args":[],"queue":"#{@queue_name}"})) }
+
+    Wurk::Scheduled::Enq.new(@config).enqueue_jobs([sset])
+
+    assert_equal [false], @main.claims_for('EVALSHA').uniq
+    assert_equal [false], @main.claims_for('LPUSH').uniq
+    assert_equal 1, @main.with { |c| c.call('LLEN', @public_queue) }.to_i
+  end
+
+  # Stats flush. INCRBY is additive, so a replayed pipeline counts the window
+  # twice on every `stat:` key it touches. Driven straight at #write_stats: the
+  # public #flush_stats would drain the process-wide Processor counters other
+  # tests in this worker are also reading.
+  def test_stats_flush_does_not_claim_apply_safety
+    Wurk::Launcher.new(@config).send(:write_stats, 3, 1, 0)
+
+    assert_equal [false], @main.claims_for('INCRBY')
+  end
+
+  # The beat is the one split call site: its writes converge on the same
+  # identity hash and keep the backoff, while the signal LPOPs — a dashboard
+  # TERM/TSTP each — get their own checkout that must never replay.
+  def test_heartbeat_write_claims_apply_safety_but_the_signal_drain_does_not
+    Wurk::Heartbeat.new(identity: "#{@ns}:1:x", config: @config).beat!
+
+    assert_equal [true], @main.claims_for('HSET')
+    assert_equal [false], @main.claims_for('LPOP')
+  end
+
+  # Poison-pill recovery counter: an over-count kills a healthy job.
+  def test_poison_pill_counter_does_not_claim_apply_safety
+    on_default_pool { Wurk::Middleware::PoisonPill.track!({ 'jid' => @ns, 'class' => 'HardJob' }, queue: @queue_name) }
+
+    assert_equal [false], @main.claims_for('INCR')
   end
 
   private

--- a/test/unit/redis_idempotent_forwarding_test.rb
+++ b/test/unit/redis_idempotent_forwarding_test.rb
@@ -1,0 +1,376 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# F5 follow-up. `RedisPool#with` now takes the caller's apply-safety claim
+# (`idempotent:`), but almost nothing in lib/ touches a pool directly — every
+# subsystem goes through a wrapper (Wurk.redis, Capsule#redis, Component#redis,
+# the middleware mixin, the pool-or-default helpers). A wrapper that dropped the
+# keyword would pin its callers to the safe default with no way to opt back in,
+# so the forwarding is asserted here once, centrally, instead of per subsystem.
+class RedisIdempotentForwardingTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  # Every wrapper in lib/ that ends in a `RedisPool#with` checkout. Listed
+  # explicitly so a new wrapper added without the keyword shows up as a diff
+  # here rather than as a silently ignored `idempotent: true` in production.
+  WRAPPERS = [
+    [Wurk.singleton_class,                    :redis],
+    [Sidekiq.singleton_class,                 :redis],
+    [Wurk::Configuration,                     :redis],
+    [Wurk::Capsule,                           :redis],
+    [Wurk::Capsule,                           :fetch_redis],
+    [Wurk::Component,                         :redis],
+    [Wurk::Middleware::ServerMiddleware,      :redis],
+    [Wurk::Limiter.singleton_class,           :redis],
+    [Wurk::Cron::LoopSet,                     :redis],
+    [Wurk::Web::Extension::Helpers,           :redis],
+    [Wurk::Leader,                            :redis_call],
+    [Wurk::Stats::History,                    :with_redis],
+    [Wurk::Deploy,                            :with_redis],
+    [Wurk::Profiler.singleton_class,          :with_pool],
+    [Wurk::Metrics::History.singleton_class,  :with_pool]
+  ].freeze
+
+  # Records the claim each checkout carried. Subclasses the real pool because
+  # PoolCheckout dispatches on the RedisPool type, so a bare double would take
+  # the foreign-pool branch and prove nothing; `#with` is overridden, and
+  # ConnectionPool builds connections lazily, so no socket is ever opened.
+  class RecordingPool < Wurk::RedisPool
+    attr_reader :claims
+
+    def initialize
+      super(size: 1, name: 'recording', url: Wurk::Test.redis_url)
+      @claims = []
+    end
+
+    def with(idempotent: false)
+      @claims << idempotent
+      yield :conn
+    end
+  end
+
+  # What a host actually hands to `Sidekiq::Client#redis_pool=` or a `pool:`
+  # kwarg when it wants to count/trace round trips: a bare decorator whose
+  # `#with` takes no keywords at all.
+  class ForeignPool
+    attr_reader :checkouts
+
+    def initialize
+      @checkouts = 0
+    end
+
+    def with
+      @checkouts += 1
+      yield :conn
+    end
+  end
+
+  # The capsule duck type `Wurk.redis_pool` resolves through — the same seam
+  # Wurk::Web::PoolScope uses to divert the dashboard onto the web pool.
+  Handle = Struct.new(:redis_pool)
+
+  # Config duck type for the wrappers that delegate to `config.redis` rather
+  # than to a pool of their own.
+  class RecordingConfig
+    attr_reader :claims
+
+    def initialize
+      @claims = []
+    end
+
+    def redis(idempotent: false)
+      @claims << idempotent
+      yield :conn
+    end
+  end
+
+  class ComponentHost
+    include Wurk::Component
+
+    attr_reader :config
+
+    def initialize(config)
+      @config = config
+    end
+  end
+
+  class MiddlewareHost
+    include Wurk::Middleware::ServerMiddleware
+  end
+
+  class ExtensionHost
+    include Wurk::Web::Extension::Helpers
+  end
+
+  def setup
+    super
+    @pool = RecordingPool.new
+    @config = RecordingConfig.new
+    Wurk::Limiter.reset_config!
+  end
+
+  def teardown
+    Thread.current[:wurk_capsule] = nil
+    Wurk::Limiter.reset_config!
+  ensure
+    super
+  end
+
+  # --- foreign pools ------------------------------------------------------
+
+  # The drop-in seam: `Sidekiq::Client#redis_pool=`, `Sidekiq::Web.redis_pool=`
+  # and the `pool:` kwargs all accept any ConnectionPool-shaped object, and
+  # `def with; yield conn; end` is a legal one. Forwarding a keyword it never
+  # declared is an ArgumentError, so PoolCheckout must drop the claim there —
+  # a foreign pool keeps the conservative behavior it had before F5.
+  def test_foreign_pool_never_receives_the_claim
+    foreign = ForeignPool.new
+
+    assert_equal :conn, Wurk::PoolCheckout.with(foreign, true) { |c| c }
+    assert_equal :conn, Wurk::PoolCheckout.with(foreign, false) { |c| c }
+
+    assert_equal 2, foreign.checkouts
+  end
+
+  # Wrappers reach the pool through PoolCheckout, so a host-supplied pool
+  # survives a claim made anywhere upstream — not just a direct checkout.
+  def test_wrappers_tolerate_a_foreign_pool_under_a_claim
+    foreign = ForeignPool.new
+    cap = Wurk::Capsule.new('idempotent-foreign', Wurk::Configuration.new)
+    cap.define_singleton_method(:redis_pool) { foreign }
+    cap.define_singleton_method(:fetch_redis_pool) { foreign }
+
+    cap.redis(idempotent: true) { |c| c }
+    cap.fetch_redis(idempotent: true) { |c| c }
+    Wurk::Deploy.new(pool: foreign).send(:with_redis, idempotent: true) { |c| c }
+    Wurk::Leader.new(pool: foreign).send(:redis_call, idempotent: true) { |c| c }
+
+    assert_equal 4, foreign.checkouts
+  end
+
+  # A real RedisPool does understand it, so the claim must survive the seam —
+  # otherwise `idempotent: true` would be silently inert everywhere.
+  def test_wurk_redis_pool_does_receive_the_claim
+    Wurk::PoolCheckout.with(@pool, true) { |c| c }
+    Wurk::PoolCheckout.with(@pool, false) { |c| c }
+
+    assert_equal [true, false], @pool.claims
+  end
+
+  # --- structural sweep --------------------------------------------------
+
+  def test_every_pool_wrapper_accepts_the_claim
+    WRAPPERS.each do |owner, meth|
+      params = owner.instance_method(meth).parameters
+
+      assert_includes params, %i[key idempotent], "#{owner}##{meth} drops idempotent:"
+    end
+  end
+
+  def test_every_pool_wrapper_defaults_to_apply_unsafe
+    WRAPPERS.each do |owner, meth|
+      params = owner.instance_method(meth).parameters
+
+      refute_includes params, %i[keyreq idempotent], "#{owner}##{meth} made the claim mandatory"
+    end
+  end
+
+  # --- Wurk.redis / Sidekiq.redis ----------------------------------------
+
+  # The drop-in contract: third-party gems call `Sidekiq.redis { |c| ... }` and
+  # `Wurk.redis { |c| ... }` with no arguments, and get the safe default.
+  def test_zero_arg_call_shape_is_unchanged
+    returned = on_recording_pool { [Wurk.redis { |c| c }, Sidekiq.redis { |c| c }] }
+
+    assert_equal %i[conn conn], returned
+    assert_equal [false, false], @pool.claims
+  end
+
+  def test_wurk_redis_forwards_the_claim
+    on_recording_pool { Wurk.redis(idempotent: true) { |c| c } }
+
+    assert_equal [true], @pool.claims
+  end
+
+  def test_sidekiq_redis_forwards_the_claim
+    on_recording_pool { Sidekiq.redis(idempotent: true) { |c| c } }
+
+    assert_equal [true], @pool.claims
+  end
+
+  # --- capsule / configuration / component -------------------------------
+
+  def test_capsule_redis_forwards_the_claim
+    cap = capsule_on_recording_pool
+
+    assert_equal :conn, cap.redis(idempotent: true) { |c| c }
+    cap.redis { |c| c }
+
+    assert_equal [true, false], @pool.claims
+  end
+
+  # The reliable fetcher's BLMOVE pool is a separate checkout path, so it needs
+  # its own forwarding — it is the first caller that will claim apply-safety.
+  def test_capsule_fetch_redis_forwards_the_claim
+    cap = capsule_on_recording_pool
+
+    assert_equal :conn, cap.fetch_redis(idempotent: true) { |c| c }
+    cap.fetch_redis { |c| c }
+
+    assert_equal [true, false], @pool.claims
+  end
+
+  def test_configuration_redis_forwards_the_claim
+    config = Wurk::Configuration.new
+    pool = @pool
+    config.define_singleton_method(:redis_pool) { pool }
+
+    assert_equal :conn, config.redis(idempotent: true) { |c| c }
+    config.redis { |c| c }
+
+    assert_equal [true, false], @pool.claims
+  end
+
+  def test_component_redis_forwards_the_claim_to_its_config
+    host = ComponentHost.new(@config)
+
+    assert_equal :conn, host.redis(idempotent: true) { |c| c }
+    host.redis { |c| c }
+
+    assert_equal [true, false], @config.claims
+  end
+
+  def test_server_middleware_redis_forwards_the_claim_to_its_config
+    mw = MiddlewareHost.new
+    mw.config = @config
+
+    assert_equal :conn, mw.redis(idempotent: true) { |c| c }
+    mw.redis { |c| c }
+
+    assert_equal [true, false], @config.claims
+  end
+
+  # --- wrappers that fall back to the default pool -----------------------
+
+  def test_limiter_redis_forwards_the_claim
+    on_recording_pool do
+      assert_equal :conn, Wurk::Limiter.redis(idempotent: true) { |c| c }
+      Wurk::Limiter.redis { |c| c }
+    end
+
+    assert_equal [true, false], @pool.claims
+  end
+
+  def test_cron_loop_set_redis_forwards_the_claim
+    loops = Wurk::Cron::LoopSet.new(@config)
+
+    assert_equal :conn, loops.send(:redis, idempotent: true) { |c| c }
+    loops.send(:redis) { |c| c }
+
+    assert_equal [true, false], @config.claims
+  end
+
+  def test_cron_loop_set_redis_forwards_the_claim_without_a_config
+    loops = Wurk::Cron::LoopSet.new
+    on_recording_pool { loops.send(:redis, idempotent: true) { |c| c } }
+
+    assert_equal [true], @pool.claims
+  end
+
+  def test_web_extension_helper_redis_forwards_the_claim
+    helper = ExtensionHost.new
+    on_recording_pool do
+      assert_equal :conn, helper.redis(idempotent: true) { |c| c }
+      helper.redis { |c| c }
+    end
+
+    assert_equal [true, false], @pool.claims
+  end
+
+  # Each of the wrappers below picks between an injected pool and the process
+  # default, so it has *two* checkout expressions rather than one. A keyword
+  # forwarded on the injected leg and dropped on the fallback leg downgrades the
+  # claim silently in whichever configuration the author didn't exercise — hence
+  # both legs, not just the one the subsystem happens to use today.
+
+  def test_stats_history_with_redis_forwards_on_both_branches
+    injected = Wurk::Stats::History.new(1, pool: @pool)
+    fallback = Wurk::Stats::History.new(1)
+
+    assert_both_branches_forward(
+      injected: ->(claim) { injected.send(:with_redis, idempotent: claim) { |c| c } },
+      fallback: ->(claim) { fallback.send(:with_redis, idempotent: claim) { |c| c } }
+    )
+  end
+
+  def test_deploy_with_redis_forwards_on_both_branches
+    injected = Wurk::Deploy.new(pool: @pool)
+    fallback = Wurk::Deploy.new
+
+    assert_both_branches_forward(
+      injected: ->(claim) { injected.send(:with_redis, idempotent: claim) { |c| c } },
+      fallback: ->(claim) { fallback.send(:with_redis, idempotent: claim) { |c| c } }
+    )
+  end
+
+  def test_metrics_history_with_pool_forwards_on_both_branches
+    assert_both_branches_forward(
+      injected: ->(claim) { Wurk::Metrics::History.send(:with_pool, @pool, idempotent: claim) { |c| c } },
+      fallback: ->(claim) { Wurk::Metrics::History.send(:with_pool, nil, idempotent: claim) { |c| c } }
+    )
+  end
+
+  def test_profiler_with_pool_forwards_on_both_branches
+    assert_both_branches_forward(
+      injected: ->(claim) { Wurk::Profiler.send(:with_pool, @pool, idempotent: claim) { |c| c } },
+      fallback: ->(claim) { Wurk::Profiler.send(:with_pool, nil, idempotent: claim) { |c| c } }
+    )
+  end
+
+  # Leader is the three-way case: explicit pool → bound config → process default.
+  def test_leader_redis_call_forwards_on_every_branch
+    assert_equal :conn, Wurk::Leader.new(pool: @pool).send(:redis_call, idempotent: true) { |c| c }
+    Wurk::Leader.new(config: @config).send(:redis_call, idempotent: true) { |c| c }
+    Wurk::Leader.new(config: @config).send(:redis_call) { |c| c }
+    on_recording_pool { Wurk::Leader.new.send(:redis_call, idempotent: true) { |c| c } }
+
+    assert_equal [true, true], @pool.claims
+    assert_equal [true, false], @config.claims
+  end
+
+  private
+
+  # Drives a pool-or-default wrapper down both legs — the injected pool outside
+  # the scope, the default pool inside it — asserting each leg carries the claim
+  # it was handed. Both legs land on the same recorder, so the expected sequence
+  # is the two claims per leg in call order.
+  def assert_both_branches_forward(injected:, fallback:)
+    assert_equal :conn, injected.call(true)
+    injected.call(false)
+
+    on_recording_pool do
+      assert_equal :conn, fallback.call(true)
+      fallback.call(false)
+    end
+
+    assert_equal [true, false, true, false], @pool.claims
+  end
+
+  # Points `Wurk.redis_pool` at the recorder for the duration of the block.
+  def on_recording_pool
+    prev = Thread.current[:wurk_capsule]
+    Thread.current[:wurk_capsule] = Handle.new(@pool)
+    yield
+  ensure
+    Thread.current[:wurk_capsule] = prev
+  end
+
+  def capsule_on_recording_pool
+    cap = Wurk::Capsule.new('idempotent-forwarding', Wurk::Configuration.new)
+    pool = @pool
+    cap.define_singleton_method(:redis_pool) { pool }
+    cap.define_singleton_method(:fetch_redis_pool) { pool }
+    cap
+  end
+end

--- a/test/unit/redis_pool_test.rb
+++ b/test/unit/redis_pool_test.rb
@@ -233,6 +233,49 @@ class RedisPoolTest < Wurk::Test::UnitCase
     assert_equal Wurk::RedisPool::CONN_MAX_ATTEMPTS - 1, conn.closes
   end
 
+  # --- partially-applied blocks: no replay, whatever the error proves (F5) ---
+
+  # A block is several round trips and redis-client re-dials mid-block, so
+  # CannotConnect can land on the second pipeline of a push whose first already
+  # wrote. Replaying it would double-enqueue that first group.
+  def test_pre_apply_error_after_a_completed_round_trip_is_not_replayed
+    conn = PartialBlockConn.new(kind: :cannot_connect)
+    pool = pool_wrapping(conn)
+
+    no_sleep(pool) { assert_raises(RedisClient::CannotConnectError) { pool.with(&:exec) } }
+    assert_equal 1, conn.blocks, 'the round trip that already applied would be re-issued'
+    assert_equal 0, conn.closes
+  end
+
+  # Same hole on the failover branch: READONLY proves the *rejected* write went
+  # to a replica, not that the pipeline before it did.
+  def test_failover_reply_after_a_completed_round_trip_is_not_replayed
+    conn = PartialBlockConn.new(kind: :readonly)
+    pool = pool_wrapping(conn)
+
+    assert_raises(RedisClient::ReadOnlyError) { pool.with(&:exec) }
+    assert_equal 1, conn.blocks
+  end
+
+  def test_refused_replay_after_partial_progress_is_reported_once
+    events = []
+    conn = PartialBlockConn.new(kind: :cannot_connect)
+    pool = pool_wrapping(conn, on_error: ->(info) { events << info })
+
+    assert_raises(RedisClient::CannotConnectError) { pool.with(&:exec) }
+    assert_equal([{ attempt: 1, retried: false }], events.map { |e| e.slice(:attempt, :retried) })
+  end
+
+  # The claim is exactly "re-running my block is a no-op", so partial progress
+  # changes nothing for a caller that made it.
+  def test_idempotent_block_still_replays_after_a_completed_round_trip
+    conn = PartialBlockConn.new(kind: :cannot_connect, raises: 1)
+    pool = pool_wrapping(conn)
+
+    no_sleep(pool) { assert_equal(:ok, pool.with(idempotent: true, &:exec)) }
+    assert_equal 2, conn.blocks
+  end
+
   # --- post-write errors: never replayed unless the caller opts in (F5) ---
 
   def test_read_timeout_is_not_replayed_by_default
@@ -497,7 +540,7 @@ class RedisPoolTest < Wurk::Test::UnitCase
       failover: [RedisClient::FailoverError, 'Expected to connect to a master, but the server is a replica']
     }.freeze
 
-    attr_reader :calls, :closes
+    attr_reader :calls, :closes, :round_trips
 
     def initialize(kind:, raises:, close_raises: false)
       @kind = kind
@@ -505,12 +548,47 @@ class RedisPoolTest < Wurk::Test::UnitCase
       @close_raises = close_raises
       @calls = 0
       @closes = 0
+      @round_trips = 0
     end
 
+    # Fails outright before anything reaches the server, so the odometer the
+    # pool's replay guard reads only moves on the attempt that succeeds.
     def exec
       @calls += 1
       if @calls <= @raises
         klass, msg = ERRORS.fetch(@kind)
+        raise klass, msg
+      end
+      @round_trips += 1
+      :ok
+    end
+
+    def close
+      @closes += 1
+      raise 'boom' if @close_raises
+    end
+  end
+
+  # A connection whose block lands `deliver` round trips and *then* fails —
+  # the mid-block re-dial shape, where a connect-phase error says nothing about
+  # the pipelines already acknowledged.
+  class PartialBlockConn
+    attr_reader :blocks, :closes, :round_trips
+
+    def initialize(kind:, raises: 99, deliver: 1)
+      @kind = kind
+      @raises = raises
+      @deliver = deliver
+      @blocks = 0
+      @closes = 0
+      @round_trips = 0
+    end
+
+    def exec
+      @blocks += 1
+      @round_trips += @deliver
+      if @blocks <= @raises
+        klass, msg = FlakyConn::ERRORS.fetch(@kind)
         raise klass, msg
       end
       :ok
@@ -518,7 +596,6 @@ class RedisPoolTest < Wurk::Test::UnitCase
 
     def close
       @closes += 1
-      raise 'boom' if @close_raises
     end
   end
 end

--- a/test/unit/redis_pool_test.rb
+++ b/test/unit/redis_pool_test.rb
@@ -205,16 +205,7 @@ class RedisPoolTest < Wurk::Test::UnitCase
     assert_equal 0, conn.closes
   end
 
-  # --- connection-error backoff (#101) ---
-
-  def test_retries_connection_error_with_backoff_then_succeeds
-    conn = FlakyConn.new(kind: :timeout, raises: 1)
-    pool = pool_wrapping(conn)
-
-    no_sleep(pool) { assert_equal(:ok, pool.with(&:exec)) }
-    assert_equal 2, conn.calls
-    assert_equal 1, conn.closes, 'connection is closed before the backoff retry'
-  end
+  # --- connect-phase errors: replayed whatever the block does (F5) ---
 
   def test_retries_cannot_connect_error
     conn = FlakyConn.new(kind: :cannot_connect, raises: 1)
@@ -222,15 +213,77 @@ class RedisPoolTest < Wurk::Test::UnitCase
 
     no_sleep(pool) { assert_equal(:ok, pool.with(&:exec)) }
     assert_equal 2, conn.calls
+    assert_equal 1, conn.closes, 'connection is closed before the backoff retry'
   end
 
-  def test_connection_error_retries_to_the_cap_then_raises
-    conn = FlakyConn.new(kind: :timeout, raises: 99)
+  def test_retries_failover_error
+    conn = FlakyConn.new(kind: :failover, raises: 1)
+    pool = pool_wrapping(conn)
+
+    no_sleep(pool) { assert_equal(:ok, pool.with(&:exec)) }
+    assert_equal 2, conn.calls
+  end
+
+  def test_connect_phase_error_retries_to_the_cap_then_raises
+    conn = FlakyConn.new(kind: :cannot_connect, raises: 99)
+    pool = pool_wrapping(conn)
+
+    no_sleep(pool) { assert_raises(RedisClient::CannotConnectError) { pool.with(&:exec) } }
+    assert_equal Wurk::RedisPool::CONN_MAX_ATTEMPTS, conn.calls
+    assert_equal Wurk::RedisPool::CONN_MAX_ATTEMPTS - 1, conn.closes
+  end
+
+  # --- post-write errors: never replayed unless the caller opts in (F5) ---
+
+  def test_read_timeout_is_not_replayed_by_default
+    conn = FlakyConn.new(kind: :read_timeout, raises: 1)
+    pool = pool_wrapping(conn)
+
+    no_sleep(pool) { assert_raises(RedisClient::ReadTimeoutError) { pool.with(&:exec) } }
+    assert_equal 1, conn.calls, 'the command may have applied; replaying would duplicate it'
+    assert_equal 0, conn.closes
+  end
+
+  def test_write_timeout_is_not_replayed_by_default
+    conn = FlakyConn.new(kind: :write_timeout, raises: 1)
+    pool = pool_wrapping(conn)
+
+    no_sleep(pool) { assert_raises(RedisClient::WriteTimeoutError) { pool.with(&:exec) } }
+    assert_equal 1, conn.calls
+  end
+
+  def test_bare_connection_error_is_not_replayed_by_default
+    conn = FlakyConn.new(kind: :timeout, raises: 1)
     pool = pool_wrapping(conn)
 
     no_sleep(pool) { assert_raises(RedisClient::ConnectionError) { pool.with(&:exec) } }
+    assert_equal 1, conn.calls
+  end
+
+  def test_idempotent_blocks_replay_a_read_timeout_with_backoff
+    conn = FlakyConn.new(kind: :read_timeout, raises: 1)
+    pool = pool_wrapping(conn)
+
+    no_sleep(pool) { assert_equal(:ok, pool.with(idempotent: true, &:exec)) }
+    assert_equal 2, conn.calls
+    assert_equal 1, conn.closes, 'connection is closed before the backoff retry'
+  end
+
+  def test_idempotent_connection_error_retries_to_the_cap_then_raises
+    conn = FlakyConn.new(kind: :timeout, raises: 99)
+    pool = pool_wrapping(conn)
+
+    no_sleep(pool) { assert_raises(RedisClient::ConnectionError) { pool.with(idempotent: true, &:exec) } }
     assert_equal Wurk::RedisPool::CONN_MAX_ATTEMPTS, conn.calls
     assert_equal Wurk::RedisPool::CONN_MAX_ATTEMPTS - 1, conn.closes
+  end
+
+  def test_failover_message_retry_ignores_the_idempotent_flag
+    conn = FlakyConn.new(kind: :readonly, raises: 1)
+    pool = pool_wrapping(conn)
+
+    assert_equal(:ok, pool.with(&:exec))
+    assert_equal 2, conn.calls, 'a READONLY reply proves the write went to a replica, never applied'
   end
 
   # --- telemetry hook ---
@@ -240,7 +293,7 @@ class RedisPoolTest < Wurk::Test::UnitCase
     conn = FlakyConn.new(kind: :timeout, raises: 99)
     pool = pool_wrapping(conn, on_error: ->(info) { events << info })
 
-    no_sleep(pool) { assert_raises(RedisClient::ConnectionError) { pool.with(&:exec) } }
+    no_sleep(pool) { assert_raises(RedisClient::ConnectionError) { pool.with(idempotent: true, &:exec) } }
 
     summary = events.map { |e| [e[:attempt], e[:retried], e[:pool], e[:error].class] }
 
@@ -267,8 +320,17 @@ class RedisPoolTest < Wurk::Test::UnitCase
     assert_empty events
   end
 
+  def test_notifies_once_when_a_replay_is_refused
+    events = []
+    conn = FlakyConn.new(kind: :read_timeout, raises: 1)
+    pool = pool_wrapping(conn, on_error: ->(info) { events << info })
+
+    assert_raises(RedisClient::ReadTimeoutError) { pool.with(&:exec) }
+    assert_equal([{ attempt: 1, retried: false }], events.map { |e| e.slice(:attempt, :retried) })
+  end
+
   def test_a_raising_telemetry_hook_never_breaks_the_retry_path
-    conn = FlakyConn.new(kind: :timeout, raises: 1)
+    conn = FlakyConn.new(kind: :cannot_connect, raises: 1)
     pool = pool_wrapping(conn, on_error: ->(_info) { raise 'telemetry boom' })
 
     no_sleep(pool) { assert_equal(:ok, pool.with(&:exec)) }
@@ -429,7 +491,10 @@ class RedisPoolTest < Wurk::Test::UnitCase
                   'UNBLOCKED force unblock from blocking operation, instance state changed (master -> replica?)'],
       other: [RedisClient::CommandError, 'ERR wrong number of arguments'],
       timeout: [RedisClient::ConnectionError, 'Connection timed out'],
-      cannot_connect: [RedisClient::CannotConnectError, 'Errno::ECONNREFUSED']
+      read_timeout: [RedisClient::ReadTimeoutError, 'Waited 2.5 seconds'],
+      write_timeout: [RedisClient::WriteTimeoutError, 'Waited 2.5 seconds'],
+      cannot_connect: [RedisClient::CannotConnectError, 'Errno::ECONNREFUSED'],
+      failover: [RedisClient::FailoverError, 'Expected to connect to a master, but the server is a replica']
     }.freeze
 
     attr_reader :calls, :closes

--- a/test/unit/scheduled_poller_test.rb
+++ b/test/unit/scheduled_poller_test.rb
@@ -205,6 +205,69 @@ class ScheduledPollerTest < Wurk::Test::UnitCase
   end
   # rubocop:enable Metrics/AbcSize, Minitest/MultipleAssertions
 
+  # ZPOPBYSCORE claims no apply-safety, so a read timeout reaches #drain_set
+  # instead of being replayed. The outcome of that pop is unknown, so the set's
+  # drain ends there while its sibling still drains on the same tick.
+  def test_pop_read_timeout_ends_the_set_and_leaves_the_sibling_draining
+    drain_with_failing_pop
+
+    assert_equal 1, @pool.with { |c| c.call('ZCARD', @schedule) }, 'the timed-out set must be left alone'
+    assert_equal 0, @pool.with { |c| c.call('ZCARD', @retry) }, 'the sibling set must still drain'
+  end
+
+  # Unknown outcome, not "nothing due": a pop that may have taken a job down
+  # with it is reported rather than swallowed.
+  def test_pop_read_timeout_is_reported_with_the_set_it_hit
+    captured = drain_with_failing_pop
+    sets = captured.map { |(_, ctx)| ctx[:set] }
+
+    assert_equal [@schedule], sets
+    assert_instance_of RedisClient::ReadTimeoutError, captured.dig(0, 0)
+  end
+
+  # Drains both sets through an Enq whose first pop raises; returns the
+  # [exception, context] pairs the error handlers captured.
+  def drain_with_failing_pop
+    sets = [@schedule, @retry]
+    sets.each { |set| schedule_job(set: set, at: Time.now.to_f - 10) }
+    captured = capture_errors
+    enq = Wurk::Scheduled::Enq.new(@config)
+    enq.instance_variable_set(:@config, PopFailingConfig.new(@config))
+    enq.enqueue_jobs(sets)
+    captured
+  end
+
+  # Swaps the error handlers for one that records [exception, context].
+  def capture_errors
+    captured = []
+    @config.error_handlers.replace([->(ex, ctx, _cfg) { captured << [ex, ctx] }])
+    captured
+  end
+
+  # Fails the first pop, then is the real config — the shape of a read timeout
+  # landing on ZPOPBYSCORE after the pool has refused to replay it.
+  class PopFailingConfig
+    def initialize(real)
+      @real = real
+      @calls = 0
+    end
+
+    def redis(**, &)
+      @calls += 1
+      raise RedisClient::ReadTimeoutError, 'pop timed out' if @calls == 1
+
+      @real.redis(**, &)
+    end
+
+    def respond_to_missing?(name, include_private = false)
+      @real.respond_to?(name, include_private) || super
+    end
+
+    def method_missing(name, ...)
+      @real.public_send(name, ...)
+    end
+  end
+
   # --- Poller#enqueue -----------------------------------------------
 
   def test_poller_enqueue_delegates_to_configured_enq


### PR DESCRIPTION
## Summary
- `RedisPool#with`/`run` now splits retry by apply-safety: `CannotConnectError`/`FailoverError` (and the READONLY/NOREPLICAS/UNBLOCKED failover path) stay retryable by default; `ReadTimeoutError`/`WriteTimeoutError`/bare `ConnectionError` raise instead of silently replaying a block whose command may have already applied. `pool.with(idempotent: true)` opts a block back into full backoff.
- `idempotent:` forwarded through every pool wrapper (`Component#redis`, `Configuration#redis`, `Capsule#redis`, `Wurk.redis`, `Wurk::Middleware.redis`, `Limiter.redis`, `Cron.redis`).
- Genuinely idempotent hot paths (fetcher SMEMBERS/LMOVE/BLMOVE, reaper reads, data-API/web reads, queue pause/unpause, heartbeat's identity-hash write, `RedisPool#info`) opted back in.
- Fixed the five confirmed non-idempotent callers so they no longer replay on a post-write timeout: `Client#atomic_push` (duplicate job), `Scheduled#zpopbyscore` (lost scheduled job), `Launcher#write_stats` (double-counted stats), `Heartbeat#drain_signals` (dropped dashboard TERM/TSTP), `PoisonPill#bump_counter` (premature kill).
- Fault-injection coverage: unit-level `FlakyConn` faults for Read/WriteTimeout-not-replayed, CannotConnect-retried, and `idempotent: true` replay; a real-TCP-blip integration regression asserting a seeded `<identity>-signals` entry survives a heartbeat retry exactly once (no drop, no duplicate).

## Test plan
- [x] `bin/rake test` — 2896 runs, 0 failures
- [x] `bin/rake test:parity` — 23 runs, 0 failures
- [x] `bundle exec rubocop` on touched files — clean

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788217857&installation_model_id=11168&pr_number=353&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F353&signature=6fa9a2475564a5c326304a0fe81cc33a731c6739ec144511583dc352a6991348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in idempotent mode for replay-safe Redis operations, available across supported Redis access points and integrations.
  * Improved handling of Redis outages to reduce duplicate jobs and preserve heartbeat signals during transient failures.
* **Bug Fixes**
  * Ambiguous read/write failures now surface immediately instead of being automatically replayed.
  * Scheduled processing continues for unaffected queues when one queue encounters a Redis timeout.
* **Documentation**
  * Clarified retry behavior, buffering, replay safety, and operations that may drop or duplicate work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->