### PR TITLE
fix(batch): sub-key TTLs, ZSET trims, callback loss window

### DIFF
--- a/docs/batches.md
+++ b/docs/batches.md
@@ -400,16 +400,53 @@ by `GET /api/batches` and `GET /api/batches/:bid`.
 | After `:success` fires | 24 hours | `Batch::POST_SUCCESS_EXPIRY_SECONDS`, override per batch with `linger=` |
 | Callback dedup markers | 30 days | `Batch::CALLBACK_NOTIFY_TTL` |
 
-A batch costs one hash (`b-<bid>`) plus the sets it actually needs — `-jids`,
-`-failed`, `-died`, `-kids`, `-pkids` — each holding at most one entry per job or
-child, plus one small marker key per callback event that fired. The footprint is
-bounded entirely by TTL: Wurk never sweeps batches, Redis expires them.
+A batch costs one hash (`b-<bid>`) plus the sub-keys it actually needs —
+`-jids`, `-failed`, `-died`, `-kids`, `-pkids`, plus the three callback dedup
+markers (`-complete`, `-success`, `-death`) — each holding at most one entry
+per job, child, or fired event. **Every sub-key is TTL'd at the site that
+creates it**, not swept later:
+
+- `BATCH_PUSH`, `BATCH_SCHEDULE`, `BATCH_ACK_FAILED` and `BATCH_ACK_COMPLETE`
+  (the Lua scripts in `lib/wurk/lua.rb`) each `EXPIRE … NX` the sub-key(s) they
+  create, using `Batch::DEFAULT_EXPIRY_SECONDS`.
+- `link_to_parent` stamps `-kids`/`-pkids` the same way when a child batch first
+  links to its parent.
+- `Callbacks#record_event` stamps `b-<bid>` itself `NX` when a callback fires,
+  since a child batch outliving its parent's window can resurrect that hash
+  with an `HSET`.
+- `Callbacks#dedup_set` writes the dedup markers with `SET … EX` directly
+  (`CALLBACK_NOTIFY_TTL`), so they never need a separate stamp.
+
+`NX` everywhere means only a key with *no* TTL gets one — a live batch's clock,
+and the shorter post-success `linger` window, are never overwritten. The
+footprint is bounded entirely by TTL: Wurk never sweeps a whole batch, Redis
+expires the pieces individually as they age out.
+
+The two index ZSETs — `batches` (all batches, scored by creation time) and
+`dead-batches` (batches that fired `:death`, scored by death time) — are
+bounded on a second axis: member count, not just TTL. `Batch.trim_index`
+(`lib/wurk/batch.rb`) runs in the same pipeline as the `ZADD` that grows each
+set:
+
+- `ZREMRANGEBYSCORE key -inf (cutoff` evicts entries older than the trim
+  window (`DEFAULT_EXPIRY_SECONDS` by default — the same window as the batch
+  hash TTL, so an index entry retires in step with the data it points at).
+- `ZREMRANGEBYRANK key 0 -max` caps the member count at `Batch::INDEX_MAX`
+  (1,000,000) as a backstop, same shape as `DeadSet#trim`'s rank-based cap.
+
+Without this, nothing ever shrinks either set — `Status#delete` and the
+death-recovery `ZREM` are the only other removals, both manual — so `batches`
+and `dead-batches` grew for the life of the Redis instance regardless of TTL
+on the underlying hashes. A batch that overrides `expires_in` beyond the trim
+window outlives its index entry: still reachable by bid, just no longer
+enumerated by `BatchSet` or `DeadSet`.
 
 Two behaviours worth knowing:
 
 - A job that dies **after** its batch keys expired would recreate them with no
-  TTL. The death handler re-stamps with `EXPIRE … NX`, so resurrected keys get a
-  clock and live batches keep theirs.
+  TTL. The death handler (`DeathHandler.restamp_ttls`) re-stamps every sub-key
+  with `EXPIRE … NX` on death — the one moment the batch is known to be
+  winding down — so resurrected keys get a clock and live batches keep theirs.
 - `linger=` on an already-flushed batch writes straight to Redis, so it works on
   a batch reopened by bid. `description=`, `callback_queue=`, `callback_class=`,
   `tags=` and `expires_in` do **not** — they are only persisted by the first

--- a/lib/wurk/batch.rb
+++ b/lib/wurk/batch.rb
@@ -48,10 +48,21 @@ module Wurk
 
     VALID_EVENTS = %i[success complete death].freeze
 
+    # Every key a batch owns, for the sweep paths: `Status#delete` (UNLINK),
+    # `Callbacks#apply_linger` and `DeathHandler.restamp_ttls` (EXPIRE).
+    #
     # The 'live' set tracks jobs that have not yet reached a terminal state.
     # When it's empty, every job has either succeeded or died → `:complete`
     # is allowed to fire.
-    KEY_SUFFIXES = %w[jids failed died notify cbsucc kids pkids tags].freeze
+    #
+    # `complete`/`success`/`death` are the callback dedup markers written by
+    # `Callbacks#dedup_set`; they belong to the batch and must die with it.
+    # `notify`/`cbsucc`/`tags` are Sidekiq Pro's own key layout (spec §2.8) that
+    # Wurk never writes — Wurk dedups on the three markers above and indexes
+    # tags at `tags:<tag>`. They stay listed so a Redis dataset carried over
+    # from Sidekiq Pro on the gem swap gets swept too; EXPIRE/UNLINK of a
+    # missing key is a no-op for batches Wurk created itself.
+    KEY_SUFFIXES = %w[jids failed died complete success death notify cbsucc kids pkids tags].freeze
 
     THREAD_KEY = :wurk_current_batch
 
@@ -278,6 +289,10 @@ module Wurk
       Wurk::Metrics::Statsd.increment('batch.created')
     end
 
+    # Only `b-#{@bid}` is stamped here — none of the sub-keys exist yet at first
+    # flush (BATCH_PUSH/BATCH_SCHEDULE create `-jids`, the acks create
+    # `-failed`/`-died`), and EXPIRE on a missing key is a no-op. Each key is
+    # stamped `NX` where it is created instead; see BATCH_PUSH in lua.rb.
     def pipelined_first_flush(pipe, now)
       pipe.call('HSET', "b-#{@bid}", *first_flush_hash(now).flatten)
       pipe.call('EXPIRE', "b-#{@bid}", @expires_in)
@@ -312,9 +327,16 @@ module Wurk
       outer.bid
     end
 
+    # The only place `-kids`/`-pkids` are created, so this is where they get
+    # their clock. TTL is the default, not this batch's `@expires_in`: the keys
+    # belong to the *parent*, and NX means the first link sets the retention for
+    # every sibling that follows.
     def link_to_parent(pipe)
-      pipe.call('SADD', "b-#{current_parent_bid}-kids", @bid)
-      pipe.call('SADD', "b-#{current_parent_bid}-pkids", @bid)
+      parent_key = "b-#{current_parent_bid}"
+      pipe.call('SADD', "#{parent_key}-kids", @bid)
+      pipe.call('SADD', "#{parent_key}-pkids", @bid)
+      pipe.call('EXPIRE', "#{parent_key}-kids", DEFAULT_EXPIRY_SECONDS, 'NX')
+      pipe.call('EXPIRE', "#{parent_key}-pkids", DEFAULT_EXPIRY_SECONDS, 'NX')
     end
 
     def job_count

