### PR TITLE
fix: atomic leader release + cron fire CAS (slice 05a)

### DIFF
--- a/lib/wurk/cron.rb
+++ b/lib/wurk/cron.rb
@@ -564,18 +564,23 @@ module Wurk
         handle_exception(e, { context: 'cron-poller' })
       end
 
+      # The marks advance *before* the push, via CAS: the leader gate is a
+      # cached read, so a second poller can reach the same due loop for a few
+      # seconds after a handover. Losing the CAS means another tick owns this
+      # slot — enqueue nothing.
       def enqueue_if_due(loop_obj)
         return if loop_obj.paused?
 
         now = ::Time.now.to_i
-        prev_fire, next_fire = read_fire_marks(loop_obj.lid)
-        next_fire ||= loop_obj.next_fire_at(prev_fire || (now - @tick_interval))
-        return if next_fire.nil? || next_fire > now
+        slot, mark = due_slot(loop_obj, now)
+        return if slot.nil?
 
-        warn_missed_tick(loop_obj, next_fire, now)
-        jid = enqueue!(loop_obj)
-        future = loop_obj.next_fire_after(next_fire, now)
-        record_fire(loop_obj, jid, now, future)
+        future = loop_obj.next_fire_after(slot, now)
+        return unless claim_fire?(loop_obj, mark, now, future)
+
+        warn_missed_tick(loop_obj, slot, now)
+        jid = enqueue_claimed!(loop_obj)
+        record_history(loop_obj, jid, now)
         jid
       end
 
@@ -592,6 +597,18 @@ module Wurk
 
       private
 
+      # The slot this tick would fire and the token that claims it, or nil when
+      # the loop has no resolvable occurrence or none is due yet. The token is
+      # the stored `nf` when there is one, otherwise the slot we derived — see
+      # the `cron_claim_fire` script for how the two cases differ.
+      def due_slot(loop_obj, now)
+        prev_fire, next_fire, mark = read_fire_marks(loop_obj.lid)
+        next_fire ||= loop_obj.next_fire_at(prev_fire || (now - @tick_interval))
+        return if next_fire.nil? || next_fire > now
+
+        [next_fire, mark || next_fire.to_s]
+      end
+
       def warn_missed_tick(loop_obj, expected, now)
         return if now - expected <= MISSED_TICK_THRESHOLD
 
@@ -599,6 +616,34 @@ module Wurk
           "[cron] missed tick lid=#{loop_obj.lid} klass=#{loop_obj.klass} " \
           "expected_at=#{expected} fired_at=#{now} drift=#{now - expected}s"
         )
+      end
+
+      # Compare-and-swap the fire marks: only the tick still looking at the
+      # mark it read wins the slot. Manual `#fire` deliberately skips this —
+      # an operator-requested run contends with no schedule slot.
+      def claim_fire?(loop_obj, mark, fired_at, future)
+        @config.redis do |c|
+          Wurk::Lua::Loader.eval_cached(
+            c, :cron_claim_fire,
+            keys: ["#{LOOP_PREFIX}#{loop_obj.lid}"],
+            argv: [mark, fired_at.to_s, future.nil? ? '' : future.to_s]
+          )
+        end == 1
+      end
+
+      # The slot is already claimed, so a failed push loses this occurrence
+      # instead of leaving the next tick to fire it again. Ent leader election
+      # is explicitly best-effort coordination (sidekiq-ent.md §6), so a missed
+      # occurrence is tolerable where a duplicate one is not — log the gap so it
+      # stays attributable.
+      def enqueue_claimed!(loop_obj)
+        enqueue!(loop_obj)
+      rescue StandardError => e
+        logger.warn(
+          "[cron] fire lost lid=#{loop_obj.lid} klass=#{loop_obj.klass} " \
+          "mark already advanced, occurrence skipped: #{e.class}: #{e.message}"
+        )
+        raise
       end
 
       def enqueue!(loop_obj)
