### PR TITLE
docs: stop claiming "Faster" and publish the numbers that say otherwise

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Wurk
 
-100% API-compatible drop-in replacement for Sidekiq + Sidekiq Pro + Sidekiq Enterprise. Free. Faster via fork-based real parallelism. Mountable Rails engine.
+100% API-compatible drop-in replacement for Sidekiq + Sidekiq Pro + Sidekiq Enterprise. Free. Fork-based swarm for multi-core parallelism. Mountable Rails engine.
 
 Three pillars, all must stay true:
 
 1. **100% drop-in.** Same Redis key schema, same job JSON, same Ruby DSL. Existing Sidekiq jobs and Redis data keep working on a one-line gem swap. Third-party gems (sidekiq-cron, sidekiq-unique-jobs, sidekiq-scheduler, sidekiq-status, sidekiq-failures, sidekiq-throttled, etc.) pass their own test suites against Wurk.
 2. **Free.** Pro + Ent feature parity in the same gem. No tiers, no flags gating Ent behavior, no license checks.
-3. **Faster.** Every release benchmarked vs stock Sidekiq. >5% regression on enqueue / fetch+execute / bulk enqueue / swarm boot / memory blocks merge.
+3. **Measured.** Two suites, different jobs. `rake bench` is the REGRESSION gate (wurk vs its own past self; >5% on enqueue / fetch+execute / bulk enqueue / swarm boot / memory blocks merge). `rake bench:vs_sidekiq` is the COMPARISON vs stock Sidekiq. A green gate says nothing about Sidekiq. Wurk is currently SLOWER than stock Sidekiq (~0.45x-0.86x, see `docs/benchmarks.md`) — do not add a "faster" claim to the README, site, or llms.txt until that doc's numbers support it.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center"><strong>Wurk, wurk.</strong> 🪓 <em>Ready to work. Zug zug.</em></p>
 
-<p align="center"><strong>A 100% drop-in replacement for Sidekiq + Sidekiq Pro + Sidekiq Enterprise. Free forever. Faster.</strong></p>
+<p align="center"><strong>A 100% drop-in replacement for Sidekiq + Sidekiq Pro + Sidekiq Enterprise. Free forever.</strong></p>
 
 <div align="center">
 
@@ -20,6 +20,8 @@
 </div>
 
 Wurk is wire-compatible with Sidekiq — same Redis keys, same job JSON, same Ruby DSL. Swap one line in your `Gemfile` and your existing jobs, batches, limiters, cron entries, and live Redis data keep working untouched. The Pro and Enterprise feature sets ship in the same free gem, with no license check and no tiers.
