### PR TITLE
fix(limiter): read-only status, boundary sleep, held/overages (05b)

### DIFF
--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -281,9 +281,14 @@ reset: the next boundary for `bucket`, when the oldest entry leaves for
 room for `leaky`/`points`.
 
 `concurrent#status` additionally merges its counters — `held`, `held_time`,
-`immediate`, `waited`, `wait_time`, `overages`, `reclaimed`. `immediate` counts
-acquires that didn't wait, `waited`/`wait_time` those that did, `overages`
-timeouts, `reclaimed` slots evicted because they outlived `lock_timeout`.
+`immediate`, `waited`, `wait_time`, `overages`, `reclaimed`. `held`/`held_time`
+count acquired slots and the seconds they were held, `immediate` counts acquires
+that didn't wait, `waited`/`wait_time` those that did, `overages` holders that
+outran `lock_timeout` (their slot was already gone when they released),
+`reclaimed` slots evicted because they outlived `lock_timeout`.
+
+Waiting past `wait_timeout` is *not* an overage — that raises `OverLimit` and is
+counted per job in `overrated`.
 
 ---
 

--- a/lib/wurk/limiter/bucket.rb
+++ b/lib/wurk/limiter/bucket.rb
@@ -38,7 +38,7 @@ module Wurk
           remaining = deadline - ::Time.now.to_f
           raise OverLimit, self if remaining <= 0
 
-          sleep [remaining, secs_to_next.to_f, 0.05].compact.min.clamp(0.0, remaining)
+          sleep [0.05, secs_to_next.to_f].max.clamp(0.0, remaining)
         end
       end
 

--- a/lib/wurk/limiter/concurrent.rb
+++ b/lib/wurk/limiter/concurrent.rb
@@ -6,7 +6,7 @@ module Wurk
   module Limiter
     # Atomic slot acquisition in a ZSET. Score = expiry epoch; the acquire
     # script first evicts expired slots (bumping the `reclaimed` metric)
-    # then ZADDs if there's headroom.
+    # then ZADDs if there's headroom (bumping the `held` metric).
     #
     # On exhaustion: spin loop with backoff. The spec says "blocks via
     # Redis stream XREAD" — that's a perf optimization; the visible
@@ -38,33 +38,15 @@ module Wurk
         raise ArgumentError, 'block required' unless block
 
         started = monotime
-        deadline = started + @options[:wait_timeout]
         slot = random_id
-        acquired_at = nil
-        loop do
-          result = acquire(slot)
-          if result[0].to_i == 1
-            acquired_at = monotime
-            break
-          end
-
-          return if @options[:policy] == :ignore
-
-          remaining = deadline - monotime
-          if remaining <= 0
-            bump_counter('overages')
-            raise OverLimit, self
-          end
-
-          sleep [remaining, WAIT_SLEEP].min
-        end
+        acquired_at = wait_for_slot(slot, started + @options[:wait_timeout])
+        return unless acquired_at
 
         begin
           incr_immediate_or_waited(acquired_at - started)
           block.call
         ensure
-          release(slot)
-          bump_counter('held_time', (monotime - acquired_at).to_i) if acquired_at
+          record_release(slot, acquired_at)
         end
       end
 
@@ -96,6 +78,29 @@ module Wurk
 
       def stats_key
         "lmtr-stats:#{@name}"
+      end
+
+      # A ZREM that removes nothing means an acquirer already evicted our slot:
+      # we outran `lock_timeout`, which is what `overages` counts. Exhausting
+      # `wait_timeout` is a different event — it raises OverLimit and the server
+      # middleware counts it in the job's `overrated` field.
+      def record_release(slot, acquired_at)
+        bump_counter('overages') if release(slot).to_i.zero?
+        bump_counter('held_time', (monotime - acquired_at).to_i)
+      end
+
+      # Spins until a slot frees up. Returns the monotonic acquire time, nil
+      # when `policy: :ignore` gives up; raises OverLimit past `wait_timeout`.
+      def wait_for_slot(slot, deadline)
+        loop do
+          return monotime if acquire(slot)[0].to_i == 1
+          return if @options[:policy] == :ignore
+
+          remaining = deadline - monotime
+          raise OverLimit, self if remaining <= 0
+
+          sleep [remaining, WAIT_SLEEP].min
+        end
       end
 
       def acquire(slot)

--- a/lib/wurk/limiter/window.rb
+++ b/lib/wurk/limiter/window.rb
@@ -19,18 +19,15 @@ module Wurk
       end
 
       def size