--- a/lib/wurk/batch.rb
+++ b/lib/wurk/batch.rb
@@ -41,6 +41,14 @@ module Wurk
     POST_SUCCESS_EXPIRY_SECONDS = 24 * 60 * 60
     CALLBACK_NOTIFY_TTL = 30 * 24 * 60 * 60
 
+    # Member ceiling for the two batch index ZSETs (`batches`, `dead-batches`).
+    # The score axis in `.trim_index` retires entries in step with the batch data
+    # itself, so this is only the backstop for a workload creating batches faster
+    # than that window retires them. Deliberately generous: a cap that bites drops
+    # batches whose data is still live out of `BatchSet`, and at this scale the
+    # per-batch hashes dwarf the index anyway.
+    INDEX_MAX = 1_000_000
+
     # Bid is URL-safe base64 of 10 random bytes — matches Sidekiq Pro's BID
     # generator. Length matters: third-party gems that key off bid prefix
     # (sharded batches in Pro 8) inspect the first character.
@@ -77,6 +85,33 @@ module Wurk
     def self.keys_for(bid)
       base = "b-#{bid}"
       [base, *KEY_SUFFIXES.map { |s| "#{base}-#{s}" }]
+    end
+
+    # Two-axis trim of a batch index ZSET (`batches`, `dead-batches`), in the
+    # shape of the morgue trim (`DeadSet#trim`): `ZREMRANGEBYSCORE` evicts
+    # entries older than `timeout`, `ZREMRANGEBYRANK 0 -max` caps the member
+    # count — and, like the morgue, that bound keeps `max - 1` of a full set.
+    # Appended to the caller's pipeline so bounding the index costs neither
+    # writer an extra round trip.
+    #
+    # Nothing else ever shrinks either set: `Status#delete` and the
+    # death-recovery `ZREM` are manual, so an index entry outlives the batch it
+    # points at and both sets grow for the life of the Redis without this.
+    #
+    # Both index in epoch seconds — `batches` from CLOCK_REALTIME,
+    # `dead-batches` from `Time.now.to_f` — so one cutoff serves both. The
+    # default window is the batch hash TTL: past it `b-<bid>` is gone and the
+    # entry only yields an empty Status. A batch that overrode `expires_in`
+    # beyond that window outlives its index entry — still reachable by bid,
+    # just no longer enumerated by `BatchSet`.
+    #
+    # `max:` / `timeout:` override the defaults for one call, so parallel tests
+    # can drive the trim on isolated limits without mutating the process-global
+    # `Wurk.configuration`.
+    def self.trim_index(pipe, key, max: nil, timeout: nil)
+      cutoff = ::Process.clock_gettime(::Process::CLOCK_REALTIME) - (timeout || DEFAULT_EXPIRY_SECONDS)
+      pipe.call('ZREMRANGEBYSCORE', key, '-inf', "(#{cutoff}")
+      pipe.call('ZREMRANGEBYRANK', key, 0, -(max || INDEX_MAX))
     end
 
     def initialize(bid = nil)
@@ -297,6 +332,7 @@ module Wurk
       pipe.call('HSET', "b-#{@bid}", *first_flush_hash(now).flatten)
       pipe.call('EXPIRE', "b-#{@bid}", @expires_in)
       pipe.call('ZADD', 'batches', now.to_s, @bid)
+      Batch.trim_index(pipe, 'batches')
       @tags.each { |t| pipe.call('SADD', "tags:#{t}", @bid) }
       link_to_parent(pipe) if current_parent_bid
     end

--- a/lib/wurk/batch/callbacks.rb
+++ b/lib/wurk/batch/callbacks.rb
@@ -126,11 +126,17 @@ module Wurk
         end
       end
 
+      # The HSETs resurrect the hash when a callback fires for a batch whose keys
+      # already expired (a child batch outliving its parent's 30d window), so the
+      # write is followed by an NX stamp — without it the resurrected hash would
+      # have no clock at all. NX leaves a live batch's expiry, and the shorter
+      # post-success `linger` window, untouched.
       def record_event(bid, field)
         now = ::Process.clock_gettime(::Process::CLOCK_REALTIME)
         Wurk.redis do |conn|
           conn.call('HSET', "b-#{bid}", field, now.to_s)
           conn.call('HSET', "b-#{bid}", field.to_s.sub('_at', ''), '1')
+          conn.call('EXPIRE', "b-#{bid}", Batch::DEFAULT_EXPIRY_SECONDS, 'NX')
         end
       end
 

--- a/lib/wurk/batch/callbacks.rb
+++ b/lib/wurk/batch/callbacks.rb
@@ -51,11 +51,25 @@ module Wurk
       # most once per batch.
       def fire_death(bid)
         record_event(bid, 'death_at')
-        Wurk.redis { |conn| conn.call('ZADD', 'dead-batches', Time.now.to_f.to_s, bid) }
+        index_dead(bid)
         return unless dedup_set(bid, 'death')
 
         enqueue_callbacks(bid, 'death')
         cascade_death(bid)
+      end
+
+      # Index the batch as dead and bound the set in the same round trip. The
+      # score stays `Time.now.to_f` (wire format, spec §2.8); `Batch.trim_index`
+      # reads it as the epoch seconds it is. See there for why the set needs a
+      # trim at all — only `Status#delete` and the death-recovery ZREM ever
+      # remove a member, and neither runs for a batch left to expire.
+      def index_dead(bid)
+        Wurk.redis do |conn|
+          conn.pipelined do |pipe|
+            pipe.call('ZADD', 'dead-batches', Time.now.to_f.to_s, bid)
+            Batch.trim_index(pipe, 'dead-batches')
+          end
+        end
       end
 
       # A child's death means the parent — and every ancestor — can never

--- a/lib/wurk/batch/callbacks.rb
+++ b/lib/wurk/batch/callbacks.rb
@@ -26,8 +26,9 @@ module Wurk
       # parent's *own* last job acks while a child batch is still running,
       # nothing fires here; the last child's propagate_to_parent re-invokes
       # this and fires then. The SREM in pkids_drained? happens before that
-      # re-invocation, so exactly one of the racing paths fires (dedup_set
-      # absorbs the overlap).
+      # re-invocation, so at most one of the racing paths reaches a fire and
+      # the callback markers absorb the rest (see `fire_complete` for the one
+      # window that can still duplicate).
       def maybe_fire(bid, pending:, live:)
         return unless live.zero?
         return unless kids_finished?(bid)
@@ -49,6 +50,15 @@ module Wurk
       # the dedup guard so it is restored on re-death; the callback enqueue
       # and parent cascade stay behind the guard so `:death` is enqueued at
       # most once per batch.
+      #
+      # That claim-before-enqueue ordering is kept deliberately, against the
+      # enqueue-before-mark rule `fire_complete` explains: everything that
+      # makes the batch *look* dead is already persisted above the guard, so a
+      # crash in the window costs the notification while `Status`, the
+      # dashboard and `subtree_dead?` all still see a dead batch. `:complete`
+      # and `:success` have no such fallback — the callback is their whole
+      # signal — and this claim additionally gates `cascade_death`, which
+      # would otherwise re-walk the ancestor chain on every re-invocation.
       def fire_death(bid)
         record_event(bid, 'death_at')
         index_dead(bid)
@@ -84,19 +94,45 @@ module Wurk
         fire_death(parent_bid)
       end
 