@@ -639,24 +684,40 @@ module Wurk
         job.provider_job_id if job.respond_to?(:provider_job_id)
       end
 
+      # Third element is the raw `nf` string — the CAS token for #claim_fire.
+      # Comparing the bytes Redis holds, not the parsed integer, keeps the
+      # token exact regardless of how the value was written.
       def read_fire_marks(lid)
         @config.redis do |c|
-          vals = c.call('HMGET', "#{LOOP_PREFIX}#{lid}", 'lf', 'nf')
-          next_fire = vals[1]
+          prev_fire, next_fire = c.call('HMGET', "#{LOOP_PREFIX}#{lid}", 'lf', 'nf')
           # Preserve nil: treat missing or empty 'nf' as nil, not 0.
-          [vals[0]&.to_i, next_fire.nil? || next_fire.empty? ? nil : next_fire.to_i]
+          next_fire = nil if next_fire.nil? || next_fire.empty?
+          [prev_fire&.to_i, next_fire&.to_i, next_fire]
         end
       end
 
       def record_fire(loop_obj, jid, fired_at, future)
-        history_entry = Wurk.dump_json([fired_at, jid])
+        write_fire_marks(loop_obj.lid, fired_at, future)
+        record_history(loop_obj, jid, fired_at)
+      end
+
+      # Unconditional mark write, for the manual `#fire` path only. The
+      # scheduled path advances the marks through #claim_fire instead.
+      def write_fire_marks(lid, fired_at, future)
+        key = "#{LOOP_PREFIX}#{lid}"
         @config.redis do |c|
           if future.nil?
-            c.call('HSET', "#{LOOP_PREFIX}#{loop_obj.lid}", 'lf', fired_at.to_s)
-            c.call('HDEL', "#{LOOP_PREFIX}#{loop_obj.lid}", 'nf')
+            c.call('HSET', key, 'lf', fired_at.to_s)
+            c.call('HDEL', key, 'nf')
           else
-            c.call('HSET', "#{LOOP_PREFIX}#{loop_obj.lid}", 'lf', fired_at.to_s, 'nf', future.to_s)
+            c.call('HSET', key, 'lf', fired_at.to_s, 'nf', future.to_s)
           end
+        end
+      end
+
+      def record_history(loop_obj, jid, fired_at)
+        history_entry = Wurk.dump_json([fired_at, jid])
+        @config.redis do |c|
           c.call('LPUSH', "#{HISTORY_PREFIX}#{loop_obj.lid}", history_entry)
           c.call('LTRIM', "#{HISTORY_PREFIX}#{loop_obj.lid}", 0, HISTORY_CAP - 1)
         end

--- a/lib/wurk/leader.rb
+++ b/lib/wurk/leader.rb
@@ -119,6 +119,11 @@ module Wurk
     # follower, it polls every `follower_interval`. Caller must invoke
     # `stop` for orderly shutdown — the thread also releases its lock on
     # exit.
+    #
+    # The spawn happens *inside* the lock: with it outside, two callers
+    # racing into `start` both clear the nil check and both spawn, and the
+    # loser's loop is never recorded — an unjoinable second campaigner that
+    # outlives `stop` and keeps renewing the cluster lock.
     def start
       return nil if disabled?
 
@@ -126,17 +131,19 @@ module Wurk
         return @thread if @thread
 
         @done = false
+        @thread = spawn_loop_thread
       end
-      @thread = spawn_loop_thread
+      @thread
     end
 
     def stop
-      @mutex.synchronize do
+      thread = @mutex.synchronize do
         @done = true
         @sleeper.signal
+        @thread
       end
-      @thread&.join
-      @thread = nil
+      thread&.join
+      @mutex.synchronize { @thread = nil }
       release
     end
 

--- a/lib/wurk/leader.rb
+++ b/lib/wurk/leader.rb
@@ -3,6 +3,7 @@
 require 'securerandom'
 require 'socket'
 require_relative 'component'
+require_relative 'lua'
 require_relative 'pool_checkout'
 
 module Wurk
