### PR TITLE
chore(policy): declare the release strategy wurk actually runs (closes #328)

### DIFF
--- a/.maintainer.yml
+++ b/.maintainer.yml
@@ -13,8 +13,9 @@
 # for reviewer bots (coderabbit/copilot) to settle before acting. The native
 # review: block below activates the developerz review lane alongside CodeRabbit
 # (force: true, advisory — never requests changes, never approves). Everything
-# not set here uses the schema defaults (release: release-please, so merged
-# waves cut a batched release).
+# not set here uses the schema defaults. release: is now declared explicitly
+# (see the release: block) rather than inherited, because the inherited default
+# described a lane this repo does not run.
 version: 1
 
 tone:
@@ -83,6 +84,29 @@ review:
     dedupe: true
   path_filters: []
   path_instructions: []
+
+release:
+  # DECLARED, not inherited (wurk#328). The schema default is
+  # manager: release-please, which implies batched release PRs driven by
+  # release-please-config.json + .release-please-manifest.json. Neither file
+  # exists here and no release PR has ever been opened, so the inherited
+  # default described a lane this repo does not run.
+  #
+  # What actually cuts a release:
+  #   1. an operator tags vX.Y.Z
+  #   2. .github/workflows/release.yml fires on push: tags: ["v*"], cuts the
+  #      GitHub Release and publishes to RubyGems via OIDC trusted publishing
+  #   3. the maintainer agent writes the categorized notes at tag time
+  #      (see v1.2.1, published by developerz-ai[bot])
+  #
+  # `none` is the only value in the enum (release-please | none) that describes
+  # that, and it means "no release MANAGER" — it does not govern the agent's
+  # note generation, which the schema does not model at all.
+  manager: none
+  # Left at the default. The registry channels (incl. rubygems) are reserved and
+  # REJECTED at validation time, so publishing to RubyGems is declared by
+  # release.yml's OIDC step, not here.
+  channels: [github-release]
 
 escalate:
   always: [security, license, cla]


### PR DESCRIPTION
Closes #328.

`.maintainer.yml` inherited the schema default `release.manager: release-please`, which implies batched release PRs driven by `release-please-config.json` + `.release-please-manifest.json`. Neither file exists, and no release PR has ever been opened — the declared strategy described a lane this repo doesn't run.

## What actually cuts a release

1. An operator tags `vX.Y.Z`
2. `.github/workflows/release.yml` fires on `push: tags: ["v*"]`, cuts the GitHub Release, publishes to RubyGems via OIDC trusted publishing
3. The maintainer agent writes the categorized notes at tag time ([v1.2.1](https://github.com/developerz-ai/wurk/releases/tag/v1.2.1), published by `developerz-ai[bot]`)

`manager: none` is the only value in the enum (`release-please | none`) that describes that.

## Does `none` turn off the notes that work today?

No — and this was the thing worth checking before touching it. `manager` selects a release *manager*; it doesn't govern the agent's note generation, which the schema doesn't model at all. The only `notes` keys in the entire schema are `kb.repo_notes` and `kb.pages[].notes`, neither under `release:`. So the lane that works today isn't what this declaration switches off.

`channels` stays at the default `[github-release]`. The registry channels — `rubygems` included — are reserved and **rejected at validation time**, so RubyGems publishing is declared by `release.yml`'s OIDC step and can't be declared here.

## Validity is load-bearing here

This file was schema-invalid until #347, and an invalid file is discarded **whole** — the platform silently falls back to `defaultPolicy`. That's how the auto-merge posture drifted in the first place. So both revisions were validated against the live schema (`developerz.ai/schemas/maintainer.v1.json`, Draft 2020-12):

| revision | valid | `release` |
|---|---|---|
| `main` (before) | ✅ | *inherited default: release-please* |
| this branch (after) | ✅ | `{manager: none, channels: [github-release]}` |

The file still activates rather than being discarded, and `release` is the only key that changed.

## Note for the operator

This resolves the drift in the direction the issue listed first — *"set `release:` to what is really happening"*. The other option, adding release-please config to match the default, is a real change to how releases work rather than a documentation fix, so it isn't taken here. If you'd rather move wurk onto release-please, this is a one-line revert plus that config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788573871&installation_model_id=11168&pr_number=368&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F368&signature=1afd01127ab8324ef6b87dc246537bad910fb7e8aa40cf1334e448bdc392ba94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how unspecified configuration settings are handled by default.
  * Documented the release configuration and publishing channels for greater transparency.
  * No changes to the product’s functionality or end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->