-        cutoff = ::Time.now.to_f - interval_seconds
-        Wurk::Limiter.redis do |c|
-          c.call('ZREMRANGEBYSCORE', state_key, '-inf', "(#{cutoff}")
-          c.call('ZCARD', state_key).to_i
-        end
+        window_state.first
       end
 
       # used = entries still inside the window; limit = count; reset_at =
       # when the oldest entry slides out (freeing a slot), or nil when
       # idle (#16).
       def status
-        build_status(used: size, limit: @options[:count], reset_at: oldest_expiry)
+        used, oldest = window_state
+        build_status(used: used, limit: @options[:count], reset_at: oldest && (oldest + interval_seconds))
       end
 
       def within_limit(used: 1, &block)
@@ -60,11 +57,16 @@ module Wurk
         "lmtr-w:#{@name}"
       end
 
-      # Oldest timestamp + interval = the moment it leaves the window.
-      def oldest_expiry
-        row = Wurk::Limiter.redis { |c| c.call('ZRANGE', state_key, 0, 0, 'WITHSCORES') }
-        score = Wurk::Limiter.first_score(row)
-        score && (score + interval_seconds)
+      # Count + oldest in-window score, both scoped by the Redis clock, in one
+      # read-only round trip. Reads never trim (the acquire script owns that):
+      # a dashboard host whose clock ran ahead used to evict live entries just
+      # by rendering `status`, freeing the window for a second full charge.
+      # Oldest timestamp + interval = the moment it leaves the window; -1 =
+      # nothing in window.
+      def window_state
+        count, oldest = lua(:limiter_window_status, keys: [state_key], argv: [interval_seconds])
+        score = oldest.to_f
+        [count.to_i, score.negative? ? nil : score]
       end
 
       def interval_seconds

--- a/lib/wurk/lua/limiter_concurrent_acquire.lua
+++ b/lib/wurk/lua/limiter_concurrent_acquire.lua
@@ -6,7 +6,10 @@
 -- ARGV[3] = slot_id (caller-generated; SHA-fingerprinted on the Ruby side)
 -- ARGV[4] = ttl seconds
 -- Returns {acquired, held, reclaimed}. acquired: 1 if slot recorded, 0 if full.
--- reclaimed: count of expired slots evicted on this pass.
+-- held: live ZCARD gauge after this pass. reclaimed: expired slots evicted here.
+-- The lifetime `held` counter in the stats hash is bumped here, not on the Ruby
+-- side, so it stays atomic with the ZADD (a process dying mid-acquire can't
+-- undercount) and costs no extra round trip on the acquire path.
 local cs_key = KEYS[1]
 local st_key = KEYS[2]
 local t = redis.call('TIME')
@@ -22,6 +25,7 @@ end
 local held = redis.call('ZCARD', cs_key)
 if held < limit then
   redis.call('ZADD', cs_key, now + lock_to, slot_id)
+  redis.call('HINCRBY', st_key, 'held', 1)
   redis.call('EXPIRE', cs_key, ttl)
   redis.call('EXPIRE', st_key, ttl)
   return {1, held + 1, reclaimed}

--- a/lib/wurk/lua/limiter_window_status.lua
+++ b/lib/wurk/lua/limiter_window_status.lua
@@ -1,0 +1,22 @@
+-- Window limiter: read-only probe — entries inside the window plus the oldest
+-- score still in it, in one atomic round trip.
+-- Deliberately does NOT trim: ZREMRANGEBYSCORE lives exclusively in
+-- limiter_window_acquire.lua. `size`/`status` are introspection the dashboard
+-- runs on every GET, from a host whose clock Wurk does not control; the old
+-- Ruby-side read trimmed against that client clock, so a host running more than
+-- one interval ahead of Redis wiped a live window on a mere read and let the
+-- next callers charge the limit a second time.
+-- Timing comes from redis TIME, the same invariant limiter_bucket_acquire.lua
+-- documents: the window boundary tracks the Redis clock, never the caller's.
+-- The cutoff is inclusive to mirror exactly what the acquire trim retains
+-- (it removes [-inf, cutoff), so a score of exactly cutoff is still in window).
+-- KEYS[1] = lmtr-w:<name>
+-- ARGV[1] = interval seconds (float ok)
+-- Returns {count_in_window, oldest_in_window_score_or_-1}.
+local key = KEYS[1]
+local t = redis.call('TIME')
+local now = tonumber(t[1]) + tonumber(t[2]) / 1000000
+local cutoff = tostring(now - tonumber(ARGV[1]))
+local current = redis.call('ZCOUNT', key, cutoff, '+inf')
+local oldest = redis.call('ZRANGEBYSCORE', key, cutoff, '+inf', 'WITHSCORES', 'LIMIT', 0, 1)
+return {current, oldest[2] or '-1'}