+      # `:complete` and `:success` mark their dedup key *after* the enqueue,
+      # never before (F16). Nothing re-drives a fire once the acking job's
+      # BATCH_ACK_SUCCESS has SREM'd its jid — that job's retry gets
+      # `pending == -1` and returns before maybe_fire — so a claim-then-enqueue
+      # ordering turns a crash in between into callbacks that are never
+      # enqueued by anyone, ever. Enqueuing first makes the durable side effect
+      # happen before the marker that suppresses it.
+      #
+      # The accepted direction is a duplicate over a lost callback: callback
+      # jobs retry like any other job and must already be idempotent (spec
+      # §2.4, §12 "Callback retries"), so firing one twice is a cost the app
+      # is required to absorb, while losing one silently strands the batch.
+      #
+      # `dedup_marked?` still collapses every *sequential* re-invocation — a
+      # reclaimed child re-running propagate_to_parent, a second DeathHandler
+      # pass — so the duplicate window is only two genuinely concurrent acks
+      # interleaving between each other's check and mark.
+      #
+      # `record_event` stays ahead of the enqueue: the callback job reads a
+      # Status snapshot and must see `complete_at`/`success_at` already set.
       def fire_complete(bid)
-        return unless dedup_set(bid, 'complete')
+        return if dedup_marked?(bid, 'complete')
 
         record_event(bid, 'complete_at')
         enqueue_callbacks(bid, 'complete')
+        dedup_set(bid, 'complete')
       end
 
+      # Same enqueue-then-mark ordering as fire_complete. `apply_linger` runs
+      # last of all: it EXPIREs `b-<bid>-success` down to the linger window,
+      # which only holds if the marker already exists — `dedup_set`'s 30d
+      # `EX` would otherwise re-create it outside that window.
       def fire_success(bid)
-        return unless dedup_set(bid, 'success')
+        return if dedup_marked?(bid, 'success')
 
         record_event(bid, 'success_at')
         emit_duration_metric(bid)
         enqueue_callbacks(bid, 'success')
+        dedup_set(bid, 'success')
         apply_linger(bid)
       end
 
@@ -104,10 +140,11 @@ module Wurk
       # full success. `created_at` shares the CLOCK_REALTIME epoch we record it
       # with. No-op without a dogstatsd client.
       #
-      # Strictly best-effort: `fire_success` has already burned the `success`
-      # dedup key by the time we run, so a raise here (e.g. a Redis hiccup on the
-      # HGET) would permanently strand the success callbacks and linger that
-      # follow — a retry can't re-fire them. Swallow and log instead.
+      # Strictly best-effort: this runs on the acking job's thread ahead of the
+      # enqueue, and that ack already removed the jid, so a raise here (e.g. a
+      # Redis hiccup on the HGET) would abort `fire_success` with nothing left
+      # to re-drive it — the success callbacks and linger would be stranded for
+      # good. Swallow and log instead.
       def emit_duration_metric(bid)
         created = Wurk.redis { |conn| conn.call('HGET', "b-#{bid}", 'created_at') }
         return if created.nil? || created.to_s.empty?
@@ -130,9 +167,22 @@ module Wurk
         end
       end
 
-      # Atomically marks `bid` as having fired `event`. Returns true the
-      # first time, false thereafter — caller skips the enqueue when false.
-      # SET NX makes this safe under racing acks.
+      # True once `b-<bid>-<event>` exists, i.e. an enqueue pass for `event`
+      # has completed. The read-side half of the enqueue-then-mark ordering in
+      # `fire_complete`/`fire_success`; `fire_death` needs no equivalent
+      # because its `dedup_set` still doubles as the claim.
+      def dedup_marked?(bid, event)
+        Wurk.redis { |conn| conn.call('EXISTS', "b-#{bid}-#{event}") }.to_i == 1
+      end
+
+      # Writes `b-<bid>-<event>`, the marker that `event`'s callbacks have been
+      # enqueued. Returns true when this call created it, false when it was
+      # already there.
+      #
+      # Two usages, deliberately different: `fire_death` calls it *before* its
+      # enqueue and treats the return as a claim (at most once); `fire_complete`
+      # and `fire_success` call it *after* theirs and ignore the return, gating
+      # on `dedup_marked?` instead. SET NX keeps both safe under racing acks.
       def dedup_set(bid, event)
         Wurk.redis do |conn|
           ok = conn.call('SET', "b-#{bid}-#{event}", '1', 'NX', 'EX', Batch::CALLBACK_NOTIFY_TTL)

--- a/lib/wurk/batch/death_handler.rb
+++ b/lib/wurk/batch/death_handler.rb
@@ -21,7 +21,7 @@ module Wurk
             conn,
             :batch_ack_complete,
             keys: ["b-#{bid}", "b-#{bid}-jids", "b-#{bid}-died", "b-#{bid}-failed"],
-            argv: [job['jid']]
+            argv: [job['jid'], Batch::DEFAULT_EXPIRY_SECONDS]
           )
         end
         live, _died, first_death = Array(result).map(&:to_i)
@@ -38,9 +38,12 @@ module Wurk
         Wurk::Batch::Callbacks.maybe_fire(bid, pending: Wurk::Batch::Callbacks.pending_for(bid), live: 0)
       end
 
-      # A stale job can die AFTER its batch keys expired; the ack writes
-      # recreate them with no TTL — permanent key leakage. EXPIRE NX stamps
-      # only keys that lost their TTL, leaving live batches' clocks alone.
+      # BATCH_ACK_COMPLETE stamps the two keys it can itself resurrect; this
+      # sweeps the rest of the batch (`-jids`, `-failed`, `-kids`, `-pkids`,
+      # callback markers). A death is the one moment we know the batch is
+      # winding down, so it is worth a round trip to leave nothing without a
+      # clock. EXPIRE NX touches only keys that have none, so a live batch's
+      # clock and a post-success `linger` window both survive.
       def self.restamp_ttls(bid)
         Wurk.redis do |conn|
           conn.pipelined do |pipe|

--- a/lib/wurk/batch/server_middleware.rb
+++ b/lib/wurk/batch/server_middleware.rb
@@ -85,7 +85,7 @@ module Wurk
             conn,
             :batch_ack_failed,
             keys: ["b-#{bid}", "b-#{bid}-failed"],
-            argv: [jid]
+            argv: [jid, Batch::DEFAULT_EXPIRY_SECONDS]
           )
         end
       end

--- a/lib/wurk/client.rb
+++ b/lib/wurk/client.rb
@@ -385,7 +385,7 @@ module Wurk
           :batch_push,
           keys: ["b-#{j['bid']}", "b-#{j['bid']}-jids", "queue:#{j['queue']}", 'queues',
                  "b-#{j['bid']}-died", 'dead-batches'],
-          argv: [j['queue'], j['jid'], Wurk.dump_json(j), j['bid']]
+          argv: [j['queue'], j['jid'], Wurk.dump_json(j), j['bid'], Wurk::Batch::DEFAULT_EXPIRY_SECONDS]
         )
       end
     end
@@ -404,7 +404,8 @@ module Wurk
           conn,
           :batch_schedule,
           keys: ['schedule', "b-#{j['bid']}", "b-#{j['bid']}-jids"],