+
+**On speed:** Wurk is not currently faster than stock Sidekiq — it runs at roughly 0.45×–0.86× depending on workload shape, because reliable fetch and per-job metrics cost extra Redis round-trips. Numbers, method, and the reproduction command are in [docs/benchmarks.md](docs/benchmarks.md); run them yourself with `rake bench:vs_sidekiq`.
 
 ## Install
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,99 @@
+# Benchmarks
+
+Wurk is **not** currently faster than stock Sidekiq. Measured, published, and tracked here rather than claimed.
+
+Two different benchmark suites live in `bench/`. They answer different questions and only one of them compares against Sidekiq.
+
+| Suite | Question | Command | Gates merges |
+|---|---|---|---|
+| `bench/*.rb` | Did *this PR* slow wurk down vs `main`? | `rake bench` | Yes — >5% regression blocks |
+| `bench/vs_sidekiq.rb` | Is wurk faster than *stock Sidekiq*? | `rake bench:vs_sidekiq` | No |
+
+The regression gate can be fully green while wurk is slower than Sidekiq. It measures wurk against its own past self. Do not read `rake bench` as a competitive result.
+
+## Throughput vs stock Sidekiq
+
+wurk 1.4.0 · sidekiq 8.1.6 · ruby 3.4.9 (x86_64-linux) · 6 cores · local Redis · median of 3 runs × 4000 jobs.
+
+Ratios below 1.00 mean wurk is slower.
+
+**1 process × 5 threads**
+
+| Workload | Sidekiq | Wurk | Ratio |
+|---|---|---|---|
+| noop | 1579 jobs/s | 714 jobs/s | 0.45× |
+| cpu | 171 jobs/s | 138 jobs/s | 0.81× |
+| io | 731 jobs/s | 538 jobs/s | 0.74× |
+
+**4 processes × 5 threads** — `wurkswarm` (4 forks) vs 4 independent `sidekiq` processes
+
+| Workload | Sidekiq | Wurk | Ratio |
+|---|---|---|---|
+| noop | 4240 jobs/s | 2061 jobs/s | 0.49× |
+| cpu | 494 jobs/s | 424 jobs/s | 0.86× |
+| io | 2709 jobs/s | 1791 jobs/s | 0.66× |
+
+Boot to first job: sidekiq ~0.67s, wurk ~0.97s.
+
+Forking does not close the gap. A stock Sidekiq user reaches multi-core by running N processes — that is the second table. The swarm's advantage is copy-on-write memory and a single supervisor, not throughput.
+
+## Workload shapes
+
+"Faster" is meaningless without naming the work. Three shapes, all in `bench/vs_sidekiq/job.rb`:
+
+| Shape | Body | Measures |
+|---|---|---|
+| `noop` | empty `perform` | pure framework overhead — fetch, middleware, dispatch, ack |
+| `cpu` | fixed arithmetic loop | holds the GVL; the shape fork-based parallelism exists for |
+| `io` | `sleep` | releases the GVL; threads and forks both scale — the honest control |
+
+`cpu` is the noisiest shape (±24–33% run to run). Single runs of it mean nothing; one isolated run read 1.17× before the median settled at 0.81×.
+
+## Why wurk is slower
+
+Redis round-trips per job, counted with `INFO commandstats` over 500 jobs:
+
+| Engine | Per job | Breakdown |
+|---|---|---|
+| Sidekiq | ~1 | 1 BRPOP. Stat counters buffered in memory, flushed on a timer. |
+| Wurk | ~12 | 2 reliable fetch (LMOVE + LREM) · 9 metrics (6 HINCRBY + 3 EXPIRE) · 1 SMEMBERS |
+
+Two costs, opposite verdicts:
+
+- **Reliable fetch** — 2 round-trips vs BRPOP's 1. This is [`Wurk::Fetcher::Reliable`](reliability.md), the default. Sidekiq's equivalent (`super_fetch`) is a paid Pro feature; stock Sidekiq's BRPOP loses in-flight jobs when a worker is killed. The extra round-trip buys a guarantee, and is not a defect.
+- **Unbatched metrics** — 9 of the 12. `Wurk::Metrics::History` writes 3 HINCRBY + EXPIRE per job, twice over. Sidekiq buffers identical counters in memory and flushes on an interval. This is the actual gap.
+
+## Running it
+
+```bash
+bin/rake bench:vs_sidekiq                            # 1 proc × 5 threads
+WURK_BENCH_VS_PROCESSES=4 bin/rake bench:vs_sidekiq  # swarm vs 4 sidekiq procs
+```
+
+Needs a local Redis. First run installs `bench/vs_sidekiq/Gemfile` (stock Sidekiq, isolated bundle).
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `WURK_BENCH_VS_JOBS` | `5000` | jobs enqueued per run |
+| `WURK_BENCH_VS_CONCURRENCY` | `5` | threads per worker process |
+| `WURK_BENCH_VS_PROCESSES` | `1` | worker processes per side |
+| `WURK_BENCH_VS_RUNS` | `3` | runs per (shape, engine); median reported |
+| `WURK_BENCH_VS_SHAPES` | `noop,cpu,io` | subset of shapes to run |
+| `WURK_BENCH_VS_CPU_ITERS` | `20000` | arithmetic iterations in the `cpu` shape |
+| `WURK_BENCH_VS_IO_SECONDS` | `0.005` | sleep duration in the `io` shape |
+| `WURK_BENCH_VS_VERBOSE` | unset | stream worker output instead of logging to `tmp/` |
+| `WURK_BENCH_DB` | `12` | Redis logical DB (never 0 — the bench FLUSHDBs) |
+
+## Fairness
+
+The comparison is only worth reading if the control is real. What the harness guarantees:
+
+- **Stock Sidekiq is actually stock.** Wurk ships `lib/sidekiq.rb` (the drop-in require shim) and Bundler puts every bundled gem's `lib/` on `$LOAD_PATH` — so inside the repo bundle, `bundle exec sidekiq` boots **wurk**. The Sidekiq side therefore runs from `bench/vs_sidekiq/Gemfile` with `RUBYOPT` and `RUBYLIB` cleared. The two distinct versions printed in the header are the proof; identical versions mean the run is void.
+- **Identical job code.** `include Sidekiq::Job` resolves to wurk's compat module on one side and the real gem on the other. Same file, both sides.
+- **Identical payloads.** Jobs are hand-built into the shared Redis key schema and pushed by the driver, so neither side's client library is on the clock.
+- **Boot excluded from the rate.** Throughput is measured over drain (first completion → last). Boot is reported separately, never folded into the rate.
+- **Alternating runs.** Sides alternate tightly so thermal drift and background load hit both engines evenly.
+
+## Status
+
+The claim "faster than Sidekiq" has been removed from the README and the site until the numbers support it. Closing the gap means batching the `Metrics::History` writes — the trade is dashboard counters lagging by the flush interval, and a hard crash dropping the unflushed window, which is the trade Sidekiq already makes.

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Wurk — a free, faster, 100% drop-in replacement for Sidekiq + Pro + Enterprise</title>
-  <meta name="description" content="Wurk is a 100% API-compatible drop-in replacement for Sidekiq, Sidekiq Pro, and Sidekiq Enterprise. Same Redis schema, same job JSON, same Ruby DSL. Pro + Enterprise features in one free gem. Faster via fork-based real parallelism.">
+  <title>Wurk — a free, 100% drop-in replacement for Sidekiq + Pro + Enterprise</title>
+  <meta name="description" content="Wurk is a 100% API-compatible drop-in replacement for Sidekiq, Sidekiq Pro, and Sidekiq Enterprise. Same Redis schema, same job JSON, same Ruby DSL. Pro + Enterprise features in one free gem, including a fork-based swarm for multi-core parallelism.">
   <link rel="canonical" href="https://developerz-ai.github.io/wurk/">
   <meta property="og:type" content="website">