--- a/test/integration/limiter_stress_test.rb
+++ b/test/integration/limiter_stress_test.rb
@@ -67,12 +67,13 @@ class LimiterStressTest < Wurk::Test::UnitCase
     assert_equal 0, limiter.size, 'every slot released at the end'
   end
 
-  # All limiter acquire/release scripts ship as files, get a precomputed SHA,
-  # and run via EVALSHA (with NOSCRIPT recovery) — never re-uploaded per call.
+  # Every limiter script — acquire, release and the read-only window probe —
+  # ships as a file, gets a precomputed SHA, and runs via EVALSHA (with NOSCRIPT
+  # recovery) — never re-uploaded per call.
   def test_all_limiter_lua_scripts_are_evalsha_cached
     %i[limiter_concurrent_acquire limiter_concurrent_release limiter_bucket_acquire
-       limiter_window_acquire limiter_leaky_acquire limiter_points_acquire
-       limiter_points_refund].each do |name|
+       limiter_window_acquire limiter_window_status limiter_leaky_acquire
+       limiter_points_acquire limiter_points_refund].each do |name|
       assert Wurk::Lua::SCRIPTS.key?(name), "missing Lua script #{name}"
       assert_match(/\A[0-9a-f]{40}\z/, Wurk::Lua::SHAS[name], "no precomputed SHA for #{name}")
     end

--- a/test/unit/limiter_bucket_test.rb
+++ b/test/unit/limiter_bucket_test.rb
@@ -137,4 +137,44 @@ class LimiterBucketTest < Wurk::Test::UnitCase
 
     assert ran
   end
+
+  # F9: `[remaining, secs_to_next, 0.05].min` always picked the 0.05 floor
+  # (remaining and secs_to_next are both bigger almost always), so the old
+  # code busy-polled every 50ms instead of sleeping to the boundary. Assert
+  # bounds on the sleep *duration* itself — the clock value the retry loop
+  # actually waits on — rather than how many times it looped or called Redis,
+  # which is an implementation detail that would still pass under the bug.
+  def test_wait_sleeps_toward_the_boundary_not_a_fixed_poll_floor
+    align_to_top_of_second
+    l = Wurk::Limiter.bucket("pb-#{@suffix}", 1, :second, wait_timeout: 3)
+    l.within_limit {} # exhausts the current second right after it started
+
+    slept = []
+    l.define_singleton_method(:sleep) do |secs|
+      slept << secs
+      Kernel.sleep(secs)
+    end
+    ran = false
+    l.within_limit { ran = true }
+
+    assert ran
+    refute_empty slept
+    assert slept.first.between?(0.051, 1.0),
+           "first sleep (#{slept.first}) must target the boundary distance, not the 0.05 poll floor"
+  end
+
+  private
+
+  # Busy-wait until just past a whole second so the bucket we exhaust next has
+  # close to a full second of runway before its boundary — otherwise the test
+  # would flake on runs that happen to start near the tail of a second, where
+  # even the fixed sleep-to-boundary logic legitimately returns ~0.05s.
+  def align_to_top_of_second
+    loop do
+      now = Time.now.to_f
+      break if (now - now.floor) < 0.3
+
+      sleep 0.01
+    end
+  end
 end

--- a/test/unit/limiter_concurrent_test.rb
+++ b/test/unit/limiter_concurrent_test.rb
@@ -149,6 +149,75 @@ class LimiterConcurrentTest < Wurk::Test::UnitCase
     assert_raises(ArgumentError) { l.within_limit }
   end
 