-          argv: [j['at'].to_s, Wurk.dump_json(j.except('enqueued_at', 'at')), j['jid']]
+          argv: [j['at'].to_s, Wurk.dump_json(j.except('enqueued_at', 'at')), j['jid'],
+                 Wurk::Batch::DEFAULT_EXPIRY_SECONDS]
         )
       end
     end

--- a/lib/wurk/lua.rb
+++ b/lib/wurk/lua.rb
@@ -131,8 +131,16 @@ module Wurk
     # success after the dead job is manually retried to success). The
     # `b-<bid>-death` notify dedup key is untouched, so `:death` cannot
     # re-fire.
+    #
+    # The two EXPIRE NX calls are what keep the batch bounded: `b-<bid>-jids` is
+    # born here, and only `Batch#ensure_first_flush!` ever stamped a TTL — on the
+    # hash alone — so an abandoned or invalidated batch leaked its live-jid set
+    # forever. A late re-push (retry, scheduled promotion) can also resurrect an
+    # already-expired `b-<bid>` through the HINCRBYs above, again TTL-less. NX
+    # stamps only keys that currently have no TTL, so a running batch's clock and
+    # the shorter post-success `linger` window (Callbacks#apply_linger) both win.
     # KEYS = [b-<bid>, b-<bid>-jids, queue_list, queues_set, b-<bid>-died, dead-batches]
-    # ARGV = [queue_name, jid, job_json, bid]
+    # ARGV = [queue_name, jid, job_json, bid, expiry_seconds]
     # Returns 1.
     BATCH_PUSH = <<~LUA
       if redis.call("srem", KEYS[5], ARGV[2]) == 1 then
@@ -147,6 +155,8 @@ module Wurk
           redis.call("hincrby", KEYS[1], "pending", 1)
         end
       end
+      redis.call("expire", KEYS[1], ARGV[5], "NX")
+      redis.call("expire", KEYS[2], ARGV[5], "NX")
       redis.call("sadd", KEYS[4], ARGV[1])
       redis.call("lpush", KEYS[3], ARGV[3])
       return 1
@@ -165,14 +175,19 @@ module Wurk
     # it, the re-push routes through BATCH_PUSH, whose guard finds the jid already
     # live (SADD == 0) → pure LPUSH, no recount. So registration happens exactly
     # once, here, at enqueue.
+    #
+    # The other path that can create `b-<bid>-jids`, so it carries the same NX
+    # expiry stamp as BATCH_PUSH.
     # KEYS = [schedule, b-<bid>, b-<bid>-jids]
-    # ARGV = [at_score, job_json, jid]
+    # ARGV = [at_score, job_json, jid, expiry_seconds]
     # Returns 1.
     BATCH_SCHEDULE = <<~LUA
       if redis.call("sadd", KEYS[3], ARGV[3]) == 1 then
         redis.call("hincrby", KEYS[2], "total", 1)
         redis.call("hincrby", KEYS[2], "pending", 1)
       end
+      redis.call("expire", KEYS[2], ARGV[4], "NX")
+      redis.call("expire", KEYS[3], ARGV[4], "NX")
       redis.call("zadd", KEYS[1], ARGV[1], ARGV[2])
       return 1
     LUA
@@ -208,13 +223,18 @@ module Wurk
     # currently in a failing/retrying state. Re-failures of the same jid are
     # idempotent. Cleared by BATCH_ACK_SUCCESS (retry passed) or
     # BATCH_ACK_COMPLETE (job died). Spec §2.5, §2.8.
+    #
+    # `b-<bid>-failed` is born here, so it carries the same NX expiry stamp as
+    # BATCH_PUSH.
     # KEYS = [b-<bid>, b-<bid>-failed]
-    # ARGV = [jid]
+    # ARGV = [jid, expiry_seconds]
     # Returns 1.
     BATCH_ACK_FAILED = <<~LUA
       if redis.call("sadd", KEYS[2], ARGV[1]) == 1 then
         redis.call("hincrby", KEYS[1], "failures", 1)
       end
+      redis.call("expire", KEYS[1], ARGV[2], "NX")
+      redis.call("expire", KEYS[2], ARGV[2], "NX")
       return 1
     LUA
 
@@ -224,8 +244,11 @@ module Wurk
     # live jids so the batch can fire `:complete` even with terminally failed
     # jobs. `b-<bid>-failed` holds only currently-retrying jids; `b-<bid>-died`
     # holds terminally-dead ones (spec §2.8 — the two sets are distinct).
+    #
+    # `b-<bid>-died` is born here, so it carries the same NX expiry stamp as
+    # BATCH_PUSH.
     # KEYS = [b-<bid>, b-<bid>-jids, b-<bid>-died, b-<bid>-failed]
-    # ARGV = [jid]
+    # ARGV = [jid, expiry_seconds]
     # Returns [live_jids_remaining, died_count, first_death]. `first_death`
     # is 1 the first time *any* jid is SADDed into the died set, 0 thereafter
     # — caller uses it to fire `:death` exactly once per batch.
@@ -236,6 +259,8 @@ module Wurk
         redis.call("hincrby", KEYS[1], "failures", -1)
       end
       local died_added = redis.call("sadd", KEYS[3], ARGV[1])
+      redis.call("expire", KEYS[1], ARGV[2], "NX")
+      redis.call("expire", KEYS[3], ARGV[2], "NX")
       local first_death = 0
       if was_pre_existing_death == 0 and died_added == 1 then
         first_death = 1

