### PR TITLE
fix(site): accessibility pass on the marketing page

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -288,7 +288,11 @@
     </div>
   </header>
 
-  <main id="main">
+  <!-- tabindex="-1" so the skip link MOVES FOCUS rather than only scrolling.
+       Without it the browser jumps the viewport but leaves focus on the link,
+       so the next Tab goes back into the header nav — the very thing the link
+       exists to skip. (Same treatment YARD already gives api/ #main.) -->
+  <main id="main" tabindex="-1">
     <div class="wrap">
       <section class="hero" style="border-top:none">
         <h1>Wurk <i class="fa-solid fa-bolt bolt" aria-hidden="true"></i></h1>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -31,7 +31,11 @@
       --code: #0d1117; --radius: 8px;
     }
     * { box-sizing: border-box; }
-    html { scroll-behavior: smooth; }
+    /* 73px sticky header (12 + 48 logo + 12 + 1px rule) would otherwise cover
+       whatever a jump lands on: #features and #install put their <h2> at y=31,
+       under the bar. Offsetting the scrollport fixes fragment navigation and the
+       browser's scroll-focused-element-into-view in one line. */
+    html { scroll-behavior: smooth; scroll-padding-top: 88px; }
     body {
       margin: 0; background: var(--bg); color: var(--fg);
       font: 16px/1.6 system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
@@ -39,6 +43,23 @@
     }
     a { color: var(--fg); text-decoration: none; }
     a:hover { text-decoration: underline; text-underline-offset: 2px; }