@@ -90,9 +91,19 @@ module Wurk
 
     # CAS DEL — only drop the key if we still own it, otherwise a stale
     # release would yank leadership from whichever follower took over.
+    # GET-then-DEL is not that CAS: our key can lapse between the two
+    # commands and a follower can win the election in the gap, whereupon
+    # the bare DEL deletes *its* lock and leaves the cluster leaderless
+    # (or, once the ex-leader re-campaigns, doubly led) for up to one
+    # renew interval — double cron fires, double rollups. The compare and
+    # the delete happen in one server-side step instead, via the script
+    # `Unique.release_if_owner` already shares.
+    #
+    # `idempotent:` — a replay after a lost reply finds the key either
+    # already gone or no longer ours, so it can only be a no-op.
     def release
-      redis_call do |c|
-        c.call('DEL', @key) if c.call('GET', @key) == @owner
+      redis_call(idempotent: true) do |c|
+        Wurk::Lua::Loader.eval_cached(c, :release_if_owner, keys: [@key], argv: [@owner])
       end
       @held = false
       @token = nil

--- a/lib/wurk/lua.rb
+++ b/lib/wurk/lua.rb
@@ -335,6 +335,41 @@ module Wurk
       return removed
     LUA
 
+    # Ent Periodic (§2): compare-and-swap the fire marks of `loops:<lid>`.
+    # The cron poller's leader gate is a cached read (`Component#leader?`,
+    # LEADER_CACHE_TTL_MS), so for a few seconds after a handover two
+    # processes both believe they lead and both reach the same due loop —
+    # HMGET → decide → enqueue → HSET then fires it twice. Claiming the slot
+    # atomically is what makes a tick fire exactly once; the loser gets 0 and
+    # enqueues nothing. Values written are the same decimal-epoch strings the
+    # Ruby path wrote, byte for byte — the dashboard reads these fields.
+    #
+    # `nf` present: the caller must still be looking at the mark it read
+    # (byte compare, so no parse can drift the token).
+    # `nf` absent: the caller derived the slot from `lf`, so refuse once `lf`
+    # has reached it — that is the exhausted-schedule case, where the winner
+    # cleared `nf` and a loser would otherwise re-fire the very same slot.
+    # KEYS = [loops:<lid>]
+    # ARGV = [expected `nf` (or the derived slot), new `lf`, new `nf` ('' → HDEL)]
+    # Returns 1 when this caller claimed the slot, 0 otherwise.
+    CRON_CLAIM_FIRE = <<~LUA
+      local key = KEYS[1]
+      local cur = redis.call("hget", key, "nf")
+      if cur and cur ~= "" then
+        if cur ~= ARGV[1] then return 0 end
+      else
+        local lf = tonumber(redis.call("hget", key, "lf") or "")
+        if lf and lf >= tonumber(ARGV[1]) then return 0 end
+      end
+      redis.call("hset", key, "lf", ARGV[2])
+      if ARGV[3] == "" then
+        redis.call("hdel", key, "nf")
+      else
+        redis.call("hset", key, "nf", ARGV[3])
+      end
+      return 1
+    LUA
+
     # Limiter scripts live in `lib/wurk/lua/limiter_*.lua` — one file per
     # type. Loaded at boot, the file's basename (minus `.lua`) becomes the
     # SCRIPTS key as a symbol. Keeping them as separate files makes diffing
@@ -359,7 +394,8 @@ module Wurk
       batch_append_callback: BATCH_APPEND_CALLBACK,
       fast_delete_job: FAST_DELETE_JOB,
       fast_delete_by_class: FAST_DELETE_BY_CLASS,
-      release_if_owner: RELEASE_IF_OWNER
+      release_if_owner: RELEASE_IF_OWNER,
+      cron_claim_fire: CRON_CLAIM_FIRE
     }.merge(FILE_SCRIPTS).freeze
 
     # SHA1 of each script source — matches what `SCRIPT LOAD` returns.

