### PR TITLE
fix(batch,limiter): dedup/cap batch callbacks, sweep lmtr-list

### DIFF
--- a/docs/plans/2026/07/31/101-leak-logic-perf-fixes/06-batch-limiter-key-hygiene.md
+++ b/docs/plans/2026/07/31/101-leak-logic-perf-fixes/06-batch-limiter-key-hygiene.md
@@ -30,6 +30,10 @@
 - Unit: `Limits.list` after meta-hash expiry → dead name removed from `lmtr-list`.
 - Parity: batch suite (`bin/rake test:parity`) — TTL additions must not break Sidekiq Pro batch semantics (keys still live ≥ linger windows).
 
+## Deferred
+
+**Limiter read-side pagination rewrite:** Step 7 mentions `SSCAN`-based pagination as an optional optimization for `Limits.list` (`app/controllers/wurk/api_controller.rb:185-189`). After S6 lands and the `lmtr-list` SADD/SREM sweep runs, the read path self-heals — the set no longer leaks indefinitely. The current `SMEMBERS` + sort + slice approach (`web/enterprise.rb:28-33`) remains acceptable for small-to-moderate limiter counts and defers the pagination rewrite. Revisit only if observed deployment with 1000+ limiters shows latency concern on the dashboard's limiter list page.
+
 ## Done when
 
 - No TTL-less batch sub-key reachable from any creation path.