-  <meta property="og:title" content="Wurk — free, faster, drop-in Sidekiq replacement">
-  <meta property="og:description" content="Swap one Gemfile line. Same Redis schema and DSL. Pro + Enterprise feature parity in one free gem. Fork-based real parallelism.">
+  <meta property="og:title" content="Wurk — free, drop-in Sidekiq Pro + Enterprise replacement">
+  <meta property="og:description" content="Swap one Gemfile line. Same Redis schema and DSL. Pro + Enterprise feature parity in one free gem. Reliable fetch and a fork-based swarm included.">
   <meta property="og:url" content="https://developerz-ai.github.io/wurk/">
   <meta property="og:image" content="https://developerz-ai.github.io/wurk/wurk-logo.png">
   <meta name="twitter:card" content="summary">
@@ -299,7 +299,7 @@
         <p class="strapline">Wurk, wurk. 🪓 Ready to work. Zug zug.</p>
         <p class="lede">
           A 100% drop-in replacement for Sidekiq + Sidekiq Pro + Sidekiq Enterprise.
-          Free forever. Faster.
+          Free forever.
         </p>
         <div class="cta">
           <a class="btn primary" href="https://wurk.demo.developerz.ai/wurk"><i class="fa-solid fa-gauge-high" aria-hidden="true"></i> View the live demo</a>
@@ -332,8 +332,9 @@ gem <span class="add">"wurk"</span></pre>
           </div>
           <div class="pillar">
             <span class="ic"><i class="fa-solid fa-bolt" aria-hidden="true"></i></span>