--- a/lib/wurk/lua.rb
+++ b/lib/wurk/lua.rb
@@ -284,12 +284,13 @@ module Wurk
 
     # Ent Unique (§3): atomic compare-and-delete of a lock key. Replaces the
     # two-command GET-then-DEL — between those calls the key can expire and a
-    # fresh enqueue can grab it, and the bare DEL would then drop the new
+    # fresh owner can grab it, and the bare DEL would then drop the new
     # owner's lock. Shared by `Unique::ServerMiddleware#release` (normal
-    # success/start release) and `Unique::DEATH_HANDLER` (automatic-death
-    # release) so the two paths cannot drift.
-    # KEYS = [unique:<sha256>]
-    # ARGV = [owning jid]
+    # success/start release), `Unique::DEATH_HANDLER` (automatic-death
+    # release) and `Leader#release` (stepping down from the cluster lock)
+    # so those paths cannot drift.
+    # KEYS = [the lock key — unique:<sha256> | dear-leader]
+    # ARGV = [the owner that must still hold it — jid | <host>:<pid>:<nonce>]
     # Returns 1 when the key was deleted, 0 otherwise.
     RELEASE_IF_OWNER = <<~LUA
       if redis.call("get", KEYS[1]) == ARGV[1] then

--- a/test/unit/cron_test.rb
+++ b/test/unit/cron_test.rb
@@ -28,10 +28,12 @@ class CronTest < Wurk::Test::UnitCase
     super
     @suffix = "cron#{Process.pid}#{object_id}"
     @lids = []
+    @configs = []
   end
 
   def teardown
     @lids.each { |lid| Wurk::Cron.unregister(lid) }
+    @configs.each(&:reset_redis_pools!)
   ensure
     super
   end
@@ -596,6 +598,141 @@ class CronTest < Wurk::Test::UnitCase
     cfg[:cron_tick_interval] = 0.25
 
     assert_equal 0.25, Wurk::Cron::Poller.new(cfg).instance_variable_get(:@tick_interval)