--- a/test/unit/batch_index_trim_test.rb
+++ b/test/unit/batch_index_trim_test.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Both batch index ZSETs are append-only from every automatic path: `batches`
+# gains a member on first flush, `dead-batches` on `:death`, and only the manual
+# `Status#delete` / death-recovery ZREMs ever remove one. A batch left to expire
+# leaves its index entry behind forever, so both sets are now trimmed on write —
+# same two axes as the morgue (`DeadSet#trim`). Spec: sidekiq-pro.md §2.8.
+#
+# Parallel safety: the trims that run through the real write paths use the
+# default window, which only evicts members older than the 30d batch expiry —
+# nothing but this file creates those. The rank axis runs on a PID-scoped key via
+# the `max:` override instead of mutating the process-global configuration.
+class BatchIndexTrimTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  WINDOW = Wurk::Batch::DEFAULT_EXPIRY_SECONDS
+
+  def setup
+    super
+    @pool  = Wurk.configuration.redis_pool
+    @ns    = "#{Process.pid}-#{object_id}"
+    @queue = "bix-#{@ns}"
+    @key   = "bix-index-#{@ns}"
+    @now   = ::Process.clock_gettime(::Process::CLOCK_REALTIME)
+  end
+
+  # --- `batches`, trimmed by the first-flush pipeline ---------------------
+
+  def test_first_flush_indexes_the_batch
+    bid = flush_batch
+
+    assert_includes members('batches'), bid
+  end
+
+  def test_first_flush_trims_stale_members_from_batches
+    seed('batches', "stale-#{@ns}" => @now - WINDOW - 60)
+    flush_batch
+
+    refute_includes members('batches'), "stale-#{@ns}"
+  end
+
+  def test_first_flush_leaves_members_inside_the_window_alone
+    seed('batches', "fresh-#{@ns}" => @now - 60)
+    flush_batch
+
+    assert_includes members('batches'), "fresh-#{@ns}"
+  end
+
+  # --- `dead-batches`, trimmed by Callbacks#index_dead --------------------
+
+  def test_fire_death_indexes_the_batch
+    bid = "bix-dead-#{@ns}"
+    Wurk::Batch::Callbacks.fire_death(bid)
+
+    assert_includes members('dead-batches'), bid
+  end
+
+  def test_fire_death_trims_stale_members_from_dead_batches
+    seed('dead-batches', "stale-#{@ns}" => @now - WINDOW - 60)
+    Wurk::Batch::Callbacks.fire_death("bix-dead-#{@ns}")
+
+    refute_includes members('dead-batches'), "stale-#{@ns}"
+  end
+
+  # --- the primitive ------------------------------------------------------
+
+  # Default window is the batch hash TTL: past it `b-<bid>` is gone and the
+  # index entry only resolves to an empty Status.
+  def test_trim_index_defaults_to_the_batch_expiry_window
+    seed(@key, 'expired' => @now - WINDOW - 60, 'live' => @now - WINDOW + 3600)
+    trim(@key)
+
+    assert_equal %w[live], members(@key)
+  end
+
+  def test_trim_index_drops_members_older_than_an_overridden_timeout
+    seed(@key, 'old' => @now - 120, 'new' => @now - 10)
+    trim(@key, timeout: 60)
+
+    assert_equal %w[new], members(@key)
+  end
+
+  # `ZREMRANGEBYRANK 0 -max` is the morgue's own bound (spec §31.8), which keeps
+  # `max - 1` of a full set. Seeded scores are recent so only the rank axis can
+  # decide survivors.
+  def test_trim_index_caps_the_member_count_by_rank
+    seed(@key, (0...5).to_h { |i| ["m#{i}", @now + i] })
+    trim(@key, max: 3)
+
+    assert_equal %w[m3 m4], members(@key)
+  end
+
+  def test_trim_index_leaves_a_set_under_both_bounds_untouched
+    seed(@key, 'a' => @now - 10, 'b' => @now - 5)
+    trim(@key, max: 10, timeout: 60)
+
+    assert_equal %w[a b], members(@key)
+  end
+
+  private
+
+  # One real job so the block doesn't synthesise the empty-batch marker; the
+  # push routes through the batch client middleware and BATCH_PUSH, exactly as
+  # in production.
+  def flush_batch
+    batch = Wurk::Batch.new
+    batch.jobs { Wurk::Client.push('class' => "BixJob@#{@ns}", 'args' => [], 'queue' => @queue) }
+    batch.bid
+  end
+
+  def seed(key, scores)
+    @pool.with { |conn| scores.each { |member, score| conn.call('ZADD', key, score.to_s, member) } }
+  end
+
+  def trim(key, **overrides)
+    @pool.with { |conn| conn.pipelined { |pipe| Wurk::Batch.trim_index(pipe, key, **overrides) } }
+  end
+
+  def members(key)
+    @pool.with { |conn| conn.call('ZRANGE', key, 0, -1) }
+  end
+end

