### PR TITLE
fix(site): make every code block keyboard-scrollable (closes #362)

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -66,6 +66,16 @@
       background: var(--code); border: 1px solid var(--line-strong); border-radius: var(--radius);
       padding: 16px 18px; overflow-x: auto; font-size: 14px; line-height: 1.6; margin: 0;
     }
+    /* Every <pre> is a scroll container (overflow-x above), and a scroll container
+       that cannot be focused cannot be scrolled by keyboard — so anything past the
+       right edge is unreachable without a pointer. Only the migration diff overflows
+       today, and only under ~430px, but the tabindex="0" is on every snippet so the
+       next long line does not silently reintroduce it (axe scrollable-region-focusable,
+       WCAG 2.1.1 Level A). Making them focusable then REQUIRES a visible focus ring,
+       or we would trade 2.1.1 for a 2.4.7 failure. */
+    pre:focus-visible {
+      outline: 2px solid var(--accent); outline-offset: 2px;
+    }
     .add { color: var(--success); } .del { color: var(--danger); } .cmt { color: var(--muted); }
 
     /* ── Copy-able code block ── */
@@ -311,7 +321,7 @@
             <button class="copy-btn" type="button" data-copy='gem "wurk"' aria-label="Copy to clipboard">
               <i class="fa-regular fa-copy" aria-hidden="true"></i> Copy
             </button>
-<pre><span class="cmt"># Gemfile</span>
+<pre tabindex="0"><span class="cmt"># Gemfile</span>
 gem <span class="add">"wurk"</span></pre>
           </div>
         </div>
@@ -415,7 +425,7 @@ gem <span class="add">"wurk"</span></pre>
               <button class="copy-btn" type="button" data-copy='gem "wurk"' aria-label="Copy to clipboard">
                 <i class="fa-regular fa-copy" aria-hidden="true"></i> Copy
               </button>
-<pre><span class="cmt"># Gemfile</span>
+<pre tabindex="0"><span class="cmt"># Gemfile</span>
 gem <span class="add">"wurk"</span>
 
 <span class="cmt"># then</span>
@@ -428,7 +438,7 @@ bundle install</pre>
               <button class="copy-btn" type="button" data-copy='mount Wurk::Engine =&gt; "/wurk"' aria-label="Copy to clipboard">
                 <i class="fa-regular fa-copy" aria-hidden="true"></i> Copy
               </button>
-<pre><span class="cmt"># config/routes.rb</span>
+<pre tabindex="0"><span class="cmt"># config/routes.rb</span>
 mount Wurk::Engine =&gt; <span class="add">"/wurk"</span></pre>
             </div>
           </div>
@@ -442,7 +452,7 @@ mount Wurk::Engine =&gt; <span class="add">"/wurk"</span></pre>
           against the same Redis during cutover. Delete the paid gems, add one line:
         </p>
         <div class="codeblock">
-<pre><span class="del">- gem "sidekiq"</span>
+<pre tabindex="0"><span class="del">- gem "sidekiq"</span>
 <span class="del">- gem "sidekiq-pro", source: "https://gems.contribsys.com/"</span>
 <span class="del">- gem "sidekiq-ent", source: "https://enterprise.contribsys.com/"</span>
 <span class="add">+ gem "wurk"</span></pre>


### PR DESCRIPTION
Closes #362.

`pre { overflow-x: auto }` turns every snippet into a scroll container. A scroll container that isn't in the tab order can't be scrolled by keyboard, so anything past the right edge is unreachable without a pointer. At 390px the migration diff overflows **236px**, hiding the three `- gem "sidekiq*"` lines that are the payload of the migration guide.

## The fix

`tabindex="0"` on **all four** snippets, not just the offending one. Only the migration diff overflows today, but the cause is the shared `pre` rule — pinning the fix to one element would let the next long line reintroduce it silently. The issue called this out and it's right.

Making them focusable then *requires* a visible focus indicator, or 2.1.1 is traded for a 2.4.7 (Focus Visible) failure. The site had no `:focus-visible` rule at all beyond `.skip-link`, so one was added.

## Verification

axe-core 4.12.1, Chromium, 390px, transitions disabled — per the issue's note that sampling mid-`.reveal` produces phantom contrast violations:

| | scrollable-region-focusable | full page sweep |
|---|---|---|
| before | **1 serious** — `#migrate > .codeblock > pre` | 1 violation |
| after | **0** | **0 violations** |

And driven by keyboard, not just linted: focus the block, arrow across, `scrollLeft` reaches **236/236px**, and the previously hidden lines are revealed.

```
focus ring: solid 2px rgb(255, 255, 255)
arrow-key scroll reached 236/236px  FULL REVEAL ✓
content now reachable: - gem "sidekiq" | - gem "sidekiq-pro", source: ... | - gem "sidekiq-ent", source: ...
```

## One correction to the issue

#362 states the block "cannot be focused" without `tabindex`. **That doesn't reproduce on current Chrome.** Since Chrome 127, scrollable regions with no focusable children are added to the tab order automatically — on Chromium 149, Tab already reached the block before this change (12 presses).

The fix still matters, for three reasons:

1. That mitigation is **Chrome-only** — Firefox and Safari don't do it.
2. axe and WCAG judge the markup, not one engine's behaviour — the violation is real and reported regardless.
3. Chrome's implicit focus draws a **1px** default outline; this now draws an explicit **2px** ring.

Net: the markup no longer depends on a browser quirk to be accessible. Recording it here so the next person measuring in Chrome isn't confused when the "before" state appears to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788573746&installation_model_id=11168&pr_number=367&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F367&signature=34ba89fa5a430882d5d01be875668ec09741cc91d31cdaf5ad8cee3e69ffd3f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->