+  end
+
+  # ---- Fire-mark CAS ---------------------------------------------------
+  #
+  # `leader?` is a cached read, so two processes can both believe they lead
+  # for seconds after a handover and both reach the same due loop. The CAS on
+  # `nf` — not the leader gate — is what keeps a slot to a single fire.
+
+  def test_racing_pollers_fire_a_due_slot_exactly_once
+    queue = "cron-race-#{@suffix}"
+    lp = register_loop("CronTest::Race#{@suffix}", queue: queue)
+    pollers = Array.new(3) { build_leader_poller }
+    rounds = 8
+    claims = 0
+
+    rounds.times do
+      arm_due_mark(lp.lid)
+      claims += race_enqueue(pollers, lp).compact.size
+    end
+    len = queue_len(queue)
+    cleanup_queue(queue)
+
+    assert_equal rounds, claims, 'exactly one racing poller may claim each due slot'
+    assert_equal rounds, len, 'a claimed slot must enqueue exactly one job'
+  end
+
+  def test_enqueue_if_due_loses_the_slot_once_the_mark_moved
+    queue = "cron-cas-#{@suffix}"
+    lp = register_loop("CronTest::Cas#{@suffix}", queue: queue)
+    poller = build_leader_poller
+    arm_due_mark(lp.lid)
+
+    first = poller.send(:enqueue_if_due, lp)
+    arm_due_mark(lp.lid)
+    poller.define_singleton_method(:claim_fire?) { |*| false }
+    second = poller.send(:enqueue_if_due, lp)
+    len = queue_len(queue)
+    cleanup_queue(queue)
+
+    refute_nil first
+    assert_nil second, 'losing the CAS must return without enqueuing'
+    assert_equal 1, len
+  end
+
+  # The exhausted-schedule case: the winner cleared `nf`, so a loser arriving
+  # with the same slot sees no mark at all. `lf` is what tells it the slot is
+  # already spent.
+  def test_claim_fire_refuses_a_slot_already_covered_by_lf
+    lp = register_loop("CronTest::Spent#{@suffix}", queue: "cron-sp-#{@suffix}")
+    poller = Wurk::Cron::Poller.new(Wurk.configuration)
+    slot = ::Time.now.to_i - 30
+    seed_mark(lp.lid, 'lf', slot + 1)
+
+    refute poller.send(:claim_fire?, lp, slot.to_s, ::Time.now.to_i, nil),
+           'a slot the loop already fired must not be re-claimable after `nf` is cleared'
+  end
+
+  def test_claim_fire_bootstraps_an_unmarked_loop_then_rejects_the_replay
+    lp = register_loop("CronTest::Boot#{@suffix}", queue: "cron-bt-#{@suffix}")
+    poller = Wurk::Cron::Poller.new(Wurk.configuration)
+    now = ::Time.now.to_i
+
+    assert poller.send(:claim_fire?, lp, now.to_s, now, now + 60),
+           'a loop with no marks yet must be claimable'
+    refute poller.send(:claim_fire?, lp, now.to_s, now, now + 60),
+           'the mark moved — a second claim on the same slot must lose'
+  end
+
+  def test_claim_fire_writes_marks_byte_identically_to_the_ruby_path
+    lp = register_loop("CronTest::Bytes#{@suffix}", queue: "cron-by-#{@suffix}")
+    poller = Wurk::Cron::Poller.new(Wurk.configuration)
+    now = ::Time.now.to_i
+
+    poller.send(:claim_fire?, lp, now.to_s, now, now + 60)
+
+    assert_equal [now.to_s, (now + 60).to_s], marks(lp.lid), 'lf/nf stay decimal-epoch strings'
+  end
+
+  def test_claim_fire_clears_nf_when_there_is_no_future_occurrence
+    lp = register_loop("CronTest::Last#{@suffix}", queue: "cron-la-#{@suffix}")
+    poller = Wurk::Cron::Poller.new(Wurk.configuration)
+    now = ::Time.now.to_i
+    seed_mark(lp.lid, 'nf', now)
+
+    poller.send(:claim_fire?, lp, now.to_s, now, nil)
+
+    assert_nil marks(lp.lid)[1], 'a nil future must HDEL nf, never write ""'
+  end
+
+  # Ent periodic is best-effort about a miss, never about a duplicate: the mark
+  # advances before the push, so a failed push drops this occurrence instead of
+  # leaving the next tick to fire it a second time.
+  def test_enqueue_if_due_advances_the_mark_before_the_push
+    lp = register_loop("CronTest::Lost#{@suffix}", queue: "cron-lo-#{@suffix}")
+    arm_due_mark(lp.lid)
+    poller = poller_whose_push_fails(StringIO.new)
+
+    assert_raises(IOError) { poller.send(:enqueue_if_due, lp) }
+    assert_operator marks(lp.lid)[1].to_i, :>, ::Time.now.to_i,
+                    'the mark must advance before the push, not after'
+  end
+
+  def test_enqueue_if_due_logs_the_occurrence_lost_to_a_failed_push
+    io = StringIO.new
+    lp = register_loop("CronTest::LostLog#{@suffix}", queue: "cron-ll-#{@suffix}")
+    arm_due_mark(lp.lid)
+    poller = poller_whose_push_fails(io)
+
+    assert_raises(IOError) { poller.send(:enqueue_if_due, lp) }
+    assert_match(/fire lost/, io.string)
+  end
+
+  # The manual `Cron.fire!` path deliberately bypasses the CAS: an operator
+  # asking for a run contends with no schedule slot.
+  def test_manual_fire_enqueues_with_the_next_mark_far_in_the_future
+    queue = "cron-manual-#{@suffix}"
+    lp = register_loop("CronTest::Manual#{@suffix}", queue: queue)
+    seed_mark(lp.lid, 'nf', ::Time.now.to_i + 86_400)
+
+    jid = Wurk::Cron::Poller.new(Wurk.configuration).fire(lp)
+    cleanup_queue(queue)
+
+    refute_nil jid, 'a manual fire must not be gated by the schedule'
+    assert_operator marks(lp.lid)[0].to_i, :>, 0, 'a manual fire still advances lf'
+  end
+
+  def test_manual_fire_records_a_history_entry
+    queue = "cron-manhist-#{@suffix}"
+    lp = register_loop("CronTest::ManHist#{@suffix}", queue: queue)
+
+    Wurk::Cron::Poller.new(Wurk.configuration).fire(lp)
+    history = history_entries(lp.lid)
+    cleanup_queue(queue)
+
+    assert_equal 1, history.size
   end
 
   # ---- DST / timezone edge cases (US / EU / AU) -----------------------