--- a/test/unit/batch_key_ttl_test.rb
+++ b/test/unit/batch_key_ttl_test.rb
@@ -1,0 +1,274 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'json'
+
+# Every Redis key a batch owns must carry a TTL from the moment it exists.
+# `#jobs` only ever stamped `b-<bid>`, so a batch that was abandoned or
+# invalidated — never acked, never successful — leaked its `-jids`/`-failed`/
+# `-died`/`-kids`/`-pkids` sets forever. The stamp now happens at each creation
+# site (BATCH_PUSH / BATCH_SCHEDULE / the acks / Batch#link_to_parent) with
+# `EXPIRE ... NX`, so a live batch's clock and the shorter post-success linger
+# window still win. Spec: docs/target/sidekiq-pro.md §2.8 (30d while pending).
+#
+# Parallel safety: every BID + queue is scoped to PID:object_id and torn down.
+class BatchKeyTtlTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  DEFAULT_TTL = Wurk::Batch::DEFAULT_EXPIRY_SECONDS
+
+  def setup
+    super
+    @pool       = Wurk.configuration.redis_pool
+    @class_name = "BatchTtlJob@#{Process.pid}-#{object_id}"
+    @queue      = "btq-#{Process.pid}-#{object_id}"
+    @cbq        = "btcb-#{Process.pid}-#{object_id}"
+    @bids       = []
+  end
+
+  def teardown
+    @pool.with do |conn|
+      @bids.uniq.each do |bid|
+        conn.call('UNLINK', *Wurk::Batch.keys_for(bid))
+        conn.call('ZREM', 'batches', bid)
+        conn.call('ZREM', 'dead-batches', bid)
+      end
+      [@queue, @cbq].each do |q|
+        conn.call('DEL', "queue:#{q}")
+        conn.call('SREM', 'queues', q)
+      end
+    end
+  ensure
+    super
+  end
+
+  # --- creation sites ----------------------------------------------------
+
+  def test_push_stamps_the_live_jids_set
+    batch = new_batch
+    batch.jobs { perform_one }
+
+    assert_default_ttl "b-#{batch.bid}-jids"
+  end
+
+  def test_scheduled_push_stamps_the_live_jids_set
+    batch = new_batch
+    batch.jobs { perform_one(at: Time.now.to_f + 3600) }
+
+    assert_default_ttl "b-#{batch.bid}-jids"
+  end
+
+  def test_failed_ack_stamps_the_failed_set
+    batch = new_batch
+    batch.jobs { perform_one }
+    fail_job(batch.bid, jid_for(batch.bid))
+
+    assert_default_ttl "b-#{batch.bid}-failed"
+  end
+
+  # Driven through the raw script, not DeathHandler.call: the handler's own
+  # restamp sweep would mask a missing stamp inside BATCH_ACK_COMPLETE, and the
+  # whole point of stamping in the script is that a process dying between the
+  # ack and that sweep still leaves no clock-less key.
+  def test_death_ack_stamps_the_died_set
+    batch = new_batch
+    batch.jobs { perform_one }
+    ack_complete(batch.bid, jid_for(batch.bid))
+
+    assert_default_ttl "b-#{batch.bid}-died"
+  end
+
+  def test_nested_batch_stamps_parent_kids_sets
+    parent, = nested
+
+    assert_default_ttl "b-#{parent.bid}-kids"
+    assert_default_ttl "b-#{parent.bid}-pkids"
+  end
+
+  # The headline case: a batch nobody ever finishes. Nothing downstream
+  # (apply_linger, the death restamp) runs for it, so every key it created has
+  # to have been stamped on the way in.
+  def test_abandoned_batch_leaves_no_key_without_a_ttl
+    parent, child = nested
+    fail_job(child.bid, jid_for(child.bid))
+    ack_complete(child.bid, jid_for(child.bid))
+
+    assert_batch_keys_clocked(parent, child)
+  end
+
+  # --- NX: never clobber a shorter window --------------------------------
+
+  def test_push_keeps_a_per_batch_expires_in_override
+    batch = new_batch
+    batch.expires_in(300)
+    batch.jobs { perform_one }
+
+    assert_operator ttl("b-#{batch.bid}"), :<=, 300
+    assert_operator ttl("b-#{batch.bid}"), :>, 240
+  end
+
+  def test_push_does_not_extend_a_shorter_window_on_the_jids_set
+    batch = new_batch
+    batch.jobs { perform_one }
+    @pool.with { |c| c.call('EXPIRE', "b-#{batch.bid}-jids", 120) }
+    batch.jobs { perform_one }
+
+    assert_operator ttl("b-#{batch.bid}-jids"), :<=, 120
+    assert_operator ttl("b-#{batch.bid}-jids"), :>, 60
+  end
+
+  # --- resurrection ------------------------------------------------------
+
+  # A retry or scheduled promotion re-pushing a job after the batch expired
+  # recreates `b-<bid>` (HINCRBY) and `b-<bid>-jids` (SADD). Before the stamp
+  # those came back with no clock and stayed forever.
+  def test_push_reclocks_a_batch_whose_keys_expired
+    batch = new_batch
+    batch.jobs { perform_one }
+    jid = jid_for(batch.bid)
+    @pool.with { |c| c.call('UNLINK', "b-#{batch.bid}", "b-#{batch.bid}-jids") }
+
+    Wurk::Client.push('class' => @class_name, 'args' => [], 'queue' => @queue, 'bid' => batch.bid, 'jid' => jid)
+
+    assert_default_ttl "b-#{batch.bid}"
+    assert_default_ttl "b-#{batch.bid}-jids"
+  end
+
+  def test_callback_event_record_reclocks_a_batch_whose_hash_expired
+    batch = new_batch
+    batch.jobs { perform_one }
+    @pool.with { |c| c.call('UNLINK', "b-#{batch.bid}") }
+
+    Wurk::Batch::Callbacks.record_event(batch.bid, 'complete_at')
+
+    assert_default_ttl "b-#{batch.bid}"
+  end
+
+  # --- keys_for covers the callback dedup markers ------------------------
+
+  def test_keys_for_includes_callback_dedup_markers
+    keys = Wurk::Batch.keys_for('abc')
+
+    %w[complete success death].each { |event| assert_includes keys, "b-abc-#{event}" }
+  end
+
+  def test_delete_removes_the_callback_dedup_markers
+    batch = new_batch
+    batch.jobs { perform_one }
+    ack_success(batch.bid, jid_for(batch.bid))
+
+    Wurk::Batch::Status.new(batch.bid).delete
+
+    %w[complete success].each do |event|
+      assert_equal 0, @pool.with { |c| c.call('EXISTS', "b-#{batch.bid}-#{event}") },
+                   "b-<bid>-#{event} outlived Status#delete"
+    end
+  end
+
+  # Post-success the dedup markers expire with the rest of the batch instead of
+  # holding their own 30d clock — by then the hash carrying the callback specs
+  # is gone too, so nothing could re-fire off them anyway.
+  def test_linger_shortens_the_callback_dedup_markers
+    batch = new_batch
+    batch.jobs { perform_one }
+    ack_success(batch.bid, jid_for(batch.bid))
+
+    assert_operator ttl("b-#{batch.bid}-success"), :<=, Wurk::Batch::POST_SUCCESS_EXPIRY_SECONDS
+    assert_operator ttl("b-#{batch.bid}-success"), :>, Wurk::Batch::POST_SUCCESS_EXPIRY_SECONDS - 60
+  end
+
+  private
+
+  def new_batch
+    batch = Wurk::Batch.new
+    batch.callback_queue = @cbq
+    @bids << batch.bid
+    batch
+  end
+
+  # Parent batch holding one job plus a nested child batch (one job) — the
+  # only path that creates the parent's `-kids`/`-pkids` sets.
+  def nested
+    parent = new_batch
+    child = nil
+    parent.jobs do
+      perform_one
+      child = new_batch
+      child.jobs { perform_one }
+    end
+    [parent, child]
+  end
+
+  # Pushed through Wurk::Client so the batch client middleware stamps the bid
+  # from Thread.current[Wurk::Batch::THREAD_KEY] and routes through the Lua.
+  def perform_one(at: nil)
+    job = { 'class' => @class_name, 'args' => [], 'queue' => @queue }
+    job['at'] = at if at
+    Wurk::Client.push(job)
+  end
+
+  def ack_success(bid, jid)
+    mw = Wurk::Batch::ServerMiddleware.new
+    mw.config = Wurk.configuration
+    mw.call(nil, { 'bid' => bid, 'jid' => jid }, @queue) {} # rubocop:disable Lint/EmptyBlock
+  end
+
+  def fail_job(bid, jid)
+    mw = Wurk::Batch::ServerMiddleware.new
+    mw.config = Wurk.configuration
+    mw.call(nil, { 'bid' => bid, 'jid' => jid }, @queue) { raise 'boom' }
+  rescue RuntimeError => e
+    raise unless e.message == 'boom'
+  end
+
+  def ack_complete(bid, jid)
+    @pool.with do |conn|
+      Wurk::Lua::Loader.eval_cached(
+        conn,
+        :batch_ack_complete,
+        keys: ["b-#{bid}", "b-#{bid}-jids", "b-#{bid}-died", "b-#{bid}-failed"],
+        argv: [jid, Wurk::Batch::DEFAULT_EXPIRY_SECONDS]
+      )
+    end
+  end
+
+  def jid_for(bid)
+    @pool.with { |c| c.call('LRANGE', "queue:#{@queue}", 0, -1) }
+         .map { |s| JSON.parse(s) }
+         .find { |j| j['bid'] == bid }
+         .fetch('jid')
+  end
+
+  def ttl(key)
+    @pool.with { |c| c.call('TTL', key) }
+  end
+
+  def keys_matching(pattern)
+    cursor = '0'
+    found  = []
+    loop do
+      cursor, chunk = @pool.with { |c| c.call('SCAN', cursor, 'MATCH', pattern, 'COUNT', 100) }
+      found.concat(chunk)
+      break if cursor == '0'
+    end
+    found
+  end
+
+  # SCANs every key the two batches own and asserts none of them lost its
+  # clock. The `-pkids` check guards against a vacuous pass: an empty scan
+  # would satisfy the `assert_empty` on its own.
+  def assert_batch_keys_clocked(parent, child)
+    keys      = [parent, child].flat_map { |b| keys_matching("b-#{b.bid}*") }
+    clockless = keys.reject { |key| ttl(key).positive? }
+
+    assert_includes keys, "b-#{parent.bid}-pkids"
+    assert_empty clockless, "batch keys with no TTL: #{clockless.join(', ')}"
+  end
+
+  def assert_default_ttl(key)
+    actual = ttl(key)
+
+    assert_operator actual, :<=, DEFAULT_TTL, "#{key} TTL #{actual} exceeds the 30d default"
+    assert_operator actual, :>, DEFAULT_TTL - 60, "#{key} has no default TTL (got #{actual})"
+  end
+end

--- a/test/unit/batch_lifecycle_test.rb
+++ b/test/unit/batch_lifecycle_test.rb
@@ -159,9 +159,10 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
     assert_equal 1, callbacks_fired(event: 'complete', bid: batch.bid)
   end
 
-  # The duration statsd metric is best-effort: fire_success has already burned
-  # the `success` dedup key by the time it runs, so a raise there would strand
-  # the success callbacks + linger with no retry to re-fire them.
+  # The duration statsd metric is best-effort: it runs ahead of the enqueue on
+  # the acking job's thread, and that ack already removed the jid, so a raise
+  # there would abort fire_success with nothing left to re-drive it — the
+  # success callbacks + linger would be stranded for good.
   def test_success_callbacks_still_fire_when_duration_metric_raises
     batch = new_batch(success: 'S', complete: 'C')
     batch.jobs { perform_one }