-            <h3>Faster</h3>
-            <p>Fork-based real parallelism. Every release benchmarked vs Sidekiq.</p>
+            <h3>Parallel</h3>
+            <p>Enterprise's forking swarm, in the free gem. Every release benchmarked against stock
+              Sidekiq &mdash; <a href="https://github.com/developerz-ai/wurk/blob/main/docs/benchmarks.md">published numbers</a>, not claims.</p>
           </div>
         </div>
       </section>

--- a/docs/site/llms.txt
+++ b/docs/site/llms.txt
@@ -1,6 +1,6 @@
 # Wurk
 
-> Wurk is a 100% API-compatible, free, faster drop-in replacement for Sidekiq, Sidekiq Pro, and Sidekiq Enterprise. It uses the same Redis key schema, the same job JSON, and the same Ruby DSL, so an existing Sidekiq app migrates with a one-line Gemfile change. Pro and Enterprise features (batches, rate limiters, unique jobs, periodic/cron, encryption) ship in the same gem with no license check. It is faster than Sidekiq via a fork-based swarm that gives real multi-core parallelism. Requires Ruby >= 3.2 and Redis >= 7.0; on JRuby/TruffleRuby/Windows it falls back to threads-only mode, behaviorally equivalent to stock Sidekiq.
+> Wurk is a 100% API-compatible, free drop-in replacement for Sidekiq, Sidekiq Pro, and Sidekiq Enterprise. It uses the same Redis key schema, the same job JSON, and the same Ruby DSL, so an existing Sidekiq app migrates with a one-line Gemfile change. Pro and Enterprise features (batches, rate limiters, unique jobs, periodic/cron, encryption) ship in the same gem with no license check. It runs a fork-based swarm for multi-core parallelism (Enterprise's sidekiqswarm, free) and uses reliable fetch (Pro's super_fetch equivalent) by default. It is NOT currently faster than stock Sidekiq — measured at roughly 0.45x-0.86x depending on workload shape, because reliable fetch and per-job metrics cost extra Redis round-trips; see the benchmarks doc. Requires Ruby >= 3.2 and Redis >= 7.0; on JRuby/TruffleRuby/Windows it falls back to threads-only mode, behaviorally equivalent to stock Sidekiq.
 
 > Prefer everything in one fetch? See [llms-full.txt](https://developerz-ai.github.io/wurk/llms-full.txt) — this map plus the full text of every guide below, inlined.
 
@@ -8,7 +8,7 @@
 
 - **Drop-in.** Same Redis key schema, job JSON, and Ruby DSL. Every public `Wurk::*` class is also exposed under its `Sidekiq::*` name (`Sidekiq::Job`, `Sidekiq::Worker`, `Sidekiq::Batch`, `Sidekiq::Limiter`, `Sidekiq.configure_server`, `Sidekiq::Client`, `Sidekiq::Pro::Web`, `Sidekiq::Enterprise`). Existing jobs, initializers, `sidekiq_options`, and live Redis data keep working. `Sidekiq.pro?` / `Sidekiq.ent?` return `false` (Wurk advertises as free OSS) — never gate behavior on them.
 - **Free.** Pro + Enterprise feature parity in one gem. No tiers, no flags, no license check.
-- **Faster.** Every release is benchmarked against stock Sidekiq on enqueue, fetch+execute, bulk enqueue, swarm boot, and memory.
+- **Parallel.** A fork-based swarm gives real multi-core parallelism from one supervisor, and reliable fetch is the default. Every release is benchmarked against stock Sidekiq (`rake bench:vs_sidekiq`) and the results are published, including when they are unfavourable — wurk is currently slower than stock Sidekiq.
 
 ## Concurrency vs parallelism (the #1 migration gotcha)
 
@@ -37,6 +37,7 @@ Job failures do NOT reach `config.error_handlers`. `Wurk::JobRetry#local` rescue
 
 ## Docs
 
+- [Benchmarks](https://github.com/developerz-ai/wurk/blob/main/docs/benchmarks.md): measured throughput vs stock Sidekiq by workload shape, why wurk is currently slower (Redis round-trips per job), the fairness guarantees of the harness, and how to reproduce.
 - [Migration guide (Sidekiq → Wurk)](https://github.com/developerz-ai/wurk/blob/main/docs/migrate-from-sidekiq.md): the comprehensive cutover — parallelism, clustered Puma, dedicated worker, gem mappings, known incompatibilities, cutover checklist.
 - [Generated API reference (YARD)](https://developerz-ai.github.io/wurk/api/): params, return types, and examples for the public classes (`Wurk::Worker`, `Wurk::Client`, `Wurk::Configuration`, `Wurk::Batch`, `Wurk::Limiter`, `Wurk::Unique`, the `Sidekiq::*` aliases).
 - [README](https://github.com/developerz-ai/wurk/blob/main/README.md): overview, install, dashboard.

--- a/tasks/llms_full.rb
+++ b/tasks/llms_full.rb
@@ -40,6 +40,7 @@ module WurkDocs
       docs/dashboard.md
       docs/authentication.md
       docs/metrics-history.md
+      docs/benchmarks.md
     ].freeze
 
     def self.build(root)


### PR DESCRIPTION
Follow-up to #365, which added the first benchmark that measures wurk against **stock Sidekiq** instead of against its own past self. It says wurk is slower — **0.45×–0.86×** depending on workload shape, at every process count tested.

#365 deliberately left the copy alone; measuring and deciding are separate jobs. This is the decision.

## The claim had more surfaces than the README

| File | What claimed it |
|---|---|
| `README.md` | tagline |
| `docs/site/index.html` | `<title>`, meta description, `og:title`, `og:description`, hero lede, "Faster" pillar |
| `docs/site/llms.txt` | summary + pillar — the AI-agent entrypoint, and the most explicit: *"It is faster than Sidekiq"* |
| `CLAUDE.md` | project description + pillar 3 |

The `og:description` matters disproportionately — it's what gets scraped into HN and Reddit link previews, so it would have carried the claim further than the page itself.

## What replaces it

The third pillar becomes **Parallel**, which is the same underlying tech stated truthfully:

> Enterprise's forking swarm, in the free gem. Every release benchmarked against stock Sidekiq — published numbers, not claims.

A forking swarm *is* Enterprise's `sidekiqswarm` shipped free. Reliable fetch *is* Pro's `super_fetch` shipped free. Both are real, both are defensible, and neither makes wurk faster than Sidekiq.

## New: `docs/benchmarks.md`

Carries the actual numbers (both process configurations), the per-job Redis round-trip breakdown that explains them, every env knob, and the fairness guarantees of the harness — including why the Sidekiq side needs its own Gemfile.

It also separates the two suites explicitly, because conflating them is what let this drift:

| Suite | Question | Gates merges |
|---|---|---|
| `rake bench` | Did this PR slow wurk down vs `main`? | Yes |
| `rake bench:vs_sidekiq` | Is wurk faster than stock Sidekiq? | No |

**A green regression gate says nothing about Sidekiq.** That distinction is now written down where someone will read it.

## Guarding against regrowth

`CLAUDE.md` pillar 3 goes from *"Faster"* to *"Measured"*, states the current standing, and instructs against re-adding a speed claim until `docs/benchmarks.md` supports it. Without that, the next contributor or agent rewriting the README puts it straight back.

Also registers `docs/benchmarks.md` in `tasks/llms_full.rb` so it's inlined into `llms-full.txt`, not just linked.

## Not in scope

The metrics hot path. Batching `Wurk::Metrics::History` would remove 9 of the 12 per-job Redis round-trips and may make a speed claim defensible again — but it's a code change with real trade-offs (counter lag, unflushed window on hard crash) and belongs in its own PR.

## Checks

`rake test:unit` — 2770 runs, 5765 assertions, 0 failures, 0 errors. No stale "faster" claim remains on any public surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788573379&installation_model_id=11168&pr_number=366&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F366&signature=d952b4a5f95060e9fd1da65030b210afd24268597a6ae02906f8bd839e99030b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project messaging to remove unsupported “faster than Sidekiq” claims.
  * Added benchmark documentation covering performance results, workloads, costs, and reproduction instructions.
  * Published measured throughput comparisons, including current performance limitations.
  * Updated landing-page and generated documentation links to include the new benchmark details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->