+    /* Links inside prose carry an always-visible underline. Colour alone is not
+       enough: --fg on a --muted paragraph is 2.6:1, under the 3:1 that WCAG 1.4.1
+       requires to tell a link from its surrounding text, and the hover underline
+       does not help a reader who never hovers. Buttons opt out — they are already
+       distinguishable by their box. */
+    main a:not(.btn):not(.navlink) { text-decoration: underline; text-underline-offset: 2px; }
+    /* Reachable by keyboard, out of the way for everyone else. */
+    .sr-only {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%); white-space: nowrap; border: 0;
+    }
+    .skip-link {
+      position: absolute; left: 8px; top: -100%; z-index: 100;
+      padding: 10px 16px; border-radius: var(--radius);
+      background: var(--fg); color: var(--bg); font-weight: 700;
+    }
+    .skip-link:focus { top: 8px; }
     .wrap { max-width: 960px; margin: 0 auto; padding: 0 20px; }
     code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
     pre {
@@ -251,10 +272,11 @@
   </style>
 </head>
 <body>
+  <a class="skip-link" href="#main">Skip to content</a>
   <header>
     <div class="wrap">
       <nav>
-        <span class="brand"><img src="wurk-logo.png" alt="Wurk — an orc ready to work"> Wurk</span>
+        <span class="brand"><img src="wurk-logo.png" alt="Wurk — an orc ready to work" width="400" height="500"> Wurk</span>
         <span class="spacer"></span>
         <a class="navlink hide" href="#features">Features</a>
         <a class="navlink hide" href="#install">Install</a>
@@ -266,7 +288,7 @@
     </div>
   </header>
 
-  <main>
+  <main id="main">
     <div class="wrap">
       <section class="hero" style="border-top:none">
         <h1>Wurk <i class="fa-solid fa-bolt bolt" aria-hidden="true"></i></h1>
@@ -292,6 +314,7 @@ gem <span class="add">"wurk"</span></pre>
       </section>
 
       <section id="pillars" class="reveal" style="border-top:none">
+        <h2 class="sr-only">Why Wurk</h2>
         <div class="pillars">
           <div class="pillar">
             <span class="ic"><i class="fa-solid fa-plug" aria-hidden="true"></i></span>
@@ -427,6 +450,7 @@ mount Wurk::Engine =&gt; <span class="add">"/wurk"</span></pre>
           walks through parallelism, clustered Puma, and the gem mappings (cron, unique-jobs).</p>
       </section>
     </div>
+    <p id="copy-status" class="sr-only" role="status" aria-live="polite"></p>
   </main>
 
   <footer>
@@ -468,13 +492,25 @@ mount Wurk::Engine =&gt; <span class="add">"/wurk"</span></pre>
         btn.addEventListener('click', function () {
           var text = btn.getAttribute('data-copy') || '';
           var original = btn.innerHTML;
-          var flash = function (markup, cls) {
+          // The button carries aria-label="Copy to clipboard", which OVERRIDES its
+          // descendant text when the accessible name is computed — so swapping
+          // innerHTML to "Copied" is invisible to a screen reader no matter what it
+          // says. The outcome has to go somewhere that is announced, and it goes
+          // there once, here, rather than in each caller.
+          var say = function (label) {
+            var live = document.getElementById('copy-status');
+            if (!live) return;
+            live.textContent = '';
+            live.textContent = label;
+          };
+          var flash = function (icon, label, cls) {
             if (cls) btn.classList.add(cls);
-            btn.innerHTML = markup;
+            btn.innerHTML = icon + ' ' + label;
+            say(label);
             setTimeout(function () { if (cls) btn.classList.remove(cls); btn.innerHTML = original; }, 1600);
           };
-          var done = function () { flash('<i class="fa-solid fa-check" aria-hidden="true"></i> Copied', 'copied'); };
-          var fail = function () { flash('<i class="fa-solid fa-xmark" aria-hidden="true"></i> Copy failed'); };
+          var done = function () { flash('<i class="fa-solid fa-check" aria-hidden="true"></i>', 'Copied', 'copied'); };
+          var fail = function () { flash('<i class="fa-solid fa-xmark" aria-hidden="true"></i>', 'Copy failed'); };
           if (navigator.clipboard && navigator.clipboard.writeText) {
             navigator.clipboard.writeText(text).then(done, fail);
           } else {


### PR DESCRIPTION
## What

An accessibility pass on `docs/site/index.html`, found by pointing the `/ui-sweep` driver and an axe run at the published site — the same sweep that ran over the sibling developerz.ai marketing site this week. One file, 43 insertions.

Every item below was **measured**, not inferred.

## The one axe violation

`link-in-text-block`, serious. The "migration guide" link (`:426`) sits inside a `--muted` paragraph (`:423`) while keeping the default link colour:

| | |
|---|---|
| link | `#e6edf3` |
| surrounding text | `#8b949e` |
| ratio | **2.60:1** (WCAG 1.4.1 needs 3:1) |
| non-colour cue | none — `a { text-decoration: none }` at `:40`, underline only on `:hover` at `:41` |

`:hover` never fires for keyboard or touch users, so for them the only outbound link in the Migrate section is indistinguishable from the sentence around it.

**Fixed with an underline, not a recolour** — deliberately. Raising the link to `--accent` `#ffffff` reaches only **3.08:1**, clearing the rule by 0.08 while leaving colour as the sole resting cue. The selector is exclusion-based (`main a:not(.btn):not(.navlink)`) so a future prose link in an `<li>` or `<td>` inherits the cue instead of silently regressing; the `.btn` that lives inside a `<p>` at `:378` opts out.

## Also fixed

| Issue | Evidence | Fix |
|---|---|---|
| **Sticky header covers jump targets** | header is **73px**; `#features` and `#install` land their `<h2>` at **y=31**, behind it. `scroll-padding-top` was unset. Also hides an element the browser scrolls to on a backward Tab (2.4.11). | `scroll-padding-top: 88px` — fixes fragment nav and focus-into-view in one line |
| **Copy buttons cannot report their outcome** | `aria-label="Copy to clipboard"` overrides descendant text when the accessible name is computed, so swapping `innerHTML` to "Copied" is unannounceable (4.1.3). No live region existed. | one `role="status"` region, set inside the shared `flash()` rather than in each caller |
| **Heading skip h1 → h3** | the pillars band has no heading, so its three `<h3>` cards hang off the page title | visually-hidden `<h2>`; nothing moves on screen |
| **Logo reserves no space** | no intrinsic `width`/`height`, so it contributes CLS before decode | `400x500`; CSS still sizes it to 48px tall |

## The skip link is not a conformance fix

It's in this PR, but calling it a WCAG 2.4.1 fix would be wrong and I want that on the record. SC 2.4.1 covers blocks *"repeated on multiple Web pages"* — this is one page, and the `api/` subsite is YARD-generated with entirely different chrome that already ships its own `<div id="main" tabindex="-1">`. axe's `bypass` rule correctly never fired, because `<main>` + `<h1>` satisfy it.

It's 3-6 tab stops of ergonomics behind a sticky header. Kept because it's eight lines. Drop it if you'd rather keep the diff to conformance only.

## Worth knowing: contrast on this site is ungated

axe reports **39 `color-contrast` incompletes**, every one *"Could not parse color string `oklch(...)`"*. Contrast here isn't under-measured, it's **not measured at all**.

I checked what was hiding behind that by computing the ratios independently — rasterising every colour through a canvas so Chrome resolves `oklch` to sRGB, then compositing semi-transparent backgrounds up the ancestor chain: **0 real failures out of 89 text nodes desktop / 86 mobile.** So nothing is wrong today and this PR changes no colours. But the gate is blind, and it'd stay blind if a future palette edit did break something.

## Verification

- **axe WCAG 2.0/2.1 A+AA: 1 violation → 0** (published site vs this branch, same config)
- measured before → after: heading skips `1->3` → **none**; images without dimensions `1` → **0**; contrast failures `0` → `0`; no sideways scroll at 390px either way
- copy announcement confirmed on **both** branches: a trusted click announces `Copied`; a rejected write announces `Copy failed` (the branch that matters — a silent failure means pasting stale content)
- anchor landings after the fix: `#features` / `#install` / `#migrate` all clear the header (y=119, y=119, y=300)

No Ruby touched, so `bin/rake test`, the parity suite and rubocop are unaffected — the only changed file is `docs/site/index.html`.

## Considered and not done

- **Underlining the footer links.** They share their colour with the surrounding `·` separators, which looks like the same defect — but the entire line is links, so nothing is ambiguous, and axe agrees (it doesn't flag them). Underlining would be a visual redesign, not a fix.
- **Custom `:focus-visible` styles.** The file has zero focus rules, but it also never sets `outline: none`, so the UA ring draws on every control and 2.4.7 is met. A real nit against the blurred sticky header, not a defect.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788325252&installation_model_id=11168&pr_number=360&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F360&signature=63bab771a6a388c375ee5d55bf979e9fa082733ac6f64d404887128f355149ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added a keyboard-accessible skip link and improved screen-reader support.
  * Added announcements for successful or failed copy actions.
  * Improved navigation to page sections and link visibility.

* **Usability**
  * Added clearer copy-button feedback.
  * Added descriptive image dimensions and page landmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->