@@ -1277,6 +1414,54 @@ class CronTest < Wurk::Test::UnitCase
   def loop_hash(lid)
     h = Wurk.redis { |c| c.call('HGETALL', "#{Wurk::Cron::LOOP_PREFIX}#{lid}") }
     h.is_a?(Array) ? h.each_slice(2).to_h : h
+  end
+
+  def loop_key(lid)
+    "#{Wurk::Cron::LOOP_PREFIX}#{lid}"
+  end
+
+  def seed_mark(lid, field, value)
+    Wurk.redis { |c| c.call('HSET', loop_key(lid), field, value.to_s) }
+  end
+
+  def marks(lid)
+    Wurk.redis { |c| c.call('HMGET', loop_key(lid), 'lf', 'nf') }
+  end
+
+  # An `nf` one second in the past makes the loop due right now whatever its
+  # schedule, so a tick has to go through the CAS to fire it.
+  def arm_due_mark(lid)
+    seed_mark(lid, 'nf', ::Time.now.to_i - 1)
+  end
+
+  def queue_len(queue)
+    Wurk.redis { |c| c.call('LLEN', "queue:#{queue}") }
+  end
+
+  # Poller on a throwaway Configuration — it inherits the worker's REDIS_URL,
+  # so it still reads and writes this test's DB — logging to `io`, whose push
+  # always fails.
+  def poller_whose_push_fails(io)
+    cfg = Wurk::Configuration.new
+    cfg.logger = Logger.new(io)
+    @configs << cfg
+    poller = Wurk::Cron::Poller.new(cfg)
+    poller.define_singleton_method(:enqueue!) { |_| raise IOError, 'redis down' }
+    poller
+  end
+
+  # Releases every poller onto the same loop at once — a barrier, so the CAS
+  # is what separates them rather than thread start-up skew.
+  def race_enqueue(pollers, loop_obj)
+    gate = Queue.new
+    threads = pollers.map do |p|
+      Thread.new do
+        gate.pop
+        p.send(:enqueue_if_due, loop_obj)
+      end
+    end
+    pollers.size.times { gate << :go }
+    threads.map(&:value)
   end
 
   def build_leader_poller

--- a/test/unit/leader_test.rb
+++ b/test/unit/leader_test.rb
@@ -11,6 +11,53 @@ class LeaderTest < Wurk::Test::UnitCase
   ENV_MUTEX = Mutex.new
   CLUSTER_KEY_MUTEX = Mutex.new
 
+  # A real pool over real Redis that records what each block claims and every
+  # command it issues, and can splice a competing writer between two of those
+  # commands. Subclasses the pool rather than doubling it because PoolCheckout
+  # dispatches on the RedisPool type — a bare double takes the foreign-pool
+  # branch and never sees the `idempotent:` claim.
+  class ProbePool < Wurk::RedisPool
+    attr_reader :claims, :commands
+
+    def initialize(name)
+      super(size: 1, name: name, url: Wurk::Test.redis_url, timeout: 2)
+      @claims = []
+      @commands = []
+      @splice = nil
+    end
+
+    # Run `blk` (handed a live connection) right after the next command any
+    # block issues, then disarm.
+    def after_next_command(&blk)
+      @splice = blk
+    end
+
+    def with(idempotent: false, &block)
+      @claims << idempotent
+      super { |conn| block.call(Probe.new(conn, self)) }
+    end
+
+    def observe(args, conn)
+      @commands << args
+      splice = @splice
+      @splice = nil
+      splice&.call(conn)
+    end
+  end
+
+  # Connection decorator: hands every command to the real connection, then to
+  # the pool that owns it.
+  class Probe
+    def initialize(conn, pool)
+      @conn = conn
+      @pool = pool
+    end
+
+    def call(*args)
+      @conn.call(*args).tap { @pool.observe(args, @conn) }
+    end
+  end
+
   def setup
     super
     @suffix = "leader-#{Process.pid}-#{object_id}"