+  # F10: `held` is the lifetime acquire counter, bumped inside the acquire Lua.
+  # It partitions exactly into `immediate` + `waited`.
+  def test_held_counts_every_successful_acquire
+    l = Wurk::Limiter.concurrent("hd-#{@suffix}", 2)
+    runs = 0
+    3.times { l.within_limit { runs += 1 } }
+    s = l.status
+
+    assert_equal 3, runs
+    assert_equal 3, s['held']
+    assert_equal s['held'], s['immediate'] + s['waited']
+  end
+
+  # A rejected acquire must not count as held — the bump lives in the ZADD
+  # branch of the acquire script, not on every call.
+  def test_held_not_counted_for_rejected_acquire
+    name = "hr-#{@suffix}"
+    l = Wurk::Limiter.concurrent(name, 1, wait_timeout: 0, policy: :ignore)
+    entered = false
+    l.within_limit do
+      other = Wurk::Limiter.concurrent(name, 1, wait_timeout: 0, policy: :ignore)
+      other.within_limit { entered = true }
+    end
+
+    refute entered, 'the second acquire was rejected'
+    assert_equal 1, l.status['held']
+  end
+
+  # F10: an overage is a holder that outran `lock_timeout` — another acquirer's
+  # ZREMRANGEBYSCORE evicted its slot, so its own release ZREMs nothing. Backdate
+  # the live slot and let a second acquirer reclaim it: same path, no sleeping.
+  def test_overage_counted_when_slot_reclaimed_before_release
+    name = "ov-#{@suffix}"
+    key = "lmtr-cs:#{name}"
+    l = Wurk::Limiter.concurrent(name, 1, lock_timeout: 60)
+    stolen = false
+    l.within_limit do
+      @pool.with { |c| c.call('ZADD', key, 'XX', 1, c.call('ZRANGE', key, 0, 0).first) }
+      Wurk::Limiter.concurrent(name, 1, wait_timeout: 0).within_limit { stolen = true }
+    end
+
+    assert stolen, 'the second acquirer reclaimed the backdated slot'
+    assert_equal 1, l.status['overages'], 'evicted holder counts one overage on release'
+  end
+
+  # The clean path releases its own slot, so ZREM returns 1 — no overage.
+  def test_no_overage_when_slot_released_normally
+    l = Wurk::Limiter.concurrent("ok-#{@suffix}", 1)
+    ran = false
+    l.within_limit { ran = true }
+
+    assert ran
+    assert_equal 0, l.status['overages']
+  end
+
+  # Exhausting `wait_timeout` raises OverLimit; that is the middleware's
+  # `overrated` counter's job, not `overages`.
+  def test_wait_timeout_is_not_an_overage
+    name = "wo-#{@suffix}"
+    l = Wurk::Limiter.concurrent(name, 1, wait_timeout: 0)
+    assert_raises(Wurk::Limiter::OverLimit) do
+      l.within_limit do
+        Wurk::Limiter.concurrent(name, 1, wait_timeout: 0).within_limit { flunk 'should not enter' }
+      end
+    end
+
+    assert_equal 0, l.status['overages']
+  end
+
   # `soonest_expiry`: while a slot is held the ZSET is non-empty so it returns
   # the slot's expiry timestamp; idle, the ZSET is empty so it returns nil. The
   # two calls cover both sides of the guard. reset_at must be a real future

--- a/test/unit/limiter_window_test.rb
+++ b/test/unit/limiter_window_test.rb
@@ -137,4 +137,85 @@ class LimiterWindowTest < Wurk::Test::UnitCase
 
     assert ran
   end