--- a/docs/target/sidekiq-pro.md
+++ b/docs/target/sidekiq-pro.md
@@ -106,7 +106,7 @@ Rules:
 - `:success` and `:death` are **not mutually exclusive** — death fires first, success never fires unless the dead job is manually retried to success.
 - Child `:success` fires before parent `:success`. Child `:complete` fires before parent `:complete`. No ordering between child `:success` and parent `:complete`.
 - **Wurk (#213):** `#on` after the first flush — following a `#jobs` call or on a batch reopened by bid — persists the callback to `b-<bid>` immediately (atomic server-side append), so it is never silently dropped. Registering on a batch whose Redis hash no longer exists raises `ArgumentError`; registering for an event that already fired logs a warning (the callback will never run).
-- **Wurk:** that append is deduped and capped. Re-registering an identical `[event, target, options]` triple is a no-op (one entry, one callback job), so reopening a batch per job to register its callback costs O(1) instead of growing the array; past 1000 entries (`Batch::CALLBACKS_MAX`) the append is refused and logged. Distinct callbacks for the same event are unaffected — any number may be registered.
+- **Wurk:** every `#on` is deduped and capped, before the first flush (in memory) and after it (in the Lua append) alike. Re-registering an identical `[event, target, options]` triple is a no-op (one entry, one callback job), so reopening a batch per job to register its callback costs O(1) instead of growing the array; past 1000 entries (`Batch::CALLBACKS_MAX`) the registration is refused and logged. Options are compared as persisted, so `a: 1` and `'a' => 1` are the same callback. Distinct callbacks for the same event are unaffected — any number may be registered.
 
 ### 2.5 `Sidekiq::Batch::Status`
 

--- a/docs/target/sidekiq-pro.md
+++ b/docs/target/sidekiq-pro.md
@@ -106,6 +106,7 @@ Rules:
 - `:success` and `:death` are **not mutually exclusive** — death fires first, success never fires unless the dead job is manually retried to success.
 - Child `:success` fires before parent `:success`. Child `:complete` fires before parent `:complete`. No ordering between child `:success` and parent `:complete`.
 - **Wurk (#213):** `#on` after the first flush — following a `#jobs` call or on a batch reopened by bid — persists the callback to `b-<bid>` immediately (atomic server-side append), so it is never silently dropped. Registering on a batch whose Redis hash no longer exists raises `ArgumentError`; registering for an event that already fired logs a warning (the callback will never run).
+- **Wurk:** that append is deduped and capped. Re-registering an identical `[event, target, options]` triple is a no-op (one entry, one callback job), so reopening a batch per job to register its callback costs O(1) instead of growing the array; past 1000 entries (`Batch::CALLBACKS_MAX`) the append is refused and logged. Distinct callbacks for the same event are unaffected — any number may be registered.
 
 ### 2.5 `Sidekiq::Batch::Status`
 

--- a/lib/wurk/batch.rb
+++ b/lib/wurk/batch.rb
@@ -133,6 +133,11 @@ module Wurk
       @linger           = nil
       @parent_bid       = nil
       @callbacks        = []
+      # Dedup index over `@callbacks`, keyed on the encoded entry. Only the
+      # pre-flush staging path feeds it — once flushed, Redis holds the array
+      # and BATCH_APPEND_CALLBACK does the deduping — so a batch reopened by
+      # bid never pays to build it.
+      @callback_index   = Set.new
       @expires_in       = DEFAULT_EXPIRY_SECONDS
       @mutable          = !@existing
       @flushed_once     = @existing
@@ -220,17 +225,22 @@ module Wurk
       self
     end
 
-    # Register a callback. Multiple callbacks of the same event are allowed.
-    # The callback target may be a Class, "Foo#bar" string spec, or anything
-    # responding to `name`. `options` must be JSON-serializable.
+    # Register a callback. Any number of *distinct* callbacks may be attached
+    # to one event; re-registering an identical `[event, target, options]`
+    # triple is a no-op, and past `CALLBACKS_MAX` entries the registration is
+    # dropped with a warning. The callback target may be a Class, "Foo#bar"
+    # string spec, or anything responding to `name`. `options` must be
+    # JSON-serializable.
     def on(event, callback, options = {})
       sym = event.to_sym
       raise ArgumentError, "invalid event #{event.inspect}" unless VALID_EVENTS.include?(sym)
       raise ArgumentError, 'callback options must be a Hash' unless options.is_a?(Hash)
 
       entry = [sym.to_s, callback_target(callback), options]
-      @callbacks << entry
-      persist_callback!(entry) if @flushed_once
+      # Before the first flush the array lives only in memory; after it, Redis
+      # is authoritative and `@callbacks` is a stale mirror nothing reads —
+      # appending to it there would just leak one entry per registration.
+      @flushed_once ? persist_callback!(entry) : stage_callback(entry)
       self
     end
 
@@ -298,6 +308,28 @@ module Wurk
     def flush_buffer(buffer)
       payloads = buffer.drain
       Wurk::Client.new.flush_batched(payloads) unless payloads.empty?
+    end
+
+    # Pre-flush counterpart to `persist_callback!`. Entries registered before
+    # the first flush only exist in memory until `first_flush_hash` writes the
+    # whole array in one HSET, so BATCH_APPEND_CALLBACK never sees them — the
+    # same dedup and cap have to be applied here or the very first write can
+    # already ship duplicates and an unbounded array.
+    #
+    # Keyed on the encoded entry, which is what actually lands in the hash:
+    # `{a: 1}` and `{'a' => 1}` are one callback once persisted, so they must
+    # be one entry here too.
+    def stage_callback(entry)
+      json = entry.to_json
+      return if @callback_index.include?(json)
+
+      if @callbacks.size >= CALLBACKS_MAX
+        Wurk.logger.warn("batch #{@bid}: #{entry[0]} callback dropped — #{CALLBACKS_MAX} callback limit reached")
+        return
+      end
+
+      @callbacks << entry
+      @callback_index << json
     end
 
     # Like `linger=`, anything registered after the first flush must reach

--- a/lib/wurk/batch.rb
+++ b/lib/wurk/batch.rb
@@ -49,6 +49,14 @@ module Wurk
     # per-batch hashes dwarf the index anyway.
     INDEX_MAX = 1_000_000
 
+    # Ceiling on the `callbacks` array of one batch hash, enforced by
+    # BATCH_APPEND_CALLBACK. Every registration re-encodes the whole array,
+    # and every entry becomes a callback job when the event fires, so an
+    # unbounded array is both a hot-path cost and a fan-out. Far above any
+    # legitimate batch — real ones register a handful — so hitting it means a
+    # loop is registering callbacks it should have registered once.
+    CALLBACKS_MAX = 1_000
+
     # Bid is URL-safe base64 of 10 random bytes — matches Sidekiq Pro's BID
     # generator. Length matters: third-party gems that key off bid prefix
     # (sharded batches in Pro 8) inspect the first character.
@@ -297,17 +305,25 @@ module Wurk
     # in-memory-only append would silently never fire (#213). Covers both
     # `on` after `#jobs` and batches reopened by bid. The append runs
     # server-side (Lua) so concurrent registrations from different processes
-    # can't lose each other to a read-modify-write race.
+    # can't lose each other to a read-modify-write race, and it dedups
+    # identical triples so the reopen-per-job shape stops growing the array.
     def persist_callback!(entry)
       event = entry[0]
-      fired = Wurk.redis do |conn|
+      status = Wurk.redis do |conn|
         Wurk::Lua::Loader.eval_cached(conn, :batch_append_callback,
-                                      keys: ["b-#{@bid}"], argv: [entry.to_json, event])
+                                      keys: ["b-#{@bid}"], argv: [entry.to_json, event, CALLBACKS_MAX])
       end
-      raise ArgumentError, "cannot register #{event} callback: batch #{@bid} no longer exists" if fired == -1
-      return unless fired == '1'
+      raise ArgumentError, "cannot register #{event} callback: batch #{@bid} no longer exists" if status == -1
 
-      Wurk.logger.warn("batch #{@bid}: #{event} callback registered after #{event} already fired — it will never run")
+      # Sentinels are Integers, the fired flag is the String the `<event>`
+      # hash field holds — asymmetric on purpose, so a sentinel can never be
+      # read as a fired event.
+      case status
+      when -2
+        Wurk.logger.warn("batch #{@bid}: #{event} callback dropped — #{CALLBACKS_MAX} callback limit reached")
+      when '1'
+        Wurk.logger.warn("batch #{@bid}: #{event} callback registered after #{event} already fired — it will never run")
+      end
     end
 
     # First flush writes the core hash, registers in the global `batches`

--- a/lib/wurk/limiter.rb
+++ b/lib/wurk/limiter.rb
@@ -25,7 +25,10 @@ module Wurk
   # Layout (one file per type under `lib/wurk/limiter/`):
   #   * `Limiter::Base` owns the metadata write (lmtr:{name}) + the global
   #     `lmtr-list` registration so the Web UI can list every limiter, and
-  #     the uniform `status` shape.
+  #     the uniform `status` shape. Membership is added once per metadata
+  #     write and swept back out by `Web::Enterprise::Limits.list` once the
+  #     metadata expires — the two halves of keeping `lmtr-list` bounded
+  #     under interpolated names.
   #   * Per-type subclasses (Concurrent / Bucket / Window / Leaky / Points)
   #     own their acquire/wait loop. Each delegates the atomic step to a
   #     Lua script in `lib/wurk/lua/limiter_*.lua`.

--- a/lib/wurk/limiter/base.rb
+++ b/lib/wurk/limiter/base.rb
@@ -104,17 +104,15 @@ module Wurk
         end
       end
 
+      # Metadata HSET + EXPIRE + `lmtr-list` SADD in a single round trip. The
+      # script also gates the SADD on the metadata being newly written, so a
+      # per-job construction (`stripe-#{user_id}`) stops rewriting a set that
+      # grows one member per name — see limiter_register.lua for why that gate
+      # is only safe while it is atomic with the HSET.
       def register!
-        Wurk::Limiter.redis do |c|
-          c.call('SADD', LIST_KEY, @name)
-          c.call(
-            'HSET', meta_key,
-            'type', type.to_s,
-            'options', JSON.dump(serializable_options),
-            'fingerprint', fingerprint
-          )
-          c.call('EXPIRE', meta_key, @options[:ttl])
-        end
+        lua(:limiter_register,
+            keys: [meta_key, LIST_KEY],
+            argv: [@name, type.to_s, JSON.dump(serializable_options), fingerprint, ttl])
       end
 
       def ttl

--- a/lib/wurk/lua.rb
+++ b/lib/wurk/lua.rb
@@ -287,10 +287,21 @@ module Wurk
     # same reopened batch cannot lose each other's writes. Refuses to write
     # when the batch hash is gone — resurrecting a bare hash would create a
     # batch that can never fire anything.
+    #
+    # Appends are deduped and capped. Reopening the same batch inside every
+    # job and re-registering its callback is a common shape, and each append
+    # pays a decode + encode of the whole array: unbounded that is O(N^2) Lua
+    # work on the way in and N identical callback jobs at fire time. An
+    # identical triple is therefore a no-op — the registration is already
+    # satisfied by the entry that is there — and past the cap the append is
+    # refused rather than allowed to grow the hash field without limit.
+    # Both sides of the comparison are normalised through cjson so an entry
+    # written by Ruby's `to_json` at first flush matches one appended here.
     # KEYS = [b-<bid>]
-    # ARGV = [callback triple JSON, event name]
-    # Returns -1 when the batch hash does not exist; otherwise the event's
-    # fired flag ("1", or nil when it has not fired yet).
+    # ARGV = [callback triple JSON, event name, max callbacks]
+    # Returns -1 when the batch hash does not exist and -2 when the cap
+    # refused the append; otherwise the event's fired flag ("1", or nil when
+    # it has not fired yet).
     BATCH_APPEND_CALLBACK = <<~LUA
       if redis.call("exists", KEYS[1]) == 0 then
         return -1
@@ -302,7 +313,17 @@ module Wurk
       else
         list = {}
       end
-      list[#list + 1] = cjson.decode(ARGV[1])
+      local entry = cjson.decode(ARGV[1])
+      local encoded = cjson.encode(entry)
+      for i = 1, #list do
+        if cjson.encode(list[i]) == encoded then
+          return redis.call("hget", KEYS[1], ARGV[2])
+        end
+      end
+      if #list >= tonumber(ARGV[3]) then
+        return -2
+      end
+      list[#list + 1] = entry
       redis.call("hset", KEYS[1], "callbacks", cjson.encode(list))
       return redis.call("hget", KEYS[1], ARGV[2])
     LUA

--- a/lib/wurk/lua/limiter_list_sweep.lua
+++ b/lib/wurk/lua/limiter_list_sweep.lua
@@ -1,0 +1,30 @@
+-- Limiter list sweep: drop `lmtr-list` members whose metadata HASH is gone.
+-- KEYS[1]   = lmtr-list
+-- ARGV[1]   = metadata key prefix ('lmtr:')
+-- ARGV[2..] = candidate names, already probed as dead by the caller
+-- Returns the number of names removed.
+--
+-- Membership carries no TTL of its own while `lmtr:<name>` expires with the
+-- limiter's ttl, so every interpolated name leaves a permanent entry behind and
+-- the SET grows forever. Names are the only thing stored here, so the sweep has
+-- to ask the metadata key whether each one is still real.
+--
+-- Re-checking EXISTS is the point of doing this in a script: the caller's probe
+-- and this call are separate round trips, and limiter_register.lua only SADDs on
+-- the *first* metadata write, so dropping a name that re-registered in between
+-- would hide a live limiter until its ttl ran out. Deciding again inside the
+-- atomic step makes both orderings safe: register-then-sweep keeps the name,
+-- sweep-then-register re-adds it.
+--
+-- The key is composed from an ARGV prefix (same shape as
+-- reliable_schedule_promote's queue prefix) because the candidate list is
+-- variable-length. The caller batches it: Lua is atomic and single-threaded in
+-- Redis, so sweeping a set that leaked for months in one call would block every
+-- other client for the whole pass.
+local removed = 0
+for i = 2, #ARGV do
+  if redis.call('EXISTS', ARGV[1] .. ARGV[i]) == 0 then
+    removed = removed + redis.call('SREM', KEYS[1], ARGV[i])
+  end
+end
+return removed

--- a/lib/wurk/lua/limiter_register.lua
+++ b/lib/wurk/lua/limiter_register.lua
@@ -1,0 +1,27 @@
+-- Limiter registration: metadata HASH + `lmtr-list` membership, atomically.
+-- KEYS[1] = lmtr:<name>   metadata HASH (type / options / fingerprint)
+-- KEYS[2] = lmtr-list     SET of every registered limiter name
+-- ARGV[1] = name
+-- ARGV[2] = type
+-- ARGV[3] = options JSON
+-- ARGV[4] = fingerprint
+-- ARGV[5] = ttl seconds
+-- Returns 1 when the name was added to `lmtr-list`, 0 when it was already one.
+--
+-- Three round trips collapsed into one: the spec blesses interpolated names
+-- (`stripe-<user_id>`), so a limiter is constructed per job and registration
+-- sits on the enqueue path rather than on boot.
+--
+-- The SADD only fires when this HSET created the metadata (the limiter is new,
+-- or its ttl had lapsed), so a set that can hold millions of members is not
+-- rewritten by every construction. The gate is safe only because it is atomic
+-- with the HSET: limiter_list_sweep.lua re-reads the same HASH inside its own
+-- atomic step, so the pair can never interleave into "metadata written,
+-- membership swept", which with the gate would hide a live limiter from the
+-- dashboard until its ttl ran out.
+local created = redis.call('HSET', KEYS[1], 'type', ARGV[2], 'options', ARGV[3], 'fingerprint', ARGV[4])
+redis.call('EXPIRE', KEYS[1], ARGV[5])
+if created > 0 then
+  return redis.call('SADD', KEYS[2], ARGV[1])
+end
+return 0

--- a/lib/wurk/web/enterprise.rb
+++ b/lib/wurk/web/enterprise.rb
@@ -22,19 +22,70 @@ module Wurk
       module Limits
         module_function
 
-        # @return [Array<String>] limiter names, optionally filtered to those
-        #   whose name contains the case-insensitive substring `filter`.
+        # Names per sweep round trip. Bounds both halves: the probe's pipeline
+        # (whose replies the client buffers) and the removal script, which is
+        # atomic — an unbatched pass over a set that leaked for months would
+        # block every other Redis client for its whole length. A healthy set
+        # fits in one slice, so the common case still costs one probe.
+        SWEEP_BATCH = 512
+
+        # @return [Array<String>] live limiter names, optionally filtered to
+        #   those whose name contains the case-insensitive substring `filter`.
+        #
+        # Listing is also the sweep. `lmtr-list` membership has no TTL of its
+        # own while `lmtr:<name>` expires with the limiter's ttl, so every
+        # interpolated name (`stripe-#{user_id}`) the spec blesses would leave a
+        # permanent member behind. Names whose metadata is gone are dropped from
+        # the SET and from the result, so the dashboard also stops rendering a
+        # row with nothing behind it. The liveness probe rides along with the
+        # SMEMBERS the listing already pays for — both are O(set) — and once the
+        # sweep has run the set is back down to live limiters.
         def list(filter: nil)
-          names = Wurk.redis(idempotent: true) { |c| c.call('SMEMBERS', Wurk::Limiter::LIST_KEY) }.sort
+          names = sweep(Wurk.redis(idempotent: true) { |c| c.call('SMEMBERS', Wurk::Limiter::LIST_KEY) }).sort
           return names if filter.nil? || filter.to_s.empty?
 
           needle = filter.to_s.downcase
           names.select { |n| n.downcase.include?(needle) }
         end
 
+        # Drop the names whose metadata is gone, return the ones still live.
+        def sweep(names)
+          names.each_slice(SWEEP_BATCH).flat_map { |slice| sweep_slice(slice) }
+        end
+
+        def sweep_slice(names)
+          live, dead = partition_live(names)
+          sweep_batch(dead) unless dead.empty?
+          live
+        end
+
+        def partition_live(names)
+          flags = Wurk.redis(idempotent: true) do |c|
+            c.pipelined { |pipe| names.each { |n| pipe.call('EXISTS', meta_key(n)) } }
+          end
+          names.partition.with_index { |_, i| flags[i].to_i == 1 }
+        end
+
+        # Claims apply-safety, unlike ProcessSet's comparable prune: the script
+        # re-decides liveness inside its own atomic step, so a replay can only
+        # remove names that are still dead.
+        def sweep_batch(names)
+          Wurk.redis(idempotent: true) do |c|
+            Wurk::Lua::Loader.eval_cached(
+              c, :limiter_list_sweep,
+              keys: [Wurk::Limiter::LIST_KEY],
+              argv: ['lmtr:', *names]
+            )
+          end
+        end
+
         def metadata(name)
-          raw = Wurk.redis(idempotent: true) { |c| c.call('HGETALL', "lmtr:#{name}") }
+          raw = Wurk.redis(idempotent: true) { |c| c.call('HGETALL', meta_key(name)) }
           raw.is_a?(Array) ? raw.each_slice(2).to_h : raw
+        end
+
+        def meta_key(name)
+          "lmtr:#{name}"
         end
 
         # Stats-key reset: drops every `lmtr-stats:` / state key for the
@@ -51,8 +102,9 @@ module Wurk
         end
 
         # Read-only reconstruction (`register: false`) from the persisted
-        # metadata. Returns nil when the meta HASH is gone or malformed —
-        # LIST membership has no TTL, so a name can outlive its metadata.
+        # metadata. Returns nil when the meta HASH is gone or malformed — the
+        # name a caller holds came from a page `list` rendered earlier, and the
+        # metadata can expire between the two.
         def rebuild(name)
           meta = metadata(name)
           return nil if meta.nil? || meta.empty?

--- a/test/unit/batch_lifecycle_test.rb
+++ b/test/unit/batch_lifecycle_test.rb
@@ -967,6 +967,63 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
     assert_match(/#{Wurk::Batch::CALLBACKS_MAX} callback limit reached/, log)
   end
 
+  # Pre-flush registrations never reach BATCH_APPEND_CALLBACK — they stage in
+  # memory and land in one HSET — so the dedup and the cap have to hold on
+  # that path too, or the first write already violates the contract.
+  def test_duplicate_callback_before_flush_persists_one_entry
+    batch = new_batch
+    100.times { batch.on(:success, 'RepeatSuccess') }
+
+    batch.jobs { perform_one }
+    ack_success(batch.bid, jid_for(@queue, batch.bid))
+
+    assert_equal 1, persisted_callbacks(batch.bid).size
+    assert_equal 1, callbacks_fired(event: 'success', bid: batch.bid)
+  end
+
+  # Options are compared as persisted: symbol and string keys serialise to the
+  # same entry, so registering both must not double-fire.
+  def test_duplicate_callback_before_flush_ignores_option_key_type
+    batch = new_batch
+    batch.on(:success, 'NormalizedSuccess', shard: 1)
+    batch.on(:success, 'NormalizedSuccess', 'shard' => 1)
+
+    batch.jobs { perform_one }
+
+    assert_equal 1, persisted_callbacks(batch.bid).size
+  end
+
+  def test_distinct_callback_options_before_flush_keep_both
+    batch = new_batch
+    batch.on(:success, 'ShardSuccess', 'shard' => 1)
+    batch.on(:success, 'ShardSuccess', 'shard' => 2)
+
+    batch.jobs { perform_one }
+    ack_success(batch.bid, jid_for(@queue, batch.bid))
+
+    assert_equal 2, callbacks_fired(event: 'success', bid: batch.bid)
+  end
+
+  def test_on_before_flush_past_the_callback_cap_is_dropped
+    batch = new_batch
+    fill_staged_callbacks(batch)
+
+    batch.on(:success, 'Overflow')
+    batch.jobs { perform_one }
+
+    assert_equal Wurk::Batch::CALLBACKS_MAX, persisted_callbacks(batch.bid).size
+    refute_includes persisted_callbacks(batch.bid).map { |c| c[1] }, 'Overflow'
+  end
+
+  def test_on_before_flush_past_the_callback_cap_logs_the_drop
+    batch = new_batch
+    fill_staged_callbacks(batch)
+
+    log = capture_log { batch.on(:success, 'Overflow') }
+
+    assert_match(/#{Wurk::Batch::CALLBACKS_MAX} callback limit reached/, log)
+  end
+
   def test_on_after_event_already_fired_does_not_enqueue_again
     batch = new_batch(success: 'EarlySuccess')
     batch.jobs { perform_one }
@@ -1104,6 +1161,12 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
 
   def persisted_callbacks(bid)
     JSON.parse(@pool.with { |c| c.call('HGET', "b-#{bid}", 'callbacks') })
+  end
+
+  # Saturate the in-memory staging array — the pre-flush twin of
+  # `fill_callbacks`, which saturates the persisted one.
+  def fill_staged_callbacks(batch)
+    Wurk::Batch::CALLBACKS_MAX.times { |i| batch.on(:success, "Filler#{i}") }
   end
 
   # Saturate the callback array without paying CALLBACKS_MAX round trips.

--- a/test/unit/batch_lifecycle_test.rb
+++ b/test/unit/batch_lifecycle_test.rb
@@ -2,6 +2,7 @@
 
 require_relative '../test_helper'
 require 'json'
+require 'stringio'
 
 # Drives the batch lifecycle end-to-end against real Redis: autoflush
 # buffering, per-batch linger retention, the callback lifecycle
@@ -15,6 +16,11 @@ require 'json'
 # torn down. No test touches another's keys.
 class BatchLifecycleTest < Wurk::Test::UnitCase
   parallelize_me!
+
+  # Guards the one test that swaps the process-global `Wurk.logger` (there is
+  # no thread-local override point) so it can't race another thread's test
+  # method within this same parallelized class.
+  LOGGER_MUTEX = Mutex.new
 
   def setup
     super
@@ -951,6 +957,16 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
     refute_includes persisted_callbacks(batch.bid).map { |c| c[1] }, 'Overflow'
   end
 
+  def test_on_past_the_callback_cap_logs_the_drop
+    batch = new_batch
+    batch.jobs { perform_one }
+    fill_callbacks(batch.bid)
+
+    log = capture_log { batch.on(:success, 'Overflow') }
+
+    assert_match(/#{Wurk::Batch::CALLBACKS_MAX} callback limit reached/, log)
+  end
+
   def test_on_after_event_already_fired_does_not_enqueue_again
     batch = new_batch(success: 'EarlySuccess')
     batch.jobs { perform_one }
@@ -1099,6 +1115,23 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
   def callbacks_fired(event:, bid:)
     queued(@cbq).count do |j|
       j['class'] == 'Wurk::Batch::CallbackJob' && j['args'][0] == bid && j['args'][2] == event
+    end
+  end
+
+  # Swap in a StringIO logger for the duration of the block and return
+  # what it captured — used to assert the cap/duplicate-registration
+  # warnings without disturbing the global IO::NULL logger other tests rely on.
+  def capture_log
+    LOGGER_MUTEX.synchronize do
+      io = StringIO.new
+      previous = Wurk.logger
+      Wurk.logger = Logger.new(io)
+      begin
+        yield
+        io.string
+      ensure
+        Wurk.logger = previous
+      end
     end
   end
 

--- a/test/unit/batch_lifecycle_test.rb
+++ b/test/unit/batch_lifecycle_test.rb
@@ -912,6 +912,45 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
     assert_match(/no longer exists/, err.message)
   end
 
+  # Reopening a batch inside every job to register its callback is a common
+  # shape; without dedup that persists one entry per job and fires the
+  # callback that many times.
+  def test_reopening_to_register_an_identical_callback_persists_one_entry
+    batch = new_batch
+    batch.jobs { perform_one }
+    bid = batch.bid
+    100.times { Wurk::Batch.new(bid).on(:success, 'RepeatSuccess') }
+
+    ack_success(bid, jid_for(@queue, bid))
+
+    assert_equal 1, persisted_callbacks(bid).size
+    assert_equal 1, callbacks_fired(event: 'success', bid: bid)
+  end
+
+  # Dedup keys on the whole triple: same target, different options stays two
+  # registrations and fires twice.
+  def test_reopening_with_different_callback_options_keeps_both
+    batch = new_batch
+    batch.jobs { perform_one }
+    Wurk::Batch.new(batch.bid).on(:success, 'ShardSuccess', 'shard' => 1)
+    Wurk::Batch.new(batch.bid).on(:success, 'ShardSuccess', 'shard' => 2)
+
+    ack_success(batch.bid, jid_for(@queue, batch.bid))
+
+    assert_equal 2, callbacks_fired(event: 'success', bid: batch.bid)
+  end
+
+  def test_on_past_the_callback_cap_is_dropped
+    batch = new_batch
+    batch.jobs { perform_one }
+    fill_callbacks(batch.bid)
+
+    batch.on(:success, 'Overflow')
+
+    assert_equal Wurk::Batch::CALLBACKS_MAX, persisted_callbacks(batch.bid).size
+    refute_includes persisted_callbacks(batch.bid).map { |c| c[1] }, 'Overflow'
+  end
+
   def test_on_after_event_already_fired_does_not_enqueue_again
     batch = new_batch(success: 'EarlySuccess')
     batch.jobs { perform_one }
@@ -1045,6 +1084,16 @@ class BatchLifecycleTest < Wurk::Test::UnitCase
 
   def jids_for(queue, bid)
     queued(queue).select { |j| j['bid'] == bid }.map { |j| j['jid'] }
+  end
+
+  def persisted_callbacks(bid)
+    JSON.parse(@pool.with { |c| c.call('HGET', "b-#{bid}", 'callbacks') })
+  end
+
+  # Saturate the callback array without paying CALLBACKS_MAX round trips.
+  def fill_callbacks(bid)
+    full = Array.new(Wurk::Batch::CALLBACKS_MAX) { |i| ['success', "Filler#{i}", {}] }
+    @pool.with { |c| c.call('HSET', "b-#{bid}", 'callbacks', JSON.generate(full)) }
   end
 
   def callbacks_fired(event:, bid:)

--- a/test/unit/limiter_test.rb
+++ b/test/unit/limiter_test.rb
@@ -135,6 +135,52 @@ class LimiterTest < Wurk::Test::UnitCase
     end
   end
 
+  # A limiter whose metadata ttl lapsed — and whose name the Web sweep then
+  # dropped — has to come back on its next construction. The registration gate
+  # keys off the metadata write, so re-creating the HASH re-adds the membership.
+  def test_constructor_reregisters_after_metadata_expiry
+    name = "rereg-#{@suffix}"
+    Wurk::Limiter.concurrent(name, 5)
+    @pool.with do |c|
+      c.call('DEL', "lmtr:#{name}")
+      c.call('SREM', Wurk::Limiter::LIST_KEY, name)
+    end
+
+    Wurk::Limiter.concurrent(name, 5)
+
+    @pool.with do |c|
+      assert_equal 1, c.call('SISMEMBER', Wurk::Limiter::LIST_KEY, name)
+      assert_equal 1, c.call('EXISTS', "lmtr:#{name}")
+    end
+  end
+
+  # Re-registering an already-registered limiter skips the SET write: with the
+  # interpolated names the spec blesses, construction runs once per job against
+  # a set that can hold millions of members. Only the Web sweep removes a name,
+  # and it re-checks the metadata atomically — so "metadata live, membership
+  # gone" is not a state Wurk itself can reach.
+  def test_repeat_construction_skips_the_list_write
+    name = "regskip-#{@suffix}"
+    Wurk::Limiter.concurrent(name, 5)
+    @pool.with { |c| c.call('SREM', Wurk::Limiter::LIST_KEY, name) }
+
+    Wurk::Limiter.concurrent(name, 5)
+
+    @pool.with { |c| assert_equal 0, c.call('SISMEMBER', Wurk::Limiter::LIST_KEY, name) }
+  end
+
+  # The ttl refresh is not part of that gate: an actively-used limiter must
+  # never let its metadata lapse under it (and take its membership with it).
+  def test_repeat_construction_refreshes_metadata_ttl
+    name = "regttl-#{@suffix}"
+    Wurk::Limiter.concurrent(name, 5)
+    @pool.with { |c| c.call('EXPIRE', "lmtr:#{name}", 100) }
+
+    Wurk::Limiter.concurrent(name, 5)
+
+    assert_operator @pool.with { |c| c.call('TTL', "lmtr:#{name}").to_i }, :>, 100
+  end
+
   # ----- delete + reset cleanup ----------------------------------------
 
   def test_delete_removes_state_keys_and_list_membership

--- a/test/unit/lua_test.rb
+++ b/test/unit/lua_test.rb
@@ -489,7 +489,89 @@ class LuaTest < Wurk::Test::UnitCase
     end
   end
 
+  # Same event, same target, different options are three different callbacks —
+  # dedup must key on the whole triple or it swallows legitimate registrations.
+  def test_batch_append_callback_appends_distinct_triples
+    bkey = "#{@ns}:b-cb1"
+    @pool.with do |c|
+      c.call('HSET', bkey, 'total', 0)
+
+      [['success', 'A', {}], ['success', 'B', {}], ['success', 'A', { 'shard' => 1 }]].each do |entry|
+        append_callback(c, bkey, entry)
+      end
+
+      assert_equal [['success', 'A', {}], ['success', 'B', {}], ['success', 'A', { 'shard' => 1 }]],
+                   callbacks(c, bkey)
+    end
+  end
+
+  # The seeded list is Ruby's `to_json` (what first flush writes), the appends
+  # go through cjson — the dedup only holds because both sides are normalised
+  # through the same encoder before comparison.
+  def test_batch_append_callback_skips_an_identical_triple
+    bkey = "#{@ns}:b-cb2"
+    entry = ['success', 'A', { 'shard' => 1 }]
+    @pool.with do |c|
+      c.call('HSET', bkey, 'callbacks', JSON.generate([entry]))
+
+      50.times { append_callback(c, bkey, entry) }
+
+      assert_equal [entry], callbacks(c, bkey)
+    end
+  end
+
+  def test_batch_append_callback_returns_the_fired_flag_for_a_skipped_triple
+    bkey = "#{@ns}:b-cb3"
+    entry = ['success', 'A', {}]
+    @pool.with do |c|
+      c.call('HSET', bkey, 'callbacks', JSON.generate([entry]), 'success', '1')
+
+      assert_equal '1', append_callback(c, bkey, entry)
+    end
+  end
+
+  def test_batch_append_callback_refuses_a_new_triple_past_the_cap
+    bkey = "#{@ns}:b-cb4"
+    full = Array.new(Wurk::Batch::CALLBACKS_MAX) { |i| ['success', "C#{i}", {}] }
+    @pool.with do |c|
+      c.call('HSET', bkey, 'callbacks', JSON.generate(full))
+
+      assert_equal(-2, append_callback(c, bkey, ['success', 'OVERFLOW', {}]))
+      assert_equal full, callbacks(c, bkey)
+    end
+  end
+
+  # The cap counts entries, not calls: a triple already in the list needs no
+  # room, so a full list still answers it with the fired flag rather than -2.
+  def test_batch_append_callback_still_dedups_at_the_cap
+    bkey = "#{@ns}:b-cb5"
+    full = Array.new(Wurk::Batch::CALLBACKS_MAX) { |i| ['success', "C#{i}", {}] }
+    @pool.with do |c|
+      c.call('HSET', bkey, 'callbacks', JSON.generate(full))
+
+      assert_nil append_callback(c, bkey, full.last)
+      assert_equal Wurk::Batch::CALLBACKS_MAX, callbacks(c, bkey).size
+    end
+  end
+
+  # -1 (gone) and -2 (capped) are distinct sentinels; the caller raises on one
+  # and logs on the other.
+  def test_batch_append_callback_refuses_a_missing_batch_hash
+    @pool.with do |c|
+      assert_equal(-1, append_callback(c, "#{@ns}:b-cb-gone", ['success', 'A', {}]))
+    end
+  end
+
   private
+
+  def append_callback(conn, bkey, entry, max: Wurk::Batch::CALLBACKS_MAX)
+    Wurk::Lua::Loader.eval_cached(conn, :batch_append_callback,
+                                  keys: [bkey], argv: [JSON.generate(entry), entry[0], max])
+  end
+
+  def callbacks(conn, bkey)
+    JSON.parse(conn.call('HGET', bkey, 'callbacks'))
+  end
 
   def promote(conn, sset, now_ms = 1_700_000_000_000)
     Wurk::Lua::Loader.eval_cached(

--- a/test/unit/lua_test.rb
+++ b/test/unit/lua_test.rb
@@ -38,6 +38,7 @@ class LuaTest < Wurk::Test::UnitCase
          batch_push batch_schedule batch_ack_success batch_ack_failed batch_ack_complete batch_invalidate
          batch_append_callback
          fast_delete_job fast_delete_by_class release_if_owner cron_claim_fire
+         limiter_register limiter_list_sweep
          limiter_concurrent_acquire limiter_concurrent_release
          limiter_bucket_acquire limiter_window_acquire limiter_window_status limiter_leaky_acquire
          limiter_points_acquire limiter_points_refund].sort,

--- a/test/unit/redis_idempotent_call_sites_test.rb
+++ b/test/unit/redis_idempotent_call_sites_test.rb
@@ -232,13 +232,27 @@ class RedisIdempotentCallSitesTest < Wurk::Test::UnitCase
     assert_equal [true], @main.claims_for('ZSCAN')
   end
 
+  # Listing limiters reads the SET, probes each name's metadata, and sweeps the
+  # names whose metadata is gone. The sweep is the one write here, and it claims
+  # too: its script re-decides liveness inside the atomic step, so a replay can
+  # only drop names that are still dead.
   def test_web_limits_read_paths_claim_apply_safety
-    on_default_pool do
-      Wurk::Web::Enterprise::Limits.list
-      Wurk::Web::Enterprise::Limits.metadata("#{@ns}-lmtr")
+    @main.with do |c|
+      c.call('SADD', Wurk::Limiter::LIST_KEY, "#{@ns}-lmtr")
+      c.call('HSET', "lmtr:#{@ns}-lmtr", 'type', 'concurrent', 'options', '{}', 'fingerprint', 'fp')
+      c.call('SADD', Wurk::Limiter::LIST_KEY, "#{@ns}-ghost")
     end
 
+    on_default_pool { Wurk::Web::Enterprise::Limits.list }
+
     assert_equal [true], @main.claims_for('SMEMBERS')
+    assert_equal [true], @main.claims_for('EXISTS')
+    assert_equal [true], @main.claims_for('EVALSHA')
+  end
+
+  def test_web_limits_metadata_claims_apply_safety
+    on_default_pool { Wurk::Web::Enterprise::Limits.metadata("#{@ns}-lmtr") }
+
     assert_equal [true], @main.claims_for('HGETALL')
   end
 

--- a/test/unit/web_enterprise_test.rb
+++ b/test/unit/web_enterprise_test.rb
@@ -11,11 +11,12 @@ class WebEnterpriseTest < Wurk::Test::UnitCase
     @limiter = "lmt-#{@ns}"
     @lid = ::Digest::SHA1.hexdigest(@ns)[0, 16]
     @class_name = "EntPeriodicJob@#{@ns}"
+    @ghosts = []
   end
 
   def teardown
     Wurk.redis do |c|
-      c.call('SREM', Wurk::Limiter::LIST_KEY, @limiter)
+      c.call('SREM', Wurk::Limiter::LIST_KEY, @limiter, *@ghosts)
       %W[lmtr:#{@limiter} lmtr-cs:#{@limiter} lmtr-b:#{@limiter}
          lmtr-w:#{@limiter} lmtr-l:#{@limiter} lmtr-p:#{@limiter}
          lmtr-stats:#{@limiter}].each { |k| c.call('DEL', k) }
@@ -51,6 +52,66 @@ class WebEnterpriseTest < Wurk::Test::UnitCase
     names = Wurk::Web::Enterprise::Limits.list(filter: 'totally-unrelated-xyz')
 
     refute_includes names, @limiter
+  end
+
+  # `lmtr-list` membership has no TTL of its own, so before the sweep every
+  # interpolated name the spec blesses (`stripe-#{user_id}`) left a member
+  # behind for good once its metadata expired.
+  def test_limits_list_drops_names_whose_metadata_expired
+    ghost = seed_ghost('gone')
+
+    names = Wurk::Web::Enterprise::Limits.list
+
+    refute_includes names, ghost
+    refute list_member?(ghost)
+  end
+
+  def test_limits_list_keeps_names_whose_metadata_is_live
+    seed_limiter
+    seed_ghost('gone')
+
+    names = Wurk::Web::Enterprise::Limits.list
+
+    assert_includes names, @limiter
+    assert list_member?(@limiter)
+  end
+
+  # The sweep runs on the whole set, before the substring filter narrows the
+  # result — otherwise a leak would only heal for names someone searched for.
+  def test_limits_list_sweeps_names_the_filter_excludes
+    seed_limiter
+    ghost = seed_ghost('gone')
+
+    names = Wurk::Web::Enterprise::Limits.list(filter: @limiter)
+
+    assert_equal [@limiter], names
+    refute list_member?(ghost)
+  end
+
+  # A set that leaked for months is swept in bounded slices; the batching must
+  # not drop the tail.
+  def test_limits_list_sweeps_past_one_batch
+    ghosts = Array.new(Wurk::Web::Enterprise::Limits::SWEEP_BATCH + 7) { |i| seed_ghost("bulk#{i}") }
+
+    Wurk::Web::Enterprise::Limits.list
+
+    live = Wurk.redis { |c| c.call('SMEMBERS', Wurk::Limiter::LIST_KEY) }
+
+    assert_empty live & ghosts
+  end
+
+  # The probe and the SREM are separate round trips, and registration only
+  # SADDs on the first metadata write — so a name that re-registered in between
+  # would be hidden until its ttl ran out. The script re-decides atomically.
+  def test_limits_sweep_batch_spares_a_name_that_re_registered
+    seed_limiter
+    ghost = seed_ghost('gone')
+
+    removed = Wurk::Web::Enterprise::Limits.sweep_batch([@limiter, ghost])
+
+    assert_equal 1, removed
+    assert list_member?(@limiter)
+    refute list_member?(ghost)
   end
 
   def test_limits_metadata_returns_hash
@@ -176,6 +237,19 @@ class WebEnterpriseTest < Wurk::Test::UnitCase
       c.call('SADD', Wurk::Limiter::LIST_KEY, @limiter)
       c.call('HSET', "lmtr:#{@limiter}", 'type', 'concurrent', 'fingerprint', 'fp', 'options', '{"limit":5}')
     end
+  end
+
+  def list_member?(name)
+    Wurk.redis { |c| c.call('SISMEMBER', Wurk::Limiter::LIST_KEY, name) }.to_i == 1
+  end
+
+  # A member whose `lmtr:<name>` metadata has expired — what an interpolated
+  # limiter name decays into once its ttl lapses.
+  def seed_ghost(suffix)
+    name = "#{@limiter}-#{suffix}"
+    @ghosts << name
+    Wurk.redis { |c| c.call('SADD', Wurk::Limiter::LIST_KEY, name) }
+    name
   end
 
   def seed_loop(paused: '0', queue: 'default')


### PR DESCRIPTION
## Summary
- S8 — `BATCH_APPEND_CALLBACK` Lua now dedups identical `[event, target, options]` triples and caps the array at `CALLBACKS_MAX` (1000), logging a warning on drop instead of growing unbounded (reopen-batch `#on` per job was O(N²) + N duplicate fires).
- S6 — `lmtr-list` no longer grows forever: `Limits.list` sweeps names whose `lmtr:<name>` meta hash has expired (batched, atomic Lua removal), and registration only `SADD`s on first metadata write instead of every construction.
- Deferred the limiter read-side `SSCAN` pagination rewrite — the sweep above self-heals the read path, documented in the plan as out of scope unless 1000+ limiters show latency.
- Test task: added coverage asserting the over-cap append actually logs the drop (existing tests covered dedup/cap/sweep behavior but not the log side-effect).

## Test plan
- [x] `bin/rake test TEST=test/unit/limiter_test.rb` — 43 runs, 0 failures
- [x] `bin/rake test TEST=test/unit/batch_lifecycle_test.rb` — 61 runs, 0 failures
- [x] `bin/rake test TEST=test/unit/web_enterprise_test.rb` — 22 runs, 0 failures
- [x] `bin/rake test` (full suite) — 2975 runs, 0 failures
- [x] `bin/rake test:parity` — 23 runs, 0 failures
- [x] `bundle exec rubocop` on changed files — no new offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788231285&installation_model_id=11168&pr_number=357&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F357&signature=c711d7026c3deffcd6de741155539e2ea4081cb94762c93efcd1f9f91e5bc09b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Batch callbacks now prevent identical registrations and cap stored callbacks at 1,000, with warnings when additional callbacks are rejected.
  * Limiter registration is more reliable, restoring expired metadata and membership while refreshing active limiter details.
  * Limiter listings automatically remove stale entries, including large batches, while preserving newly re-registered limiters.

* **Documentation**
  * Clarified limiter lifecycle behavior and deferred pagination improvements for larger dashboards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->