@@ -135,6 +182,56 @@ class LeaderTest < Wurk::Test::UnitCase
     a.release
 
     assert_equal('someone-else', Wurk.redis { |c| c.call('GET', @key) })
+  end
+
+  # GET-then-DEL is not a CAS: a follower that won the key between the two
+  # commands had its fresh lock deleted by our DEL — leaderless until the next
+  # tick, then two leaders once the ex-leader re-campaigned. Splice exactly
+  # that writer in right after the first command release issues; the compare
+  # and the delete resolve in one server-side step, so the competitor's lock
+  # survives whichever side of it the steal lands on.
+  def test_release_cannot_delete_a_competitor_that_wins_mid_release
+    pool = ProbePool.new('leader-steal')
+    ldr = Wurk::Leader.new(key: @key, pool: pool)
+    ldr.acquire
+    pool.after_next_command { |c| c.call('SET', @key, 'competitor', 'EX', 30) }
+    ldr.release
+
+    assert_equal('competitor', pool.with { |c| c.call('GET', @key) })
+  ensure
+    pool&.disconnect!
+  end
+
+  # The property the race above rests on: one round trip, and specifically the
+  # `release_if_owner` CAS shared with Wurk::Unique.
+  def test_release_is_a_single_atomic_command
+    pool = ProbePool.new('leader-probe')
+    ldr = Wurk::Leader.new(key: @key, pool: pool)
+    ldr.acquire
+    warm_script_cache(pool) # a NOSCRIPT reload would add round trips
+    pool.commands.clear
+    ldr.release
+
+    assert_equal 1, pool.commands.size, 'release must not be GET-then-DEL'
+    assert_equal(['EVALSHA', Wurk::Lua::SHAS.fetch(:release_if_owner), 1, @key, ldr.owner],
+                 pool.commands.first)
+  ensure
+    pool&.disconnect!
+  end
+
+  # A replay after a lost reply finds the key either already gone or no longer
+  # ours, so release claims the pool's idempotent budget — a blip mid-release
+  # must not leave the lock behind for the TTL to reap.
+  def test_release_claims_idempotent_replay
+    pool = ProbePool.new('leader-idem')
+    ldr = Wurk::Leader.new(key: @key, pool: pool)
+    ldr.acquire
+    pool.claims.clear
+    ldr.release
+
+    assert_equal [true], pool.claims
+  ensure
+    pool&.disconnect!
   end
 
   # ---- Fencing token ----------------------------------------------------
@@ -607,6 +704,12 @@ class LeaderTest < Wurk::Test::UnitCase
     ldr = Wurk::Leader.new(key: @key, **)
     @leaders << ldr
     ldr
+  end
+
+  # Run the CAS once against a throwaway key so its SHA is server-side cached
+  # and the measured release is a single EVALSHA.
+  def warm_script_cache(pool)
+    pool.with { |c| Wurk::Lua::Loader.eval_cached(c, :release_if_owner, keys: ["#{@key}-warm"], argv: ['nobody']) }
   end
 
   def build_config

--- a/test/unit/leader_test.rb
+++ b/test/unit/leader_test.rb
@@ -486,6 +486,24 @@ class LeaderTest < Wurk::Test::UnitCase
     assert_same t1, t2
   end
 