+
+  # ----- read-only introspection ---------------------------------------
+
+  # Reads are scoped by the Redis clock: an entry that has already slid out of
+  # the window is invisible to `size`, and `reset_at` tracks the oldest entry
+  # still *inside* it (a bare `ZRANGE 0 0` would report the stale one and put
+  # reset_at in the past).
+  def test_read_ignores_stale_entries
+    l = window_with_stale_entry('ro')
+    s = l.status
+
+    assert_equal 1, s[:used]
+    assert_operator s[:reset_at], :>, ::Time.now.to_f, 'reset_at must come from the live entry, not the stale one'
+  end
+
+  # Trimming belongs to the acquire script alone — a status read leaves the
+  # ZSET byte-for-byte as it found it.
+  def test_read_never_trims_the_window
+    l = window_with_stale_entry('rt')
+    l.status
+
+    assert_equal 1, l.size
+    assert_equal 2, zcard('rt'), 'a read must not evict anything'
+  end
+
+  # F8: the read path takes its cutoff from Redis TIME, so a dashboard host
+  # whose clock runs an hour ahead still sees a full window. The old
+  # client-clock trim wiped every entry here.
+  def test_read_is_immune_to_client_clock_skew
+    l = Wurk::Limiter.window("sk-#{@suffix}", 2, 60, wait_timeout: 0)
+    2.times { l.within_limit {} }
+    s = with_time_now(::Time.now.to_f + 3600) { l.status }
+
+    assert_equal 2, s[:used]
+    refute s[:available?]
+    assert_equal 2, zcard('sk'), 'a skewed client must not evict live entries'
+  end
+
+  # ...and the window it did not evict still holds the limit closed.
+  def test_acquire_still_enforces_limit_after_a_skewed_read
+    l = Wurk::Limiter.window("se2-#{@suffix}", 2, 60, wait_timeout: 0)
+    2.times { l.within_limit {} }
+    with_time_now(::Time.now.to_f + 3600) { l.size }
+
+    assert_raises(Wurk::Limiter::OverLimit) { l.within_limit {} }
+  end
+
+  private
+
+  # One live entry (just charged) plus one that left the window two intervals
+  # ago, written straight to Redis so the acquire script never sees it.
+  def window_with_stale_entry(prefix)
+    l = Wurk::Limiter.window("#{prefix}-#{@suffix}", 5, 60)
+    l.within_limit {}
+    @pool.with { |c| c.call('ZADD', window_key(prefix), c.call('TIME').first.to_i - 120, 'stale') }
+    l
+  end
+
+  def window_key(prefix)
+    "lmtr-w:#{prefix}-#{@suffix}"
+  end
+
+  def zcard(prefix)
+    @pool.with { |c| c.call('ZCARD', window_key(prefix)).to_i }
+  end
+
+  # Minitest 6 dropped `Time.stub`; hand-rolled override pins Time.now for the
+  # block. Process-wide, which is safe because minitest-parallel_fork gives each
+  # test class its own worker process (UnitCase.parallelize_me! is a marker for
+  # that runner, not Minitest's in-process thread pool).
+  def with_time_now(epoch_f)
+    frozen = ::Time.at(epoch_f)
+    sc = ::Time.singleton_class
+    original = ::Time.method(:now)
+    sc.define_method(:now) { frozen }
+    begin
+      yield
+    ensure
+      sc.define_method(:now) { |*a, &b| original.call(*a, &b) }
+    end
+  end
 end

--- a/test/unit/lua_test.rb
+++ b/test/unit/lua_test.rb
@@ -36,7 +36,7 @@ class LuaTest < Wurk::Test::UnitCase
          batch_append_callback
          fast_delete_job fast_delete_by_class release_if_owner cron_claim_fire
          limiter_concurrent_acquire limiter_concurrent_release
-         limiter_bucket_acquire limiter_window_acquire limiter_leaky_acquire
+         limiter_bucket_acquire limiter_window_acquire limiter_window_status limiter_leaky_acquire
          limiter_points_acquire limiter_points_refund].sort,
       Wurk::Lua::SCRIPTS.keys.sort
     )


### PR DESCRIPTION
## Summary
- F8 — `Window#status`/`#size` are now genuinely read-only (ZCOUNT/read-only Lua deriving cutoff from Redis TIME); trimming stays exclusive to the acquire script. Immune to client clock skew; acquire still enforces the limit after a skewed read.
- F9 — `Bucket` now sleeps toward the next cardinal boundary instead of busy-polling every 50ms (`secs_to_next` was dead code inside a `.min`).
- F10 — `Concurrent` now writes `held` on every successful acquire and bumps `overages` only when a release finds its slot already reclaimed, per the release Lua script's documented contract.
- Regression tests: read-only/clock-skew coverage for `Window`, held/overage coverage for `Concurrent` (landed alongside their fixes), and a new clock-bound test for `Bucket` that asserts the actual sleep duration targets the boundary — verified to fail against the pre-F9 implementation.

## Test plan
- [x] `bin/rake test TEST=test/unit/limiter_window_test.rb`
- [x] `bin/rake test TEST=test/unit/limiter_bucket_test.rb`
- [x] `bin/rake test TEST=test/unit/limiter_concurrent_test.rb`
- [x] `bin/rake test TEST=test/integration/limiter_stress_test.rb`
- [x] `bin/rake test` (full suite, 2928 runs, 0 failures)
- [x] `bin/rake test:parity`
- [x] `bundle exec rubocop test/unit/limiter_bucket_test.rb` (no new offenses vs baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788225171&installation_model_id=11168&pr_number=355&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F355&signature=733f3e80bc415c851a31d8fb2f50e2943df991235a87beeb20f31ec4714b385a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->