@@ -652,6 +653,80 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
     assert_equal 1, callbacks_fired(event: 'death', bid: batch.bid)
   end
 
+  # --- F16: the dedup marker is written after the enqueue, not before -----
+
+  # Regression guard for the loss window: with the marker claimed first, a
+  # crash between the SET and the push loses the callback for good (nothing
+  # re-drives maybe_fire once the ack SREM'd the jid). The marker must not
+  # exist yet at the moment Wurk::Client.push runs.
+  def test_complete_callback_is_enqueued_before_its_dedup_marker
+    batch = new_batch(complete: 'C')
+    batch.jobs { perform_one }
+
+    assert_equal 0, marker_state_at_push(batch.bid, 'complete') { ack_success(batch.bid, jid_for(@queue, batch.bid)) }
+    assert_equal 1, exists("b-#{batch.bid}-complete"), 'marker must be written once the enqueue pass completes'
+  end
+
+  def test_success_callback_is_enqueued_before_its_dedup_marker
+    batch = new_batch(success: 'S')
+    batch.jobs { perform_one }
+
+    assert_equal 0, marker_state_at_push(batch.bid, 'success') { ack_success(batch.bid, jid_for(@queue, batch.bid)) }
+    assert_equal 1, exists("b-#{batch.bid}-success"), 'marker must be written once the enqueue pass completes'
+  end
+
+  # `:death` deliberately keeps claim-before-enqueue — its durable mark and
+  # `dead-batches` membership are persisted before the guard, so the crash
+  # window costs the notification, not the batch's death state. Pinned so a
+  # consistency-driven reorder has to argue with this test first.
+  def test_death_callback_keeps_its_claim_before_the_enqueue
+    batch = new_batch(death: 'D')
+    batch.jobs { perform_one }
+
+    assert_equal 1, marker_state_at_push(batch.bid, 'death') { kill(batch.bid, jid_for(@queue, batch.bid)) }
+  end
+
+  # The crash the reorder closes: process dies between the push and the mark.
+  # The callback is already durably queued, and the batch is left re-fireable
+  # rather than silently stranded.
+  def test_crash_between_enqueue_and_marker_leaves_the_callback_queued
+    batch = new_batch(complete: 'C')
+    batch.jobs { perform_one }
+
+    assert_raises(RuntimeError) do
+      with_failing_dedup_set(batch.bid) { Wurk::Batch::Callbacks.fire_complete(batch.bid) }
+    end
+
+    assert_equal 1, callbacks_fired(event: 'complete', bid: batch.bid),
+                 'the callback must already be enqueued when the marker write dies'
+    assert_equal 0, exists("b-#{batch.bid}-complete")
+  end
+
+  # The accepted direction: the re-drive after such a crash duplicates rather
+  # than loses. Callback jobs retry anyway and must be idempotent (spec §12).
+  def test_redrive_after_a_lost_marker_duplicates_rather_than_loses
+    batch = new_batch(complete: 'C')
+    batch.jobs { perform_one }
+
+    assert_raises(RuntimeError) do
+      with_failing_dedup_set(batch.bid) { Wurk::Batch::Callbacks.fire_complete(batch.bid) }
+    end
+    Wurk::Batch::Callbacks.fire_complete(batch.bid)
+
+    assert_equal 2, callbacks_fired(event: 'complete', bid: batch.bid)
+  end
+
+  # A reclaimed child re-running propagate_to_parent re-enters the parent's
+  # maybe_fire with its counts still at zero — the marker read must absorb it.
+  def test_reclaimed_child_repropagating_does_not_refire_parent_callbacks
+    parent, child = nested_fully_acked(success: 'ParentSuccess', complete: 'ParentComplete')
+
+    Wurk::Batch::Callbacks.propagate_to_parent(child.bid)
+
+    assert_equal 1, callbacks_fired(event: 'complete', bid: parent.bid)
+    assert_equal 1, callbacks_fired(event: 'success', bid: parent.bid)
+  end
+
   # --- callback_specs_for queue fallback ---------------------------------
 
   # callback_specs_for falls back to the 'default' queue when callback_queue is
@@ -876,6 +951,15 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
     [parent, child]
   end
 
+  # Parent + child both acked to success, i.e. the parent's callbacks have
+  # already fired through the child's propagate_to_parent.
+  def nested_fully_acked(**parent_cbs)
+    parent, child = nested(parent_cbs: parent_cbs)
+    ack_success(parent.bid, jid_for(@queue, parent.bid))
+    ack_success(child.bid, jid_for(@queue, child.bid))
+    [parent, child]
+  end
+
   def three_deep
     grand = new_batch(death: 'GrandDeath')
     parent = child = nil
@@ -992,5 +1076,59 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
     Wurk::Client.singleton_class.send(:define_method, :push, impl)
   ensure
     $VERBOSE = verbose
+  end
+
+  # EXISTS b-<bid>-<event> sampled from inside Wurk::Client.push, i.e. exactly
+  # when a callback job is being enqueued — 0 means the marker is written after
+  # the enqueue (F16), 1 means it was claimed before. Every other push is
+  # delegated untouched so a concurrent test in this process is unaffected.
+  # The override runs with `self` rebound to Wurk::Client (define_method), so
+  # everything it needs is captured as a closure local — no test helpers.
+  def marker_state_at_push(bid, event, &)
+    observed = nil
+    pool     = @pool
+    key      = "b-#{bid}-#{event}"
+    ours     = callback_matcher(bid, event)
+    original = Wurk::Client.singleton_method(:push)
+    sampling = lambda do |item|
+      observed = pool.with { |c| c.call('EXISTS', key) }.to_i if ours.call(item)
+      original.call(item)
+    end
+    with_push_override(sampling, &)
+    observed
+  end
+
+  def callback_matcher(bid, event)
+    lambda do |item|
+      item['class'] == 'Wurk::Batch::CallbackJob' && Array(item['args']).values_at(0, 2) == [bid, event]
+    end
+  end
+
+  # Simulates the process dying between the callback enqueue and the dedup
+  # marker write. Scoped to one bid so concurrently running tests in this
+  # process keep the real implementation.
+  def with_failing_dedup_set(bid)
+    original = Wurk::Batch::Callbacks.method(:dedup_set)
+    crashing = lambda do |b, event|
+      raise 'crash' if b == bid
+
+      original.call(b, event)
+    end
+    redefine_dedup_set(crashing)
+    yield
+  ensure
+    redefine_dedup_set(->(b, event) { original.call(b, event) })
+  end
+
+  def redefine_dedup_set(impl)
+    verbose = $VERBOSE
+    $VERBOSE = nil
+    Wurk::Batch::Callbacks.singleton_class.send(:define_method, :dedup_set, impl)
+  ensure
+    $VERBOSE = verbose
+  end
+
+  def exists(key)
+    @pool.with { |c| c.call('EXISTS', key) }.to_i
   end
 end

--- a/test/unit/lua_test.rb
+++ b/test/unit/lua_test.rb
@@ -5,6 +5,9 @@ require_relative '../test_helper'
 class LuaTest < Wurk::Test::UnitCase
   parallelize_me!
 
+  # Last ARGV of every batch script: the `EXPIRE ... NX` seconds each one
+  # stamps on the keys it can create.
+  TTL = Wurk::Batch::DEFAULT_EXPIRY_SECONDS
 
   def setup
     super