+  # F12: the spawn must happen under the lock. Widen the window by parking
+  # inside `spawn_loop_thread` — with the spawn outside `synchronize` both
+  # racers clear the nil check and start a loop, and the one that loses the
+  # `@thread=` assignment is unreachable: `stop` never joins it.
+  def test_concurrent_start_spawns_a_single_loop
+    ldr = build_leader(renew_interval: 0.05, follower_interval: 0.05)
+    spawned = Queue.new
+    ldr.define_singleton_method(:spawn_loop_thread) do
+      sleep 0.1
+      super().tap { |t| spawned << t }
+    end
+
+    t1, t2 = race(2) { ldr.start }
+
+    assert_equal 1, spawned.size, 'a second start must not leak an unjoinable loop'
+    assert_same t1, t2
+  end
+
   def test_periodic_loop_acquires_when_available
     ldr = build_leader(renew_interval: 0.05, follower_interval: 0.05)
     ldr.start
@@ -704,6 +722,23 @@ class LeaderTest < Wurk::Test::UnitCase
     ldr = Wurk::Leader.new(key: @key, **)
     @leaders << ldr
     ldr
+  end
+
+  # Run the block in `count` threads released from a common barrier, so they
+  # contend rather than run in spawn order. Returns their values.
+  def race(count)
+    ready = Queue.new
+    go = Queue.new
+    racers = Array.new(count) do
+      Thread.new do
+        ready << true
+        go.pop
+        yield
+      end
+    end
+    count.times { ready.pop }
+    count.times { go << :go }
+    racers.map(&:value)
   end
 
   # Run the CAS once against a throwaway key so its SHA is server-side cached

--- a/test/unit/lua_test.rb
+++ b/test/unit/lua_test.rb
@@ -34,7 +34,7 @@ class LuaTest < Wurk::Test::UnitCase
       %i[zpopbyscore bulk_push reliable_schedule_promote reliable_requeue
          batch_push batch_schedule batch_ack_success batch_ack_failed batch_ack_complete batch_invalidate
          batch_append_callback
-         fast_delete_job fast_delete_by_class release_if_owner
+         fast_delete_job fast_delete_by_class release_if_owner cron_claim_fire
          limiter_concurrent_acquire limiter_concurrent_release
          limiter_bucket_acquire limiter_window_acquire limiter_leaky_acquire
          limiter_points_acquire limiter_points_refund].sort,


### PR DESCRIPTION
## Summary
- F3 — `Leader#release` now routes through the shared `release_if_owner` Lua CAS instead of GET-then-DEL, closing the dual-leader window where a competitor's fresh lock could be deleted mid-release.
- F12 — `Leader#start` spawns the re-election thread inside the mutex (Reaper pattern), so two racing callers can no longer both pass the nil-check and leak an unjoinable second campaigner.
- F4 — cron fire marks (`lf`/`nf` on `loops:<lid>`) advance via a single-Lua CAS (`cron_claim_fire`) so two pollers that both believe they lead after a handover can no longer double-fire the same due slot. Mark advances before the enqueue push; a failed push drops the occurrence (logged) rather than risking a duplicate.
- Race tests: single-round-trip proof for leader release (EVALSHA-only, idempotent-replay claim), a barrier-released concurrent-start regression test, and a 3-poller × 8-round real-Redis race test asserting exactly one claim/enqueue per due tick. `test/integration/periodic_leader_test.rb` (two real worker processes, one loop) stays green.

## Test plan
- [x] `bin/rake test TEST=test/unit/leader_test.rb`
- [x] `bin/rake test TEST=test/unit/cron_test.rb`
- [x] `bin/rake test TEST=test/integration/periodic_leader_test.rb`
- [x] `bin/rake test` (full suite, 2918 runs, 0 failures)
- [x] `bin/rake test:parity`
- [x] `bundle exec rubocop lib` (no new offenses; pre-existing unrelated offenses untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788223250&installation_model_id=11168&pr_number=354&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F354&signature=ddc344f7a2162484fd7b82cfd857e8afc357beccf04a02aaa35c0c9775cc6b58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->