### PR TITLE
ci: bench regression gate + measurement fixes

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,12 @@
+# Blacksmith runners (CLAUDE.md "CI standard"). actionlint only knows the
+# GitHub-hosted label set, so every `runs-on: blacksmith-*` in .github/workflows
+# is otherwise reported as an unknown label. Declaring them here is the
+# documented escape hatch, not a suppression: a typo'd Blacksmith label is still
+# an error because it is not in this list.
+#
+# Keep in sync with the labels actually used by .github/workflows/*.yml.
+self-hosted-runner:
+  labels:
+    - blacksmith-2vcpu-ubuntu-2404
+    - blacksmith-4vcpu-ubuntu-2404
+    - blacksmith-8vcpu-ubuntu-2404

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,160 @@
+name: bench
+
+# The `rake bench` regression gate (CLAUDE.md pillar 3): did THIS PR slow wurk
+# down versus its own base? It says nothing about stock Sidekiq — that is
+# `rake bench:vs_sidekiq`, which takes minutes per shape and never gates.
+#
+# Deleted in #296 for cost, restored here in a cheaper shape. The old workflow
+# ran the suite 7x across TWO 8vcpu jobs and duplicated the whole thing on every
+# push to main. This is one PR-only job that runs it 6x (best-of-3 per side) and
+# only when a bench input actually moved. A full `rake bench` is ~1 min, so
+# best-of-3 costs minutes rather than the 45 the old timeout implied — and
+# best-of-N is exactly what keeps the noisiest benches from false-positiving the
+# gate (#250): `wurk swarm boot` reports +/-24% run to run.
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # `rake bench` measures Ruby throughput only, so only Ruby/bench inputs can
+  # move it. Gate the 8vcpu job on those paths so docs-, frontend- and test-only
+  # PRs never spin a bench runner. A JOB-level `if` is correct here, unlike the
+  # step-level gate test.yml uses: bench is deliberately not a required check, so
+  # a skipped job leaves no pending status parked on the PR.
+  #
+  # Gemfile.lock is deliberately absent from the filter — it is gitignored
+  # (.gitignore:5) and can never appear in a diff; `Gemfile` and the gemspec are
+  # what actually move dependencies.
+  detect:
+    name: detect changed paths
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 5
+    outputs:
+      bench: ${{ steps.filter.outputs.bench }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          filters: |
+            bench:
+              - 'lib/**'
+              - 'exe/**'
+              - 'bench/**'
+              - 'bin/bench-compare'
+              - 'Rakefile'
+              - 'Gemfile'
+              - '*.gemspec'
+              - '.github/workflows/bench.yml'
+
+  compare:
+    name: bench vs base
+    needs: detect
+    if: needs.detect.outputs.bench == 'true'
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write # sticky delta comment
+    services:
+      redis:
+        image: redis:7.4
+        ports: ["6379:6379"]
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile
+      # Pinned so a floating Rails resolve can't perturb the numbers, and so this
+      # job reuses the gem cache test.yml's 8.0 legs already populated.
+      RAILS_VERSION: "8.0"
+      REDIS_URL: redis://localhost:6379/0
+      BENCH_RUNS: 3
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # the base run checks out base.sha, which shallow lacks
+          persist-credentials: false
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+          cache-version: rails-8.0
+      # The base checkout below rewinds the working tree. Keep the PR's
+      # comparator so the gate rule under review is the one that runs.
+      - name: stage comparator
+        run: cp bin/bench-compare /tmp/bench-compare
+      # Best-of-N: bin/bench-compare keeps the fastest run per label, damping the
+      # cross-process tail (GC, runner contention) that ips' own +/- does not
+      # capture. Applied symmetrically to both sides, so it cannot hide a real
+      # regression — only a slowdown present in every run survives.
+      - name: bench head
+        run: |
+          set -o pipefail # `| tee` must not swallow a crashed bench run
+          : > /tmp/bench-head.txt
+          for i in $(seq 1 "$BENCH_RUNS"); do
+            echo "::group::bench head run $i"
+            bundle exec rake bench | tee -a /tmp/bench-head.txt
+            echo "::endgroup::"
+          done
+      - name: bench base
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          # A silently-crashed BASE run is the dangerous one: it empties the
+          # baseline, and bin/bench-compare reads "no comparable benchmarks" as
+          # a pass. Fail loudly instead of gating on nothing.
+          set -o pipefail
+          git checkout --quiet "$BASE_SHA"
+          bundle install --quiet
+          : > /tmp/bench-base.txt
+          for i in $(seq 1 "$BENCH_RUNS"); do
+            echo "::group::bench base run $i"
+            bundle exec rake bench | tee -a /tmp/bench-base.txt
+            echo "::endgroup::"
+          done
+      # Gate rule lives in bin/bench-compare (:72-75 noise band, :102 fail_gate,
+      # :115 exit) — this step only transports its verdict.
+      - name: compare, comment, gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          code=0
+          /tmp/bench-compare /tmp/bench-base.txt /tmp/bench-head.txt > /tmp/bench-comment.md || code=$?
+          tee -a "$GITHUB_STEP_SUMMARY" < /tmp/bench-comment.md
+
+          # Sticky comment: bin/bench-compare:27 prints its marker as the first
+          # line, so a prior comment is matched by prefix and edited in place
+          # instead of stacking one per push.
+          #
+          # Best-effort past this point. A PR from a fork gets a read-only token
+          # and the comment API 403s there; the gate verdict must not be masked
+          # by a comment we were never allowed to post. The table is already in
+          # the log and the job summary above.
+          set +e
+          gh api --paginate "repos/$REPO/issues/$PR/comments" \
+            --jq '.[] | select(.body | startswith("<!-- bench-compare -->")) | .id' > /tmp/bench-comment-ids.txt
+          existing=$(head -n1 /tmp/bench-comment-ids.txt)
+          if [ -n "$existing" ]; then
+            method=PATCH
+            endpoint="repos/$REPO/issues/comments/$existing"
+          else
+            method=POST
+            endpoint="repos/$REPO/issues/$PR/comments"
+          fi
+          gh api -X "$method" "$endpoint" -F body=@/tmp/bench-comment.md > /dev/null ||
+            echo "::warning::could not post the bench comment; the delta is in the job summary"
+          exit $code

--- a/Rakefile
+++ b/Rakefile
@@ -99,13 +99,19 @@ end
 
 # `rake bench` is the REGRESSION gate — its output is fed to bin/bench-compare
 # to diff head against main, so it may only contain benchmark/ips-shaped, wurk-
-# only scripts. vs_sidekiq.rb is a different animal (comparison against another
-# engine, minutes not seconds, prints a Markdown table) and is excluded here;
-# run it on its own via `rake bench:vs_sidekiq`.
+# only scripts. Every other bench/*.rb is picked up by the glob automatically,
+# so anything that reports in a different shape has to opt out here or it joins
+# the gate and bin/bench-compare reads it as a vanished benchmark:
+#
+#   vs_sidekiq.rb    — comparison against another engine, minutes not seconds,
+#                      prints a Markdown table. `rake bench:vs_sidekiq`.
+#   command_count.rb — INFO commandstats table plus a per-job budget assertion,
+#                      no i/s at all. `rake bench:command_count`.
 BENCH_SCRIPTS = Dir.glob(File.join(GEM_ROOT, "bench", "*.rb"))
                    .grep_v(%r{/support\.rb\z})
                    .freeze
-GATE_SCRIPTS = BENCH_SCRIPTS.reject { |s| File.basename(s) == "vs_sidekiq.rb" }.freeze
+UNGATED_SCRIPTS = %w[vs_sidekiq.rb command_count.rb].freeze
+GATE_SCRIPTS = BENCH_SCRIPTS.reject { |s| UNGATED_SCRIPTS.include?(File.basename(s)) }.freeze
 
 desc "Run the benchmark gate (enqueue, fetch+execute, bulk enqueue, swarm boot, memory)"
 task :bench do

--- a/bench/bulk_enqueue.rb
+++ b/bench/bulk_enqueue.rb
@@ -6,10 +6,16 @@ require_relative "support"
 
 # Gate: >5% regression vs main blocks merge.
 #
-# Runs on a dedicated Redis logical DB (default 11) so this bench's DEL/LTRIM
+# Runs on a dedicated Redis logical DB (default 11) so this bench's DEL/UNLINK
 # of queue:default can never wipe a dev's real DB 0 data (#258/#259).
 
 BULK_SIZE = 1_000
+
+# Backlog cap for the watchdog below. Each push adds BULK_SIZE, so the queue
+# peaks near DEPTH_LIMIT + (throughput * DEPTH_POLL) entries — single-digit MB —
+# rather than growing unbounded across the 7s run.
+DEPTH_LIMIT = 25_000
+DEPTH_POLL  = 0.025
 
 pool   = Wurk::RedisPool.new(size: 5, url: bench_redis_url("11"))
 client = Wurk::Client.new(pool: pool)
@@ -18,25 +24,32 @@ items  = { "class" => "BenchJob", "queue" => "default", "args" => args }
 
 pool.with { |c| c.call("DEL", "queue:default") }
 
-Benchmark.ips do |x|
-  x.config(time: 5, warmup: 2)
-
-  # Depth cap: the queue grows by BULK_SIZE each push. We trim when depth
-  # exceeds a threshold to prevent unbounded memory growth during the benchmark.
-  # This is a periodic depth cap applied outside the core timing loop.
-  depth_limit = 50_000
-
-  x.report("wurk push_bulk(#{BULK_SIZE})") do
-    client.push_bulk(items)
-    # Check queue depth infrequently to avoid serializing the bench.
-    # Trim when we exceed the depth limit, resetting to 1 item (LTRIM 0,0).
-    # The depth cap is outside the primary measurement concern (throughput),
-    # serving only to keep Redis memory bounded.
-    pool.with do |c|
-      depth = c.call("LLEN", "queue:default")
-      c.call("LTRIM", "queue:default", 0, 0) if depth > depth_limit
-    end
+# The backlog cap runs on its own thread, never inside x.report. Nothing but
+# push_bulk may sit in the timed block: an LLEN/LTRIM pair per iteration adds a
+# whole round trip to every sample, and the gate cannot tell that overhead apart
+# from a real push_bulk regression.
+#
+# UNLINK, not LTRIM: freeing a 25k-entry list happens on Redis' background
+# thread, so draining the backlog never stalls the connection serving the bench.
+#
+# A raise in here kills the run — Thread#join re-raises below — because a dead
+# watchdog means an unbounded queue, not a merely inaccurate number.
+stop = Queue.new
+watchdog = Thread.new do
+  until stop.pop(timeout: DEPTH_POLL)
+    pool.with { |c| c.call("UNLINK", "queue:default") if c.call("LLEN", "queue:default") > DEPTH_LIMIT }
   end
+end
+
+begin
+  Benchmark.ips do |x|
+    x.config(time: 5, warmup: 2)
+
+    x.report("wurk push_bulk(#{BULK_SIZE})") { client.push_bulk(items) }
+  end
+ensure
+  stop << :stop
+  watchdog.join
 end
 
 pool.with { |c| c.call("DEL", "queue:default") }

--- a/bench/bulk_enqueue.rb
+++ b/bench/bulk_enqueue.rb
@@ -21,10 +21,21 @@ pool.with { |c| c.call("DEL", "queue:default") }
 Benchmark.ips do |x|
   x.config(time: 5, warmup: 2)
 
+  # Depth cap: the queue grows by BULK_SIZE each push. We trim when depth
+  # exceeds a threshold to prevent unbounded memory growth during the benchmark.
+  # This is a periodic depth cap applied outside the core timing loop.
+  depth_limit = 50_000
+
   x.report("wurk push_bulk(#{BULK_SIZE})") do
     client.push_bulk(items)
-    # Trim to prevent Redis memory growth during the benchmark.
-    pool.with { |c| c.call("LTRIM", "queue:default", 0, 0) }
+    # Check queue depth infrequently to avoid serializing the bench.
+    # Trim when we exceed the depth limit, resetting to 1 item (LTRIM 0,0).
+    # The depth cap is outside the primary measurement concern (throughput),
+    # serving only to keep Redis memory bounded.
+    pool.with do |c|
+      depth = c.call("LLEN", "queue:default")
+      c.call("LTRIM", "queue:default", 0, 0) if depth > depth_limit
+    end
   end
 end
 

--- a/bench/command_count.rb
+++ b/bench/command_count.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "logger"
+require "wurk"
+require_relative "support"
+
+# Per-job Redis command tripwire — the round-trip half of the "Why wurk is
+# slower" story in docs/benchmarks.md. Scripts the `INFO commandstats` method
+# that table was measured with: drain JOBS pre-enqueued noop jobs through the
+# REAL reliable fetcher and Processor#process_one, then read the server's own
+# per-command call counters and divide by jobs.
+#
+# NOT part of `rake bench`. The gate feeds its output to bin/bench-compare,
+# which only parses benchmark/ips report lines; this prints a command table and
+# asserts a budget. It is excluded from GATE_SCRIPTS in the Rakefile alongside
+# vs_sidekiq.rb — run it on its own via `rake bench:command_count`.
+#
+# EXPECTED TO FAIL until the fetch/ack/metrics batching lands: steady state
+# today is 10 commands per job against a budget of 2 — 6 unbatched
+# Metrics::History writes (4 HINCRBY + 2 EXPIRE, one pair per time bucket),
+# LMOVE + LREM + DEL for reliable fetch, ack and poison-pill retire, and one
+# SMEMBERS of the paused set per fetch. That red is the tripwire naming the
+# work, not a broken bench. (docs/benchmarks.md quotes ~12 from a hand-run of
+# the same method; the printed breakdown below is the reproducible count.)
+#
+# Only the drain is counted. Enqueue happens before CONFIG RESETSTAT — it is
+# the client's cost and enqueue.rb already benches it — and a warmup pass runs
+# first so no one-time cost (the fetch pool's connection handshake, the EVALSHA
+# cache, autoload) lands inside the window.
+#
+# `INFO commandstats` is server-wide, not per-DB, so this wants an otherwise
+# idle Redis. Foreign traffic inflates the count and shows up as commands the
+# job path never issues — read the breakdown, not just the total. The failure
+# mode is a false alarm, never a silent pass.
+#
+# Runs on a dedicated logical DB (default 9, unused by the other benches) so a
+# stray dev/CI Redis with real data is never drained or flushed. DB 0 is never
+# touched.
+
+JOBS   = Integer(ENV.fetch("WURK_BENCH_CMD_JOBS", "500"))
+BUDGET = Float(ENV.fetch("WURK_BENCH_CMD_BUDGET", "2"))
+WARMUP = [JOBS / 10, 1].max
+
+# Redis records CONFIG RESETSTAT *after* it clears the counters, so the reset
+# that opens the window shows up inside it. INFO needs no such treatment: it
+# reports the counters as they stood before it ran, so it never counts itself.
+HARNESS_COMMANDS = %w[config|resetstat].freeze
+
+class BenchJob
+  include Wurk::Job
+
+  def perform(*); end
+end
+
+# Server-side call counters, keyed by command name ("hincrby", "config|get").
+def command_calls(capsule)
+  info = capsule.redis { |c| c.call("INFO", "commandstats") }
+  info.each_line
+      .filter_map { |line| line.match(/\Acmdstat_(?<cmd>[^:]+):calls=(?<calls>\d+)/) }
+      .to_h { |m| [m[:cmd], Integer(m[:calls])] }
+      .except(*HARNESS_COMMANDS)
+end
+
+# Returns how many jobs actually ran: process_one answers nil both for "job
+# done" and "queue was empty", so the counter is the only honest witness.
+def drain(processor, jobs)
+  Wurk::Processor::PROCESSED.reset
+  jobs.times { processor.process_one }
+  Wurk::Processor::PROCESSED.reset
+end
+
+def report(calls, jobs)
+  rows = calls.sort_by { |_, count| -count }
+  rows.each { |cmd, count| printf("  %8d  %7.2f  %s\n", count, count / jobs.to_f, cmd) }
+  puts "  --------  -------"
+  total = calls.values.sum
+  printf("  %8d  %7.2f  total\n\n", total, total / jobs.to_f)
+  total / jobs.to_f
+end
+
+# The process-global config, not a fresh Wurk::Configuration.new: the default
+# server middleware chain is registered onto this one at load (wurk.rb:297-312)
+# and 6 of today's 10 commands per job are Metrics::History writes from it. A
+# fresh Configuration starts with an EMPTY chain, so benching against one would
+# hide exactly the writes this tripwire exists to watch. Every real worker boots
+# from this object.
+config = Wurk.configuration
+config.logger = Logger.new(IO::NULL)
+config.redis = { url: bench_redis_url("9") }
+config.queues = %w[default]
+capsule = config.default_capsule
+capsule.prepare!
+
+# Isolated scratch DB: a clean slate keeps this closed loop the only consumer
+# of queue:default, so every fetch finds the job we pushed.
+capsule.redis { |c| c.call("FLUSHDB") }
+capsule.redis { |c| Wurk::Lua::Loader.script_load_all(c) }
+
+client    = Wurk::Client.new(pool: capsule.redis_pool)
+processor = Wurk::Processor.new(capsule)
+
+client.push_bulk("class" => "BenchJob", "args" => Array.new(WARMUP + JOBS) { [] }, "queue" => "default")
+drain(processor, WARMUP)
+
+capsule.redis { |c| c.call("CONFIG", "RESETSTAT") }
+processed = drain(processor, JOBS)
+calls     = command_calls(capsule)
+
+capsule.redis { |c| c.call("FLUSHDB") }
+
+# A queue that ran dry parks the fetcher in BLMOVE and yields nil: fewer
+# commands for fewer jobs, which reads as an improvement. Fail loud instead.
+unless processed == JOBS
+  abort format("✗ drained %d of %d jobs — the queue ran dry, so the count is meaningless", processed, JOBS)
+end
+
+puts "wurk — #{JOBS} noop jobs drained from queue:default (INFO commandstats)\n\n"
+puts "  commands  per job  command"
+per_job = report(calls, JOBS)
+# abort writes to unbuffered stderr, which would land the verdict above the
+# table it is a verdict on.
+$stdout.flush
+
+abort format("✗ %.2f commands/job, over the budget of %.2f", per_job, BUDGET) if per_job > BUDGET
+puts format("✓ %.2f commands/job, within the budget of %.2f", per_job, BUDGET)

--- a/bench/fetch_execute.rb
+++ b/bench/fetch_execute.rb
@@ -6,21 +6,30 @@ require "wurk"
 require_relative "support"
 
 # End-to-end fetch+execute — one of the four "Faster" pillar critical paths
-# (CLAUDE.md). Each iteration enqueues one job, then drives the REAL reliable
-# fetcher (atomic LMOVE: public `queue:default` -> per-process private list)
-# and the REAL Processor#process_one: parse JSON, walk the server-middleware
-# chain, invoke `perform`, then ACK (LREM from the private list).
+# (CLAUDE.md). Each iteration drives the REAL reliable fetcher (atomic LMOVE:
+# public `queue:default` -> per-process private list) and the REAL
+# Processor#process_one: parse JSON, walk the server-middleware chain, invoke
+# `perform`, then ACK (LREM from the private list).
 #
-# Closed loop (push one, drain one) holds the queue at a steady depth so the
-# fetcher always takes the non-blocking LMOVE branch and never stalls the
-# benchmark on an empty 2s BLMOVE. The measured cost is the fetch + perform +
-# ack Redis round-trips plus the dispatch onion — the path the gate protects.
-# Real Redis round-trips keep throughput in the low thousands i/s, so cross-run
-# jitter sits inside the noise band (unlike the old `1 + 1` stub, #258/#259).
+# The queue is pre-filled (batched pipeline via Client#push_bulk) to a depth
+# deep enough to outlast warmup + the timed window, so the fetcher always
+# takes the non-blocking LMOVE branch and never stalls on an empty 2s BLMOVE.
+# The timed block is `processor.process_one` ONLY — enqueue must never appear
+# inside `x.report`, or this bench silently measures `push` cost too and
+# conflates two different critical paths (`enqueue.rb` already benches that).
+# The measured cost is the fetch + perform + ack Redis round-trips plus the
+# dispatch onion — the path the gate protects. Real Redis round-trips keep
+# throughput in the low thousands i/s, so cross-run jitter sits inside the
+# noise band (unlike the old `1 + 1` stub, #258/#259).
 #
 # Runs on a dedicated Redis logical DB (default 15, like the test layer's
 # fixed-DB slot — DB 0 is never touched) so a stray worker draining `queue:*`
 # on the default DB can't steal our jobs and starve the fetcher into BLMOVE.
+#
+# NOTE: this fixes a measurement bug (enqueue was timed inside process_one's
+# loop) — the first bench-compare run against old `main` will show a spurious
+# jump/drop on this label. That's the fix taking effect, not a regression;
+# flagged in the PR body. Land as its own commit so history is easy to bisect.
 #
 # Gate: >5% regression vs main blocks merge.
 
@@ -44,16 +53,18 @@ capsule.redis { |c| Wurk::Lua::Loader.script_load_all(c) }
 
 client    = Wurk::Client.new(pool: capsule.redis_pool)
 processor = Wurk::Processor.new(capsule)
-job       = { "class" => "BenchJob", "args" => [], "queue" => "default" }
 
-# Seed a small backlog so the first LMOVE of every tick always finds a job.
-3.times { client.push(job.dup) }
+# Pre-fill well past anything warmup + the timed window can drain, via a
+# single batched pipeline (not per-iteration) so enqueue cost never leaks
+# into the timed block below. At "low thousands i/s" (see comment above), 7s
+# of warmup+run tops out in the tens of thousands of iterations.
+SEED_DEPTH = 50_000
+client.push_bulk("class" => "BenchJob", "args" => Array.new(SEED_DEPTH) { [] }, "queue" => "default")
 
 Benchmark.ips do |x|
   x.config(time: 5, warmup: 2)
 
   x.report("wurk fetch+execute") do
-    client.push(job.dup)
     processor.process_one
   end
 end

--- a/bench/fetch_execute.rb
+++ b/bench/fetch_execute.rb
@@ -11,9 +11,6 @@ require_relative "support"
 # Processor#process_one: parse JSON, walk the server-middleware chain, invoke
 # `perform`, then ACK (LREM from the private list).
 #
-# The queue is pre-filled (batched pipeline via Client#push_bulk) to a depth
-# deep enough to outlast warmup + the timed window, so the fetcher always
-# takes the non-blocking LMOVE branch and never stalls on an empty 2s BLMOVE.
 # The timed block is `processor.process_one` ONLY — enqueue must never appear
 # inside `x.report`, or this bench silently measures `push` cost too and
 # conflates two different critical paths (`enqueue.rb` already benches that).
@@ -26,12 +23,37 @@ require_relative "support"
 # fixed-DB slot — DB 0 is never touched) so a stray worker draining `queue:*`
 # on the default DB can't steal our jobs and starve the fetcher into BLMOVE.
 #
-# NOTE: this fixes a measurement bug (enqueue was timed inside process_one's
-# loop) — the first bench-compare run against old `main` will show a spurious
-# jump/drop on this label. That's the fix taking effect, not a regression;
-# flagged in the PR body. Land as its own commit so history is easy to bisect.
+# Holding the queue non-empty is a correctness requirement, not a nicety. An
+# empty poll costs a full BLMOVE block, and benchmark-ips runs its current
+# batch (~1k iterations at this throughput) to completion before it re-checks
+# the clock — so a queue that runs dry one iteration early converts a 7s bench
+# into a ~23min one. That is how a flat 50k seed blew this job's 30min timeout
+# once the runner turned out to drain ~9.2k jobs/s. Two guards, in order:
+#
+#   1. SEED_CHUNKS is sized to outlast warmup + the timed window with margin on
+#      the reference runner, so the top-up below normally never fires at all
+#      and the measurement carries no producer contention.
+#   2. The top-up watchdog is the actual guarantee. On its own thread — never
+#      inside x.report — it refills whenever depth drops under REFILL_FLOOR, so
+#      a runner faster than the seed assumed still measures a full queue rather
+#      than hanging. Its LLEN/push_bulk cost lands on the producer thread; the
+#      only way it reaches the number is Redis-side contention, and only on the
+#      runs where the seed alone would have died.
+#
+# EMPTY_POLL backstops both: should the queue ever run dry anyway, an empty
+# poll costs 50ms instead of the fetcher's 2s default, so the run reads as a
+# fast, obvious regression instead of a CI timeout. It cannot skew the number —
+# a non-empty queue returns from the LMOVE branch and never reaches BLMOVE.
 #
 # Gate: >5% regression vs main blocks merge.
+
+# Jobs per push_bulk call, for both the seed and each top-up. Client#push_bulk
+# splits this into DEFAULT_BATCH_SIZE (1k) pipelines internally.
+REFILL_CHUNK = 25_000
+SEED_CHUNKS  = 6
+REFILL_FLOOR = 25_000
+REFILL_POLL  = 0.05
+EMPTY_POLL   = 0.05
 
 class BenchJob
   include Wurk::Job
@@ -43,30 +65,46 @@ config = Wurk::Configuration.new
 config.logger = Logger.new(IO::NULL)
 config.redis = { url: bench_redis_url("15") }
 config.queues = %w[default]
+config.fetch_poll_interval = EMPTY_POLL
 capsule = config.default_capsule
 capsule.prepare!
 
-# Isolated scratch DB: a clean slate at both ends keeps the closed loop the
-# only consumer of queue:default, so every LMOVE finds the job we just pushed.
+# Isolated scratch DB: a clean slate at both ends keeps this process the only
+# consumer of queue:default, so every LMOVE finds a job.
 capsule.redis { |c| c.call("FLUSHDB") }
 capsule.redis { |c| Wurk::Lua::Loader.script_load_all(c) }
 
 client    = Wurk::Client.new(pool: capsule.redis_pool)
 processor = Wurk::Processor.new(capsule)
 
-# Pre-fill well past anything warmup + the timed window can drain, via a
-# single batched pipeline (not per-iteration) so enqueue cost never leaks
-# into the timed block below. At "low thousands i/s" (see comment above), 7s
-# of warmup+run tops out in the tens of thousands of iterations.
-SEED_DEPTH = 50_000
-client.push_bulk("class" => "BenchJob", "args" => Array.new(SEED_DEPTH) { [] }, "queue" => "default")
+# One args array, reused by the seed and every top-up. Allocating a fresh
+# 25k-element array per refill would charge the producer's GC churn to the
+# process under measurement.
+chunk = { "class" => "BenchJob", "args" => Array.new(REFILL_CHUNK) { [] }, "queue" => "default" }
 
-Benchmark.ips do |x|
-  x.config(time: 5, warmup: 2)
+SEED_CHUNKS.times { client.push_bulk(chunk) }
 
-  x.report("wurk fetch+execute") do
-    processor.process_one
+# A raise in here kills the run — Thread#join re-raises below — because a dead
+# watchdog means a queue that can run dry, which is the failure this exists to
+# prevent.
+stop = Queue.new
+refiller = Thread.new do
+  until stop.pop(timeout: REFILL_POLL)
+    client.push_bulk(chunk) if capsule.redis { |c| c.call("LLEN", "queue:default") } < REFILL_FLOOR
   end
+end
+
+begin
+  Benchmark.ips do |x|
+    x.config(time: 5, warmup: 2)
+
+    x.report("wurk fetch+execute") do
+      processor.process_one
+    end
+  end
+ensure
+  stop << :stop
+  refiller.join
 end
 
 capsule.redis { |c| c.call("FLUSHDB") }

--- a/bench/memory.rb
+++ b/bench/memory.rb
@@ -4,19 +4,34 @@ require "logger"
 require "wurk"
 require_relative "support"
 
-# Memory / allocation profile of the fetch+execute hot path — the "memory blocks
-# merge" critical path in CLAUDE.md's "Faster" pillar. Drives the REAL
-# client.push + Processor#process_one loop (the same path fetch_execute.rb
-# benchmarks for speed) and counts the objects Ruby allocates per job via
-# GC.stat(:total_allocated_objects) — a monotonic counter GC can't perturb, so
-# no profiler dependency is needed.
+# Memory profile of the fetch+execute hot path — the "memory blocks merge"
+# critical path in CLAUDE.md's "Faster" pillar. Drives the REAL client.push +
+# Processor#process_one loop (the same path fetch_execute.rb benchmarks for
+# speed) and reports TWO series, because allocation rate alone cannot see a
+# leak: a hot path that allocates the same objects every job but never lets go
+# of them scores identically to one that frees them.
 #
-# Reported as jobs-per-1k-allocations (higher = leaner). A change that bloats
-# the hot path's allocations DROPS this number, so the bench gate
-# (bin/bench-compare) flags it exactly like an i/s regression: >5% blocks merge.
-# Allocation counts are near-deterministic, so we sample a few runs and emit a
-# benchmark/ips-compatible line ("<label>  <value> (± <err>%) i/s") with the
-# (small) run-to-run spread as the ±.
+#   wurk hot-path (jobs/1k-alloc)     — RATE. GC.stat(:total_allocated_objects)
+#     delta over the loop, as jobs per 1k allocated objects. A monotonic counter
+#     GC can't perturb, so no profiler dependency is needed.
+#
+#   wurk hot-path (retention-free/1k) — RETENTION. GC.stat(:heap_live_slots)
+#     delta over the same loop with majors settled on both sides, scored as
+#     JOBS * 1000 / (JOBS + retained): 1000 when the loop hands every slot back,
+#     halving for each whole slot retained per job.
+#
+# Both are higher = leaner, deliberately. The bench gate (bin/bench-compare)
+# flags a DROP, so a hot path that bloats and one that leaks both trip it like
+# an i/s regression — >5% blocks merge. Retention is normalized rather than
+# emitted as a raw slot count for exactly that reason: raw slots are
+# lower = better, so the gate would read a new leak as an improvement, and a
+# healthy run's count is 0, which no ratio-based gate can compare against.
+#
+# Both lines are printed in benchmark/ips report format ("<label>  <value>
+# (± <err>%) i/s") because that is the only shape bin/bench-compare parses
+# (IPS_LINE). Neither series is an i/s; the units are in the label. Counts are
+# near-deterministic, so we sample a few runs and use the run-to-run spread as
+# the ±.
 #
 # Real Redis, dedicated logical DB (default 13, mirroring fetch_execute's
 # isolation from #259). DB 0 is never touched.
@@ -46,31 +61,44 @@ client    = Wurk::Client.new(pool: capsule.redis_pool)
 processor = Wurk::Processor.new(capsule)
 job       = { "class" => "BenchJob", "args" => [], "queue" => "default" }
 
-# Closed loop: push one, drain one, JOBS times — counting allocations across the
-# whole push + fetch + middleware + perform + ack round-trip.
-def hot_path_allocations(client, processor, job, jobs)
-  GC.start
-  before = GC.stat(:total_allocated_objects)
+# Closed loop: push one, drain one, JOBS times — measuring both series across
+# the whole push + fetch + middleware + perform + ack round-trip.
+#
+# GC.start twice on each side, not once: one major leaves a handful of slots
+# unswept, which reads as 4-6 slots of phantom retention (and wobbles the
+# allocation count by ~3) even on a loop that retains nothing. A second pass
+# settles both to an exact zero, so the retention series measures a leak rather
+# than sweep timing.
+def hot_path_sample(client, processor, job, jobs)
+  2.times { GC.start }
+  allocated_before = GC.stat(:total_allocated_objects)
+  live_before      = GC.stat(:heap_live_slots)
   jobs.times do
     client.push(job.dup)
     processor.process_one
   end
-  GC.stat(:total_allocated_objects) - before
+  allocated = GC.stat(:total_allocated_objects) - allocated_before
+  2.times { GC.start }
+  [allocated, GC.stat(:heap_live_slots) - live_before]
 end
 
-# Warm up the JIT / autoload / EVALSHA cache so steady-state allocations are
-# what we measure, not one-time setup.
-hot_path_allocations(client, processor, job, [JOBS / 4, 1].max)
-
-metrics = Array.new(SAMPLES) do
-  allocs = hot_path_allocations(client, processor, job, JOBS)
-  JOBS * 1000.0 / allocs # jobs per 1k allocated objects; higher = leaner
+def report_series(label, values)
+  mean   = values.sum / values.size
+  stddev = Math.sqrt(values.sum { |v| (v - mean)**2 } / values.size)
+  err    = mean.zero? ? 0.0 : (stddev / mean * 100.0)
+  printf("%-33s %.2f (± %.1f%%) i/s\n", label, mean, err)
 end
+
+# Warm up the JIT / autoload / EVALSHA cache so steady-state numbers are what we
+# measure, not one-time setup.
+hot_path_sample(client, processor, job, [JOBS / 4, 1].max)
+
+samples = Array.new(SAMPLES) { hot_path_sample(client, processor, job, JOBS) }
 
 capsule.redis { |c| c.call("FLUSHDB") }
 
-mean   = metrics.sum / metrics.size
-stddev = Math.sqrt(metrics.sum { |m| (m - mean)**2 } / metrics.size)
-err    = mean.zero? ? 0.0 : (stddev / mean * 100.0)
-
-printf("%-28s %.2f (± %.1f%%) i/s\n", "wurk hot-path (jobs/1k-alloc)", mean, err)
+report_series("wurk hot-path (jobs/1k-alloc)", samples.map { |allocated, _| JOBS * 1000.0 / allocated })
+# Clamp the delta at 0: warmup can free more than the loop retains, and a
+# negative score would not parse as a benchmark/ips line at all.
+report_series("wurk hot-path (retention-free/1k)",
+              samples.map { |_, retained| JOBS * 1000.0 / (JOBS + [retained, 0].max) })

--- a/test/support/command_spy.rb
+++ b/test/support/command_spy.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'delegate'
+
+module Wurk
+  module Test
+    # Command-counting `Thread.current[:wurk_capsule]` install, for tests that
+    # must bound Redis traffic. Lifted from the `RoundTripCounter` pattern in
+    # test/unit/web_search_test.rb (thread-local override, not a global
+    # monkeypatch, so counting stays safe under `parallelize_me!`) but counts a
+    # different thing: RedisClientAdapter::CompatClient#round_trips
+    # (redis_client_adapter.rb:75-76) counts one per `pipelined`/`multi` call no
+    # matter how many commands it buffers, so a change that fans one command out
+    # into a ten-command pipeline would read as flat there. This counts actual
+    # commands, walking into `pipelined`/`multi` blocks to tally what they buffer.
+    #
+    # Usage:
+    #   spy = Wurk::Test::CommandSpy.new(Wurk.redis_pool)
+    #   Thread.current[:wurk_capsule] = spy
+    #   # ... exercise code under test ...
+    #   spy.count
+    #   Thread.current[:wurk_capsule] = nil
+    class CommandSpy
+      attr_reader :count
+
+      # `pipelined`/`multi` are the only DISPATCH_METHODS that can hide more than
+      # one command behind a single round trip; every other dispatch (call,
+      # call_v, blocking_call, ...) plus every convenience method (smembers,
+      # hgetall, ...) already resolves to exactly one round trip on the real
+      # connection, so `round_trips` alone counts those correctly.
+      BATCH_METHODS = %i[pipelined multi].freeze
+
+      def initialize(pool)
+        @pool = pool
+        @count = 0
+      end
+
+      # Doubles as its own `Thread.current[:wurk_capsule]` binding (`#redis_pool`
+      # returns self), same as RoundTripCounter.
+      def redis_pool = self
+
+      def with(&block)
+        @pool.with do |conn|
+          before = conn.round_trips
+          result = block.call(Tap.new(conn, self))
+          @count += conn.round_trips - before
+          result
+        end
+      end
+
+      # Called once a `pipelined`/`multi` block returns, with how many commands
+      # it actually buffered. The block's own round trip already added 1 to
+      # `@count` via the `round_trips` delta in `#with`, so this corrects that
+      # single count to the real number (including 0, for an empty block that
+      # still spends a round trip on nothing).
+      def record_batch(actual_commands)
+        @count += actual_commands - 1
+      end
+
+      # Wraps the connection `with` yields. Only `pipelined`/`multi` need
+      # overriding — every other method (`call`, `call_v`, convenience commands
+      # like `smembers`) is left to resolve on the real connection via
+      # SimpleDelegator forwarding, so it still increments the real
+      # `round_trips` counter that `#with` reads.
+      class Tap < SimpleDelegator
+        def initialize(conn, spy)
+          super(conn)
+          @spy = spy
+        end
+
+        CommandSpy::BATCH_METHODS.each do |name|
+          define_method(name) do |*args, **kwargs, &blk|
+            counter = Counter.new
+            result = __getobj__.public_send(name, *args, **kwargs) { |batch| blk.call(Batch.new(batch, counter)) }
+            @spy.record_batch(counter.count)
+            result
+          end
+        end
+      end
+
+      # Plain counter shared between a `Tap#pipelined`/`#multi` call and the
+      # `Batch` it yields.
+      class Counter
+        attr_accessor :count
+
+        def initialize
+          @count = 0
+        end
+      end
+
+      # Wraps the buffered pipeline/transaction object redis-client yields to a
+      # `pipelined`/`multi` block; each `call`-family invocation on it queues one
+      # command, so each one increments the shared counter.
+      class Batch < SimpleDelegator
+        DISPATCH_METHODS = %i[call call_v call_once call_once_v].freeze
+
+        def initialize(batch, counter)
+          super(batch)
+          @counter = counter
+        end
+
+        DISPATCH_METHODS.each do |name|
+          define_method(name) do |*args, **kwargs, &blk|
+            @counter.count += 1
+            __getobj__.public_send(name, *args, **kwargs, &blk)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -143,6 +143,7 @@ end
 
 require_relative "support/redis_namespace"
 require_relative "support/swarm_teardown"
+require_relative "support/command_spy"
 
 module Wurk
   module Test

--- a/test/unit/bench_compare_test.rb
+++ b/test/unit/bench_compare_test.rb
@@ -12,15 +12,27 @@ class BenchCompareTest < Wurk::Test::UnitCase
 
   SCRIPT = File.expand_path('../../bin/bench-compare', __dir__)
 
+  # bench/memory.rb's two series, verbatim. Both carry a parenthesized group and
+  # a `1k`/`/1k` fragment — the exact shape that could make IPS_LINE's non-greedy
+  # label capture swallow part of the value — so pin the real strings, not
+  # stand-ins.
+  ALLOC_LABEL     = 'wurk hot-path (jobs/1k-alloc)'
+  RETENTION_LABEL = 'wurk hot-path (retention-free/1k)'
+
   # benchmark/ips report line, as bin/bench-compare parses it.
   def ips_line(label, ips, err)
     format('%<label>s   %<ips>.1f (± %<err>.1f%%) i/s -    1.00k in   5.000s', label: label, ips: ips, err: err)
   end
 
-  def write_runs(label, *runs)
-    path = File.join(@dir, "#{label.gsub(/\W+/, '_')}_#{object_id}_#{runs.hash.abs}.txt")
-    File.write(path, runs.map { |ips, err| ips_line(label, ips, err) }.join("\n") << "\n")
+  # rows: [label, ips, err] triples, one report line each.
+  def write_report(tag, rows)
+    path = File.join(@dir, "#{tag.gsub(/\W+/, '_')}_#{object_id}_#{rows.hash.abs}.txt")
+    File.write(path, rows.map { |label, ips, err| ips_line(label, ips, err) }.join("\n") << "\n")
     path
+  end
+
+  def write_runs(label, *runs)
+    write_report(label, runs.map { |ips, err| [label, ips, err] })
   end
 
   # Pin BENCH_REGRESSION_PCT to the script's documented default so the gate's
@@ -86,5 +98,48 @@ class BenchCompareTest < Wurk::Test::UnitCase
 
     assert_equal 1, code
     assert_includes out, 'Missing on head'
+  end
+
+  # bench/memory.rb emits both series as benchmark/ips lines purely so this
+  # script can gate them. If IPS_LINE ever stops matching those labels the memory
+  # bench silently drops out of the comparison and reports nothing — so assert on
+  # the parsed rows, not just an exit code.
+  def test_memory_bench_series_parse_and_compare
+    rows = ->(alloc, retention) { [[ALLOC_LABEL, alloc, 0.2], [RETENTION_LABEL, retention, 0.0]] }
+    base = write_report('memory-base', rows.call(4210.0, 1000.0))
+    head = write_report('memory-head', rows.call(4208.0, 1000.0))
+
+    out, code = compare(base, head)
+
+    assert_equal 0, code
+    assert_includes out, "| `#{ALLOC_LABEL}` | 4.21k | 4.21k |"
+    assert_includes out, "| `#{RETENTION_LABEL}` | 1.00k | 1.00k | +0.0% | 🟢 |"
+  end
+
+  # The point of the retention series: a hot path that retains one slot per job
+  # halves the score, and the gate treats that exactly like an i/s regression.
+  # Allocation rate alone cannot see this — it is unchanged in both runs.
+  def test_retention_drop_trips_the_gate
+    base = write_report('leak-base', [[ALLOC_LABEL, 4210.0, 0.2], [RETENTION_LABEL, 1000.0, 0.0]])
+    head = write_report('leak-head', [[ALLOC_LABEL, 4210.0, 0.2], [RETENTION_LABEL, 500.0, 0.0]])
+
+    out, code = compare(base, head)
+
+    assert_equal 1, code
+    assert_includes out, "Regression: `#{RETENTION_LABEL}` -50.0%"
+    assert_includes out, "| `#{ALLOC_LABEL}` | 4.21k | 4.21k | +0.0% | 🟢 |"
+  end
+
+  # Landing a new series must not fail its own PR: base predates the retention
+  # line, so it is only_head (reported, never gated) rather than only_base.
+  def test_new_series_on_head_is_reported_not_gated
+    base = write_runs(ALLOC_LABEL, [4210.0, 0.2])
+    head = write_report('new-series', [[ALLOC_LABEL, 4210.0, 0.2], [RETENTION_LABEL, 1000.0, 0.0]])
+
+    out, code = compare(base, head)
+
+    assert_equal 0, code
+    assert_includes out, "_New on head: #{RETENTION_LABEL}_"
+    refute_includes out, 'Missing on head'
   end
 end

--- a/test/unit/bench_gate_scripts_test.rb
+++ b/test/unit/bench_gate_scripts_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'English'
+
+# `rake bench` pipes every GATE_SCRIPT's stdout into bin/bench-compare, which
+# reads benchmark/ips report lines and nothing else — and BENCH_SCRIPTS is a
+# glob, so a new bench/*.rb joins the gate the moment it lands. A script that
+# reports in any other shape (a Markdown table, a command tally) contributes no
+# parseable label, which bench-compare then reads as a benchmark that vanished
+# on head and fails the gate on every PR. The Rakefile's opt-out list is the
+# only thing preventing that, so it is pinned here.
+class BenchGateScriptsTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  ROOT = File.expand_path('../..', __dir__)
+
+  # Not ips reports: vs_sidekiq.rb prints a Markdown comparison table,
+  # command_count.rb an INFO commandstats tally plus a per-job budget assertion.
+  UNGATED = %w[vs_sidekiq.rb command_count.rb].freeze
+
+  def test_scripts_that_are_not_ips_reports_stay_out_of_the_gate
+    UNGATED.each do |script|
+      assert_includes bench_scripts, script, "bench/#{script} must still be runnable as `rake bench:#{script[..-4]}`"
+      refute_includes gate_scripts, script, "bench/#{script} is not an ips report — bin/bench-compare can't read it"
+    end
+  end
+
+  def test_every_other_bench_script_is_gated
+    assert_equal (bench_scripts - UNGATED).sort, gate_scripts.sort,
+                 'a new bench/*.rb is gated by default; opt it out in the Rakefile only if it is not an ips report'
+    refute_includes bench_scripts, 'support.rb', 'the shared helper is not a benchmark'
+  end
+
+  private
+
+  def bench_scripts
+    @bench_scripts ||= rakefile_constant('BENCH_SCRIPTS')
+  end
+
+  def gate_scripts
+    @gate_scripts ||= rakefile_constant('GATE_SCRIPTS')
+  end
+
+  # Loading the Rakefile defines its tasks, so it happens in a subprocess rather
+  # than inside a test worker. One spawn answers for both constants.
+  def rakefile_constant(name)
+    @rakefile_constants ||= begin
+      script = 'extend Rake::DSL; load "Rakefile"; ' \
+               'puts [BENCH_SCRIPTS, GATE_SCRIPTS].map { |s| s.map { |p| File.basename(p) }.join(",") }'
+      out = IO.popen({}, [RbConfig.ruby, '-r', 'rake', '-e', script], chdir: ROOT, err: %i[child out], &:read)
+
+      assert_equal 0, $CHILD_STATUS.exitstatus, "loading the Rakefile failed:\n#{out}"
+      names = out.lines.last(2).map { |line| line.strip.split(',') }
+      { 'BENCH_SCRIPTS' => names.first, 'GATE_SCRIPTS' => names.last }
+    end
+    @rakefile_constants.fetch(name)
+  end
+end


### PR DESCRIPTION
## Summary
- Restore the bench regression gate as a CI workflow
- Stop timing enqueue inside the fetch+execute benchmark
- Move LTRIM out of the bulk-enqueue timed block
- Add a retention series to the memory benchmark and teach the gate about it
- Add a per-job Redis command-count tripwire script
- Add a reusable Redis command-spy test helper (`test/support/command_spy.rb`), counting actual commands — including inside `pipelined`/`multi` — not just round trips, for use by upcoming perf-fix PRs

## Test plan
- [x] `bin/rake test` — 3000 runs, 0 failures
- [x] `bundle exec rubocop` clean on new/changed files (pre-existing double-quote style in `test_helper.rb` untouched)
- [x] Manually verified `CommandSpy` counts: direct call, convenience method, 3-command pipeline, 2-command multi — against real Redis
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788616112&installation_model_id=11168&pr_number=369&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F369&signature=67b9a5567da65ea6ee26187179671312367e7bb025831b907306d8acd72c38d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated pull-request benchmark comparisons with summarized results and persistent review comments.
  * Added a standalone Redis command-count benchmark.
  * Expanded memory benchmarking to report allocation and heap-retention metrics.

* **Improvements**
  * Improved queue-depth handling for bulk enqueue benchmarks.
  * Updated fetch/execute benchmarks to use a consistent pre-filled workload.
  * Kept specialized benchmarks available for individual execution while excluding them from standard gating.

* **Tests**
  * Added coverage for benchmark comparison, memory metrics, gating behavior, and Redis command tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->