@@ -213,7 +216,7 @@ class LuaTest < Wurk::Test::UnitCase
       Wurk::Lua::Loader.eval_cached(
         c, :batch_push,
         keys: [bkey, jids, list, qset, "#{@ns}:b-x-died", "#{@ns}:dead-batches"],
-        argv: ['default', 'JID1', '{"jid":"JID1"}', 'x']
+        argv: ['default', 'JID1', '{"jid":"JID1"}', 'x', TTL]
       )
 
       assert_equal '1', c.call('HGET', bkey, 'total')
@@ -235,7 +238,7 @@ class LuaTest < Wurk::Test::UnitCase
     list = "#{@ns}:queue:default"
     qset = "#{@ns}:queues"
     keys = [bkey, jids, list, qset, "#{@ns}:b-rp-died", "#{@ns}:dead-batches"]
-    argv = ['default', 'JID1', '{"jid":"JID1"}', 'rp']
+    argv = ['default', 'JID1', '{"jid":"JID1"}', 'rp', TTL]
     @pool.with do |c|
       2.times { Wurk::Lua::Loader.eval_cached(c, :batch_push, keys: keys, argv: argv) }
 
@@ -260,7 +263,7 @@ class LuaTest < Wurk::Test::UnitCase
       %w[A B].each do |jid|
         Wurk::Lua::Loader.eval_cached(
           c, :batch_push, keys: [bkey, jids, list, qset, died, dead],
-                          argv: ['default', jid, %({"jid":"#{jid}"}), 'dj']
+                          argv: ['default', jid, %({"jid":"#{jid}"}), 'dj', TTL]
         )
       end
 
@@ -280,7 +283,7 @@ class LuaTest < Wurk::Test::UnitCase
     jids  = "#{@ns}:b-s-jids"
     @pool.with do |c|
       Wurk::Lua::Loader.eval_cached(
-        c, :batch_schedule, keys: [sched, bkey, jids], argv: ['1700000000.5', '{"jid":"JID1"}', 'JID1']
+        c, :batch_schedule, keys: [sched, bkey, jids], argv: ['1700000000.5', '{"jid":"JID1"}', 'JID1', TTL]
       )
 
       assert_equal '1', c.call('HGET', bkey, 'total')
@@ -298,7 +301,7 @@ class LuaTest < Wurk::Test::UnitCase
     sched = "#{@ns}:schedule"
     bkey  = "#{@ns}:b-sr"
     jids  = "#{@ns}:b-sr-jids"
-    argv  = ['1700000000', '{"jid":"JID1"}', 'JID1']
+    argv  = ['1700000000', '{"jid":"JID1"}', 'JID1', TTL]
     @pool.with do |c|
       2.times { Wurk::Lua::Loader.eval_cached(c, :batch_schedule, keys: [sched, bkey, jids], argv: argv) }
 
@@ -328,7 +331,7 @@ class LuaTest < Wurk::Test::UnitCase
       Wurk::Lua::Loader.eval_cached(
         c, :batch_push,
         keys: [bkey, jids, list, "#{@ns}:queues", died, dead],
-        argv: ['default', 'JID1', '{"jid":"JID1"}', 'dr']
+        argv: ['default', 'JID1', '{"jid":"JID1"}', 'dr', TTL]
       )
 
       assert_equal '1', c.call('HGET', bkey, 'total')
@@ -356,7 +359,7 @@ class LuaTest < Wurk::Test::UnitCase
       Wurk::Lua::Loader.eval_cached(
         c, :batch_push,
         keys: [bkey, jids, list, "#{@ns}:queues", died, dead],
-        argv: ['default', 'JID1', '{"jid":"JID1"}', 'dp']
+        argv: ['default', 'JID1', '{"jid":"JID1"}', 'dp', TTL]
       )
 
       assert_equal %w[JID2], c.call('SMEMBERS', died)
@@ -413,8 +416,8 @@ class LuaTest < Wurk::Test::UnitCase
     @pool.with do |c|
       c.call('HSET', bkey, 'total', 1, 'pending', 1, 'failures', 0)
 
-      Wurk::Lua::Loader.eval_cached(c, :batch_ack_failed, keys: [bkey, failed], argv: ['A'])
-      Wurk::Lua::Loader.eval_cached(c, :batch_ack_failed, keys: [bkey, failed], argv: ['A'])
+      Wurk::Lua::Loader.eval_cached(c, :batch_ack_failed, keys: [bkey, failed], argv: ['A', TTL])
+      Wurk::Lua::Loader.eval_cached(c, :batch_ack_failed, keys: [bkey, failed], argv: ['A', TTL])
 
       assert_equal '1', c.call('HGET', bkey, 'failures')
       assert_equal 1, c.call('SISMEMBER', failed, 'A')
@@ -431,7 +434,7 @@ class LuaTest < Wurk::Test::UnitCase
       c.call('SADD', jids, 'A', 'B')
 
       live, died_n, first = Wurk::Lua::Loader.eval_cached(
-        c, :batch_ack_complete, keys: [bkey, jids, died, failed], argv: ['A']
+        c, :batch_ack_complete, keys: [bkey, jids, died, failed], argv: ['A', TTL]
       )
 
       assert_equal 1, live
@@ -444,7 +447,7 @@ class LuaTest < Wurk::Test::UnitCase
       assert_equal 0, c.call('SISMEMBER', failed, 'A')
 
       _live, _died_n, second_first = Wurk::Lua::Loader.eval_cached(
-        c, :batch_ack_complete, keys: [bkey, jids, died, failed], argv: ['B']
+        c, :batch_ack_complete, keys: [bkey, jids, died, failed], argv: ['B', TTL]
       )
 
       assert_equal 0, second_first
@@ -464,7 +467,7 @@ class LuaTest < Wurk::Test::UnitCase
       c.call('SADD', jids, 'A')
       c.call('SADD', failed, 'A')
 
-      Wurk::Lua::Loader.eval_cached(c, :batch_ack_complete, keys: [bkey, jids, died, failed], argv: ['A'])
+      Wurk::Lua::Loader.eval_cached(c, :batch_ack_complete, keys: [bkey, jids, died, failed], argv: ['A', TTL])
 
       assert_equal '0', c.call('HGET', bkey, 'failures')
       assert_equal 0, c.call('SISMEMBER', failed, 'A')


### PR DESCRIPTION
## Summary
- S4: TTL every batch sub-key at its creation site (Lua scripts, `link_to_parent`, `record_event`) via `EXPIRE … NX`; `DeathHandler.restamp_ttls` sweeps the rest on death.
- S5+S7: bound the `batches`/`dead-batches` index ZSETs with `Batch.trim_index` — score-based cutoff plus rank-based cap (`Batch::INDEX_MAX`), run in-pipeline with each `ZADD`.
- F16: close the callback-loss window by enqueueing `:complete`/`:success` callbacks before marking their dedup key, accepting a rare duplicate over a silently lost callback.
- Docs: `docs/batches.md` "Expiry and Redis footprint" now documents creation-site TTL stamping and the two-axis index trim.

## Test plan
- [x] `bin/rake test` (batch TTL/trim/callback unit tests added in this PR)
- [x] docs-only follow-up commit, no code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788228325&installation_model_id=11168&pr_number=356&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F356&signature=713282727a3186d095cab5846e0b41bc5ac9f33293107b87fde33d780220f15a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->