### PR TITLE
perf(fetch): 4 RTT/job down to ~1 — fetch, ack, and metrics batching

### DIFF
--- a/bench/command_count.rb
+++ b/bench/command_count.rb
@@ -22,8 +22,8 @@ require_relative "support"
 # counted in commands.
 #
 # The budget is re-baselined to 3, the settled floor for this command shape —
-# down from ~10 (docs/benchmarks.md:58) before this PR group. The one
-# candidate to lose was the poison-pill DEL, meaningful only for a job the
+# down from ~10 (docs/benchmarks.md, "Why wurk is slower") before this PR group.
+# The one candidate to lose was the poison-pill DEL, meaningful only for a job the
 # reaper reclaimed — step 4 of
 # docs/plans/2026/08/06/101-faster-than-sidekiq/02-fetch-ack-metrics.md, now
 # settled: it stays. A reclaimed payload is byte-identical to a first-attempt
@@ -33,7 +33,7 @@ require_relative "support"
 # folding LREM + DEL + LMOVE into one script would read as 4 here, not 1. Those
 # 3 commands cost one round trip between them (down from 4 before this PR
 # group), which is the number that actually drives throughput — see
-# `bench:fetch_execute` and docs/benchmarks.md:106.
+# `bench:fetch_execute` and docs/benchmarks.md, "Status".
 #
 # Two costs that used to show here are already gone: an SMEMBERS of the paused
 # set per fetch pass (Fetcher::Reliable now reads that SET once per PAUSED_TTL)
@@ -62,6 +62,13 @@ require_relative "support"
 
 JOBS   = Integer(ENV.fetch("WURK_BENCH_CMD_JOBS", "500"))
 BUDGET = Float(ENV.fetch("WURK_BENCH_CMD_BUDGET", "3"))
+# The floor, checked as strictly as the ceiling. A count that DROPS is a win,
+# but an unannounced one leaves the comment above, docs/benchmarks.md and the
+# plan all quoting a number no run reproduces — the failure mode this script
+# exists to prevent, in the direction a budget alone can't see. Landing a
+# reduction means re-baselining here and republishing the prose in the same
+# commit, which is the point.
+BASELINE = Float(ENV.fetch("WURK_BENCH_CMD_BASELINE", "3"))
 WARMUP = [JOBS / 10, 1].max
 
 # Redis records CONFIG RESETSTAT *after* it clears the counters, so the reset
@@ -144,4 +151,12 @@ per_job = report(calls, JOBS)
 $stdout.flush
 
 abort format("✗ %.2f commands/job, over the budget of %.2f", per_job, BUDGET) if per_job > BUDGET
-puts format("✓ %.2f commands/job, within the budget of %.2f", per_job, BUDGET)
+if per_job < BASELINE
+  abort format(
+    "✗ %.2f commands/job, under the recorded baseline of %.2f — re-baseline this script and republish " \
+    "docs/benchmarks.md from this run",
+    per_job, BASELINE
+  )
+end
+puts format("✓ %.2f commands/job, within the budget of %.2f and at the recorded baseline of %.2f",
+            per_job, BUDGET, BASELINE)

--- a/bench/command_count.rb
+++ b/bench/command_count.rb
@@ -15,13 +15,19 @@ require_relative "support"
 # asserts a budget. It is excluded from GATE_SCRIPTS in the Rakefile alongside
 # vs_sidekiq.rb — run it on its own via `rake bench:command_count`.
 #
-# EXPECTED TO FAIL until the fetch/ack/metrics batching lands: steady state
-# today is 9 commands per job against a budget of 2 — 6 unbatched
-# Metrics::History writes (4 HINCRBY + 2 EXPIRE, one pair per time bucket), plus
-# LMOVE + LREM + DEL for reliable fetch, ack and poison-pill retire. That red is
-# the tripwire naming the work, not a broken bench. (An SMEMBERS of the paused
-# set per fetch used to make it 10; Fetcher::Reliable now reads that SET once
-# per PAUSED_TTL, so it no longer shows up in the table at all.)
+# EXPECTED TO FAIL until the ack piggyback lands: steady state today is 3
+# commands per job against a budget of 2 — LMOVE + LREM + DEL for reliable
+# fetch, ack and poison-pill retire. That red is the tripwire naming the work,
+# not a broken bench. Two costs that used to show here are gone: an SMEMBERS of
+# the paused set per fetch pass (Fetcher::Reliable now reads that SET once per
+# PAUSED_TTL) and 6 Metrics::History writes per job (Metrics::Accumulator folds
+# them in memory; Metrics::Flusher drains them every FLUSH_INTERVAL).
+#
+# Those metrics writes are ZERO here, not amortized: this loop runs no Launcher,
+# so no flusher ticks inside the window. A real worker pays one 6-command
+# pipeline per (class, minute) every 5 seconds no matter its throughput, which
+# rounds to nothing per job at any rate this bench would measure — but the
+# table below is a per-job budget, and that cost is not in it.
 #
 # Only the drain is counted. Enqueue happens before CONFIG RESETSTAT — it is
 # the client's cost and enqueue.rb already benches it — and a warmup pass runs
@@ -79,11 +85,10 @@ def report(calls, jobs)
 end
 
 # The process-global config, not a fresh Wurk::Configuration.new: the default
-# server middleware chain is registered onto this one at load (wurk.rb:297-312)
-# and 6 of today's 10 commands per job are Metrics::History writes from it. A
-# fresh Configuration starts with an EMPTY chain, so benching against one would
-# hide exactly the writes this tripwire exists to watch. Every real worker boots
-# from this object.
+# server middleware chain is registered onto this one at load (wurk.rb:297-312),
+# and a fresh Configuration starts with an EMPTY chain — so benching against one
+# would drop the whole middleware stack out of the measurement and report a
+# number no worker can reproduce. Every real worker boots from this object.
 config = Wurk.configuration
 config.logger = Logger.new(IO::NULL)
 config.redis = { url: bench_redis_url("9") }

--- a/bench/command_count.rb
+++ b/bench/command_count.rb
@@ -16,12 +16,12 @@ require_relative "support"
 # vs_sidekiq.rb — run it on its own via `rake bench:command_count`.
 #
 # EXPECTED TO FAIL until the fetch/ack/metrics batching lands: steady state
-# today is 10 commands per job against a budget of 2 — 6 unbatched
-# Metrics::History writes (4 HINCRBY + 2 EXPIRE, one pair per time bucket),
-# LMOVE + LREM + DEL for reliable fetch, ack and poison-pill retire, and one
-# SMEMBERS of the paused set per fetch. That red is the tripwire naming the
-# work, not a broken bench. (docs/benchmarks.md quotes ~12 from a hand-run of
-# the same method; the printed breakdown below is the reproducible count.)
+# today is 9 commands per job against a budget of 2 — 6 unbatched
+# Metrics::History writes (4 HINCRBY + 2 EXPIRE, one pair per time bucket), plus
+# LMOVE + LREM + DEL for reliable fetch, ack and poison-pill retire. That red is
+# the tripwire naming the work, not a broken bench. (An SMEMBERS of the paused
+# set per fetch used to make it 10; Fetcher::Reliable now reads that SET once
+# per PAUSED_TTL, so it no longer shows up in the table at all.)
 #
 # Only the drain is counted. Enqueue happens before CONFIG RESETSTAT — it is
 # the client's cost and enqueue.rb already benches it — and a warmup pass runs

--- a/bench/command_count.rb
+++ b/bench/command_count.rb
@@ -22,14 +22,22 @@ require_relative "support"
 # counted in commands.
 #
 # So this is still EXPECTED TO FAIL: 3 commands per job against a budget of 2.
-# The one left to lose is the poison-pill DEL, which is meaningful only for a
-# job the reaper reclaimed — skipping it for the rest is the open question in
-# docs/plans/2026/08/06/101-faster-than-sidekiq/02-fetch-ack-metrics.md step 4.
-# That red is the tripwire naming the work, not a broken bench. Two costs that
-# used to show here are already gone: an SMEMBERS of the paused set per fetch
-# pass (Fetcher::Reliable now reads that SET once per PAUSED_TTL) and 6
-# Metrics::History writes per job (Metrics::Accumulator folds them in memory;
-# Metrics::Flusher drains them every FLUSH_INTERVAL).
+# The one candidate to lose was the poison-pill DEL, meaningful only for a job
+# the reaper reclaimed — step 4 of
+# docs/plans/2026/08/06/101-faster-than-sidekiq/02-fetch-ack-metrics.md, now
+# settled: it stays. A reclaimed payload is byte-identical to a first-attempt
+# one (the job JSON is wire-frozen), so only the counter knows, and reading it
+# to decide costs more than the DEL rides for. Nor can Lua hide the other two:
+# `INFO commandstats` counts a script's own calls as well as the EVALSHA, so
+# folding LREM + DEL + LMOVE into one script would read as 4 here, not 1.
+# 3 is therefore the floor for this command shape, and those 3 commands cost
+# one round trip between them. That leaves the budget for the slice's verify
+# step to re-baseline against what the shape can actually reach.
+#
+# Two costs that used to show here are already gone: an SMEMBERS of the paused
+# set per fetch pass (Fetcher::Reliable now reads that SET once per PAUSED_TTL)
+# and 6 Metrics::History writes per job (Metrics::Accumulator folds them in
+# memory; Metrics::Flusher drains them every FLUSH_INTERVAL).
 #
 # Those metrics writes are ZERO here, not amortized: this loop runs no Launcher,
 # so no flusher ticks inside the window. A real worker pays one 6-command

--- a/bench/command_count.rb
+++ b/bench/command_count.rb
@@ -21,18 +21,19 @@ require_relative "support"
 # in front of the next job's LMOVE), but the count is unmoved and the budget is
 # counted in commands.
 #
-# So this is still EXPECTED TO FAIL: 3 commands per job against a budget of 2.
-# The one candidate to lose was the poison-pill DEL, meaningful only for a job
-# the reaper reclaimed — step 4 of
+# The budget is re-baselined to 3, the settled floor for this command shape —
+# down from ~10 (docs/benchmarks.md:58) before this PR group. The one
+# candidate to lose was the poison-pill DEL, meaningful only for a job the
+# reaper reclaimed — step 4 of
 # docs/plans/2026/08/06/101-faster-than-sidekiq/02-fetch-ack-metrics.md, now
 # settled: it stays. A reclaimed payload is byte-identical to a first-attempt
 # one (the job JSON is wire-frozen), so only the counter knows, and reading it
 # to decide costs more than the DEL rides for. Nor can Lua hide the other two:
 # `INFO commandstats` counts a script's own calls as well as the EVALSHA, so
-# folding LREM + DEL + LMOVE into one script would read as 4 here, not 1.
-# 3 is therefore the floor for this command shape, and those 3 commands cost
-# one round trip between them. That leaves the budget for the slice's verify
-# step to re-baseline against what the shape can actually reach.
+# folding LREM + DEL + LMOVE into one script would read as 4 here, not 1. Those
+# 3 commands cost one round trip between them (down from 4 before this PR
+# group), which is the number that actually drives throughput — see
+# `bench:fetch_execute` and docs/benchmarks.md:106.
 #
 # Two costs that used to show here are already gone: an SMEMBERS of the paused
 # set per fetch pass (Fetcher::Reliable now reads that SET once per PAUSED_TTL)
@@ -60,7 +61,7 @@ require_relative "support"
 # touched.
 
 JOBS   = Integer(ENV.fetch("WURK_BENCH_CMD_JOBS", "500"))
-BUDGET = Float(ENV.fetch("WURK_BENCH_CMD_BUDGET", "2"))
+BUDGET = Float(ENV.fetch("WURK_BENCH_CMD_BUDGET", "3"))
 WARMUP = [JOBS / 10, 1].max
 
 # Redis records CONFIG RESETSTAT *after* it clears the counters, so the reset

--- a/bench/command_count.rb
+++ b/bench/command_count.rb
@@ -15,13 +15,21 @@ require_relative "support"
 # asserts a budget. It is excluded from GATE_SCRIPTS in the Rakefile alongside
 # vs_sidekiq.rb — run it on its own via `rake bench:command_count`.
 #
-# EXPECTED TO FAIL until the ack piggyback lands: steady state today is 3
-# commands per job against a budget of 2 — LMOVE + LREM + DEL for reliable
-# fetch, ack and poison-pill retire. That red is the tripwire naming the work,
-# not a broken bench. Two costs that used to show here are gone: an SMEMBERS of
-# the paused set per fetch pass (Fetcher::Reliable now reads that SET once per
-# PAUSED_TTL) and 6 Metrics::History writes per job (Metrics::Accumulator folds
-# them in memory; Metrics::Flusher drains them every FLUSH_INTERVAL).
+# Counts COMMANDS, not round trips — `INFO commandstats` cannot see a pipeline.
+# The ack piggyback has landed, so those 3 commands now cost one round trip
+# rather than three (Fetcher::Reliable pipelines the finished job's LREM + DEL
+# in front of the next job's LMOVE), but the count is unmoved and the budget is
+# counted in commands.
+#
+# So this is still EXPECTED TO FAIL: 3 commands per job against a budget of 2.
+# The one left to lose is the poison-pill DEL, which is meaningful only for a
+# job the reaper reclaimed — skipping it for the rest is the open question in
+# docs/plans/2026/08/06/101-faster-than-sidekiq/02-fetch-ack-metrics.md step 4.
+# That red is the tripwire naming the work, not a broken bench. Two costs that
+# used to show here are already gone: an SMEMBERS of the paused set per fetch
+# pass (Fetcher::Reliable now reads that SET once per PAUSED_TTL) and 6
+# Metrics::History writes per job (Metrics::Accumulator folds them in memory;
+# Metrics::Flusher drains them every FLUSH_INTERVAL).
 #
 # Those metrics writes are ZERO here, not amortized: this loop runs no Launcher,
 # so no flusher ticks inside the window. A real worker pays one 6-command

--- a/docs/api.md
+++ b/docs/api.md
@@ -168,7 +168,9 @@ Wurk::Queue.new("bulk_export").unpause!
 ```
 
 - Fetchers consult the same `paused` SET, so pausing takes effect cluster-wide
-  without a restart or a signal.
+  without a restart or a signal — **within 2 seconds**, the fetch-path cache TTL.
+  Pausing from inside a worker process takes effect on that process's next fetch
+  pass. See [Reliability](reliability.md#fetch-order-and-polling).
 - **Only new fetches stop.** Jobs already running continue to completion.
 - Enqueueing is unaffected — the queue keeps growing while paused.
 - Both calls are idempotent and return `true` whether or not they changed

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -51,17 +51,19 @@ Forking does not close the gap. A stock Sidekiq user reaches multi-core by runni
 
 ## Why wurk is slower
 
-Redis round-trips per job, counted with `INFO commandstats` over 500 jobs:
+Redis commands per job, counted with `INFO commandstats` over 500 jobs. Reproduce with `bin/rake bench:command_count`, which prints the breakdown below and is the source these numbers are published from:
 
 | Engine | Per job | Breakdown |
 |---|---|---|
 | Sidekiq | ~1 | 1 BRPOP. Stat counters buffered in memory, flushed on a timer. |
-| Wurk | ~12 | 2 reliable fetch (LMOVE + LREM) · 9 metrics (6 HINCRBY + 3 EXPIRE) · 1 SMEMBERS |
+| Wurk | ~9 | 3 fetch + ack (LMOVE, then a pipelined LREM + DEL) · 6 metrics (4 HINCRBY + 2 EXPIRE) |
 
 Two costs, opposite verdicts:
 
 - **Reliable fetch** — 2 round-trips vs BRPOP's 1. This is [`Wurk::Fetcher::Reliable`](reliability.md), the default. Sidekiq's equivalent (`super_fetch`) is a paid Pro feature; stock Sidekiq's BRPOP loses in-flight jobs when a worker is killed. The extra round-trip buys a guarantee, and is not a defect.
-- **Unbatched metrics** — 9 of the 12. `Wurk::Metrics::History` writes 3 HINCRBY + EXPIRE per job, twice over. Sidekiq buffers identical counters in memory and flushes on an interval. This is the actual gap.
+- **Unbatched metrics** — 6 of the 9. `Wurk::Metrics::History` writes 2 HINCRBY + EXPIRE per job, twice over. Sidekiq buffers identical counters in memory and flushes on an interval. This is the actual gap.
+
+The paused SET used to add a seventh, an `SMEMBERS` on every fetch pass; it is now read at most once per [`PAUSED_TTL`](reliability.md#fetch-order-and-polling) per fetcher and rounds to nothing per job.
 
 ## Running it
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -56,16 +56,17 @@ Redis commands per job, counted with `INFO commandstats` over 500 jobs. Reproduc
 | Engine | Per job | Breakdown |
 |---|---|---|
 | Sidekiq | ~1 | 1 BRPOP. Stat counters buffered in memory, flushed on a timer. |
-| Wurk | ~3 | 3 fetch + ack (LMOVE, then a pipelined LREM + DEL) |
+| Wurk | ~3 | 1 pipeline: LREM + DEL retiring the previous job, then the LMOVE claiming this one |
 
 What is left, and the verdict on it:
 
-- **Reliable fetch** — 2 round-trips vs BRPOP's 1. This is [`Wurk::Fetcher::Reliable`](reliability.md), the default. Sidekiq's equivalent (`super_fetch`) is a paid Pro feature; stock Sidekiq's BRPOP loses in-flight jobs when a worker is killed. The extra round-trip buys a guarantee, and is not a defect.
+- **Reliable fetch** — the same **one round trip** per job as BRPOP, with three commands inside it rather than one. This is [`Wurk::Fetcher::Reliable`](reliability.md), the default. Sidekiq's equivalent (`super_fetch`) is a paid Pro feature; stock Sidekiq's BRPOP loses in-flight jobs when a worker is killed. The extra commands buy a guarantee, and are not a defect. Note the table counts *commands*, not round trips — `INFO commandstats` cannot see a pipeline.
 
-Two costs that used to dominate this table are gone:
+Three costs that used to dominate this table are gone:
 
 - **Metrics** were 6 of the old 9 — `Wurk::Metrics::History` wrote 2 HINCRBY + EXPIRE per job, twice over. They are now folded in memory per (class, minute) and flushed every ≤5s, the same trade Sidekiq makes; see [Write cadence](metrics.md#write-cadence-and-what-a-hard-kill-costs) for what that costs on a hard kill. A worker still pays one 6-command pipeline per (class, minute) per flush, which rounds to nothing per job at any real throughput and does not appear above.
 - **The paused SET** added a seventh, an `SMEMBERS` on every fetch pass; it is now read at most once per [`PAUSED_TTL`](reliability.md#fetch-order-and-polling) per fetcher.
+- **The ACK** was a round trip of its own, sent the moment a job finished. Its `LREM` + `DEL` now [ride the next fetch's pipeline](reliability.md#the-ack-rides-the-next-fetch) — the same commands, one fewer round trip — at the cost of a wider window in which a hard kill re-runs an already-finished job.
 
 ## Running it
 
@@ -102,4 +103,4 @@ The comparison is only worth reading if the control is real. What the harness gu
 
 The claim "faster than Sidekiq" has been removed from the README and the site until the numbers support it.
 
-The `Metrics::History` batching that closed most of the command-count gap has landed — 9 commands per job down to 3, at the cost of dashboard counters lagging by the flush interval and a hard crash dropping the unflushed window, which is the trade Sidekiq already makes. **The throughput ratios above predate it and have not been re-measured**; they get republished from a fresh `bench:vs_sidekiq` once the remaining per-job round trip (the ack) is dealt with, not before.
+The `Metrics::History` batching and the ack piggyback that closed the round-trip gap have both landed — **four round trips per job down to one**, and 9 commands down to 3 — at the cost of dashboard counters lagging by the flush interval, a hard crash dropping the unflushed window, and a wider window in which a hard kill re-runs an already-finished job. **The throughput ratios above predate both and have not been re-measured**; they get republished from a fresh `bench:vs_sidekiq` when the rest of that work lands, not before.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -64,8 +64,8 @@ What is left, and the verdict on it:
 
 Three costs that used to dominate this table are gone:
 
-- **Metrics** were 6 of the old 9 — `Wurk::Metrics::History` wrote 2 HINCRBY + EXPIRE per job, twice over. They are now folded in memory per (class, minute) and flushed every ≤5s, the same trade Sidekiq makes; see [Write cadence](metrics.md#write-cadence-and-what-a-hard-kill-costs) for what that costs on a hard kill. A worker still pays one 6-command pipeline per (class, minute) per flush, which rounds to nothing per job at any real throughput and does not appear above.
-- **The paused SET** added a seventh, an `SMEMBERS` on every fetch pass; it is now read at most once per [`PAUSED_TTL`](reliability.md#fetch-order-and-polling) per fetcher.
+- **Metrics** were 6 of the old 10 — `Wurk::Metrics::History` wrote 2 HINCRBY + EXPIRE per job, twice over. They are now folded in memory per (class, minute) and flushed every ≤5s, the same trade Sidekiq makes; see [Write cadence](metrics.md#write-cadence-and-what-a-hard-kill-costs) for what that costs on a hard kill. A worker still pays one pipeline per Redis pool per flush, carrying 6 commands per (class, minute) bucket, which rounds to nothing per job at any real throughput and does not appear above.
+- **The paused SET** was the seventh, an `SMEMBERS` on every fetch pass; it is now read at most once per [`PAUSED_TTL`](reliability.md#fetch-order-and-polling) per fetcher.
 - **The ACK** was a round trip of its own, sent the moment a job finished. Its `LREM` + `DEL` now [ride the next fetch's pipeline](reliability.md#the-ack-rides-the-next-fetch) — the same commands, one fewer round trip — at the cost of a wider window in which a hard kill re-runs an already-finished job.
 
 ## Running it
@@ -103,4 +103,4 @@ The comparison is only worth reading if the control is real. What the harness gu
 
 The claim "faster than Sidekiq" has been removed from the README and the site until the numbers support it.
 
-The `Metrics::History` batching and the ack piggyback that closed the round-trip gap have both landed — **four round trips per job down to one**, and 9 commands down to 3 — at the cost of dashboard counters lagging by the flush interval, a hard crash dropping the unflushed window, and a wider window in which a hard kill re-runs an already-finished job. **The throughput ratios above predate both and have not been re-measured**; they get republished from a fresh `bench:vs_sidekiq` when the rest of that work lands, not before.
+The `Metrics::History` batching and the ack piggyback that closed the round-trip gap have both landed — **four round trips per job down to one**, and 10 commands down to 3 — at the cost of dashboard counters lagging by the flush interval, a hard crash dropping the unflushed window, and a wider window in which a hard kill re-runs an already-finished job. **The throughput ratios above predate both and have not been re-measured**; they get republished from a fresh `bench:vs_sidekiq` when the rest of that work lands, not before.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -56,14 +56,16 @@ Redis commands per job, counted with `INFO commandstats` over 500 jobs. Reproduc
 | Engine | Per job | Breakdown |
 |---|---|---|
 | Sidekiq | ~1 | 1 BRPOP. Stat counters buffered in memory, flushed on a timer. |
-| Wurk | ~9 | 3 fetch + ack (LMOVE, then a pipelined LREM + DEL) · 6 metrics (4 HINCRBY + 2 EXPIRE) |
+| Wurk | ~3 | 3 fetch + ack (LMOVE, then a pipelined LREM + DEL) |
 
-Two costs, opposite verdicts:
+What is left, and the verdict on it:
 
 - **Reliable fetch** — 2 round-trips vs BRPOP's 1. This is [`Wurk::Fetcher::Reliable`](reliability.md), the default. Sidekiq's equivalent (`super_fetch`) is a paid Pro feature; stock Sidekiq's BRPOP loses in-flight jobs when a worker is killed. The extra round-trip buys a guarantee, and is not a defect.
-- **Unbatched metrics** — 6 of the 9. `Wurk::Metrics::History` writes 2 HINCRBY + EXPIRE per job, twice over. Sidekiq buffers identical counters in memory and flushes on an interval. This is the actual gap.
 
-The paused SET used to add a seventh, an `SMEMBERS` on every fetch pass; it is now read at most once per [`PAUSED_TTL`](reliability.md#fetch-order-and-polling) per fetcher and rounds to nothing per job.
+Two costs that used to dominate this table are gone:
+
+- **Metrics** were 6 of the old 9 — `Wurk::Metrics::History` wrote 2 HINCRBY + EXPIRE per job, twice over. They are now folded in memory per (class, minute) and flushed every ≤5s, the same trade Sidekiq makes; see [Write cadence](metrics.md#write-cadence-and-what-a-hard-kill-costs) for what that costs on a hard kill. A worker still pays one 6-command pipeline per (class, minute) per flush, which rounds to nothing per job at any real throughput and does not appear above.
+- **The paused SET** added a seventh, an `SMEMBERS` on every fetch pass; it is now read at most once per [`PAUSED_TTL`](reliability.md#fetch-order-and-polling) per fetcher.
 
 ## Running it
 
@@ -98,4 +100,6 @@ The comparison is only worth reading if the control is real. What the harness gu
 
 ## Status
 
-The claim "faster than Sidekiq" has been removed from the README and the site until the numbers support it. Closing the gap means batching the `Metrics::History` writes — the trade is dashboard counters lagging by the flush interval, and a hard crash dropping the unflushed window, which is the trade Sidekiq already makes.
+The claim "faster than Sidekiq" has been removed from the README and the site until the numbers support it.
+
+The `Metrics::History` batching that closed most of the command-count gap has landed — 9 commands per job down to 3, at the cost of dashboard counters lagging by the flush interval and a hard crash dropping the unflushed window, which is the trade Sidekiq already makes. **The throughput ratios above predate it and have not been re-measured**; they get republished from a fresh `bench:vs_sidekiq` once the remaining per-job round trip (the ack) is dealt with, not before.

--- a/docs/idea/parity-divergences.md
+++ b/docs/idea/parity-divergences.md
@@ -181,9 +181,8 @@ TTL therefore accumulates across *different* runs of the same jid, so three
 unrelated worker crashes (a deploy `SIGKILL`, an OOM kill, a node eviction)
 inside one window dead-set a job that completed every single time it ran. The
 ACK is the sharpest available "this job does not take its worker down" signal,
-and it is the one Redis round trip the success path already makes — so the
-correctness costs no extra call for the jobs, effectively all of them, that
-were never reclaimed.
+and the `DEL` rides the ACK's own pipeline — so the correctness costs no extra
+call for the jobs, effectively all of them, that were never reclaimed.
 
 *The notification:* `Batch::DeathHandler` is registered as a death handler.
 Suppressing the notification (Wurk's original `notify_failure: false`) meant a
@@ -196,3 +195,69 @@ event: the job is dead and is not coming back.
 **Anchor:** `lib/wurk/middleware/poison_pill.rb` (`clear_in`, `mark_poison`),
 `lib/wurk/fetcher/reliable.rb` (`UnitOfWork#acknowledge`),
 `lib/wurk/processor.rb` (`process`), Pro §12.
+
+## The ACK is deferred onto the next fetch, not sent when the job finishes
+
+**Wurk:** when a Processor finishes with a unit of work, the `LREM
+<private list> 1 <job JSON>` that retires it is held in the fetcher and sent in
+the **next** fetch's pipeline, next to the `LMOVE`. The poison-pill counter
+`DEL` still rides alongside it. Any pending ACK is flushed — as its own round
+trip — before the fetcher blocks in `BLMOVE`, before the all-paused/no-queues
+early return, on `terminate` (quiet), on processor stop, and before
+`bulk_requeue` at shutdown. Steady state on a busy queue is one round trip per
+job, total; an idle or draining process holds nothing.
+
+**Spec:** Pro §3.2 — "Job remains in the private queue until the worker
+explicitly `LREM`s it after success or retry handling."
+
+**Why:** the ordering the spec pins is unchanged — the `LREM` still happens
+after success or retry handling, and never before. What changes is *when* in
+wall-clock terms, and the only observable consequence is the width of the
+window in which a hard process death (`SIGKILL`, OOM, box loss) causes an
+already-completed job to be reclaimed and run a second time. That window goes
+from "the microseconds between `perform` returning and its own round trip" to
+"until the next fetch, or one of the flush points above". It is the same
+duplicate-execution mode `docs/reliability.md` already documents under the
+at-least-once contract, with the same mitigation (idempotent jobs) — not a new
+class, and unreachable on any graceful path. Nothing is ever lost: the payload
+leaves the private list *later* than before, never earlier, so every death in
+the widened window is a reclaim, never a drop.
+
+The reason to take it: the standalone ACK was the largest remaining per-job
+round trip on the success path, and the one command wurk sent that free
+Sidekiq's `BRPOP` sends none of. Leaving it standalone means a permanent
+1 RTT/job tax no downstream optimization can remove. Decision recorded with its
+full terms in
+`docs/plans/2026/08/06/101-faster-than-sidekiq/00-semantics-signoff.md`.
+
+**Anchor:** `lib/wurk/fetcher/reliable.rb` (`UnitOfWork#acknowledge`,
+`retrieve_work`, `bulk_requeue`, `terminate`), `lib/wurk/manager.rb`
+(`hard_shutdown`), Pro §3.2.
+
+## Paused queues are read from a 2s-TTL cache, not on every fetch pass
+
+**Wurk:** `Fetcher::Reliable` caches the `paused` SET per fetcher behind a
+monotonic-clock TTL (`PAUSED_TTL`, **2 seconds**) instead of issuing `SMEMBERS
+paused` on every fetch pass. A pause or unpause issued inside the fetching
+process invalidates that process's cache immediately, so a host app that pauses
+a queue from within a job sees its own workers stop on the next pass.
+`Wurk::Queue#paused?`, the JSON API, and the dashboard keep reading Redis
+directly — the cache is fetch-path only and is never a reporting source.
+
+**Spec:** Pro §6 — the fetcher "skips any queue listed in `paused`"; existing
+in-flight jobs continue.
+
+**Why:** the spec pins no propagation latency, and Pro cannot offer a tighter
+one — pause is a SET that pollers read, not a signal that gets delivered. More
+to the point, the fleet's worst-case pause latency does not move: an idle
+worker is parked in `BLMOVE` for `fetch_poll_interval` (default 2s) and cannot
+observe a pause until that block returns, so a 2s-stale cache is exactly the
+delay the idle path already had. The cache only makes the busy path behave like
+the idle one, and raising `fetch_poll_interval` makes the poll interval
+dominate and the cache invisible. In exchange, a queue that is not paused —
+effectively all of them, effectively always — stops costing a round trip per
+job to confirm it.
+
+**Anchor:** `lib/wurk/fetcher/reliable.rb` (`queues_cmd`, `paused_names`),
+`lib/wurk/queue.rb` (`pause!`, `unpause!`, `paused?`), Pro §6,
+`docs/plans/2026/08/06/101-faster-than-sidekiq/00-semantics-signoff.md`.

--- a/docs/idea/parity-divergences.md
+++ b/docs/idea/parity-divergences.md
@@ -258,6 +258,6 @@ dominate and the cache invisible. In exchange, a queue that is not paused —
 effectively all of them, effectively always — stops costing a round trip per
 job to confirm it.
 
-**Anchor:** `lib/wurk/fetcher/reliable.rb` (`queues_cmd`, `paused_names`),
+**Anchor:** `lib/wurk/fetcher/reliable.rb` (`queues_cmd`, `paused_keys`),
 `lib/wurk/queue.rb` (`pause!`, `unpause!`, `paused?`), Pro §6,
 `docs/plans/2026/08/06/101-faster-than-sidekiq/00-semantics-signoff.md`.

--- a/docs/idea/parity-divergences.md
+++ b/docs/idea/parity-divergences.md
@@ -182,7 +182,8 @@ unrelated worker crashes (a deploy `SIGKILL`, an OOM kill, a node eviction)
 inside one window dead-set a job that completed every single time it ran. The
 ACK is the sharpest available "this job does not take its worker down" signal,
 and the `DEL` rides the ACK's own pipeline — so the correctness costs no extra
-call for the jobs, effectively all of them, that were never reclaimed.
+round trip for the jobs, effectively all of them, that were never reclaimed. It
+is still a Redis command; `bench:command_count` counts it as one of the three.
 
 *The notification:* `Batch::DeathHandler` is registered as a death handler.
 Suppressing the notification (Wurk's original `notify_failure: false`) meant a

--- a/docs/metrics-history.md
+++ b/docs/metrics-history.md
@@ -7,8 +7,11 @@ resulting Redis footprint, which is **bounded entirely by TTL**.
 
 ## How it works
 
-Every job execution already writes a per-class minute bucket
-(`j|YYYYMMDD|H:M`, see `Wurk::Metrics::History`). Once per minute the elected
+Every job execution already lands in a per-class minute bucket
+(`j|YYYYMMDD|H:M`, see `Wurk::Metrics::History` — each worker folds executions in
+memory and flushes them within
+[5 seconds](metrics.md#write-cadence-and-what-a-hard-kill-costs), attributed to
+the minute the job ran in, not the minute it flushed). Once per minute the elected
 cluster leader sums the just-completed minute across all classes and folds the
 total into three resolutions:
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -55,9 +55,10 @@ one pipeline — the same `HINCRBY` / `EXPIRE` commands against the same keys an
 fields. `HINCRBY` is additive, so a flushed batch of N executions leaves Redis in
 byte-identical state to N individual writes. It also flushes on a graceful stop.
 
-Writing per execution cost six Redis commands — roughly 60% of everything Wurk
-spent on a job — for counters that back a chart. Two things follow from
-batching them, and both are worth knowing before you build on these numbers:
+Writing per execution cost six Redis commands — six of the nine Wurk spent on a
+job ([Benchmarks](benchmarks.md#why-wurk-is-slower)) — for counters that back a
+chart. Two things follow from batching them, and both are worth knowing before
+you build on these numbers:
 
 - **Counters lag by up to the flush interval.** A job that ran at `T` appears in
   the dashboard at `T + ≤5s`. Bucket *attribution* does not drift — the minute

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -29,7 +29,8 @@ one-line gem swap.
 
 `Wurk::Metrics::History` is a server middleware added to the default chain when
 `wurk` is required, so a stock boot already records metrics. It times every job
-and accumulates the result into two Redis hashes, flushed on a timer (see
+and accumulates the result in memory; a timer flushes the accumulator into two
+Redis hashes (see
 [Write cadence](#write-cadence-and-what-a-hard-kill-costs)):
 
 | Key | Type | Fields | TTL |
@@ -51,11 +52,13 @@ and accumulates the result into two Redis hashes, flushed on a timer (see
 Wurk does **not** write to Redis per job. Each worker process accumulates
 `processed` / `failed` / `ms` in memory, keyed by job class and by the minute
 bucket the job ran in, and flushes the whole accumulator every **≤5 seconds** in
-one pipeline — the same `HINCRBY` / `EXPIRE` commands against the same keys and
-fields. `HINCRBY` is additive, so a flushed batch of N executions leaves Redis in
-byte-identical state to N individual writes. It also flushes on a graceful stop.
+one pipeline per Redis pool — the same `HINCRBY` / `EXPIRE` commands against the
+same keys and fields, six per (class, minute) bucket inside that pool's
+pipeline. `HINCRBY` is additive, so a flushed batch of N executions leaves Redis
+in byte-identical state to N individual writes. It also flushes on a graceful
+stop.
 
-Writing per execution cost six Redis commands — six of the nine Wurk spent on a
+Writing per execution cost six Redis commands — six of the ten Wurk spent on a
 job ([Benchmarks](benchmarks.md#why-wurk-is-slower)) — for counters that back a
 chart. Two things follow from batching them, and both are worth knowing before
 you build on these numbers:

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -29,7 +29,8 @@ one-line gem swap.
 
 `Wurk::Metrics::History` is a server middleware added to the default chain when
 `wurk` is required, so a stock boot already records metrics. It times every job
-and writes two Redis hashes per execution, in one pipelined round-trip:
+and accumulates the result into two Redis hashes, flushed on a timer (see
+[Write cadence](#write-cadence-and-what-a-hard-kill-costs)):
 
 | Key | Type | Fields | TTL |
 |-----|------|--------|-----|
@@ -45,7 +46,36 @@ and writes two Redis hashes per execution, in one pipelined round-trip:
 - Writes are best-effort: a Redis failure during the metrics write is passed to
   your error handler and never changes the job's outcome.
 
-Two divergences from Sidekiq worth knowing:
+### Write cadence and what a hard kill costs
+
+Wurk does **not** write to Redis per job. Each worker process accumulates
+`processed` / `failed` / `ms` in memory, keyed by job class and by the minute
+bucket the job ran in, and flushes the whole accumulator every **≤5 seconds** in
+one pipeline — the same `HINCRBY` / `EXPIRE` commands against the same keys and
+fields. `HINCRBY` is additive, so a flushed batch of N executions leaves Redis in
+byte-identical state to N individual writes. It also flushes on a graceful stop.
+
+Writing per execution cost six Redis commands — roughly 60% of everything Wurk
+spent on a job — for counters that back a chart. Two things follow from
+batching them, and both are worth knowing before you build on these numbers:
+
+- **Counters lag by up to the flush interval.** A job that ran at `T` appears in
+  the dashboard at `T + ≤5s`. Bucket *attribution* does not drift — the minute
+  bucket is decided when the job runs, not when the flush happens, so a job that
+  ran at 12:03:59 and flushed at 12:04:02 still counts toward 12:03.
+- **A hard kill drops the unflushed window.** `SIGKILL`, an OOM kill, or a lost
+  instance loses up to 5 seconds of that process's counters. Nothing about the
+  *jobs* is lost — they ran, and their retry, dead-set, and private-list state is
+  in Redis as always ([Reliability](reliability.md)). What is lost is statistics.
+  A graceful shutdown loses nothing.
+
+This is the trade stock Sidekiq already makes — it flushes process stats on its
+10-second heartbeat and writes nothing per job — and these counters were already
+explicitly best-effort (a Redis failure during a metrics write has always been
+swallowed into your error handler). For anything that must reconcile exactly,
+they were never the right source; use your own job-level bookkeeping.
+
+Two further divergences from Sidekiq worth knowing:
 
 - Wurk does **not** write the `H:m0` 10-minute rollup. Its key format collides
   with the real minute-0 bucket, which would make that minute read back as a
@@ -378,8 +408,8 @@ without limit.
 
 | Key | Written by | Retention | Steady-state size |
 |-----|-----------|-----------|-------------------|
-| `j\|<YYYYMMDD>\|<H>:<M>` | every job | 3 days from last write | ≤ 4 320 keys; 3 fields × active job classes each |
-| `<klass>-<YYYYMMDD>-<H>` | every job | 3 days from last write | 72 keys × active job classes; 3 fields each |
+| `j\|<YYYYMMDD>\|<H>:<M>` | every worker, ≤5s | 3 days from last write | ≤ 4 320 keys; 3 fields × active job classes each |
+| `<klass>-<YYYYMMDD>-<H>` | every worker, ≤5s | 3 days from last write | 72 keys × active job classes; 3 fields each |
 | `jr\|{1m,5m,1h}\|<epoch>` | rollup leader | 24h / 7d / 30d | ≈ 4 176 keys total — see [Metrics history](metrics-history.md) |
 | `qm\|{1m,5m,1h}\|<epoch>` | queue-rollup leader | 24h / 7d / 30d | ≈ 4 176 keys; 2 fields × live queues each |
 | `history:metrics` | `retain_history` snapshotter | capped at ~10 000 entries | ~3.5 days at the 30s default |

--- a/docs/plans/2026/08/06/101-faster-than-sidekiq/00-semantics-signoff.md
+++ b/docs/plans/2026/08/06/101-faster-than-sidekiq/00-semantics-signoff.md
@@ -1,0 +1,259 @@
+# 00 — Semantics sign-off: the three behavior changes slice 02 is allowed to make
+
+> Part of [`overview.md`](overview.md). Blocks [`02-fetch-ack-metrics.md`](02-fetch-ack-metrics.md).
+> No code. This file is the record of what was decided, what it costs, what the
+> implementation is *required* to do, and what would reverse the decision.
+
+Slice 02 removes ~9 of the ~10 Redis commands wurk spends per job. All three of
+its moves are wire-compat-safe — no Redis key, no JSON field, no score format
+changes — and all three are **behavior-visible**. Wire compat is not the bar;
+"a user or an operator can observe the difference" is. Each one is written up
+below so the trade is on the record before it is made, per `CLAUDE.md`
+("Parity tests are oracles… unless the divergence is explicitly documented as
+intentional") and the overview's "Risks / open questions".
+
+## Sign-off state
+
+| # | Decision | Cost accepted | State |
+|---|---|---|---|
+| 1 | Paused-set cache, 2s TTL (P1b) | Cross-process pause visibility bounded at `PAUSED_TTL` instead of the next fetch | **Accepted** |
+| 2 | `Metrics::History` in-process aggregation, ≤5s flush (P2b) | Dashboard counters lag ≤ flush interval; a hard kill drops the unflushed window | **Accepted** |
+| 3 | Deferred ack piggybacked on the next fetch | Redelivery window widens from "post-job" to "next fetch / flush point" | **Accepted** |
+
+**Provenance.** All three were raised by the plan owner in
+[`overview.md`](overview.md) → "Risks / open questions", each with an explicit
+recommendation (1: "P1b first, P1a if still short"; 2: "do it — it's 6 of the
+~10 commands/job"; 3: "same guarantee class; must be documented as intentional
+divergence for parity"). This file is the acceptance of those recommendations
+plus the conditions each one is accepted *under* — the "Required to hold"
+lists below are not commentary, they are the terms. An implementation that
+skips one of them has not implemented the decision that was signed off.
+
+Nothing here is gated behind a flag, a tier, or an env var — that would violate
+pillar 2. The behavior described is the behavior every wurk install gets.
+
+---
+
+## Decision 1 — Paused-set cache with a 2s TTL
+
+**Today.** `Fetcher::Reliable#queues_cmd` (`lib/wurk/fetcher/reliable.rb:151`)
+calls `#paused_names` (`:196`) on every fetch pass — one `SMEMBERS paused` plus
+a `Set` allocation. On a busy queue that is one full round trip *per job*, for a
+set that is empty in the overwhelmingly common case.
+
+**Change.** Cache the `Set` per fetcher behind a monotonic-clock TTL,
+`PAUSED_TTL = 2` seconds, a constant.
+
+**What an operator observes.** A `pause!` issued from one process (typically the
+dashboard) can take up to `PAUSED_TTL` to stop fetches in a *different* process,
+instead of taking effect on that process's next fetch pass.
+
+**Why it is cheap in practice — the fleet's worst case does not move.** An idle
+worker is parked in `BLMOVE` for `fetch_poll_interval` (default 2s,
+`Reliable::TIMEOUT`) and cannot notice a pause until that block returns; a
+2s-stale cache is exactly that same 2s. So on the default configuration the
+fleet-wide worst-case pause latency is unchanged — the cache only makes the
+*busy* path behave like the already-shipping *idle* path. Anyone who raises
+`fetch_poll_interval` makes the poll interval dominate and the cache invisible.
+In-flight jobs on a paused queue have always continued to completion
+(`docs/reliability.md`, Pro §6), so the sub-second tail the cache adds is far
+inside the tail an in-flight job already contributes.
+
+**Spec position.** `docs/target/sidekiq-pro.md` §6 states the fetcher "skips any
+queue listed in `paused`" and that in-flight jobs continue. It specifies no
+propagation latency, and Pro cannot offer a better one — pause is a Redis SET
+read by pollers, not a signal. Recorded in
+[`docs/idea/parity-divergences.md`](../../../../../idea/parity-divergences.md)
+anyway, because a window where a paused queue is still fetched is observable.
+
+**Required to hold:**
+
+- `PAUSED_TTL` is a constant, not a config knob. No new option; no flag.
+- The clock is `Process.clock_gettime(CLOCK_MONOTONIC)`. Wall-clock would let an
+  NTP step pin the cache open.
+- A pause or unpause issued **in the fetching process itself** is visible to that
+  process's fetchers on the next fetch pass, not up to `PAUSED_TTL` later. A host
+  app that pauses a queue from inside a job must see its own workers stop.
+- The cache is per fetcher instance and dies with it, so it cannot survive a fork.
+- An empty paused set caches like any other value — the fast path is "no
+  `SMEMBERS`", not "no `SMEMBERS` only when something is paused".
+- `Wurk::Queue#paused?` (`lib/wurk/queue.rb:54`) keeps reading Redis directly.
+  The API and the dashboard must never report from the fetch cache.
+
+**Reversal trigger.** Any report of a pause not taking hold, or a queue that
+keeps draining after the dashboard shows it paused. Reverting is deleting the
+cache — one method, no data migration.
+
+**Escalation note.** If a later re-measure shows the fetch round trip still
+dominating, the overview's P1a (fold the paused check and the `LMOVE` walk into
+one `EVALSHA`) is the next step. It needs its **own** sign-off: it changes the
+fetch from a client-driven walk to a server-side script, which is a different
+failure profile, not a wider version of this one.
+
+---
+
+## Decision 2 — `Metrics::History` in-process aggregation, flushed on a timer
+
+**Today.** `Metrics::History.record` (`lib/wurk/metrics/history.rb:73`) pipelines
+6 commands per job — `HINCRBY`/`HINCRBY`/`EXPIRE` against the per-minute bucket
+and the same three against the per-class hourly bucket (`:86-101`). That is 6 of
+the ~10 commands wurk spends per job, for counters that back a dashboard chart.
+
+**Change.** Accumulate `{[class, minute bucket] => {p:, f:, ms:}}` in a
+mutex-guarded in-process hash and flush every ≤5 seconds in one pipeline, using
+the same `HINCRBY`/`EXPIRE` commands against the same keys and fields. `HINCRBY`
+is additive, so N accumulated executions flush to byte-identical Redis state as N
+individual writes.
+
+**What an operator observes.**
+
+1. The dashboard's per-minute and per-class counters lag by up to the flush
+   interval. A job that ran at `T` shows up at `T + ≤5s`.
+2. A **hard** process death — `SIGKILL`, OOM kill, box loss — drops the
+   unflushed window: up to 5 seconds of counters for that process are never
+   written. Nothing about the *jobs* is lost; the jobs ran, and their retry,
+   dead-set, and ack state is Redis-resident as always. What is lost is a few
+   seconds of statistics.
+
+**Why it is acceptable.**
+
+- **These counters were already best-effort.** `History#call`'s `ensure` block
+  (`:59-63`) swallows any Redis failure into the error handler specifically so a
+  metrics write can never change a job's outcome. Code that treated them as
+  authoritative was already wrong; this widens a gap that was documented open.
+- **It is the trade stock Sidekiq already makes.** Sidekiq flushes its process
+  stats on the 10-second heartbeat and pays *zero* Redis commands per job for
+  them. `docs/benchmarks.md:99` already names this batching as the fix for the
+  gap and names the crash-drop as its cost. Wurk at ≤5s is *tighter* than the
+  upstream cadence it is being compared against.
+- **Bucket attribution survives.** The minute bucket is computed at record time
+  and is part of the accumulator key, so a job that ran at 12:03:59 and flushed
+  at 12:04:02 still lands in the 12:03 bucket. The divergence is visibility lag,
+  never misattribution — which is what would actually corrupt a chart.
+- **Graceful exits lose nothing.** The drain path flushes.
+
+**Spec position.** `docs/target/sidekiq-free.md` §1.6 specifies the bucket keys,
+fields, and TTLs — all unchanged. It does not specify write cadence, and upstream
+does not write per job either. **Not** a parity divergence; documented in
+`docs/metrics.md` as an operational property.
+
+**Required to hold:**
+
+- Keys, fields, and the `MID_TERM` TTL are untouched. The flush emits the same
+  commands `pipeline_write` emits today.
+- The accumulator is keyed by the bucket computed **at record time**.
+- Flush on `stop`, in an `ensure`, so a graceful drain loses nothing.
+- The flush is best-effort on the same terms as today: a Redis failure goes to
+  the error handler and never propagates into a job. It must not silently drop
+  the accumulated window on a *transient* failure — the natural shape is to
+  re-merge the unflushed counts and retry on the next tick.
+- The interval is ≤5s. It exists to bound the lag, not to be tuned; if it ever
+  needs to be tunable it reuses the existing `config[:metrics_rollup_interval]`
+  naming rather than inventing a knob.
+- A test asserts flushed state is byte-identical to per-job writes, against real
+  Redis (never a mock — `CLAUDE.md`).
+
+**Reversal trigger.** Any evidence that dashboard counters are wrong rather than
+late — a sum that does not reconcile against `Wurk::Stats`, or a bucket
+attributed to the wrong minute. Lag is the accepted cost; incorrectness is not.
+
+---
+
+## Decision 3 — Deferred ack, piggybacked on the next fetch
+
+**Today.** `UnitOfWork#acknowledge` (`lib/wurk/fetcher/reliable.rb:56`) spends a
+round trip of its own the moment the Processor finishes with a job: `LREM
+<private list> 1 <job JSON>`, with the poison-pill counter `DEL` already riding
+along in the same pipeline. On a busy queue that is a full round trip per job
+whose only purpose is bookkeeping.
+
+**Change.** Hold the completed job's `LREM` in the fetcher and send it in the
+**next** fetch's pipeline, alongside the non-blocking `LMOVE`. Steady state on a
+busy queue: one round trip per job, total.
+
+**What changes about the guarantee — precisely.**
+
+Wurk is at-least-once and stays at-least-once. A job is never lost, because the
+payload never leaves the private list any earlier than it does today — it leaves
+*later*, if anything. What widens is the window in which a hard process death
+causes a **completed** job to be reclaimed and run a second time: today that
+window is "between the last line of `perform` and the `LREM` a few microseconds
+later"; after the change it is "between the last line of `perform` and the next
+fetch, or the flush points below, whichever comes first".
+
+That is the same failure mode `docs/reliability.md` already documents under
+"Duplicate execution — be honest about this", with a wider mouth. It is not a new
+class of failure, and it is not reachable by a graceful exit — only by `SIGKILL`,
+OOM, or hardware loss.
+
+**Why it is acceptable.** The window it widens is already the window the
+at-least-once contract exists to cover, and the mitigation is unchanged and
+already mandatory: idempotent jobs. Meanwhile it is the single largest remaining
+per-job round trip on the success path — the one command wurk sends that Sidekiq
+sends zero of. Buying it back means either this, or accepting that the ack is a
+permanent 1 RTT/job tax that no amount of downstream optimization can remove.
+
+**Spec position.** `docs/target/sidekiq-pro.md` §3.2: "Job remains in the private
+queue until the worker explicitly `LREM`s it after success or retry handling."
+Wurk still `LREM`s after success or retry handling, and still only after — the
+`LREM` is issued later in wall-clock terms, not earlier in the ordering. Recorded
+in [`docs/idea/parity-divergences.md`](../../../../../idea/parity-divergences.md).
+
+**Required to hold — these are correctness conditions, not preferences:**
+
+- **Flush before `bulk_requeue`.** `Manager#hard_shutdown` (`lib/wurk/manager.rb:144`)
+  calls `Fetcher#bulk_requeue` on the in-flight units. A *completed* job whose ack
+  is still pending would pass the `reliable_requeue` Lua's `LREM` guard, get
+  `RPUSH`ed back to the public queue, and run twice — on **every** graceful
+  shutdown, not just on a kill. Pending acks flush first, unconditionally.
+- **Flush before blocking.** `retrieve_work` (`:105`) must flush pending acks
+  before it parks in `BLMOVE`; a blocking call cannot join a pipeline, and parking
+  for `fetch_poll_interval` with an ack pending is the widened window for no gain.
+- **Flush on the `queues.empty?` early return** (`:113-118`, every queue paused or
+  none configured) and on **`terminate`** (`:163`). `terminate` is the trap: quiet
+  is one-way, `retrieve_work` short-circuits forever after it, so an unflushed ack
+  at that point would sit until shutdown.
+- **Flush on processor stop/terminate**, in an `ensure`.
+- **Exactly one `LREM` per job.** Deferring must not let a job be `LREM`'d twice
+  or dropped from the pending set without being sent. Pin it with a command count,
+  not an eyeball — `test/support/command_spy.rb` exists for this.
+- **Pending acks are per fetcher, per process, never shared across a fork.**
+- The poison-pill counter `DEL` keeps riding the same pipeline as its `LREM`
+  (`lib/wurk/middleware/poison_pill.rb:25`), so the counter is still retired by the
+  ack and not by a round trip of its own.
+
+**Second-order effect, accepted.** A job that finishes and is then `SIGKILL`ed
+before its ack flushes gets reclaimed by the reaper, which increments
+`super_fetch:recovered:<jid>`. `docs/reliability.md`'s rule — "anything that
+finishes an attempt counts", i.e. a finished attempt should not accrue a recovery
+— now has a slightly wider window where a finished-but-unacked attempt does
+accrue one. Reaching the `RECOVERY_THRESHOLD` of 3 requires three hard kills
+landing inside that window for the same `jid` within 72h, and each of those
+reclaims is a duplicate execution in its own right. Same failure mode, same
+mitigation; no new class.
+
+**Reversal trigger.** Any duplicate execution on a *graceful* path — that would
+mean a flush point was missed, not that the trade was wrong. `bulk_requeue` and
+the drain path are the two to watch.
+
+---
+
+## Verification these decisions are signed off *against*
+
+Slice 02 is not done until, beyond its own "Done when":
+
+- `test/integration/reaper_kill9_test.rb` is green — it exercises exactly the
+  window decision 3 widens.
+- `test/integration/graceful_shutdown_test.rb` is green, with a case that a job
+  completed immediately before `SIGTERM` is **not** requeued.
+- A test proves cross-process pause takes hold within `PAUSED_TTL`, and that an
+  in-process pause takes hold on the next fetch pass.
+- A test proves the `Metrics::History` accumulator flushes to byte-identical
+  Redis state, and flushes on stop.
+- `bin/rake test:parity` is green. Any parity test that fails is wurk being
+  wrong, not the oracle — none of these three decisions is licence to edit one.
+- `docs/reliability.md`, `docs/metrics.md`, `docs/api.md`, and
+  `docs/idea/parity-divergences.md` describe the shipped behavior. They were
+  written ahead of the code in this branch; if the implementation lands
+  different constants or different flush points, the docs are wrong and get
+  fixed in the same commit.

--- a/docs/plans/2026/08/06/101-faster-than-sidekiq/00-semantics-signoff.md
+++ b/docs/plans/2026/08/06/101-faster-than-sidekiq/00-semantics-signoff.md
@@ -4,7 +4,8 @@
 > No code. This file is the record of what was decided, what it costs, what the
 > implementation is *required* to do, and what would reverse the decision.
 
-Slice 02 removes ~9 of the ~10 Redis commands wurk spends per job. All three of
+Slice 02 removes 7 of the ~10 Redis commands wurk spends per job, leaving the 3
+the reliable fetch itself costs (`bench:command_count`). All three of
 its moves are wire-compat-safe — no Redis key, no JSON field, no score format
 changes — and all three are **behavior-visible**. Wire compat is not the bar;
 "a user or an operator can observe the difference" is. Each one is written up

--- a/docs/plans/2026/08/06/101-faster-than-sidekiq/02-fetch-ack-metrics.md
+++ b/docs/plans/2026/08/06/101-faster-than-sidekiq/02-fetch-ack-metrics.md
@@ -1,6 +1,6 @@
 # 02 — Fetch, ack, metrics: 4 RTT/job → ~1
 
-> Part of [`overview.md`](overview.md). Depends on: 01 (map), sign-offs in overview "Risks". This slice moves the headline noop ratio.
+> Part of [`overview.md`](overview.md). Depends on: 01 (map) and [`00-semantics-signoff.md`](00-semantics-signoff.md) — read its "Required to hold" lists before writing code; they are conditions of acceptance, not advice. This slice moves the headline noop ratio.
 
 ## Files to change
 

--- a/docs/plans/2026/08/06/101-faster-than-sidekiq/02-fetch-ack-metrics.md
+++ b/docs/plans/2026/08/06/101-faster-than-sidekiq/02-fetch-ack-metrics.md
@@ -25,6 +25,6 @@
 
 ## Done when
 
-- Busy-queue steady state ≤2 Redis commands/job measured via the `INFO commandstats` method (`docs/benchmarks.md:54`), down from ~10.
+- Busy-queue steady state ≤3 Redis commands/job measured via the `INFO commandstats` method (`docs/benchmarks.md`, "Why wurk is slower"), down from ~10. 3, not the ~2 this line first asked for: step 4 settled on keeping the poison-pill `DEL`, so LREM + DEL + LMOVE is the floor for this command shape. `bench/command_count.rb` is the authority, and it holds the count to exactly that in both directions.
 - noop ratio moves materially (expected into ≥0.8× territory before slice 03).
 - kill-9 reclaim, graceful drain, pause/unpause integration tests green; parity green; coverage ≥90/90.

--- a/docs/plans/2026/08/06/101-faster-than-sidekiq/05-redis-layer-pools.md
+++ b/docs/plans/2026/08/06/101-faster-than-sidekiq/05-redis-layer-pools.md
@@ -1,6 +1,6 @@
 # 05 — Redis layer: adapter tax, checkout frames, pool reuse
 
-> Part of [`overview.md`](overview.md). Depends on: none (disjoint files). Every win here multiplies across all commands (~10/job today, ~2 after 02).
+> Part of [`overview.md`](overview.md). Depends on: none (disjoint files). Every win here multiplies across all commands (~10/job before 02, 3 after).
 
 ## Files to change
 

--- a/docs/plans/2026/08/06/101-faster-than-sidekiq/overview.md
+++ b/docs/plans/2026/08/06/101-faster-than-sidekiq/overview.md
@@ -14,6 +14,7 @@ Close the wurk-vs-Sidekiq gap (noop 0.45×, io 0.66–0.74×, cpu 0.81–0.86×,
 
 ## Plan files (execute in order)
 
+0. [`00-semantics-signoff.md`](00-semantics-signoff.md) — the three behavior-visible decisions 02 depends on, accepted with their terms. No code changes. Blocks 02.
 1. [`01-hotspot-map.md`](01-hotspot-map.md) — reference map: every measured hotspot with file:line. No code changes.
 2. [`02-fetch-ack-metrics.md`](02-fetch-ack-metrics.md) — the headline fix: 4 RTT/job → ~1 (paused-set cache, in-process metrics aggregation, ack piggyback). `fetcher/reliable.rb`, `metrics/history.rb`.
 3. [`03-processor-dispatch.md`](03-processor-dispatch.md) — per-job Ruby cost: chain traverse, tid/context/logger allocations. `processor.rb`, `middleware/chain.rb`, `job_logger.rb`.
@@ -37,10 +38,10 @@ Slices 02–07 touch disjoint files (per CLAUDE.md: no worktrees; parallel agent
 
 ## Risks / open questions
 
-- **Semantics sign-offs needed** (all wire-compat-safe, all behavior-visible; decide before 02):
-  - `Metrics::History` in-process aggregation + ≤5s flush (P2b): dashboard minute-buckets lag up to flush interval. Recommendation: do it — it's 6 of the ~10 commands/job and `docs/benchmarks.md:99` already names it as the fix.
-  - Paused-set cache (P1b, TTL ~2s) or Lua-folded fetch (P1a): queue pause takes effect within TTL instead of next fetch. Recommendation: P1b first, P1a if still short.
-  - Deferred ack piggyback (02 step 3): widens the at-least-once redelivery window from "ack after job" to "ack on next fetch / ≤100ms flush". Same guarantee class; must be documented as intentional divergence for parity.
+- ~~**Semantics sign-offs needed**~~ **Settled** — all three accepted, with their terms, in [`00-semantics-signoff.md`](00-semantics-signoff.md). Read it before implementing 02; the "Required to hold" lists there are conditions of acceptance, not suggestions (in particular: pending acks flush before `bulk_requeue`, or every graceful shutdown re-runs completed work).
+  - `Metrics::History` in-process aggregation + ≤5s flush (P2b): dashboard minute-buckets lag up to flush interval. **Accepted** — it's 6 of the ~10 commands/job and `docs/benchmarks.md:99` already names it as the fix.
+  - Paused-set cache (P1b, TTL 2s): queue pause takes effect within TTL instead of next fetch. **Accepted**; Lua-folded fetch (P1a) stays deferred and needs its own sign-off if 02 comes up short.
+  - Deferred ack piggyback (02 step 3): widens the at-least-once redelivery window from "ack after job" to "ack on next fetch / flush point". Same guarantee class. **Accepted**; recorded in `docs/idea/parity-divergences.md`.
 - Middleware **instance caching stays rejected** (per-job-fresh is the documented Sidekiq contract, `middleware/chain.rb:10-12`); 03 only cheapens construction/traverse. `Object.const_get` memoization stays rejected (Rails reloading).
 - cpu workload may stay <1.0× at 1 process — it's GVL-bound in both; wurk's win there is the swarm story, not per-thread. Don't chase it with unsafe changes.
 - If noop is still <1.0× after 02+03: remaining gap is dispatch-onion depth (`processor.rb:211-228`, 7 frames + 6-entry chain vs Sidekiq's ~1). Escalation options (conditional registration of no-op built-ins) need their own sign-off — drop-in contract review.

--- a/docs/plans/2026/08/06/101-faster-than-sidekiq/status.yml
+++ b/docs/plans/2026/08/06/101-faster-than-sidekiq/status.yml
@@ -4,8 +4,8 @@ status: in_progress
 created_by: sebi
 worked_by: ""
 owner: sebi
-percent: 5
-current_focus: "02-fetch-ack-metrics.md — sign-offs recorded, implementation next"
+percent: 25
+current_focus: "02-fetch-ack-metrics.md — steps 1-5 landed (PR #370); its 'Done when' still needs the vs_sidekiq re-measure, which 08 owns"
 slices:
   - file: 00-semantics-signoff.md
     status: complete
@@ -14,8 +14,8 @@ slices:
     status: not_started
     percent: 0
   - file: 02-fetch-ack-metrics.md
-    status: not_started
-    percent: 0
+    status: in_progress
+    percent: 90
   - file: 03-processor-dispatch.md
     status: not_started
     percent: 0
@@ -36,5 +36,7 @@ slices:
     percent: 0
 evidence:
   - "00-semantics-signoff.md — all three slice-02 semantics decisions accepted with their terms; divergences published in docs/reliability.md, docs/metrics.md, docs/api.md, docs/idea/parity-divergences.md"
+  - "02-fetch-ack-metrics.md steps 1-5 landed on perf/fetch-ack-metrics (PR #370): paused-set cache on a 2s monotonic TTL, Metrics::Accumulator + Flusher on a 5s cadence, ack piggybacked onto the next fetch's pipeline, per-queue string cache. bench:command_count 10 -> 3 commands/job; bench:fetch_execute 1.41k -> 2.53k i/s; rake bench gate labels unchanged."
+  - "02 is not closed: its 'Done when' also asks for the noop ratio, and docs/benchmarks.md still carries pre-change vs_sidekiq numbers. 08-bench-gate-verify.md owns the re-measure and the republish."
 notes: "Absorbs slice 08-perf-quick-wins (P1-P13) of docs/plans/2026/07/31/101-leak-logic-perf-fixes/. Sign-offs for slice 02 are SETTLED in 00-semantics-signoff.md (History flush cadence P2b, paused-set cache TTL P1b, deferred-ack redelivery window) — its 'Required to hold' lists are conditions of acceptance; the hard one is flushing pending acks before bulk_requeue. Lua-folded fetch (P1a) stays deferred, needs its own sign-off. Slice 08 step 1 (restore bench CI) should land before any perf commit."
 last_updated: 2026-08-06

--- a/docs/plans/2026/08/06/101-faster-than-sidekiq/status.yml
+++ b/docs/plans/2026/08/06/101-faster-than-sidekiq/status.yml
@@ -1,12 +1,15 @@
 plan: 101-faster-than-sidekiq
 title: Faster than Sidekiq
-status: not_started
+status: in_progress
 created_by: sebi
 worked_by: ""
 owner: sebi
-percent: 0
-current_focus: ""
+percent: 5
+current_focus: "02-fetch-ack-metrics.md — sign-offs recorded, implementation next"
 slices:
+  - file: 00-semantics-signoff.md
+    status: complete
+    percent: 100
   - file: 01-hotspot-map.md
     status: not_started
     percent: 0
@@ -31,6 +34,7 @@ slices:
   - file: 08-bench-gate-verify.md
     status: not_started
     percent: 0
-evidence: []
-notes: "Absorbs slice 08-perf-quick-wins (P1-P13) of docs/plans/2026/07/31/101-leak-logic-perf-fixes/. Sign-offs needed before slice 02: History flush cadence (P2b), paused-set cache TTL (P1b), deferred-ack redelivery window. Slice 08 step 1 (restore bench CI) should land before any perf commit."
+evidence:
+  - "00-semantics-signoff.md — all three slice-02 semantics decisions accepted with their terms; divergences published in docs/reliability.md, docs/metrics.md, docs/api.md, docs/idea/parity-divergences.md"
+notes: "Absorbs slice 08-perf-quick-wins (P1-P13) of docs/plans/2026/07/31/101-leak-logic-perf-fixes/. Sign-offs for slice 02 are SETTLED in 00-semantics-signoff.md (History flush cadence P2b, paused-set cache TTL P1b, deferred-ack redelivery window) — its 'Required to hold' lists are conditions of acceptance; the hard one is flushing pending acks before bulk_requeue. Lua-folded fetch (P1a) stays deferred, needs its own sign-off. Slice 08 step 1 (restore bench CI) should land before any perf commit."
 last_updated: 2026-08-06

--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -288,7 +288,8 @@ job runs through `Wurk::Middleware::PoisonPill`:
 - `INCR super_fetch:recovered:<jid>` with a **72h TTL** (wire-compatible with
   Sidekiq Pro — tooling that watches those keys expects 72h).
 - The counter is dropped when the job **acks** — the round trip that removes it
-  from its private list carries the `DEL`, so the reset costs nothing extra.
+  from its private list carries the `DEL`, so the reset costs no extra round
+  trip (it is still a Redis command, one of the three in that pipeline).
   Anything that finishes an attempt counts (a clean run, or a raise that booked
   a retry): the job proved it does not take its worker down. Only reclaims of an
   attempt that never finished accumulate, so unrelated crashes spread across the

--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -12,7 +12,7 @@ The path a job takes:
 | `perform_async` → Redis | Client push (optional [outage buffer](#client-side-redis-outage-buffering)) | Redis unreachable and buffering off → the call raises |
 | `schedule` / `retry` ZSET → queue | Scheduler poller | Pop-then-push window, unless [`reliable_scheduler!`](#the-reliable-scheduler) |
 | queue → worker | [Reliable fetch](#reliable-fetch) (BLMOVE + private list) | None — that's the point |
-| worker → done | ACK on completion, [reaper](#the-reaper) on death | None, but **duplicate execution is possible** |
+| worker → done | [ACK](#the-ack-rides-the-next-fetch) on the next fetch, [reaper](#the-reaper) on death | None, but **duplicate execution is possible** |
 
 ---
 
@@ -82,8 +82,8 @@ queue:<public queue name>|<host>|<pid>|<nonce>|<index>
 > would strand it. See [How "dead" is decided](#how-dead-is-decided) for how
 > liveness is checked differently for nonce-bearing vs. pre-nonce keys.
 
-The job stays in that private list for the entire duration of `perform`. Only
-when the Processor finishes does it ACK:
+The job stays in that private list for the entire duration of `perform`, and
+past it. It leaves only on an ACK:
 
 ```
 LREM  queue:default|web-1|4711|0  1  <job JSON>
@@ -91,7 +91,7 @@ LREM  queue:default|web-1|4711|0  1  <job JSON>
 
 `count = 1` is safe because every payload carries a unique `jid`.
 
-The job is ACKed when the job succeeded **or** when the retry layer booked the
+A job becomes ACK-able when it succeeded **or** when the retry layer booked the
 outcome (scheduled a retry, sent it to the dead set, or a middleware
 re-enqueued it). If neither happened — the process died — the payload is still
 sitting in the private list.
@@ -99,6 +99,34 @@ sitting in the private list.
 **That is why `SIGKILL` is safe.** There is no in-memory-only state to lose: at
 every instant, the payload exists in Redis, in exactly one of the public queue
 or one private list.
+
+### The ACK rides the next fetch
+
+The `LREM` is not sent the instant the Processor is done with the job. It is
+held in the fetcher and pipelined with the **next** fetch's `LMOVE`, so a
+worker draining a busy queue spends one Redis round trip per job in total
+rather than one to fetch and another to ACK.
+
+A pending ACK never sits on an idle worker. It is flushed, as its own round
+trip, before any of:
+
+- the fetcher blocking in `BLMOVE` (a blocking call can't join a pipeline),
+- a fetch pass with nothing to fetch — every served queue paused, or none
+  configured,
+- `SIGTSTP` quiet, which stops the fetcher permanently and so would otherwise
+  strand it until shutdown,
+- the processor stopping,
+- the [shutdown requeue](#graceful-shutdown).
+
+**What this costs.** The window in which a *hard* death — `SIGKILL`, OOM kill,
+lost instance — reclaims an already-finished job and runs it a second time
+widens from "the microseconds after `perform` returned" to "until the next
+fetch, or one of the flushes above". This is the same duplicate execution the
+at-least-once contract already covers (see *Duplicate execution — be honest
+about this*, below), with the same mitigation: idempotent jobs. It is not
+reachable by any graceful path, and nothing can be **lost** — the payload leaves
+the private list later than it used to, never earlier, so every death inside the
+widened window is a reclaim, not a drop.
 
 ### Fetch order and polling
 
@@ -118,15 +146,36 @@ Default is `Wurk::Fetcher::Reliable::TIMEOUT`, **2 seconds**. The socket read
 timeout is set one second wider than the block window so a legitimately blocked
 `BLMOVE` never trips it.
 
-Paused queues (`SMEMBERS paused`) are skipped on every fetch pass. In-flight
-jobs on a paused queue continue to completion.
+Paused queues are skipped on every fetch pass. In-flight jobs on a paused queue
+continue to completion.
+
+The `paused` SET is read with `SMEMBERS` at most once every
+`Fetcher::Reliable::PAUSED_TTL` (**2 seconds**, monotonic clock) per fetcher,
+not once per fetch — otherwise a queue that nobody has paused would cost a
+round trip per job just to keep confirming it. A `pause!` issued from another
+process therefore takes hold within `PAUSED_TTL` rather than on the very next
+fetch. Issued from *inside* a worker process, it takes hold on that process's
+next fetch pass.
+
+That does not move the fleet's worst case: an idle worker is parked in `BLMOVE`
+for `fetch_poll_interval` — 2 seconds by default — and can't observe a pause
+until the block returns, so the cache is exactly the delay the idle path
+already had. Raise `fetch_poll_interval` and the poll interval dominates.
+`Wurk::Queue#paused?`, the JSON API, and the dashboard read Redis directly and
+are never served from this cache.
 
 ### Graceful shutdown
 
 On `SIGTERM`, in-flight jobs get until `shutdown_timeout` (default **25s**,
-`config[:timeout]`) to finish. Whatever is still running at the deadline is
-moved private-list → public queue by `bulk_requeue`, using an LREM-guarded
-`RPUSH` in one Lua hop, before the threads are killed.
+`config[:timeout]`) to finish. Pending ACKs are flushed first, then whatever is
+still running at the deadline is moved private-list → public queue by
+`bulk_requeue`, using an LREM-guarded `RPUSH` in one Lua hop, before the threads
+are killed.
+
+That ordering is load-bearing. A job that finished moments before the deadline
+has an ACK still pending; requeuing before flushing it would find the payload
+still in the private list, pass the guard, and re-run completed work on every
+graceful shutdown.
 
 The LREM guard is what makes this safe against the race where a Processor ACKs
 between the snapshot and the move: LREM removes 0 → RPUSH is skipped → a
@@ -238,12 +287,16 @@ job runs through `Wurk::Middleware::PoisonPill`:
 
 - `INCR super_fetch:recovered:<jid>` with a **72h TTL** (wire-compatible with
   Sidekiq Pro — tooling that watches those keys expects 72h).
-- The counter is dropped the moment the job **acks** — the round trip that
-  removes it from its private list carries the `DEL`. Anything that finishes an
-  attempt counts (a clean run, or a raise that booked a retry): the job proved
-  it does not take its worker down. Only reclaims of an attempt that never
-  finished accumulate, so unrelated crashes spread across the 72h window can't
-  dead-set a job that has been completing all along.
+- The counter is dropped when the job **acks** — the round trip that removes it
+  from its private list carries the `DEL`, so the reset costs nothing extra.
+  Anything that finishes an attempt counts (a clean run, or a raise that booked
+  a retry): the job proved it does not take its worker down. Only reclaims of an
+  attempt that never finished accumulate, so unrelated crashes spread across the
+  72h window can't dead-set a job that has been completing all along. Because
+  [the ACK rides the next fetch](#the-ack-rides-the-next-fetch), a job hard-killed
+  after finishing but before its ACK flushed does accrue a recovery; crossing the
+  threshold that way needs three such kills on the same `jid` inside 72h, each of
+  which is a duplicate execution in its own right.
   The reset needs the jid, which the ACK path takes from the payload it has
   already parsed. A unit of work carrying no jid — a blank one, or a custom
   `config[:fetch_class]` whose unit of work has no jid slot at all — still acks
@@ -525,6 +578,25 @@ Key schema, counter keys, TTLs, lock names, and statsd metric names all match
 Pro exactly — external tooling built against `super_fetch:recovered:*`,
 `super_fetch:reaper`, `sidekiq.jobs.poison`, or the `queue:<q>|<host>|<pid>|<idx>`
 naming works unchanged.
+
+### Intentional divergences
+
+Wire compatibility is absolute; *timing* is where Wurk deviates on purpose.
+Three deviations on this page are deliberate and recorded — none of them
+changes a key, a field, or a guarantee class, and none is behind a flag:
+
+| Divergence | Pro behavior | Wurk behavior | Cost |
+|---|---|---|---|
+| [ACK timing](#the-ack-rides-the-next-fetch) | `LREM` right after success or retry handling | Same ordering, pipelined with the next fetch; flushed before every idle, quiet, stop, or shutdown | A hard kill can re-run an already-finished job for longer. At-least-once either way |
+| [Paused-queue visibility](#fetch-order-and-polling) | `SMEMBERS paused` per fetch pass | Cached 2s per fetcher; in-process pause is immediate | Cross-process pause lands within 2s. Unchanged fleet-wide worst case |
+| [Shutdown requeue](#graceful-shutdown) | In-flight jobs stay in the private list until the process boots again | Moved back to the public queue immediately | None — a rolling deploy recovers the work without waiting for a restart |
+
+The full argument for each, the conditions they were accepted under, and what
+would reverse them: [parity divergences](idea/parity-divergences.md) and
+`docs/plans/2026/08/06/101-faster-than-sidekiq/00-semantics-signoff.md`. Job
+metrics are batched on the same reasoning — that one is in
+[Metrics](metrics.md#write-cadence-and-what-a-hard-kill-costs), since it affects
+dashboard counters rather than delivery.
 
 ---
 

--- a/lib/wurk/fetcher.rb
+++ b/lib/wurk/fetcher.rb
@@ -12,5 +12,11 @@ module Wurk
     # and stop pulling new work the instant a process is quieted. No-op in the
     # abstract base; Reliable flips its drain flag.
     def terminate; end
+
+    # Send any ACK the fetcher is holding back rather than sending immediately.
+    # Processor calls this as it stops, so a job that finished but whose ACK
+    # never caught a fetch to ride on can't be reclaimed as unfinished. No-op
+    # in the abstract base; only Reliable defers.
+    def flush_pending_acks; end
   end
 end

--- a/lib/wurk/fetcher/reliable.rb
+++ b/lib/wurk/fetcher/reliable.rb
@@ -16,6 +16,12 @@ module Wurk
     # between fetch and ack leaves the job in the private list, where the
     # next boot of this process reclaims it via bulk_requeue.
     #
+    # The ACK does not take a round trip of its own: it is held here and
+    # pipelined in front of the next fetch's LMOVE, so a worker draining a busy
+    # queue costs one round trip per job in total. See #flush_pending_acks for
+    # the paths that must send a held ACK before they stop fetching, and
+    # docs/idea/parity-divergences.md for the window that widens.
+    #
     # Priority handling: iterate queues_cmd in order with non-blocking
     # LMOVE, then fall back to a blocking BLMOVE on the first queue so an
     # empty poll doesn't spin Redis. BLMOVE has no multi-key form, so
@@ -47,32 +53,36 @@ module Wurk
       # immediately after #quiet, so this pause adds no drain latency.
       QUIET_PAUSE = 0.05
 
-      # Carries the public queue key, the raw (still-JSON) job payload,
-      # and the capsule we use to reach Redis. ACK removes from the private
-      # list; requeue pushes back to the public queue head so the job is
-      # next pulled. LREM count=1 is idempotent for our payloads since
-      # each job's JSON contains a unique `jid`.
+      # Carries the public queue key, the raw (still-JSON) job payload, the
+      # capsule we use to reach Redis, and the fetcher that holds this unit's
+      # ACK until it can ride a pipeline. ACK removes from the private list;
+      # requeue pushes back to the public queue head so the job is next pulled.
+      # LREM count=1 is idempotent for our payloads since each job's JSON
+      # contains a unique `jid`.
       #
       # `jid` is filled in by the Processor once it has parsed the payload —
       # the fetcher never parses. It is only used to retire the job's
       # poison-pill recovery counter, so an ACK without one is still a
       # complete ACK.
-      UnitOfWork = Struct.new(:queue, :job, :config, :jid, keyword_init: true) do
-        # The counter DEL rides this round trip rather than taking one of its
-        # own: the ACK is the only Redis call the success path makes, and a
+      UnitOfWork = Struct.new(:queue, :job, :config, :jid, :fetcher, keyword_init: true) do
+        # Deferred, never skipped: the LREM goes back to the fetcher, which
+        # pipelines it in front of the next fetch's LMOVE instead of spending a
+        # round trip of its own. Ordering against the job is unchanged — the
+        # LREM still happens only after success or retry handling (Pro §3.2) —
+        # so all that moves is the wall clock. Every path that stops fetching
+        # flushes first; see #flush_pending_acks.
+        def acknowledge
+          fetcher.defer_ack(self)
+        end
+
+        # Queue this unit's ACK into an already-open pipeline. The counter DEL
+        # rides the same round trip rather than taking one of its own: a
         # per-job call would be a fetch+execute regression for the sake of a
         # key that exists for roughly no jobs. See Middleware::PoisonPill.
-        def acknowledge
-          private_list = Reliable.private_queue_name(queue)
+        def write_ack(pipe)
+          pipe.call('LREM', Reliable.private_queue_name(queue), 1, job)
           job_jid = jid.to_s
-          return config.redis { |conn| conn.call('LREM', private_list, 1, job) } if job_jid.empty?
-
-          config.redis do |conn|
-            conn.pipelined do |pipe|
-              pipe.call('LREM', private_list, 1, job)
-              Middleware::PoisonPill.clear_in(pipe, job_jid)
-            end
-          end
+          Middleware::PoisonPill.clear_in(pipe, job_jid) unless job_jid.empty?
         end
 
         def queue_name
@@ -84,10 +94,11 @@ module Wurk
         end
       end
 
-      # Class-level so UnitOfWork can compute the private list without
-      # carrying a back-reference to its parent fetcher. Index defaults to
-      # 0 — we run one fetcher per capsule today. Multi-processor topology
-      # (one private list per processor slot) is a future Manager concern.
+      # Class-level: the name is a pure function of the public queue and this
+      # process's identity, and the fetcher, its units and the Reaper all need
+      # it. Index defaults to 0 — we run one fetcher per capsule today.
+      # Multi-processor topology (one private list per processor slot) is a
+      # future Manager concern.
       #
       # The nonce marks the incarnation. host+pid alone is ambiguous once PID
       # namespaces are in play: a restarted container reuses both, so the
@@ -127,6 +138,50 @@ module Wurk
         @paused = nil
         @paused_generation = nil
         @paused_expires_at = 0.0
+        @pending_acks = {}
+        @pending_lock = ::Mutex.new
+      end
+
+      # Take custody of a finished job's LREM instead of sending it now. One
+      # slot per processor thread: a capsule shares a single fetcher across its
+      # processors, and each thread's fetch → execute → ACK cycle is strictly
+      # sequential, so a thread only ever writes its own slot. The lock is for
+      # the flush paths, which drain every slot from a different thread.
+      def defer_ack(uow)
+        @pending_lock.synchronize { @pending_acks[::Thread.current] = uow }
+      end
+
+      # Send every held ACK now, in one pipeline of its own.
+      #
+      # Called from every path that stops fetching — nothing else would send
+      # them — and from #bulk_requeue, where it is a correctness requirement
+      # rather than an optimization: a finished job whose LREM is still pending
+      # is not in Manager#hard_shutdown's in-flight list, so the requeue Lua's
+      # LREM guard would still find its payload, RPUSH it onto the public
+      # queue, and run it a second time on every graceful shutdown.
+      def flush_pending_acks
+        pending = @pending_lock.synchronize do
+          held = @pending_acks
+          @pending_acks = {}
+          held
+        end
+        return if pending.empty?
+
+        begin
+          # Apply-safe for the same reason the piggybacked copy is: a replayed
+          # LREM finds the payload already gone and removes nothing, and the
+          # counter DEL is idempotent by definition. Claiming it buys the drain
+          # path the full connection-blip backoff.
+          config.redis(idempotent: true) do |conn|
+            conn.pipelined { |pipe| pending.each_value { |uow| uow.write_ack(pipe) } }
+          end
+        rescue StandardError
+          # Put them back rather than drop them: an LREM that is never sent
+          # leaves a finished job in the private list for the next boot's
+          # reaper to reclaim and run again. Newer slots win the merge.
+          @pending_lock.synchronize { @pending_acks = pending.merge(@pending_acks) }
+          raise
+        end
       end
 
       # Every pass that yields no job has to cost wall-clock time: Processor#run
@@ -136,6 +191,7 @@ module Wurk
       # the two short-circuits below have to pay it themselves.
       def retrieve_work
         if @done
+          flush_pending_acks
           sleep QUIET_PAUSE
           return nil
         end
@@ -145,15 +201,12 @@ module Wurk
         # full poll interval rather than re-running queues_cmd as fast as the CPU
         # allows. Mirrors Sidekiq's BasicFetch guard, upstream #4825.
         if queues.empty?
+          flush_pending_acks
           sleep poll_interval
           return nil
         end
 
-        queues.each do |public_q|
-          uow = lmove(public_q)
-          return uow if uow
-        end
-        blmove(queues.first)
+        walk(queues)
       end
 
       # Called on shutdown for jobs the Processor couldn't finish in time.
@@ -168,6 +221,11 @@ module Wurk
       # in-flight in the private list until the next boot; we prefer the
       # immediate move so a rolling deploy recovers work without a restart.
       def bulk_requeue(in_progress)
+        # First and unconditional — see #flush_pending_acks. Deliberately not
+        # rescued: if the ACKs could not be sent we would be requeueing jobs
+        # whose completion we failed to record. Leaving them in the private
+        # list for the next boot's reaper is the safer of the two.
+        flush_pending_acks
         return if in_progress.nil? || in_progress.empty?
 
         config.redis { |conn| requeue_pipelined(conn, in_progress) }
@@ -191,11 +249,46 @@ module Wurk
       # one sitting in the between-jobs window (Processor#run only re-checks its
       # own @done between iterations). Quiet is one-way — matches Sidekiq TSTP
       # (spec §21.3), there is no un-terminate.
+      #
+      # Which is exactly why it flushes: after this, retrieve_work short-circuits
+      # for good, so an ACK held here would otherwise sit until shutdown.
       def terminate
         @done = true
+        flush_pending_acks
+      rescue StandardError => e
+        # Runs on the Manager's thread mid-shutdown, where a raise would skip
+        # the rest of the quiet path. The ACKs are back in their slots, so the
+        # next flush point (Processor's ensure) retries them.
+        handle_exception(e, { context: 'Error flushing pending acks' })
       end
 
       private
+
+      # Capsule doesn't define handle_exception (it's a Configuration method);
+      # override Component's delegation so error handlers fire.
+      def handle_exception(ex, ctx = {})
+        config.config.handle_exception(ex, ctx)
+      end
+
+      # Non-blocking pass over the fetchable queues. The pending ACK rides the
+      # first LMOVE and only the first: the walk is one fetch, so a second copy
+      # of the same LREM would be a wasted command on every queue we find
+      # empty. By the time we fall through to BLMOVE this thread is holding
+      # nothing — which is the point, since a blocking call can't join a
+      # pipeline and would strand the ACK for a whole poll interval.
+      def walk(queues)
+        ack = take_pending_ack
+        queues.each do |public_q|
+          uow = lmove(public_q, ack)
+          ack = nil
+          return uow if uow
+        end
+        blmove(queues.first)
+      end
+
+      def take_pending_ack
+        @pending_lock.synchronize { @pending_acks.delete(::Thread.current) }
+      end
 
       # One pipelined RELIABLE_REQUEUE EVALSHA per UoW. Mirrors
       # Client#push_batched_pipelined: a pipelined EVALSHA surfaces NOSCRIPT
@@ -251,10 +344,27 @@ module Wurk
       # and ack leaves behind, which the next boot's Reaper already reclaims. The
       # replay then pulls a different job; nothing duplicates and nothing is
       # lost, at worst one job waits out this process's lifetime.
-      def lmove(public_q)
+      # A replayed ACK is a no-op (LREM removes nothing the second time, DEL is
+      # already done), so folding it in costs the retry nothing.
+      def lmove(public_q, ack = nil)
         priv = self.class.private_queue_name(public_q)
-        job = config.redis(idempotent: true) { |conn| conn.call('LMOVE', public_q, priv, 'RIGHT', 'LEFT') }
-        job ? UnitOfWork.new(queue: public_q, job: job, config: config) : nil
+        job = config.redis(idempotent: true) do |conn|
+          if ack
+            conn.pipelined do |pipe|
+              ack.write_ack(pipe)
+              pipe.call('LMOVE', public_q, priv, 'RIGHT', 'LEFT')
+            end.last
+          else
+            conn.call('LMOVE', public_q, priv, 'RIGHT', 'LEFT')
+          end
+        end
+        job ? UnitOfWork.new(queue: public_q, job: job, config: config, fetcher: self) : nil
+      rescue StandardError
+        # The ACK left its slot but never reached Redis. Hand it back so a
+        # later flush still retires the job — otherwise a finished job sits in
+        # the private list until the next boot's reaper runs it again.
+        defer_ack(ack) if ack
+        raise
       end
 
       def blmove(public_q)
@@ -268,7 +378,7 @@ module Wurk
         job = config.fetch_redis(idempotent: true) do |conn|
           conn.blocking_call(timeout + 1, 'BLMOVE', public_q, priv, 'RIGHT', 'LEFT', timeout)
         end
-        job ? UnitOfWork.new(queue: public_q, job: job, config: config) : nil
+        job ? UnitOfWork.new(queue: public_q, job: job, config: config, fetcher: self) : nil
       end
 
       # BLMOVE block timeout for an empty poll. `config.fetch_poll_interval`

--- a/lib/wurk/fetcher/reliable.rb
+++ b/lib/wurk/fetcher/reliable.rb
@@ -60,11 +60,17 @@ module Wurk
       # LREM count=1 is idempotent for our payloads since each job's JSON
       # contains a unique `jid`.
       #
+      # `queue_name` (the queue without its `queue:` prefix) and
+      # `private_queue` come off the fetcher's per-queue cache at build time:
+      # both are pure functions of the queue this unit came from, so deriving
+      # them here would be a per-job cost for a per-queue fact.
+      #
       # `jid` is filled in by the Processor once it has parsed the payload —
       # the fetcher never parses. It is only used to retire the job's
       # poison-pill recovery counter, so an ACK without one is still a
       # complete ACK.
-      UnitOfWork = Struct.new(:queue, :job, :config, :jid, :fetcher, keyword_init: true) do
+      UnitOfWork = Struct.new(:queue, :queue_name, :private_queue, :job, :config, :jid, :fetcher,
+                              keyword_init: true) do
         # Deferred, never skipped: the LREM goes back to the fetcher, which
         # pipelines it in front of the next fetch's LMOVE instead of spending a
         # round trip of its own. Ordering against the job is unchanged — the
@@ -79,14 +85,16 @@ module Wurk
         # rides the same round trip rather than taking one of its own: a
         # per-job call would be a fetch+execute regression for the sake of a
         # key that exists for roughly no jobs. See Middleware::PoisonPill.
+        #
+        # Sending it only for the jobs that own one is not available to us:
+        # whether a job was reclaimed lives in the counter, and a reclaimed
+        # payload is byte-identical to a first-attempt one (the job JSON is
+        # wire-frozen, so the reaper cannot flag it). Reading the counter to
+        # decide would spend the very round trip the DEL is riding for free.
         def write_ack(pipe)
-          pipe.call('LREM', Reliable.private_queue_name(queue), 1, job)
+          pipe.call('LREM', private_queue, 1, job)
           job_jid = jid.to_s
           Middleware::PoisonPill.clear_in(pipe, job_jid) unless job_jid.empty?
-        end
-
-        def queue_name
-          queue.delete_prefix(Keys::QUEUE_PREFIX)
         end
 
         def requeue
@@ -95,8 +103,10 @@ module Wurk
       end
 
       # Class-level: the name is a pure function of the public queue and this
-      # process's identity, and the fetcher, its units and the Reaper all need
-      # it. Index defaults to 0 — we run one fetcher per capsule today.
+      # process's identity, and both the fetcher and the Reaper need it (the
+      # fetcher's units carry the string #queue_keys built for them, so nothing
+      # on the hot path calls this per job). Index defaults to 0 — we run one
+      # fetcher per capsule today.
       # Multi-processor topology (one private list per processor slot) is a
       # future Manager concern.
       #
@@ -140,6 +150,10 @@ module Wurk
         @paused_expires_at = 0.0
         @pending_acks = {}
         @pending_lock = ::Mutex.new
+        @queue_keys = {}
+        @queue_keys_pid = ::Process.pid
+        @prefixed_queues = nil
+        @prefixed_source = nil
       end
 
       # Take custody of a finished job's LREM instead of sending it now. One
@@ -232,16 +246,19 @@ module Wurk
       end
 
       # Prefixed queue keys (`queue:<name>`) in fetch order. Strict mode
-      # preserves declaration order. Random/weighted shuffle each call —
-      # `@queues` is pre-expanded by weight in Capsule#queues=, so uniform
-      # shuffle yields weighted fairness; .uniq trims duplicates. Paused
-      # queues are filtered after shuffle so the membership test runs on
-      # the smallest possible set.
+      # preserves declaration order and, with nothing paused, hands back the
+      # prebuilt array as-is — the steady-state fetch allocates nothing here,
+      # matching Sidekiq's own strict path (fetch.rb:79-87). Random/weighted
+      # shuffle each call — `@queues` is pre-expanded by weight in
+      # Capsule#queues=, so uniform shuffle yields weighted fairness; .uniq
+      # trims duplicates. Paused queues are filtered after shuffle so the
+      # membership test runs on the smallest possible set.
       def queues_cmd
-        names = config.mode == :strict ? config.queues : config.queues.shuffle.uniq
-        paused = paused_names
-        names = names.reject { |q| paused.include?(q) } unless paused.empty?
-        names.map { |q| "#{Keys::QUEUE_PREFIX}#{q}" }
+        paused = paused_keys
+        keys = config.mode == :strict ? prefixed_queues : prefixed_queues.shuffle.uniq
+        return keys if paused.empty?
+
+        keys.reject { |key| paused.include?(key) }
       end
 
       # Quiet hook (Manager#quiet). Flips the drain flag so retrieve_work
@@ -301,7 +318,7 @@ module Wurk
           in_progress.each do |uow|
             Wurk::Lua::Loader.public_send(
               eval_method, pipe, :reliable_requeue,
-              keys: [self.class.private_queue_name(uow.queue), uow.queue],
+              keys: [queue_keys(uow.queue).first, uow.queue],
               argv: [uow.job]
             )
           end
@@ -319,6 +336,11 @@ module Wurk
       # install. Returns a Set for O(1) lookup against the (often
       # weighted-expanded) queue list.
       #
+      # Members are unprefixed on the wire (Sidekiq Pro's `paused` SET, which we
+      # never touch); the cache stores them prefixed because the only reader
+      # tests them against the `queue:<name>` keys it is about to LMOVE, and
+      # prefixing here is once per TTL instead of once per queue per pass.
+      #
       # Monotonic clock, so an NTP step can't pin the cache open. Per instance,
       # so it dies with the fetcher and can never cross a fork.
       #
@@ -326,15 +348,61 @@ module Wurk
       # second SMEMBERS and overwrites with an equally fresh read; @paused is
       # published before the freshness stamps so a reader that trusts the stamps
       # can never see the value they don't belong to.
-      def paused_names
+      def paused_keys
         generation = self.class.paused_generation
         now = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
         return @paused if @paused_generation == generation && now < @paused_expires_at
 
-        @paused = config.redis(idempotent: true) { |conn| conn.call('SMEMBERS', Keys::PAUSED_SET) }.to_set
+        members = config.redis(idempotent: true) { |conn| conn.call('SMEMBERS', Keys::PAUSED_SET) }
+        @paused = members.to_set { |q| "#{Keys::QUEUE_PREFIX}#{q}" }
         @paused_generation = generation
         @paused_expires_at = now + PAUSED_TTL
         @paused
+      end
+
+      # `queue:<name>` for every queue this capsule serves. Rebuilt only when
+      # Capsule#queues= swaps the list in — it always allocates a fresh array,
+      # so identity is the whole check. Published before the source it came
+      # from, so a reader that trusts the source can never see a list built
+      # from a different one.
+      def prefixed_queues
+        source = config.queues
+        return @prefixed_queues if @prefixed_source.equal?(source)
+
+        @prefixed_queues = source.map { |q| "#{Keys::QUEUE_PREFIX}#{q}".freeze }.freeze
+        @prefixed_source = source
+        @prefixed_queues
+      end
+
+      # The two strings a fetch derives from a public queue key: this process's
+      # private list for it (a `gethostname` syscall plus a five-part
+      # interpolation) and the unprefixed name the Processor tags the job with.
+      # Both are pure functions of the queue and this process's identity, so
+      # they cost one build per queue rather than two per job.
+      #
+      # Rebuilt when the pid moves: a fetcher materialized before a fork would
+      # otherwise keep claiming into a private list stamped with the parent's
+      # pid, which the Reaper reads as owned by a live process — so nothing this
+      # child leaves behind would ever be reclaimed.
+      #
+      # Copy-on-write rather than mutated in place: processor threads share one
+      # fetcher and read this without a lock. A racing writer's entry can be
+      # lost, and the next fetch rebuilds it.
+      def queue_keys(public_q)
+        pid = ::Process.pid
+        if @queue_keys_pid != pid
+          @queue_keys = {}
+          @queue_keys_pid = pid
+        end
+
+        cache = @queue_keys
+        cached = cache[public_q]
+        return cached if cached
+
+        built = [self.class.private_queue_name(public_q).freeze,
+                 public_q.delete_prefix(Keys::QUEUE_PREFIX).freeze].freeze
+        @queue_keys = cache.merge(public_q => built)
+        built
       end
 
       # Both LMOVE forms claim apply-safety, so fetch keeps the full
@@ -347,7 +415,7 @@ module Wurk
       # A replayed ACK is a no-op (LREM removes nothing the second time, DEL is
       # already done), so folding it in costs the retry nothing.
       def lmove(public_q, ack = nil)
-        priv = self.class.private_queue_name(public_q)
+        priv, name = queue_keys(public_q)
         job = config.redis(idempotent: true) do |conn|
           if ack
             conn.pipelined do |pipe|
@@ -358,7 +426,7 @@ module Wurk
             conn.call('LMOVE', public_q, priv, 'RIGHT', 'LEFT')
           end
         end
-        job ? UnitOfWork.new(queue: public_q, job: job, config: config, fetcher: self) : nil
+        job ? unit_of_work(public_q, priv, name, job) : nil
       rescue StandardError
         # The ACK left its slot but never reached Redis. Hand it back so a
         # later flush still retires the job — otherwise a finished job sits in
@@ -368,7 +436,7 @@ module Wurk
       end
 
       def blmove(public_q)
-        priv = self.class.private_queue_name(public_q)
+        priv, name = queue_keys(public_q)
         timeout = poll_interval
         # Dedicated fetch pool, not the main one: a parked BLMOVE holds its slot
         # for the whole block window, so routing it here keeps idle fetchers from
@@ -378,7 +446,14 @@ module Wurk
         job = config.fetch_redis(idempotent: true) do |conn|
           conn.blocking_call(timeout + 1, 'BLMOVE', public_q, priv, 'RIGHT', 'LEFT', timeout)
         end
-        job ? UnitOfWork.new(queue: public_q, job: job, config: config, fetcher: self) : nil
+        job ? unit_of_work(public_q, priv, name, job) : nil
+      end
+
+      # Both fetch paths hand the unit every string its Processor and its ACK
+      # will need, so neither re-derives one per job.
+      def unit_of_work(public_q, priv, name, job)
+        UnitOfWork.new(queue: public_q, queue_name: name, private_queue: priv,
+                       job: job, config: config, fetcher: self)
       end
 
       # BLMOVE block timeout for an empty poll. `config.fetch_poll_interval`

--- a/lib/wurk/fetcher/reliable.rb
+++ b/lib/wurk/fetcher/reliable.rb
@@ -161,8 +161,13 @@ module Wurk
       # processors, and each thread's fetch → execute → ACK cycle is strictly
       # sequential, so a thread only ever writes its own slot. The lock is for
       # the flush paths, which drain every slot from a different thread.
+      #
+      # The slot holds a list rather than a single unit because a failed flush
+      # can hand an older ACK back to a thread that has already deferred a newer
+      # one (see #restore_pending_acks). Everywhere else it holds exactly one,
+      # and the array is reused empty rather than reallocated per job.
       def defer_ack(uow)
-        @pending_lock.synchronize { @pending_acks[::Thread.current] = uow }
+        @pending_lock.synchronize { (@pending_acks[::Thread.current] ||= []) << uow }
       end
 
       # Send every held ACK now, in one pipeline of its own.
@@ -174,12 +179,11 @@ module Wurk
       # LREM guard would still find its payload, RPUSH it onto the public
       # queue, and run it a second time on every graceful shutdown.
       def flush_pending_acks
-        pending = @pending_lock.synchronize do
-          held = @pending_acks
-          @pending_acks = {}
-          held
-        end
-        return if pending.empty?
+        pending = claim_pending_acks
+        # A thread whose ACK already rode a fetch leaves its queue behind empty;
+        # dropping the hash those queues lived in is also how the entry of a
+        # processor thread that has since died is reclaimed.
+        return if pending.each_value.all?(&:empty?)
 
         begin
           # Apply-safe for the same reason the piggybacked copy is: a replayed
@@ -187,13 +191,10 @@ module Wurk
           # counter DEL is idempotent by definition. Claiming it buys the drain
           # path the full connection-blip backoff.
           config.redis(idempotent: true) do |conn|
-            conn.pipelined { |pipe| pending.each_value { |uow| uow.write_ack(pipe) } }
+            conn.pipelined { |pipe| pending.each_value { |uows| uows.each { |uow| uow.write_ack(pipe) } } }
           end
         rescue StandardError
-          # Put them back rather than drop them: an LREM that is never sent
-          # leaves a finished job in the private list for the next boot's
-          # reaper to reclaim and run again. Newer slots win the merge.
-          @pending_lock.synchronize { @pending_acks = pending.merge(@pending_acks) }
+          restore_pending_acks(pending)
           raise
         end
       end
@@ -303,8 +304,36 @@ module Wurk
         blmove(queues.first)
       end
 
+      # Exactly one, even when a failed flush left this thread holding two: the
+      # walk is one fetch and one pipeline, and the rest go out on the next.
       def take_pending_ack
-        @pending_lock.synchronize { @pending_acks.delete(::Thread.current) }
+        @pending_lock.synchronize { @pending_acks[::Thread.current]&.shift }
+      end
+
+      def claim_pending_acks
+        @pending_lock.synchronize do
+          held = @pending_acks
+          @pending_acks = {}
+          held
+        end
+      end
+
+      # Put a failed flush's ACKs back rather than drop them: an LREM that is
+      # never sent leaves a finished job in the private list for the next boot's
+      # reaper to reclaim and run again.
+      #
+      # Prepended per thread rather than merged by thread: the flush runs while
+      # the processors keep working, so a thread we claimed an ACK from may have
+      # finished another job and deferred a second one meanwhile. Keeping only
+      # one of the two re-runs whichever job lost.
+      def restore_pending_acks(pending)
+        @pending_lock.synchronize do
+          pending.each do |thread, uows|
+            next if uows.empty?
+
+            (@pending_acks[thread] ||= []).unshift(*uows)
+          end
+        end
       end
 
       # One pipelined RELIABLE_REQUEUE EVALSHA per UoW. Mirrors

--- a/lib/wurk/fetcher/reliable.rb
+++ b/lib/wurk/fetcher/reliable.rb
@@ -31,6 +31,15 @@ module Wurk
       # Default BLMOVE block timeout; overridable via config.fetch_poll_interval.
       TIMEOUT = 2
 
+      # How long a fetcher may answer from its own copy of the `paused` SET
+      # before re-reading it. Deliberately equal to the default poll interval:
+      # a worker parked in BLMOVE already cannot observe a pause until that
+      # block returns, so caching the busy path for the same window leaves the
+      # fleet's worst-case pause latency where it was. A constant, never a
+      # config knob — see
+      # docs/plans/2026/08/06/101-faster-than-sidekiq/00-semantics-signoff.md.
+      PAUSED_TTL = 2
+
       # Backoff for the quieted short-circuit. Manager#quiet terminates the
       # shared fetcher before it terminates the processors, and Processor#run
       # loops on its *own* flag — so in that window every processor would spin
@@ -91,10 +100,33 @@ module Wurk
         "#{public_queue}|#{host}|#{::Process.pid}|#{Component::PROCESS_NONCE}|#{index}"
       end
 
+      # Guards the generation bump only. Fetchers read the counter without it —
+      # a torn read is impossible for an Integer reference, and a fetcher that
+      # misses a bump by microseconds picks it up on its next pass.
+      PAUSED_GENERATION_LOCK = Mutex.new
+
+      @paused_generation = 0
+
+      class << self
+        # Every fetcher in this process caches the paused SET against this
+        # counter, so bumping it expires all of them at once.
+        attr_reader :paused_generation
+
+        # Queue#pause!/#unpause! call this. Without it a host app that pauses a
+        # queue from inside a job would keep watching its own workers drain that
+        # queue for up to PAUSED_TTL — the one staleness the sign-off refuses.
+        def invalidate_paused_cache!
+          PAUSED_GENERATION_LOCK.synchronize { @paused_generation += 1 }
+        end
+      end
+
       def initialize(capsule)
         super()
         @config = capsule
         @done = false
+        @paused = nil
+        @paused_generation = nil
+        @paused_expires_at = 0.0
       end
 
       # Every pass that yields no job has to cost wall-clock time: Processor#run
@@ -110,9 +142,8 @@ module Wurk
 
         queues = queues_cmd
         # Nothing fetchable — every queue paused, or none configured. Back off a
-        # full poll interval rather than re-running queues_cmd (an SMEMBERS per
-        # pass, on the main pool) as fast as the CPU allows. Mirrors Sidekiq's
-        # BasicFetch guard, upstream #4825.
+        # full poll interval rather than re-running queues_cmd as fast as the CPU
+        # allows. Mirrors Sidekiq's BasicFetch guard, upstream #4825.
         if queues.empty?
           sleep poll_interval
           return nil
@@ -189,12 +220,28 @@ module Wurk
         requeue_pipelined(conn, in_progress, eval_method: :eval_with_source)
       end
 
-      # SMEMBERS of the `paused` SET. One round-trip per fetch pass; the
-      # set is tiny in practice (one entry per paused queue) so the cost
-      # is dominated by the BLMOVE that follows. Returns a Set for O(1)
-      # lookup against the (often weighted-expanded) queue list.
+      # SMEMBERS of the `paused` SET, at most once per PAUSED_TTL per fetcher
+      # instead of once per fetch pass — on a busy queue that was a full round
+      # trip per job spent re-confirming a set that is empty for almost every
+      # install. Returns a Set for O(1) lookup against the (often
+      # weighted-expanded) queue list.
+      #
+      # Monotonic clock, so an NTP step can't pin the cache open. Per instance,
+      # so it dies with the fetcher and can never cross a fork.
+      #
+      # Processor threads share one fetcher and race here. The loser pays a
+      # second SMEMBERS and overwrites with an equally fresh read; @paused is
+      # published before the freshness stamps so a reader that trusts the stamps
+      # can never see the value they don't belong to.
       def paused_names
-        config.redis(idempotent: true) { |conn| conn.call('SMEMBERS', Keys::PAUSED_SET) }.to_set
+        generation = self.class.paused_generation
+        now = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+        return @paused if @paused_generation == generation && now < @paused_expires_at
+
+        @paused = config.redis(idempotent: true) { |conn| conn.call('SMEMBERS', Keys::PAUSED_SET) }.to_set
+        @paused_generation = generation
+        @paused_expires_at = now + PAUSED_TTL
+        @paused
       end
 
       # Both LMOVE forms claim apply-safety, so fetch keeps the full

--- a/lib/wurk/launcher.rb
+++ b/lib/wurk/launcher.rb
@@ -11,6 +11,7 @@ require_relative 'leader'
 require_relative 'cron'
 require_relative 'metrics/rollup'
 require_relative 'metrics/queue_rollup'
+require_relative 'metrics/flusher'
 require_relative 'history'
 require_relative 'fetcher/reaper'
 require_relative 'timer_loop'
@@ -49,7 +50,7 @@ module Wurk
     # shutdown lands right after boot; teardown must not hang on it.
     BOOT_RECLAIM_JOIN_TIMEOUT = 5
 
-    attr_accessor :managers, :poller, :cron_poller, :metrics_rollup, :queue_rollup, :history
+    attr_accessor :managers, :poller, :cron_poller, :metrics_rollup, :queue_rollup, :metrics_flusher, :history
 
     def initialize(config, embedded: false)
       @config = config
@@ -61,18 +62,11 @@ module Wurk
       @done = false
       @beat_timer = TimerLoop.new(BEAT_PAUSE)
       @managers = build_managers
-      @poller = build_poller
-      @cron_poller = build_cron_poller
-      @metrics_rollup = build_metrics_rollup
-      @queue_rollup = build_queue_rollup
-      @history = build_history
+      build_loops
       @leader = build_leader
       @reaper = build_reaper
-      @started_at = nil
-      @heartbeat = nil
-      @heartbeat_thread = nil
-      @boot_reclaim_thread = nil
       @health_server = build_health_server
+      reset_thread_state
     end
 
     # Boot order matters:
@@ -93,7 +87,7 @@ module Wurk
       @config.capsules.each_value(&:prepare!)
       @config.freeze!
       @heartbeat_thread = safe_thread('heartbeat', &method(:start_heartbeat)) if async_beat
-      [@poller, @leader, @cron_poller, @metrics_rollup, @queue_rollup, @history].compact.each(&:start)
+      [@poller, @leader, @cron_poller, @metrics_rollup, @queue_rollup, @metrics_flusher, @history].compact.each(&:start)
       @managers.each(&:start)
       @reaper.start
       # Run on a background thread so /ready probe isn't delayed by a large
@@ -215,10 +209,16 @@ module Wurk
     end
 
     # Split out of #release_components to keep it under the AbcSize/
-    # CyclomaticComplexity ceilings — these three are the "periodic loop"
-    # releases, independently guarded like everything else in the tail.
+    # CyclomaticComplexity ceilings — these are the "periodic loop" releases,
+    # independently guarded like everything else in the tail.
+    #
+    # The metrics flusher goes first: its #terminate drains the last window of
+    # per-job counters into the `j|…` minute buckets, and Metrics::Rollup reads
+    # exactly those buckets — stopping the rollup first would give its final
+    # tick nothing to roll.
     def stop_periodic_components
-      [@cron_poller, @metrics_rollup, @queue_rollup, @history].each { |t| teardown_step(t.class) { t&.terminate } }
+      [@metrics_flusher, @cron_poller, @metrics_rollup, @queue_rollup,
+       @history].each { |t| teardown_step(t.class) { t&.terminate } }
       teardown_step('reaper') { @reaper&.stop }
       teardown_step('leader') { @leader&.stop }
     end
@@ -352,37 +352,32 @@ module Wurk
       @config.capsules.values.map { |cap| Manager.new(cap, shutdown: method(:request_shutdown)) }
     end
 
-    def build_poller
-      Wurk::Scheduled::Poller.new(@config)
+    # The periodic loops, built in one place because they are started together
+    # (#run) and released together (#stop_periodic_components). Every process
+    # runs every one of them; what differs is who does the work inside a tick:
+    #
+    #   poller / reaper   every process, work shared through Redis
+    #   cron_poller       leader only enqueues — that is the exactly-once guard
+    #   metrics_rollup    leader only writes the cluster-total chart buckets
+    #                     (cadence: `config.metrics_rollup_interval`)
+    #   queue_rollup      leader only writes the `qm|…` per-queue gauges
+    #   metrics_flusher   NOT leader-gated: the counters it drains exist only in
+    #                     this process's memory, so every process flushes its own
+    #   history           Ent §5 snapshotter, leader-gated, opt-in via
+    #                     `config.retain_history`
+    def build_loops
+      @poller = Wurk::Scheduled::Poller.new(@config)
+      @cron_poller = Wurk::Cron::Poller.new(@config)
+      @metrics_rollup = Wurk::Metrics::Rollup.new(@config)
+      @queue_rollup = Wurk::Metrics::QueueRollup.new(@config)
+      @metrics_flusher = Wurk::Metrics::Flusher.new(@config)
+      @history = Wurk::History.new(@config) if @config.history_enabled?
     end
 
-    # Periodic (cron) tick loop. Like the scheduler poller, every process runs
-    # one, but only the elected leader enqueues — the single-leader invariant is
-    # what guarantees exactly one enqueue per (loop, tick) across the cluster.
-    def build_cron_poller
-      Wurk::Cron::Poller.new(@config)
-    end
-
-    # Leader-only metrics rollup. Every process runs one, but only the elected
-    # leader writes the cluster-total time-series buckets the dashboard charts
-    # read — a non-leader tick returns early. Tune the cadence (tests shrink it)
-    # with `config.metrics_rollup_interval`.
-    def build_metrics_rollup
-      Wurk::Metrics::Rollup.new(@config)
-    end
-
-    # Leader-only per-queue gauge sampler. Like the metrics rollup, every
-    # process runs one but only the leader writes the `qm|…` size/latency
-    # buckets the Historical tab's per-queue charts read.
-    def build_queue_rollup
-      Wurk::Metrics::QueueRollup.new(@config)
-    end
-
-    # Ent §5 Historical Metrics snapshotter — only when the host opted in via
-    # `config.retain_history`. Leader-gated like the rollups, so just one
-    # process emits the cluster-wide snapshot per interval.
-    def build_history
-      Wurk::History.new(@config) if @config.history_enabled?
+    # Filled in by #run. Declared up front so #initialize reads as the full
+    # inventory of what a Launcher owns.
+    def reset_thread_state
+      @started_at = @heartbeat = @heartbeat_thread = @boot_reclaim_thread = nil
     end
 
     # Every worker process campaigns for the single cluster lock (`dear-leader`);

--- a/lib/wurk/metrics/accumulator.rb
+++ b/lib/wurk/metrics/accumulator.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module Wurk
+  module Metrics
+    # The in-memory half of Wurk::Metrics::History. Every execution folds into a
+    # `{pool => {minute => {class => [processed, failed, ms]}}}` tree under one
+    # mutex; Wurk::Metrics::Flusher drains it into Redis on a timer. `HINCRBY`
+    # is additive, so N folded executions leave Redis in the same state as the N
+    # individual pipelines the hot path used to send.
+    #
+    # Knows nothing about Redis — History owns the write, this owns the counts.
+    #
+    # The minute is the bucket the job *ran* in, decided by the caller at record
+    # time. That is what keeps the batching a visibility lag instead of a
+    # misattribution: a job that runs at 12:03:59 and flushes at 12:04:02 still
+    # counts toward 12:03. Signed off in
+    # docs/plans/2026/08/06/101-faster-than-sidekiq/00-semantics-signoff.md §2.
+    #
+    # Keyed by the pool the recording middleware handed us (nil = the process
+    # default), so a multi-capsule process flushes each capsule's counts through
+    # the pool that capsule's jobs ran on.
+    class Accumulator
+      # Ceiling on minute buckets retained per pool. Only reachable through
+      # #merge_back: a flush that keeps failing puts its counts back every tick,
+      # and a Redis outage that outlives the process would otherwise grow a
+      # structure fed by the job hot path without bound. The newest buckets win
+      # — they are the ones the dashboard is still drawing — and the oldest are
+      # dropped, which these counters have always been allowed to do (a Redis
+      # failure during a metrics write has never changed a job's outcome).
+      MAX_RETAINED_MINUTES = 60
+
+      def initialize
+        @lock = ::Mutex.new
+        @pools = {}
+      end
+
+      # Hot path. Three hash lookups under the mutex; allocates only the first
+      # time a (pool, minute, class) triple is seen.
+      def add(pool, klass, minute, ms, success)
+        @lock.synchronize do
+          counts = (((@pools[pool] ||= {})[minute] ||= {})[klass] ||= [0, 0, 0])
+          counts[success ? 0 : 1] += 1
+          counts[2] += ms
+        end
+      end
+
+      # Hands the whole tree over and starts a fresh one, so recording never
+      # blocks behind the flush's Redis round trip.
+      def drain
+        @lock.synchronize do
+          drained = @pools
+          @pools = {}
+          drained
+        end
+      end
+
+      # Puts one pool's counts back after its write failed, so the next tick
+      # retries them instead of dropping the window. Merged rather than
+      # assigned: jobs kept recording into the fresh tree while the flush was in
+      # flight, and those counts have not been written yet either.
+      def merge_back(pool, minutes)
+        @lock.synchronize do
+          into = (@pools[pool] ||= {})
+          minutes.each { |minute, classes| merge_minute(into, minute, classes) }
+          trim(into)
+        end
+      end
+
+      def empty?
+        @lock.synchronize { @pools.empty? }
+      end
+
+      private
+
+      def merge_minute(into, minute, classes)
+        target = (into[minute] ||= {})
+        classes.each do |klass, counts|
+          existing = target[klass]
+          if existing
+            counts.each_with_index { |count, i| existing[i] += count }
+          else
+            target[klass] = counts
+          end
+        end
+      end
+
+      def trim(minutes)
+        excess = minutes.size - MAX_RETAINED_MINUTES
+        return if excess <= 0
+
+        minutes.keys.min(excess).each { |minute| minutes.delete(minute) }
+      end
+    end
+  end
+end

--- a/lib/wurk/metrics/flusher.rb
+++ b/lib/wurk/metrics/flusher.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require_relative '../component'
+require_relative '../timer_loop'
+require_relative 'history'
+
+module Wurk
+  module Metrics
+    # Drains Wurk::Metrics::History's in-process accumulator into Redis every
+    # `History::FLUSH_INTERVAL` seconds.
+    #
+    # Deliberately NOT leader-gated, unlike every other periodic component here
+    # (Metrics::Rollup, Metrics::QueueRollup, Wurk::History). Those publish
+    # *cluster* state that one process should own; this publishes counters that
+    # only exist inside this process's memory and that no other process can
+    # write. A leader gate would strand every follower's metrics until it died.
+    #
+    # One tick per process, not per capsule: the accumulator is process-wide and
+    # already keyed by the pool each capsule's jobs recorded through.
+    class Flusher
+      include Component
+
+      # `accumulator` is a collaborator, not an option: every real boot flushes
+      # the process-wide one. Tests inject their own so a broken pool stays
+      # inside the test that built it.
+      def initialize(config, accumulator: History::ACCUMULATOR)
+        @config = config
+        @accumulator = accumulator
+        @timer = TimerLoop.new(History::FLUSH_INTERVAL)
+        @thread = nil
+      end
+
+      def start
+        return @thread if @thread
+
+        @timer.reset
+        @thread = safe_thread('metrics-flush') { @timer.run { tick } }
+      end
+
+      # Flushes once more in an `ensure`: this stops the only thread that would
+      # have written the window accumulated since the last tick, so without it a
+      # graceful shutdown would drop up to FLUSH_INTERVAL of counters — the cost
+      # the sign-off accepts for a *hard* kill only.
+      #
+      # Launcher#stop joins the manager drains before the teardown tail reaches
+      # us, so by the time this runs no job is still recording.
+      #
+      # Cleared only on a confirmed join (Thread#join returns nil on timeout): a
+      # wedged thread must stay tracked so #start's guard returns it instead of
+      # calling @timer.reset, which would un-terminate the loop it is still
+      # inside and leave two threads draining the same accumulator.
+      def terminate
+        @timer.terminate
+        @thread = nil if @thread&.join(TimerLoop::JOIN_TIMEOUT)
+      ensure
+        tick
+      end
+
+      # Never raises: this runs on a `safe_thread`, whose watchdog re-raises
+      # after reporting, and a reported-then-dead flusher would silently stop
+      # every counter in the process for a blip Redis recovers from. The
+      # accumulator has already merged the failed window back for the next tick.
+      def tick
+        History.flush(@accumulator)
+      rescue StandardError => e
+        handle_exception(e, { context: 'metrics-flush' })
+      end
+    end
+  end
+end

--- a/lib/wurk/metrics/history.rb
+++ b/lib/wurk/metrics/history.rb
@@ -2,6 +2,7 @@
 
 require_relative '../middleware'
 require_relative '../pool_checkout'
+require_relative 'accumulator'
 
 module Wurk
   module Metrics
@@ -31,9 +32,10 @@ module Wurk
     # running we keep its bucket around for the retention window measured from
     # *last write*, not from first write. So we EXPIRE unconditionally.
     #
-    # The middleware is hot-path — every successful job pays for it. Writes are
-    # pipelined in a single round-trip per job (1 HINCRBY × 2 + 1 EXPIRE per
-    # bucket × 2 buckets = 6 commands, batched).
+    # The middleware is hot-path — every job pays for it — so it does not touch
+    # Redis at all. Each execution folds into a process-wide Accumulator and
+    # Wurk::Metrics::Flusher writes the whole tree out every FLUSH_INTERVAL, in
+    # the same 6-commands-per-(class, minute) shape the per-job pipeline sent.
     class History
       include Wurk::Middleware::ServerMiddleware
 
@@ -43,6 +45,22 @@ module Wurk
 
       MINUTE_KEY_PREFIX = 'j|'
       DATE_FORMAT = '%Y%m%d'           # YYYYMMDD — matches Sidekiq's j| key
+
+      # Ceiling on how stale an unflushed counter can be, in seconds. A
+      # constant, never a config knob: it exists to bound the dashboard's lag,
+      # not to be tuned. Sidekiq — the engine these numbers get compared
+      # against — flushes its own process stats on a 10s heartbeat and writes
+      # nothing per job, so this is the tighter of the two. Signed off in
+      # docs/plans/2026/08/06/101-faster-than-sidekiq/00-semantics-signoff.md §2.
+      FLUSH_INTERVAL = 5
+
+      # Process-wide, like Processor::PROCESSED — the counters belong to the
+      # process, not to a middleware instance (the chain builds one per capsule)
+      # and not to a job.
+      ACCUMULATOR = Accumulator.new
+
+      # Hourly buckets are already class-scoped, so their fields are bare.
+      HOUR_FIELDS = %w[p f ms].freeze
 
       def call(_worker, job, _queue)
         klass = job['class']
@@ -54,8 +72,11 @@ module Wurk
           result
         ensure
           duration = (monotonic_ms - started).round
-          # Best-effort: a metrics write failure must never propagate into
-          # the job result. The processor already finalized the ack path.
+          # Best-effort: a metrics failure must never propagate into the job
+          # result. The processor already finalized the ack path. Recording is
+          # in-memory now, so what this catches is a bad payload (a `class` that
+          # is not a String) rather than a Redis blip — the Redis half moved to
+          # Flusher, which reports on its own thread.
           begin
             self.class.record(klass, duration, success: success, redis_pool: redis_pool)
           rescue StandardError => e
@@ -65,39 +86,46 @@ module Wurk
       end
 
       class << self
-        # Single Redis round-trip per job. `success: true` → `<klass>|p`;
-        # `success: false` → `<klass>|f`. `<klass>|ms` accumulates total
-        # runtime in milliseconds for *both* outcomes (so an operator can
-        # ask "how much wall-clock time has FooJob consumed?" without
-        # branching on outcome).
-        def record(klass, duration_ms, success:, redis_pool: nil, at: ::Time.now)
+        # No Redis. `success: true` → `<klass>|p`; `success: false` →
+        # `<klass>|f`. `<klass>|ms` accumulates total runtime in milliseconds
+        # for *both* outcomes (so an operator can ask "how much wall-clock time
+        # has FooJob consumed?" without branching on outcome).
+        #
+        # `at:` defaults to nil rather than `::Time.now`: this runs once per job
+        # and the bucket only needs whole UTC minutes, which #minute_bucket
+        # reads straight off the clock as an Integer.
+        def record(klass, duration_ms, success:, redis_pool: nil, at: nil)
           return if klass.nil? || klass.empty?
 
           ms = duration_ms.to_i
           ms = 0 if ms.negative?
-          buckets = { minute: minute_key(at), hour: hour_key(klass, at) }
-          with_pool(redis_pool) { |conn| pipeline_write(conn, klass, ms, success, buckets) }
+          ACCUMULATOR.add(redis_pool, klass, minute_bucket(at), ms, success)
           nil
         end
 
-        # The minute bucket carries per-class `<klass>|p|f|ms` fields; the
-        # hourly bucket is already class-scoped so its fields are bare
-        # `p|f|ms`. Pipeline all 6 commands in one round-trip.
-        def pipeline_write(conn, klass, ms, success, buckets)
-          outcome = success ? 'p' : 'f'
-          class_outcome = "#{klass}|#{outcome}"
-          class_ms = "#{klass}|ms"
-          conn.pipelined do |pipe|
-            incr_bucket(pipe, buckets[:minute], [class_outcome, class_ms, ms, MID_TERM])
-            incr_bucket(pipe, buckets[:hour], [outcome, 'ms', ms, MID_TERM])
+        # Drains an accumulator into Redis, one pipeline per pool. Raises the
+        # first pool's failure after every other pool has had its turn —
+        # Wurk::Metrics::Flusher owns turning that into an error-handler call.
+        #
+        # Only the *failed* pool's counts are merged back. Putting the whole
+        # drained tree back would re-send the writes that already landed, and
+        # HINCRBY would count them twice.
+        #
+        # The argument is a collaborator, not an option: a process has exactly
+        # one accumulator and nothing in wurk passes a second. Tests pass their
+        # own so a deliberately broken pool cannot leak into a parallel test's
+        # flush through the process-wide one.
+        def flush(accumulator = ACCUMULATOR)
+          error = nil
+          accumulator.drain.each do |pool, minutes|
+            write(pool, minutes)
+          rescue StandardError => e
+            accumulator.merge_back(pool, minutes)
+            error = e
           end
-        end
+          raise error if error
 
-        def incr_bucket(pipe, key, parts)
-          outcome_field, ms_field, ms, ttl = parts
-          pipe.call('HINCRBY', key, outcome_field, 1)
-          pipe.call('HINCRBY', key, ms_field, ms)
-          pipe.call('EXPIRE', key, ttl)
+          nil
         end
 
         # Public formatters — Wurk::Metrics::Query reuses these so the two
@@ -111,6 +139,47 @@ module Wurk
         def hour_key(klass, time)
           t = time.utc
           "#{klass}-#{t.strftime(DATE_FORMAT)}-#{t.hour}"
+        end
+
+        private
+
+        # Whole UTC minutes since the epoch. Integer arithmetic on a raw clock
+        # read, so nothing is allocated per job.
+        def minute_bucket(at)
+          return ::Process.clock_gettime(::Process::CLOCK_REALTIME, :second) / 60 unless at
+
+          at.to_i / 60
+        end
+
+        def write(pool, minutes)
+          with_pool(pool) do |conn|
+            conn.pipelined do |pipe|
+              minutes.each do |minute, classes|
+                at = ::Time.at(minute * 60).utc
+                key = minute_key(at)
+                classes.each { |klass, counts| write_class(pipe, key, at, klass, counts) }
+              end
+            end
+          end
+        end
+
+        def write_class(pipe, bucket_key, at, klass, counts)
+          incr_bucket(pipe, bucket_key, ["#{klass}|p", "#{klass}|f", "#{klass}|ms"], counts)
+          incr_bucket(pipe, hour_key(klass, at), HOUR_FIELDS, counts)
+        end
+
+        # `p`/`f` are emitted only when non-zero, so a bucket ends up with the
+        # exact field set the per-job path produced: `HINCRBY <field> 0` would
+        # materialize a counter no unbatched write ever created, and the read
+        # side would start reporting a `f: 0` series for classes that have never
+        # failed. `ms` is unconditional — the per-job path always incremented
+        # it, including by zero.
+        def incr_bucket(pipe, key, fields, counts)
+          processed, failed, ms = counts
+          pipe.call('HINCRBY', key, fields[0], processed) if processed.positive?
+          pipe.call('HINCRBY', key, fields[1], failed) if failed.positive?
+          pipe.call('HINCRBY', key, fields[2], ms)
+          pipe.call('EXPIRE', key, MID_TERM)
         end
       end
 

--- a/lib/wurk/processor.rb
+++ b/lib/wurk/processor.rb
@@ -10,8 +10,11 @@ require_relative 'profiler'
 module Wurk
   # Inside each Manager, N Processors run in parallel. Each owns one thread,
   # pulls a UnitOfWork from the capsule's fetcher, parses the payload, walks
-  # the server middleware chain, invokes `perform`, then ACKs (removes the
-  # payload from the per-process private list).
+  # the server middleware chain, invokes `perform`, then ACKs (retires the
+  # payload from the per-process private list). The ACK is handed to the
+  # fetcher, which pipelines it with the next fetch rather than spending a
+  # round trip on it — #flush_acks covers the case where there is no next
+  # fetch.
   #
   # Shutdown is two-stage:
   #   * `terminate` flips a flag; the run loop exits between jobs.
@@ -137,7 +140,11 @@ module Wurk
     private
 
     def run
-      process_one until @done
+      begin
+        process_one until @done
+      ensure
+        flush_acks
+      end
       @callback&.call(self)
     rescue Wurk::Shutdown
       @callback&.call(self)
@@ -145,6 +152,24 @@ module Wurk
       handle_exception(e, { context: '!shutdown' })
       @callback&.call(self)
       raise
+    end
+
+    # The fetcher holds each finished job's LREM until a fetch can pipeline it
+    # (Fetcher::Reliable#defer_ack). This thread has stopped fetching, so
+    # nothing else will send the one it may still be holding — and a finished
+    # job left in the private list is invisible to Manager#hard_shutdown's
+    # in-flight list, so the next boot's reaper would run it a second time.
+    #
+    # Inside the loop's own ensure rather than the method's: the callback below
+    # drops this Processor from the Manager's pool, which is what lets
+    # Manager#stop return and close the capsule's Redis pool out from under us.
+    # `respond_to?` because a config[:fetch_class] fetcher need not defer, and
+    # the capsule has no fetcher at all if the launcher died before prepare!.
+    def flush_acks
+      fetcher = @capsule.fetcher
+      fetcher.flush_pending_acks if fetcher.respond_to?(:flush_pending_acks)
+    rescue StandardError => e
+      handle_exception(e, { context: 'Error flushing pending acks' })
     end
 
     def fetch
@@ -166,8 +191,8 @@ module Wurk
 
       # The fetcher never parses, so hand it the jid we just read: the ACK
       # retires this job's poison-pill recovery counter inside the round trip
-      # it already makes. A fetcher plugged in via `config[:fetch_class]` has
-      # no jid slot and simply ACKs — the counter then ages out on its 72h TTL.
+      # it rides. A fetcher plugged in via `config[:fetch_class]` has no jid
+      # slot and simply ACKs — the counter then ages out on its 72h TTL.
       uow.jid = job_hash['jid'] if uow.respond_to?(:jid=)
 
       ack = false

--- a/lib/wurk/queue.rb
+++ b/lib/wurk/queue.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'fetcher/reliable'
 require_relative 'job_record'
 
 module Wurk
@@ -11,6 +12,11 @@ module Wurk
   # of the `paused` SET drives both `paused?` and the fetcher's queue filter
   # (see `Wurk::Fetcher::Reliable#queues_cmd`). In-flight jobs continue to
   # completion — pausing only stops new fetches.
+  #
+  # Fetchers answer from a `PAUSED_TTL` cache rather than re-reading the SET
+  # every pass, so `pause!`/`unpause!` expire this process's copy inline and
+  # other processes pick the change up within the TTL. `paused?` is a reporting
+  # call and always reads Redis.
   #
   # Spec: docs/target/sidekiq-free.md §19.2, sidekiq-pro.md §6.
   class Queue
@@ -58,12 +64,14 @@ module Wurk
     # 0 when the name was already present. In-flight jobs are untouched.
     def pause! # rubocop:disable Naming/PredicateMethod
       Wurk.redis(idempotent: true) { |conn| conn.call('SADD', Keys::PAUSED_SET, @name) }
+      Fetcher::Reliable.invalidate_paused_cache!
       true
     end
 
     # Resume fetches. Idempotent.
     def unpause! # rubocop:disable Naming/PredicateMethod
       Wurk.redis(idempotent: true) { |conn| conn.call('SREM', Keys::PAUSED_SET, @name) }
+      Fetcher::Reliable.invalidate_paused_cache!
       true
     end
 

--- a/test/unit/fetcher_reliable_test.rb
+++ b/test/unit/fetcher_reliable_test.rb
@@ -79,6 +79,16 @@ class FetcherReliableTest < Wurk::Test::UnitCase
     assert_same @capsule, uow.config
   end
 
+  # The ACK is written from a string the fetch already built, so a finished job
+  # never re-derives the private list name (a gethostname syscall) to retire
+  # itself.
+  def test_unit_of_work_carries_the_private_list_it_will_be_acked_from
+    enqueue('p1')
+    uow = @fetcher.retrieve_work
+
+    assert_equal private_queue, uow.private_queue
+  end
+
   def test_retrieve_work_returns_nil_when_terminated
     @fetcher.terminate
 
@@ -477,6 +487,38 @@ class FetcherReliableTest < Wurk::Test::UnitCase
     @fetcher.queues_cmd.each { |q| assert_includes %w[queue:hot queue:cold], q }
   end
 
+  # The strict path is the steady state for almost every install, and it runs
+  # once per fetch attempt: with nothing paused it must hand back the array it
+  # built at first use rather than re-prefixing every queue name.
+  def test_queues_cmd_strict_reuses_the_array_it_prebuilt
+    @capsule.queues = %W[#{@queue_name} #{@queue_name}-b]
+
+    assert_same @fetcher.queues_cmd, @fetcher.queues_cmd
+  end
+
+  # ...but the prebuild is a cache, not a snapshot taken at boot: Capsule#queues=
+  # is a public setter, so a fetcher that kept serving the old list would fetch
+  # from queues it is no longer configured for.
+  def test_queues_cmd_follows_a_capsule_that_swaps_its_queue_list
+    @capsule.queues = %W[#{@queue_name}-a]
+
+    assert_equal ["#{@public_queue}-a"], @fetcher.queues_cmd
+
+    @capsule.queues = %W[#{@queue_name}-b]
+
+    assert_equal ["#{@public_queue}-b"], @fetcher.queues_cmd
+  end
+
+  # A paused queue still drops out of the strict list — the prebuilt array is
+  # only handed back untouched when there is nothing to filter.
+  def test_queues_cmd_strict_still_filters_a_paused_queue
+    other = "#{@queue_name}-other"
+    @capsule.queues = [@queue_name, other]
+    Wurk::Queue.new(other).pause!
+
+    assert_equal [@public_queue], @fetcher.queues_cmd
+  end
+
   # --- private queue naming -----------------------------------------
 
   def test_private_queue_name_uses_pipe_separators_and_encodes_identity
@@ -496,6 +538,33 @@ class FetcherReliableTest < Wurk::Test::UnitCase
 
     assert_equal @fetcher.identity.split(':').last, nonce
     assert_equal nonce, Wurk::Fetcher::Reliable.private_queue_name(@public_queue).split('|')[3]
+  end
+
+  # Two strings per fetch (the private list key and the unprefixed queue name)
+  # are pure functions of the queue, and the private one costs a gethostname
+  # syscall to build — so they are built once per queue, not once per job.
+  def test_the_strings_derived_from_a_queue_are_built_once
+    assert_same @fetcher.send(:queue_keys, @public_queue), @fetcher.send(:queue_keys, @public_queue)
+    assert_equal [private_queue, @queue_name], @fetcher.send(:queue_keys, @public_queue)
+  end
+
+  # The pid is half the private list's identity. A fetcher materialized before a
+  # fork would keep claiming into a list stamped with the parent's pid — and the
+  # Reaper reads that owner as alive, so nothing this child left behind would
+  # ever be reclaimed. Simulates the fork by aging the cache's pid stamp; a real
+  # one is covered by the swarm integration tests.
+  def test_a_fetch_after_a_fork_claims_into_this_process_private_list
+    inherited = "#{@public_queue}|parent-host|1|parent-nonce|0"
+    @fetcher.instance_variable_set(:@queue_keys, { @public_queue => [inherited, @queue_name] })
+    @fetcher.instance_variable_set(:@queue_keys_pid, 1)
+    enqueue('after-fork')
+
+    @fetcher.retrieve_work
+
+    assert_equal 1, llen(private_queue)
+    assert_equal 0, llen(inherited), "the parent's private list must not be claimed into"
+  ensure
+    @pool.with { |c| c.call('DEL', inherited) }
   end
 
   def test_private_queue_name_honors_dyno_env_when_set

--- a/test/unit/fetcher_reliable_test.rb
+++ b/test/unit/fetcher_reliable_test.rb
@@ -76,8 +76,8 @@ class FetcherReliableTest < Wurk::Test::UnitCase
   end
 
   # Every queue paused → nothing to block on, so retrieve_work must back off a
-  # poll interval itself. Returning instantly hot-loops Processor#run and pays
-  # an SMEMBERS of the paused set on every pass (upstream Sidekiq #4825).
+  # poll interval itself. Returning instantly hot-loops Processor#run on passes
+  # that can never return a job (upstream Sidekiq #4825).
   def test_retrieve_work_backs_off_a_poll_interval_when_no_queue_is_fetchable
     @config.fetch_poll_interval = 0.2
     Wurk::Queue.new(@queue_name).pause!

--- a/test/unit/fetcher_reliable_test.rb
+++ b/test/unit/fetcher_reliable_test.rb
@@ -322,6 +322,30 @@ class FetcherReliableTest < Wurk::Test::UnitCase
     assert_equal 0, llen(private_queue)
   end
 
+  # A flush runs on the Manager's thread while the processors keep working, so
+  # the thread it took an ACK from can finish another job and defer a second one
+  # into the same slot before the rescue puts the first back. Keeping only one
+  # of the two leaves the loser in the private list for the next boot's reaper —
+  # a silent second run of a finished job, which is the outcome the restore
+  # exists to prevent.
+  def test_a_failed_flush_keeps_an_ack_deferred_while_it_was_in_flight
+    priv = private_queue
+    enqueue('flush-race-1')
+    enqueue('flush-race-2')
+    acked_before = @fetcher.retrieve_work
+    acked_during = @fetcher.retrieve_work
+    acked_before.acknowledge
+
+    assert_equal 2, llen(priv), 'precondition: neither ACK has been sent'
+
+    with_dead_redis(before_raise: -> { acked_during.acknowledge }) do
+      assert_raises(DeadRedis) { @fetcher.flush_pending_acks }
+    end
+    @fetcher.flush_pending_acks
+
+    assert_equal 0, llen(priv), 'the ACK the flush was holding must not lose its slot to the newer one'
+  end
+
   # Same contract on the piggybacked copy: the walk takes the ACK out of its
   # slot before it sends it, so a fetch that blows up has to hand it back.
   # `queues_cmd` is warmed first so the failure lands on the LMOVE, not on the
@@ -646,9 +670,14 @@ class FetcherReliableTest < Wurk::Test::UnitCase
   end
 
   # Runs the block with every main-pool checkout raising, then restores the real
-  # pool so the assertions that follow can read Redis.
-  def with_dead_redis
-    @capsule.define_singleton_method(:redis) { |**_opts, &_blk| raise DeadRedis }
+  # pool so the assertions that follow can read Redis. `before_raise` fires in
+  # place of the write the caller expected to land, for a test that has to reach
+  # into the window a failing call holds open.
+  def with_dead_redis(before_raise: nil)
+    @capsule.define_singleton_method(:redis) do |**_opts, &_blk|
+      before_raise&.call
+      raise DeadRedis
+    end
     yield
   ensure
     @capsule.singleton_class.remove_method(:redis)

--- a/test/unit/fetcher_reliable_test.rb
+++ b/test/unit/fetcher_reliable_test.rb
@@ -12,6 +12,27 @@ class FetcherReliableTest < Wurk::Test::UnitCase
   # so it can't race with a parallel sibling reading the same variable.
   ENV_MUTEX = Mutex.new
 
+  # Raised by #with_dead_redis in place of a real connection error, so a test
+  # asserting the failure path can't accidentally pass on some other raise.
+  class DeadRedis < StandardError; end
+
+  # CommandSpy counts commands; the piggyback's whole point is round trips, so
+  # this counts checkouts too — each of the fetch and flush paths spends exactly
+  # one command or one pipeline per checkout.
+  class TripCountingSpy < Wurk::Test::CommandSpy
+    attr_reader :trips
+
+    def initialize(pool)
+      super
+      @trips = 0
+    end
+
+    def with(&)
+      @trips += 1
+      super
+    end
+  end
+
   def setup
     super
     @queue_name   = "fr-#{Process.pid}:#{object_id}"
@@ -91,13 +112,63 @@ class FetcherReliableTest < Wurk::Test::UnitCase
 
   # --- acknowledge / SIGKILL behavior ---------------------------------
 
-  def test_acknowledge_removes_job_from_private_list
+  # The ACK is held, not sent: it rides the next fetch's pipeline. Until then
+  # the payload stays in the private list, which is exactly the window a hard
+  # kill can now hit — see docs/idea/parity-divergences.md.
+  def test_acknowledge_holds_the_lrem_rather_than_spending_a_round_trip
     enqueue('ack-me')
     uow = @fetcher.retrieve_work
     uow.acknowledge
 
+    assert_equal 1, llen(private_queue), 'the ACK must not take a round trip of its own'
+  end
+
+  def test_acknowledge_removes_job_from_private_list_once_flushed
+    enqueue('ack-me')
+    uow = @fetcher.retrieve_work
+    uow.acknowledge
+    @fetcher.flush_pending_acks
+
     assert_equal 0, llen(private_queue)
     assert_equal 0, llen(@public_queue)
+  end
+
+  # The headline of the piggyback: the next fetch retires the job just finished
+  # and picks up the next one in the same pipeline.
+  def test_the_held_ack_rides_the_next_fetch
+    enqueue('j1')
+    enqueue('j2')
+    @fetcher.retrieve_work.acknowledge
+
+    second = @fetcher.retrieve_work
+
+    assert_equal [second.job], lrange(private_queue), 'only the job just fetched may still be private'
+  end
+
+  # "Exactly one LREM per job", pinned by a count rather than an eyeball: the
+  # whole job costs one checkout carrying LREM + DEL (retiring the previous job)
+  # + LMOVE (fetching the next). A held ACK re-sent on each queue of the walk,
+  # or left in its slot after a successful send, shows up here.
+  def test_a_job_costs_one_checkout_of_three_commands
+    enqueue('j1')
+    enqueue('j2')
+    @fetcher.retrieve_work.tap { |uow| uow.jid = 'jid-1' }.acknowledge
+    spy = install_command_spy
+
+    @fetcher.retrieve_work
+
+    assert_equal 1, spy.trips
+    assert_equal 3, spy.count
+  end
+
+  def test_acknowledge_itself_issues_no_command
+    enqueue('free-ack')
+    uow = @fetcher.retrieve_work
+    spy = install_command_spy
+
+    uow.acknowledge
+
+    assert_equal 0, spy.count
   end
 
   def test_unacked_job_survives_in_private_list_after_simulated_sigkill
@@ -121,6 +192,7 @@ class FetcherReliableTest < Wurk::Test::UnitCase
     uow = @fetcher.retrieve_work
     uow.jid = jid
     uow.acknowledge
+    @fetcher.flush_pending_acks
 
     assert_equal 0, llen(private_queue), 'the ACK still removes the job from the private list'
     assert_equal 0, Wurk::Middleware::PoisonPill.recovery_count(jid)
@@ -135,7 +207,10 @@ class FetcherReliableTest < Wurk::Test::UnitCase
     assert_nil uow.jid
 
     uow.acknowledge
+    spy = install_command_spy
+    @fetcher.flush_pending_acks
 
+    assert_equal 1, spy.count
     assert_equal 0, llen(private_queue)
   end
 
@@ -148,9 +223,126 @@ class FetcherReliableTest < Wurk::Test::UnitCase
     uow = @fetcher.retrieve_work
     uow.jid = ''
     uow.acknowledge
+    @fetcher.flush_pending_acks
 
     assert_equal 0, llen(private_queue)
     assert_equal('sentinel', @pool.with { |c| c.call('GET', prefix) })
+  end
+
+  # --- flush points ---------------------------------------------------
+
+  # A blocking BLMOVE can't join a pipeline, so an ACK still held when the walk
+  # comes up empty would sit for a whole poll interval. The walk sends it on the
+  # way past: the pipeline that finds nothing to LMOVE still carries the LREM.
+  def test_a_held_ack_is_sent_before_the_fetcher_blocks
+    @config.fetch_poll_interval = 0.05
+    enqueue('last')
+    @fetcher.retrieve_work.acknowledge
+
+    assert_nil @fetcher.retrieve_work, 'precondition: an empty queue, so this falls through to BLMOVE'
+    assert_equal 0, llen(private_queue)
+  end
+
+  # Every served queue paused: the walk never runs, so the early return has to
+  # send the held ACK itself.
+  def test_a_held_ack_is_sent_when_no_queue_is_fetchable
+    @config.fetch_poll_interval = 0.05
+    enqueue('paused-after')
+    @fetcher.retrieve_work.acknowledge
+    Wurk::Queue.new(@queue_name).pause!
+
+    assert_nil @fetcher.retrieve_work
+    assert_equal 0, llen(private_queue)
+  end
+
+  # Quiet is one-way: after it retrieve_work short-circuits forever, so an ACK
+  # held at that point would sit until shutdown.
+  def test_terminate_sends_held_acks
+    enqueue('quiet-me')
+    @fetcher.retrieve_work.acknowledge
+
+    @fetcher.terminate
+
+    assert_equal 0, llen(private_queue)
+  end
+
+  # ...and the short-circuit sends one deferred after quiet, for the processor
+  # that finishes its last job in that window and loops once more.
+  def test_the_quieted_short_circuit_sends_held_acks
+    enqueue('quiet-then-ack')
+    uow = @fetcher.retrieve_work
+    @fetcher.terminate
+    uow.acknowledge
+
+    assert_nil @fetcher.retrieve_work
+    assert_equal 0, llen(private_queue)
+  end
+
+  # A Redis failure on the quiet path must not escape: Manager#quiet has no
+  # rescue, and a raise there skips the rest of the drain. The ACK stays held
+  # for the next flush point instead.
+  def test_terminate_reports_a_failed_flush_instead_of_raising
+    errors = []
+    @config.error_handlers.replace([->(ex, _ctx, _cfg) { errors << ex }])
+    enqueue('quiet-blip')
+    @fetcher.retrieve_work.acknowledge
+    with_dead_redis { @fetcher.terminate }
+
+    assert_equal 1, errors.size
+    assert_equal 1, llen(private_queue), 'the ACK must survive a failed quiet flush'
+  end
+
+  # An idle fetcher must not spend a round trip announcing it has nothing to ACK.
+  def test_flushing_with_nothing_held_costs_no_round_trip
+    spy = install_command_spy
+
+    assert_nil @fetcher.flush_pending_acks
+    assert_equal 0, spy.count
+  end
+
+  # A transient failure must not eat the ACK — an LREM that is never sent leaves
+  # a finished job for the next boot's reaper to run again.
+  def test_a_failed_flush_keeps_the_acks_it_could_not_send
+    enqueue('flush-blip')
+    @fetcher.retrieve_work.acknowledge
+
+    with_dead_redis { assert_raises(DeadRedis) { @fetcher.flush_pending_acks } }
+    @fetcher.flush_pending_acks
+
+    assert_equal 0, llen(private_queue)
+  end
+
+  # Same contract on the piggybacked copy: the walk takes the ACK out of its
+  # slot before it sends it, so a fetch that blows up has to hand it back.
+  # `queues_cmd` is warmed first so the failure lands on the LMOVE, not on the
+  # paused-set read ahead of it.
+  def test_a_failed_fetch_hands_the_held_ack_back
+    enqueue('fetch-blip')
+    @fetcher.retrieve_work.acknowledge
+    @fetcher.queues_cmd
+
+    with_dead_redis { assert_raises(DeadRedis) { @fetcher.retrieve_work } }
+    @fetcher.flush_pending_acks
+
+    assert_equal 0, llen(private_queue)
+  end
+
+  # One fetcher is shared by every processor thread, so a held ACK belongs to
+  # the thread that finished the job: another thread's fetch must not send it
+  # (it would be paying for work it isn't doing, and the owning thread would
+  # then send it again). A flush, unlike a fetch, drains every thread's slot.
+  def test_a_held_ack_belongs_to_the_thread_that_finished_the_job
+    enqueue('j1')
+    enqueue('j2')
+    held = Thread.new { @fetcher.retrieve_work.tap(&:acknowledge).job }.value
+
+    @fetcher.retrieve_work
+
+    assert_includes lrange(private_queue), held, "another thread's fetch must not send it"
+
+    @fetcher.flush_pending_acks
+
+    refute_includes lrange(private_queue), held, 'a flush drains every thread'
   end
 
   # --- requeue (single) ----------------------------------------------
@@ -181,10 +373,12 @@ class FetcherReliableTest < Wurk::Test::UnitCase
   end
 
   # hard_shutdown reads `job` off another thread, so a Processor can ACK
-  # (LREM the private copy) between that read and the requeue. The LREM guard
-  # then removes nothing and skips the RPUSH — a job that already finished is
-  # not resurrected onto the public queue.
-  def test_bulk_requeue_skips_rpush_when_job_already_acked
+  # between that read and the requeue — and a held ACK is invisible to it, so
+  # without the flush the requeue Lua's LREM guard would still find the payload
+  # in the private list and RPUSH a finished job back onto the public queue.
+  # That would re-run the last job of every busy processor on every graceful
+  # shutdown, which is the reversal trigger in the slice-02 sign-off.
+  def test_bulk_requeue_sends_held_acks_before_it_requeues
     enqueue('bq-acked')
     uow = @fetcher.retrieve_work
     uow.acknowledge
@@ -192,7 +386,17 @@ class FetcherReliableTest < Wurk::Test::UnitCase
     @fetcher.bulk_requeue([uow])
 
     assert_equal 0, llen(private_queue)
-    assert_equal 0, llen(@public_queue), 'acked job must not be re-pushed'
+    assert_equal 0, llen(@public_queue), 'a finished job must not be re-pushed'
+  end
+
+  # The flush is unconditional: a processor that finished its last job holds an
+  # ACK even when nothing is left in flight to requeue.
+  def test_bulk_requeue_sends_held_acks_with_nothing_in_flight
+    enqueue('bq-nothing-inflight')
+    @fetcher.retrieve_work.acknowledge
+
+    assert_nil @fetcher.bulk_requeue([])
+    assert_equal 0, llen(private_queue)
   end
 
   def test_bulk_requeue_moves_each_uow_to_its_own_queue
@@ -363,6 +567,24 @@ class FetcherReliableTest < Wurk::Test::UnitCase
     box
   end
 
+  # Points the capsule's main pool at a counting stand-in. PoolCheckout falls
+  # through to `pool.with` for anything that isn't a RedisPool, so the fetcher's
+  # `idempotent: true` claims resolve here unchanged.
+  def install_command_spy
+    spy = TripCountingSpy.new(@pool)
+    @capsule.define_singleton_method(:redis_pool) { spy }
+    spy
+  end
+
+  # Runs the block with every main-pool checkout raising, then restores the real
+  # pool so the assertions that follow can read Redis.
+  def with_dead_redis
+    @capsule.define_singleton_method(:redis) { |**_opts, &_blk| raise DeadRedis }
+    yield
+  ensure
+    @capsule.singleton_class.remove_method(:redis)
+  end
+
   # Monotonic wall-clock cost of the block, in seconds.
   def elapsed
     started = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
@@ -398,6 +620,6 @@ class FetcherReliableTest < Wurk::Test::UnitCase
   end
 
   def uow_for(public_queue, payload)
-    Wurk::Fetcher::Reliable::UnitOfWork.new(queue: public_queue, job: payload, config: @capsule)
+    Wurk::Fetcher::Reliable::UnitOfWork.new(queue: public_queue, job: payload, config: @capsule, fetcher: @fetcher)
   end
 end

--- a/test/unit/fetcher_test.rb
+++ b/test/unit/fetcher_test.rb
@@ -3,9 +3,10 @@
 require_relative '../test_helper'
 
 # The abstract Wurk::Fetcher base class defines the drop-in fetcher contract
-# (retrieve_work / bulk_requeue / terminate) as safe no-ops. A custom
-# config[:fetch_class] that subclasses it inherits these, so Manager#quiet can
-# call terminate and Manager#hard_shutdown can call bulk_requeue unconditionally.
+# (retrieve_work / bulk_requeue / terminate / flush_pending_acks) as safe
+# no-ops. A custom config[:fetch_class] that subclasses it inherits these, so
+# Manager#quiet can call terminate, Manager#hard_shutdown can call bulk_requeue,
+# and a stopping Processor can flush ACKs, all unconditionally.
 class FetcherTest < Wurk::Test::UnitCase
   parallelize_me!
 
@@ -25,5 +26,10 @@ class FetcherTest < Wurk::Test::UnitCase
   def test_terminate_defaults_to_noop
     # Quiet hook: a subclass without its own terminate must not raise when quieted.
     assert_nil @fetcher.terminate
+  end
+
+  def test_flush_pending_acks_defaults_to_noop
+    # Only Reliable defers its ACK; a subclass that ACKs inline has nothing to send.
+    assert_nil @fetcher.flush_pending_acks
   end
 end

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -264,6 +264,7 @@ class LauncherTest < Wurk::Test::UnitCase
     launcher.instance_variable_set(:@leader, nil)
     launcher.cron_poller = nil
     launcher.metrics_rollup = nil
+    launcher.metrics_flusher = nil
 
     launcher.run(async_beat: false)
 
@@ -285,7 +286,7 @@ class LauncherTest < Wurk::Test::UnitCase
     err = assert_raises(RuntimeError) { launcher.run(async_beat: false) }
 
     assert_equal 'redis down at boot', err.message, 'the boot failure must still reach the caller'
-    assert_equal %i[cron_poller metrics_rollup queue_rollup reaper leader heartbeat exit health], seen
+    assert_equal %i[metrics_flusher cron_poller metrics_rollup queue_rollup reaper leader heartbeat exit health], seen
   end
 
   # The rollback is guarded: a launcher that cannot tear itself down must still
@@ -612,7 +613,7 @@ class LauncherTest < Wurk::Test::UnitCase
 
     launcher.stop
 
-    assert_equal %i[cron_poller metrics_rollup queue_rollup reaper leader heartbeat exit health], seen
+    assert_equal %i[metrics_flusher cron_poller metrics_rollup queue_rollup reaper leader heartbeat exit health], seen
   end
 
   def test_stop_reports_a_manager_that_raises_mid_drain
@@ -640,7 +641,7 @@ class LauncherTest < Wurk::Test::UnitCase
 
     launcher.stop
 
-    assert_equal %i[cron_poller metrics_rollup queue_rollup reaper heartbeat exit health], seen
+    assert_equal %i[metrics_flusher cron_poller metrics_rollup queue_rollup reaper heartbeat exit health], seen
   end
 
   def test_stop_closes_the_health_server_when_clearing_the_heartbeat_raises
@@ -1143,6 +1144,8 @@ class LauncherTest < Wurk::Test::UnitCase
     launcher.instance_variable_get(:@leader).define_singleton_method(:start) { nil }
     # Don't spawn the real cron tick thread (it would poll Redis on a timer).
     launcher.cron_poller.define_singleton_method(:start) { nil }
+    # Same for the metrics flusher — its loop outlives a test that never stops.
+    launcher.metrics_flusher.define_singleton_method(:start) { nil }
   end
 
   # Stubs every collaborator #stop's teardown tail touches and records, in
@@ -1151,7 +1154,7 @@ class LauncherTest < Wurk::Test::UnitCase
   # which also covers the safe-nav else branch in the timer-loop sweep.
   def record_teardown(launcher)
     seen = []
-    %i[cron_poller metrics_rollup queue_rollup].each do |name|
+    %i[metrics_flusher cron_poller metrics_rollup queue_rollup].each do |name|
       record_stop(launcher.public_send(name), :terminate, seen, name)
     end
     record_stop(launcher.instance_variable_get(:@reaper), :stop, seen, :reaper)
@@ -1223,12 +1226,18 @@ class LauncherTest < Wurk::Test::UnitCase
       m.define_singleton_method(:quiet) { nil }
       m.define_singleton_method(:stop) { |_d| nil }
     end
-    launcher.poller = launcher.cron_poller = launcher.metrics_rollup = launcher.queue_rollup = launcher.history = nil
+    nil_out_loops(launcher)
     launcher.instance_variable_set(:@leader, nil)
     reaper = launcher.instance_variable_get(:@reaper)
     reaper.define_singleton_method(:start) { nil }
     reaper.define_singleton_method(:stop) { nil }
     reaper.define_singleton_method(:reclaim!) { nil }
+  end
+
+  # Every periodic loop Launcher#build_loops constructs.
+  def nil_out_loops(launcher)
+    launcher.poller = launcher.cron_poller = launcher.metrics_rollup = nil
+    launcher.queue_rollup = launcher.metrics_flusher = launcher.history = nil
   end
 
   # The poller is the first thing #run starts, so nothing else comes up before

--- a/test/unit/manager_test.rb
+++ b/test/unit/manager_test.rb
@@ -388,8 +388,11 @@ class ManagerTest < Wurk::Test::UnitCase
     Wurk::Fetcher::Reliable.private_queue_name(@public_queue)
   end
 
+  # `fetcher:` is what #acknowledge defers into; a unit without one raises
+  # NoMethodError the moment anything ACKs it.
   def make_uow(payload)
-    Wurk::Fetcher::Reliable::UnitOfWork.new(queue: @public_queue, job: payload, config: @capsule)
+    Wurk::Fetcher::Reliable::UnitOfWork.new(queue: @public_queue, job: payload,
+                                            config: @capsule, fetcher: @capsule.fetcher)
   end
 
   # Stand-in for a Processor that satisfies the Manager's interface without

--- a/test/unit/metrics_accumulator_test.rb
+++ b/test/unit/metrics_accumulator_test.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Pure in-memory state machine — no Redis, no process globals, so every test
+# owns its own accumulator.
+class MetricsAccumulatorTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  MINUTE = 29_712_337 # arbitrary; only its identity as a bucket key matters
+
+  def setup
+    super
+    @acc = Wurk::Metrics::Accumulator.new
+  end
+
+  def test_starts_empty
+    assert_predicate @acc, :empty?
+    assert_empty @acc.drain
+  end
+
+  def test_add_folds_successes_failures_and_runtime
+    3.times { add(ms: 10) }
+    2.times { add(ms: 5, success: false) }
+
+    assert_equal({ nil => { MINUTE => { 'FooJob' => [3, 2, 40] } } }, @acc.drain)
+  end
+
+  # A multi-capsule process records through more than one pool, and each pool's
+  # counts have to flush through the pool that capsule's jobs ran on.
+  def test_add_keys_by_pool
+    pool = Object.new
+    add
+    add(pool: pool)
+
+    assert_equal [nil, pool], @acc.drain.keys
+  end
+
+  def test_add_keys_by_minute_and_class
+    add
+    add(klass: 'BarJob')
+    add(minute: MINUTE + 1)
+
+    drained = @acc.drain[nil]
+
+    assert_equal [MINUTE, MINUTE + 1], drained.keys
+    assert_equal %w[FooJob BarJob], drained[MINUTE].keys
+  end
+
+  # Recording must never block behind a flush's round trip: the drain hands the
+  # tree over and installs a fresh one, so an add racing the write lands in the
+  # next window rather than in the batch already being sent.
+  def test_drain_hands_over_the_tree_and_starts_a_fresh_one
+    @acc.add(nil, 'FooJob', MINUTE, 7, true)
+    drained = @acc.drain
+
+    assert_predicate @acc, :empty?
+
+    @acc.add(nil, 'FooJob', MINUTE, 1, true)
+
+    assert_equal [1, 0, 7], drained[nil][MINUTE]['FooJob']
+  end
+
+  # A failed write puts its counts back, and the counts that arrived while it
+  # was in flight are still there — so the retry has to add to them, not
+  # overwrite them.
+  def test_merge_back_adds_to_what_arrived_during_the_flush
+    @acc.add(nil, 'FooJob', MINUTE, 10, true)
+    failed = @acc.drain
+    @acc.add(nil, 'FooJob', MINUTE, 3, false)
+    @acc.add(nil, 'BarJob', MINUTE, 1, true)
+
+    @acc.merge_back(nil, failed[nil])
+
+    assert_equal({ 'FooJob' => [1, 1, 13], 'BarJob' => [1, 0, 1] }, @acc.drain[nil][MINUTE])
+  end
+
+  def test_merge_back_restores_a_pool_and_minute_that_no_longer_exist
+    @acc.add(nil, 'FooJob', MINUTE, 4, true)
+    failed = @acc.drain
+
+    @acc.merge_back(nil, failed[nil])
+
+    assert_equal failed, @acc.drain
+  end
+
+  # An outage that outlives the cap must not grow a structure the job hot path
+  # feeds. The newest buckets are the ones the dashboard is still drawing, so
+  # they are the ones that survive.
+  def test_merge_back_caps_retained_minutes_and_keeps_the_newest
+    cap = Wurk::Metrics::Accumulator::MAX_RETAINED_MINUTES
+    (cap + 10).times { |i| add(minute: MINUTE + i) }
+    failed = @acc.drain
+
+    @acc.merge_back(nil, failed[nil])
+
+    assert_equal(((MINUTE + 10)..(MINUTE + cap + 9)).to_a, @acc.drain[nil].keys.sort)
+  end
+
+  private
+
+  def add(pool: nil, klass: 'FooJob', minute: MINUTE, ms: 1, success: true)
+    @acc.add(pool, klass, minute, ms, success)
+  end
+end

--- a/test/unit/metrics_flusher_test.rb
+++ b/test/unit/metrics_flusher_test.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'securerandom'
+
+class MetricsFlusherTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @at = ::Time.utc(2026, 5, 21, 14, 37, 12)
+    @klass = "FlushJob-#{SecureRandom.hex(8)}"
+    @acc = Wurk::Metrics::Accumulator.new
+    @config = Wurk::Configuration.new
+    @config.logger = ::Logger.new(IO::NULL)
+    @reported = []
+    @config.error_handlers << ->(ex, ctx, _cfg) { @reported << [ex.message, ctx[:context]] }
+  end
+
+  def teardown
+    Wurk.redis do |c|
+      c.call('UNLINK', Wurk::Metrics::History.hour_key(@klass, @at))
+      c.call('HDEL', minute_key, "#{@klass}|p", "#{@klass}|f", "#{@klass}|ms")
+    end
+  ensure
+    super
+  end
+
+  def test_uses_the_history_flush_interval
+    assert_equal 5, Wurk::Metrics::History::FLUSH_INTERVAL
+  end
+
+  def test_defaults_to_the_process_wide_accumulator
+    flusher = Wurk::Metrics::Flusher.new(@config)
+
+    assert_same Wurk::Metrics::History::ACCUMULATOR, flusher.instance_variable_get(:@accumulator)
+  end
+
+  def test_start_is_idempotent
+    flusher = build_flusher
+    thread = flusher.start
+
+    assert_same thread, flusher.start
+  ensure
+    flusher.terminate
+  end
+
+  def test_tick_drains_the_accumulator_into_redis
+    accumulate(2, ms: 40)
+
+    build_flusher.tick
+
+    assert_equal '2', processed
+    assert_predicate @acc, :empty?
+  end
+
+  # Every other periodic component the Launcher runs is leader-gated. This one
+  # must not be: the counters it writes exist only in this process's memory, so
+  # a gate would strand every follower's metrics until it died. Raising from
+  # `leader?` turns "consulted the gate" into a failed flush.
+  def test_tick_never_consults_the_leader_lock
+    flusher = build_flusher
+    flusher.define_singleton_method(:leader?) { raise 'leader gate consulted' }
+    accumulate(1)
+
+    flusher.tick
+
+    assert_equal '1', processed
+  end
+
+  # tick runs on a safe_thread, whose watchdog re-raises after reporting — a
+  # flusher that died on a blip would silently stop every counter in the process
+  # for something Redis recovers from.
+  def test_tick_reports_a_failed_flush_without_raising_or_dropping_the_window
+    @acc.add(BrokenPool.new, @klass, @at.to_i / 60, 1, true)
+
+    build_flusher.tick
+
+    assert_equal [['redis down', 'metrics-flush']], @reported
+    refute_predicate @acc, :empty?
+  end
+
+  # The signed-off cost is that a *hard* kill drops the unflushed window. A
+  # graceful stop must not: terminate stops the only thread that would have
+  # written it, so it writes it itself on the way out.
+  def test_terminate_flushes_the_window_accumulated_since_the_last_tick
+    flusher = build_flusher
+    flusher.start
+    accumulate(3, ms: 7)
+
+    flusher.terminate
+
+    assert_equal '3', processed
+  end
+
+  def test_terminate_flushes_even_when_the_loop_was_never_started
+    accumulate(1)
+
+    build_flusher.terminate
+
+    assert_equal '1', processed
+  end
+
+  class BrokenPool
+    def with(&)
+      raise 'redis down'
+    end
+  end
+
+  private
+
+  def build_flusher
+    Wurk::Metrics::Flusher.new(@config, accumulator: @acc)
+  end
+
+  def accumulate(count, ms: 1)
+    count.times { @acc.add(nil, @klass, @at.to_i / 60, ms, true) }
+  end
+
+  def minute_key
+    Wurk::Metrics::History.minute_key(@at)
+  end
+
+  def processed
+    Wurk.redis { |c| c.call('HGET', minute_key, "#{@klass}|p") }
+  end
+end

--- a/test/unit/metrics_history_test.rb
+++ b/test/unit/metrics_history_test.rb
@@ -172,15 +172,25 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
 
   # The behavior change slice 02 signed off on: nothing reaches Redis until a
   # flush. Everything below it is about that staying invisible on the wire.
+  #
+  # Proven on the wire rather than by reading the bucket back empty: `record`
+  # folds into the process-wide accumulator, which the argless `flush` in the
+  # parallel siblings of this class also drains, so an absent key would prove
+  # only that no sibling flushed in the window. The two halves use different
+  # class names for the same reason — the recorded one stays in that shared
+  # accumulator, and counting it twice here is not a failure worth asserting on.
   def test_record_writes_nothing_until_the_flush
-    Wurk::Metrics::History.record(@klass, 42, success: true, at: @at)
-    minute = Wurk::Metrics::History.minute_key(@at)
+    spy = Wurk::Test::CommandSpy.new(Wurk.redis_pool)
+    Thread.current[:wurk_capsule] = spy
+    Wurk::Metrics::History.record("#{@klass}Recorded", 42, success: true, at: @at)
 
-    assert_nil(Wurk.redis { |c| c.call('HGET', minute, "#{@klass}|p") })
+    assert_equal 0, spy.count
 
-    Wurk::Metrics::History.flush
+    fold { |acc| acc.add(nil, @klass, bucket, 42, true) }
 
-    assert_equal('1', Wurk.redis { |c| c.call('HGET', minute, "#{@klass}|p") })
+    assert_equal('1', minute_fields(@klass)['p'])
+  ensure
+    Thread.current[:wurk_capsule] = nil
   end
 
   # The whole trade: N executions must leave Redis in exactly the state N

--- a/test/unit/metrics_history_test.rb
+++ b/test/unit/metrics_history_test.rb
@@ -17,25 +17,35 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
 
   def teardown
     Wurk.redis do |c|
-      cursor = '0'
-      loop do
-        cursor, keys = c.call('SCAN', cursor, 'MATCH', "*#{@klass}*", 'COUNT', 500)
-        c.call('DEL', *keys) unless keys.empty?
-        break if cursor == '0'
-      end
-      # Per-class fields live in shared, non-class-named minute buckets that
-      # SCAN can't reach. HDEL our fields from every bucket this test could
-      # have written: the fixed @at bucket (record tests) AND the current-time
-      # bucket (middleware tests record at Time.now).
-      bucket_keys = [@at, ::Time.now.utc].map do |t|
-        Wurk::Metrics::History.minute_key(t)
-      end
-      bucket_keys.uniq.each do |key|
-        c.call('HDEL', key, "#{@klass}|p", "#{@klass}|f", "#{@klass}|ms")
-      end
+      drop_class_keys(c)
+      drop_bucket_fields(c)
     end
   ensure
     super
+  end
+
+  # Hourly buckets are class-named, so SCAN reaches them.
+  def drop_class_keys(conn)
+    cursor = '0'
+    loop do
+      cursor, keys = conn.call('SCAN', cursor, 'MATCH', "*#{@klass}*", 'COUNT', 500)
+      conn.call('DEL', *keys) unless keys.empty?
+      break if cursor == '0'
+    end
+  end
+
+  # Per-class fields live in shared, non-class-named minute buckets that SCAN
+  # can't reach. HDEL every field this instance could have written from every
+  # bucket it could have written to: the fixed @at bucket and its predecessor
+  # (record tests) AND the current-time bucket (middleware tests record at
+  # Time.now). Matched by prefix, because some tests suffix @klass to compare
+  # two class names inside one bucket.
+  def drop_bucket_fields(conn)
+    keys = [@at, @at - 60, ::Time.now.utc].map { |t| Wurk::Metrics::History.minute_key(t) }
+    keys.uniq.each do |key|
+      mine = conn.call('HKEYS', key).select { |f| f.start_with?(@klass) }
+      conn.call('HDEL', key, *mine) unless mine.empty?
+    end
   end
 
   # ---- bucket key formatting -----------------------------------------------
@@ -58,6 +68,7 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
 
   def test_record_writes_processed_counter_in_minute_bucket
     Wurk::Metrics::History.record(@klass, 42, success: true, at: @at)
+    Wurk::Metrics::History.flush
 
     minute = Wurk::Metrics::History.minute_key(@at)
     val = Wurk.redis { |c| c.call('HGET', minute, "#{@klass}|p") }
@@ -67,6 +78,7 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
 
   def test_record_writes_failed_counter_when_unsuccessful
     Wurk::Metrics::History.record(@klass, 8, success: false, at: @at)
+    Wurk::Metrics::History.flush
 
     minute = Wurk::Metrics::History.minute_key(@at)
     val = Wurk.redis { |c| c.call('HGET', minute, "#{@klass}|f") }
@@ -77,6 +89,7 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
   def test_record_accumulates_ms_across_success_and_failure
     Wurk::Metrics::History.record(@klass, 10, success: true, at: @at)
     Wurk::Metrics::History.record(@klass, 25, success: false, at: @at)
+    Wurk::Metrics::History.flush
 
     minute = Wurk::Metrics::History.minute_key(@at)
     val = Wurk.redis { |c| c.call('HGET', minute, "#{@klass}|ms") }
@@ -93,6 +106,7 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
     at = ::Time.utc(2026, 5, 21, 14, 37, 0)
     x0 = ::Time.utc(2026, 5, 21, 14, 30, 0)
     Wurk::Metrics::History.record(@klass, 5, success: true, at: at)
+    Wurk::Metrics::History.flush
 
     x0_val = Wurk.redis { |c| c.call('HGET', Wurk::Metrics::History.minute_key(x0), "#{@klass}|p") }
 
@@ -104,6 +118,7 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
   def test_record_writes_hourly_bucket
     Wurk::Metrics::History.record(@klass, 20, success: true, at: @at)
     Wurk::Metrics::History.record(@klass, 30, success: false, at: @at)
+    Wurk::Metrics::History.flush
 
     hour = Wurk::Metrics::History.hour_key(@klass, @at)
     p, f, ms = Wurk.redis { |c| c.call('HMGET', hour, 'p', 'f', 'ms') }
@@ -115,6 +130,7 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
 
   def test_record_sets_minute_ttl_to_mid_term
     Wurk::Metrics::History.record(@klass, 1, success: true, at: @at)
+    Wurk::Metrics::History.flush
 
     ttl = Wurk.redis { |c| c.call('TTL', Wurk::Metrics::History.minute_key(@at)) }
 
@@ -124,6 +140,7 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
 
   def test_record_sets_hourly_ttl_to_mid_term
     Wurk::Metrics::History.record(@klass, 1, success: true, at: @at)
+    Wurk::Metrics::History.flush
 
     ttl = Wurk.redis { |c| c.call('TTL', Wurk::Metrics::History.hour_key(@klass, @at)) }
 
@@ -134,6 +151,7 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
   def test_record_ignores_blank_klass
     Wurk::Metrics::History.record(nil, 1, success: true, at: @at)
     Wurk::Metrics::History.record('', 1, success: true, at: @at)
+    Wurk::Metrics::History.flush
 
     minute = Wurk::Metrics::History.minute_key(@at)
 
@@ -142,11 +160,136 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
 
   def test_record_clamps_negative_duration_to_zero
     Wurk::Metrics::History.record(@klass, -50, success: true, at: @at)
+    Wurk::Metrics::History.flush
 
     minute = Wurk::Metrics::History.minute_key(@at)
     val = Wurk.redis { |c| c.call('HGET', minute, "#{@klass}|ms") }
 
     assert_equal '0', val
+  end
+
+  # ---- in-process accumulation --------------------------------------------
+
+  # The behavior change slice 02 signed off on: nothing reaches Redis until a
+  # flush. Everything below it is about that staying invisible on the wire.
+  def test_record_writes_nothing_until_the_flush
+    Wurk::Metrics::History.record(@klass, 42, success: true, at: @at)
+    minute = Wurk::Metrics::History.minute_key(@at)
+
+    assert_nil(Wurk.redis { |c| c.call('HGET', minute, "#{@klass}|p") })
+
+    Wurk::Metrics::History.flush
+
+    assert_equal('1', Wurk.redis { |c| c.call('HGET', minute, "#{@klass}|p") })
+  end
+
+  # The whole trade: N executions must leave Redis in exactly the state N
+  # individual pipelines left it in — same keys, same fields, same values.
+  # Anything else is a dashboard that reads differently after the swap.
+  def test_flushed_state_is_identical_to_per_execution_writes
+    batched = "#{@klass}Batched"
+    per_job = "#{@klass}PerJob"
+
+    fold { |acc| 10.times { |i| execution(acc, batched, i) } }
+    10.times { |i| fold { |acc| execution(acc, per_job, i) } }
+
+    assert_equal({ 'p' => '7', 'f' => '3', 'ms' => '82' }, hour_fields(per_job))
+    assert_equal hour_fields(per_job), hour_fields(batched)
+    assert_equal minute_fields(per_job), minute_fields(batched)
+  end
+
+  # `HINCRBY <field> 0` would materialize a counter the per-job path never
+  # created, and the read side would start reporting an `f: 0` series for
+  # classes that have never failed.
+  def test_flush_omits_an_outcome_that_never_happened
+    fold { |acc| 3.times { acc.add(nil, @klass, bucket, 5, true) } }
+
+    assert_equal %w[ms p], hour_fields(@klass).keys.sort
+    assert_equal %w[ms p], minute_fields(@klass).keys.sort
+  end
+
+  # Bucket attribution is decided when the job runs, not when the flush happens:
+  # a drain carrying two minutes must land in two buckets, not in one.
+  def test_flush_keeps_each_minute_in_its_own_bucket
+    Wurk::Metrics::History.record(@klass, 5, success: true, at: @at)
+    Wurk::Metrics::History.record(@klass, 5, success: true, at: @at - 60)
+    Wurk::Metrics::History.flush
+
+    %i[at prev].each do |which|
+      key = Wurk::Metrics::History.minute_key(which == :at ? @at : @at - 60)
+
+      assert_equal('1', Wurk.redis { |c| c.call('HGET', key, "#{@klass}|p") }, which.to_s)
+    end
+  end
+
+  # 6 commands per (class, minute) per flush — the same 6 the hot path used to
+  # send per job. 100 executions must not cost 600.
+  def test_a_flush_costs_six_commands_regardless_of_execution_count
+    spy = Wurk::Test::CommandSpy.new(Wurk.redis_pool)
+    acc = Wurk::Metrics::Accumulator.new
+    100.times { acc.add(spy, @klass, bucket, 5, true) }
+
+    Wurk::Metrics::History.flush(acc)
+
+    assert_equal 6, spy.count
+  end
+
+  # An idle worker must not spend a round trip every FLUSH_INTERVAL just to say
+  # nothing happened.
+  def test_flushing_an_empty_accumulator_costs_no_round_trip
+    spy = Wurk::Test::CommandSpy.new(Wurk.redis_pool)
+    Thread.current[:wurk_capsule] = spy
+
+    assert_nil Wurk::Metrics::History.flush(Wurk::Metrics::Accumulator.new)
+    assert_equal 0, spy.count
+  ensure
+    Thread.current[:wurk_capsule] = nil
+  end
+
+  # A transient Redis failure must not eat the window.
+  def test_a_failed_flush_keeps_its_counts
+    acc = flaky_accumulator
+
+    assert_raises(RuntimeError) { Wurk::Metrics::History.flush(acc) }
+    refute_predicate acc, :empty?
+  end
+
+  def test_the_tick_after_a_failed_flush_writes_the_counts_it_kept
+    acc = flaky_accumulator
+    assert_raises(RuntimeError) { Wurk::Metrics::History.flush(acc) }
+
+    Wurk::Metrics::History.flush(acc)
+
+    assert_equal('1', Wurk.redis { |c| c.call('HGET', Wurk::Metrics::History.minute_key(@at), "#{@klass}|p") })
+  end
+
+  # One pool's failure must not put the pools that already wrote back on the
+  # retry list — HINCRBY would count them twice on the next tick.
+  def test_a_failed_pool_does_not_drag_a_healthy_one_back_into_the_accumulator
+    healthy = "#{@klass}Healthy"
+    acc = Wurk::Metrics::Accumulator.new
+    acc.add(nil, healthy, bucket, 1, true)
+    acc.add(FlakyPool.new(Wurk.redis_pool), @klass, bucket, 1, true)
+
+    assert_raises(RuntimeError) { Wurk::Metrics::History.flush(acc) }
+    Wurk::Metrics::History.flush(acc)
+
+    assert_equal({ 'p' => '1', 'ms' => '1' }, minute_fields(healthy))
+  end
+
+  # Raises once, then delegates — a Redis blip, not a dead server.
+  class FlakyPool
+    def initialize(pool)
+      @pool = pool
+      @failed = false
+    end
+
+    def with(&)
+      return @pool.with(&) if @failed
+
+      @failed = true
+      raise 'redis down'
+    end
   end
 
   # ---- middleware integration ---------------------------------------------
@@ -155,6 +298,7 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
     mw = build_middleware
     job = { 'class' => @klass }
     result = mw.call(nil, job, 'default') { :ok }
+    Wurk::Metrics::History.flush
 
     assert_equal :ok, result
     minute = Wurk::Metrics::History.minute_key(::Time.now.utc)
@@ -187,6 +331,7 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
   def test_default_server_chain_records_without_initializer
     before = ::Time.now.utc
     Wurk.configuration.default_capsule.server_middleware.invoke(nil, { 'class' => @klass }, 'default') { :ok }
+    Wurk::Metrics::History.flush
 
     assert recorded_processed_between?(before, ::Time.now.utc),
            'expected processed=1 in the minute bucket'
@@ -198,31 +343,76 @@ class MetricsHistoryTest < Wurk::Test::UnitCase
     assert_raises(::RuntimeError) do
       mw.call(nil, job, 'default') { raise 'boom' }
     end
+    Wurk::Metrics::History.flush
 
     minute = Wurk::Metrics::History.minute_key(::Time.now.utc)
 
     assert_equal('1', Wurk.redis { |c| c.call('HGET', minute, "#{@klass}|f") })
   end
 
-  def test_middleware_swallows_redis_failure_post_perform
-    broken_pool = Object.new
-    def broken_pool.with(&)
-      raise 'redis down'
-    end
-
+  # Recording is in-memory, so the failure the middleware has to swallow is no
+  # longer a Redis blip (that moved to Flusher) but a payload it cannot key on —
+  # here a `class` that isn't a String, which blows up on `#empty?`. The job's
+  # return value must survive it and the error must reach the handler.
+  def test_middleware_swallows_a_record_failure_post_perform
+    reported = []
     cfg = Wurk::Configuration.new
     cfg.logger = Logger.new(IO::NULL)
-    # Stub redis_pool on this throwaway capsule so the middleware reads our broken pool.
-    cfg.default_capsule.instance_variable_set(:@redis_pool, broken_pool)
+    cfg.error_handlers << ->(ex, ctx, _cfg) { reported << [ex.class, ctx[:context]] }
     mw = Wurk::Metrics::History.new
     mw.config = cfg
 
-    result = mw.call(nil, { 'class' => @klass }, 'default') { :ok }
+    result = mw.call(nil, { 'class' => Object.new }, 'default') { :ok }
 
     assert_equal :ok, result
+    assert_equal [[NoMethodError, 'Wurk::Metrics::History']], reported
   end
 
   private
+
+  # The @at minute, as Accumulator keys it.
+  def bucket
+    @at.to_i / 60
+  end
+
+  # Folds executions into a throwaway accumulator and flushes it, so a test can
+  # compare batched against per-execution writes without either one touching the
+  # process-wide accumulator a parallel test is also using.
+  def fold
+    acc = Wurk::Metrics::Accumulator.new
+    yield acc
+    Wurk::Metrics::History.flush(acc)
+  end
+
+  # Execution `index` of a fixed ten: seven successes at 10ms, three failures
+  # at 4ms. Same sequence whether it is folded into one flush or ten.
+  def execution(acc, klass, index)
+    index < 7 ? acc.add(nil, klass, bucket, 10, true) : acc.add(nil, klass, bucket, 4, false)
+  end
+
+  # One execution behind a pool that fails its first checkout — a Redis blip,
+  # not a dead server.
+  def flaky_accumulator
+    Wurk::Metrics::Accumulator.new.tap { |acc| acc.add(FlakyPool.new(Wurk.redis_pool), @klass, bucket, 9, true) }
+  end
+
+  def hour_fields(klass)
+    hgetall(Wurk::Metrics::History.hour_key(klass, @at))
+  end
+
+  # This class's fields out of the shared minute bucket, prefix stripped, so two
+  # class names in the same bucket compare directly.
+  def minute_fields(klass)
+    hgetall(Wurk::Metrics::History.minute_key(@at))
+      .select { |field, _| field.start_with?("#{klass}|") }
+      .transform_keys { |field| field.split('|', 2).last }
+  end
+
+  # redis-client returns HGETALL as a Hash or a flat Array depending on version.
+  def hgetall(key)
+    raw = Wurk.redis { |c| c.call('HGETALL', key) }
+    raw.is_a?(::Hash) ? raw : ::Hash[*raw]
+  end
 
   def build_middleware
     mw = Wurk::Metrics::History.new

--- a/test/unit/metrics_query_test.rb
+++ b/test/unit/metrics_query_test.rb
@@ -100,6 +100,7 @@ class MetricsQueryTest < Wurk::Test::UnitCase
     Wurk::Metrics::History.record(@klass_a, 100, success: true, at: @now)
     Wurk::Metrics::History.record(@klass_a, 200, success: false, at: @now - 60)
     Wurk::Metrics::History.record(@klass_b, 50, success: true, at: @now)
+    Wurk::Metrics::History.flush
 
     rows = Wurk::Metrics::Query.top_jobs(minutes: 5, now: @now)
     found = rows.to_h
@@ -117,6 +118,7 @@ class MetricsQueryTest < Wurk::Test::UnitCase
     [31, 32, 33].each do |m|
       Wurk::Metrics::History.record(@klass_a, 100, success: true, at: ::Time.utc(2026, 5, 21, 14, m, 0))
     end
+    Wurk::Metrics::History.flush
 
     found = Wurk::Metrics::Query.top_jobs(minutes: 10, now: @now).to_h
 
@@ -126,6 +128,7 @@ class MetricsQueryTest < Wurk::Test::UnitCase
   def test_top_jobs_sorted_descending_by_volume
     5.times { Wurk::Metrics::History.record(@klass_a, 1, success: true, at: @now) }
     2.times { Wurk::Metrics::History.record(@klass_b, 1, success: true, at: @now) }
+    Wurk::Metrics::History.flush
 
     rows = Wurk::Metrics::Query.top_jobs(minutes: 5, now: @now)
     classes = rows.map(&:first).select { |k| [@klass_a, @klass_b].include?(k) }
@@ -136,6 +139,7 @@ class MetricsQueryTest < Wurk::Test::UnitCase
   def test_top_jobs_filters_by_prefix
     Wurk::Metrics::History.record(@klass_a, 1, success: true, at: @now)
     Wurk::Metrics::History.record(@klass_b, 1, success: true, at: @now)
+    Wurk::Metrics::History.flush
 
     rows = Wurk::Metrics::Query.top_jobs(class_filter: 'Alpha', minutes: 5, now: @now)
     klasses = rows.map(&:first)
@@ -150,6 +154,7 @@ class MetricsQueryTest < Wurk::Test::UnitCase
   # for MID_TERM (3 days), so the whole range is backed by data.
   def test_top_jobs_hours_reaches_the_documented_ceiling
     Wurk::Metrics::History.record(@klass_a, 5, success: true, at: @now)
+    Wurk::Metrics::History.flush
 
     [9, Wurk::Metrics::Query::MAX_HOURS].each do |hours|
       rows = Wurk::Metrics::Query.top_jobs(hours: hours, now: @now)
@@ -160,6 +165,7 @@ class MetricsQueryTest < Wurk::Test::UnitCase
 
   def test_top_jobs_hours_arg_converts_to_minutes
     Wurk::Metrics::History.record(@klass_a, 7, success: true, at: @now)
+    Wurk::Metrics::History.flush
 
     rows = Wurk::Metrics::Query.top_jobs(hours: 1, now: @now)
 
@@ -171,6 +177,7 @@ class MetricsQueryTest < Wurk::Test::UnitCase
   def test_for_job_minutes_returns_chronological_rows
     Wurk::Metrics::History.record(@klass_a, 10, success: true, at: @now - 60)
     Wurk::Metrics::History.record(@klass_a, 25, success: true, at: @now)
+    Wurk::Metrics::History.flush
 
     rows = Wurk::Metrics::Query.for_job(@klass_a, minutes: 3, now: @now)
 
@@ -189,6 +196,7 @@ class MetricsQueryTest < Wurk::Test::UnitCase
 
   def test_for_job_hours_returns_chronological_rows
     Wurk::Metrics::History.record(@klass_a, 99, success: true, at: @now)
+    Wurk::Metrics::History.flush
 
     rows = Wurk::Metrics::Query.for_job(@klass_a, hours: 2, now: @now)
 

--- a/test/unit/processor_test.rb
+++ b/test/unit/processor_test.rb
@@ -186,6 +186,69 @@ class ProcessorTest < Wurk::Test::UnitCase
     refute_predicate processor.thread, :alive?
   end
 
+  # --- held ACKs at stop ------------------------------------------------
+
+  # A processor's last job is the trap the ACK piggyback sets: it finishes,
+  # hands its LREM to the fetcher, and the run loop then exits without ever
+  # fetching again. Nothing else would send it, and a finished job is no longer
+  # in flight, so Manager#hard_shutdown can't see it either — it would sit in
+  # the private list until the next boot's reaper ran it a second time.
+  def test_run_sends_a_held_ack_when_the_loop_stops
+    klass = define_worker_recording
+    enqueue(class: klass.name, args: [])
+    @processor.process_one
+    @processor.terminate
+
+    assert_equal 1, llen(private_queue), 'precondition: the ACK is held, not sent'
+
+    @processor.send(:run)
+
+    assert_equal [[]], klass.sink
+    assert_equal 0, llen(private_queue)
+  end
+
+  # Before the callback, not after it: the callback drops this Processor from
+  # the Manager's pool, which is what lets Manager#stop return and close the
+  # capsule's Redis pool out from under the flush.
+  def test_a_held_ack_is_sent_before_the_stop_callback_fires
+    klass = define_worker_recording
+    enqueue(class: klass.name, args: [])
+    private_at_callback = nil
+    processor = new_processor { |_p| private_at_callback = llen(private_queue) }
+    processor.process_one
+    processor.terminate
+
+    processor.send(:run)
+
+    assert_equal 0, private_at_callback
+  end
+
+  # The flush is the last thing a dying thread does; a Redis blip there must be
+  # reported, not turned into a thread that dies with an exception.
+  def test_a_failed_stop_flush_is_reported_not_raised
+    errors = []
+    @config.error_handlers.replace([->(ex, _ctx, _cfg) { errors << ex }])
+    @capsule.fetcher.define_singleton_method(:flush_pending_acks) { raise 'redis down' }
+    @processor.terminate
+
+    @processor.send(:run)
+
+    assert_equal 1, errors.size
+  end
+
+  # A fetcher plugged in via config[:fetch_class] need not defer anything, so it
+  # need not answer the flush at all.
+  def test_run_tolerates_a_fetcher_that_does_not_defer
+    @capsule.fetcher = Object.new
+    called = []
+    processor = new_processor { |p| called << p }
+    processor.terminate
+
+    processor.send(:run)
+
+    assert_equal [processor], called
+  end
+
   # --- successful processing -------------------------------------------
 
   def test_process_one_runs_perform_and_acks
@@ -193,6 +256,7 @@ class ProcessorTest < Wurk::Test::UnitCase
     enqueue(class: klass.name, args: [1, 'two', { 'k' => 'v' }])
 
     @processor.process_one
+    settle_acks
 
     assert_equal [1, 'two', { 'k' => 'v' }], klass.sink.first
     assert_equal 0, llen(private_queue), 'expected UoW to be acked'
@@ -212,6 +276,7 @@ class ProcessorTest < Wurk::Test::UnitCase
     assert_equal 1, Wurk::Middleware::PoisonPill.recovery_count(payload['jid'])
 
     @processor.process_one
+    settle_acks
 
     assert_equal 0, Wurk::Middleware::PoisonPill.recovery_count(payload['jid'])
   end
@@ -226,6 +291,7 @@ class ProcessorTest < Wurk::Test::UnitCase
     2.times { Wurk::Middleware::PoisonPill.track!(json, queue: @queue_name) }
 
     @processor.process_one
+    settle_acks
 
     assert_equal :recovered, Wurk::Middleware::PoisonPill.track!(json, queue: @queue_name)
     assert_equal 1, Wurk::Middleware::PoisonPill.recovery_count(payload['jid'])
@@ -241,6 +307,7 @@ class ProcessorTest < Wurk::Test::UnitCase
     Wurk::Middleware::PoisonPill.track!(Wurk.dump_json(payload), queue: @queue_name)
 
     @processor.process_one
+    settle_acks
 
     assert_equal 0, Wurk::Middleware::PoisonPill.recovery_count(payload['jid'])
   end
@@ -292,15 +359,10 @@ class ProcessorTest < Wurk::Test::UnitCase
     payload = enqueue(class: klass.name, args: [], retry: true)
 
     @processor.process_one
+    settle_acks
 
     assert_equal 0, llen(private_queue), 'retrier handles → UoW must ack'
-    # JobRetry ZADDs the rewritten payload into the canonical `retry` ZSET.
-    found = @pool.with do |c|
-      c.call('ZRANGE', Wurk::Keys::RETRY, 0, -1).find { |raw| raw.include?(%("jid":"#{payload['jid']}")) }
-    end
-    @pool.with { |c| c.call('ZREM', Wurk::Keys::RETRY, found) } if found
-
-    refute_nil found, 'expected JobRetry to ZADD the failure into retry'
+    refute_nil take_retry_entry_for(payload['jid']), 'expected JobRetry to ZADD the failure into retry'
   end
 
   def test_process_one_acks_on_jobretry_handled
@@ -308,6 +370,7 @@ class ProcessorTest < Wurk::Test::UnitCase
     enqueue(class: klass.name, args: [])
 
     @processor.process_one
+    settle_acks
 
     assert_equal 0, llen(private_queue), 'Handled should be treated as a clean exit'
   end
@@ -317,6 +380,7 @@ class ProcessorTest < Wurk::Test::UnitCase
     enqueue(class: klass.name, args: [])
 
     @processor.process_one
+    settle_acks
 
     assert_equal 0, llen(private_queue)
   end
@@ -329,6 +393,7 @@ class ProcessorTest < Wurk::Test::UnitCase
     @pool.with { |c| c.call('LPUSH', @public_queue, payload) }
 
     @processor.process_one
+    settle_acks
 
     members = @pool.with { |c| c.call('ZRANGE', Wurk::Keys::DEAD, 0, -1) }
 
@@ -342,6 +407,7 @@ class ProcessorTest < Wurk::Test::UnitCase
     @pool.with { |c| c.call('LPUSH', @public_queue, payload) }
 
     @processor.process_one
+    settle_acks
 
     assert_equal 0, llen(private_queue)
   end
@@ -388,6 +454,7 @@ class ProcessorTest < Wurk::Test::UnitCase
     enqueue(class: klass.name, args: ['ok'], bid: 'B123')
 
     @processor.process_one
+    settle_acks
 
     assert_equal ['ok'], klass.sink.first
     assert_equal 0, llen(private_queue), 'job without bid= setter must still ack'
@@ -535,6 +602,14 @@ class ProcessorTest < Wurk::Test::UnitCase
     nil
   end
 
+  # The ACK rides the next fetch, so a test that drives a single `process_one`
+  # has to settle it before asserting on the private list or the poison-pill
+  # counter. A running processor settles it on its next fetch, or — when there
+  # is no next fetch — in Processor#run's ensure.
+  def settle_acks
+    @capsule.fetcher.flush_pending_acks
+  end
+
   def private_queue
     Wurk::Fetcher::Reliable.private_queue_name(@public_queue)
   end
@@ -552,6 +627,17 @@ class ProcessorTest < Wurk::Test::UnitCase
   # A job payload that is never pushed to Redis — for the stubbed-fetch tests.
   def json_for(klass)
     Wurk.dump_json('class' => klass.name, 'args' => [], 'queue' => @queue_name, 'jid' => SecureRandom.hex(6))
+  end
+
+  # JobRetry ZADDs the rewritten payload into the canonical `retry` ZSET, which
+  # every test in this worker shares — so this takes the entry back out as it
+  # reads it.
+  def take_retry_entry_for(jid)
+    entry = @pool.with do |c|
+      c.call('ZRANGE', Wurk::Keys::RETRY, 0, -1).find { |raw| raw.include?(%("jid":"#{jid}")) }
+    end
+    @pool.with { |c| c.call('ZREM', Wurk::Keys::RETRY, entry) } if entry
+    entry
   end
 
   def dead_count_for(jid)

--- a/test/unit/queue_pause_test.rb
+++ b/test/unit/queue_pause_test.rb
@@ -172,7 +172,7 @@ class QueuePauseTest < Wurk::Test::UnitCase
   # install, and re-confirming it once per fetch is the round trip per job the
   # cache exists to delete.
   def test_empty_paused_set_is_read_once_per_ttl_not_once_per_pass
-    fetcher, capsule, counter = build_fetcher_with_paused_counter
+    fetcher, capsule, counter = build_pinned_fetcher_with_paused_counter
 
     10.times { fetcher.queues_cmd }
 
@@ -182,7 +182,7 @@ class QueuePauseTest < Wurk::Test::UnitCase
   end
 
   def test_paused_set_stays_cached_while_a_queue_is_paused
-    fetcher, capsule, counter = build_fetcher_with_paused_counter
+    fetcher, capsule, counter = build_pinned_fetcher_with_paused_counter
     Wurk::Queue.new(@qname).pause!
 
     10.times { refute_includes fetcher.queues_cmd, @rqname }
@@ -240,7 +240,7 @@ class QueuePauseTest < Wurk::Test::UnitCase
   # cross-process case the sign-off bounds at PAUSED_TTL instead of making
   # immediate.
   def test_pause_from_another_process_is_invisible_until_the_cache_expires
-    fetcher, capsule = build_fetcher(%W[#{@qname}])
+    fetcher, capsule = build_fetcher(%W[#{@qname}], PinnedGeneration)
 
     assert_includes fetcher.queues_cmd, @rqname
 
@@ -273,7 +273,7 @@ class QueuePauseTest < Wurk::Test::UnitCase
   # Reporting is never served from the fetch cache: the dashboard has to show
   # what Redis says right now, even mid-TTL.
   def test_paused_predicate_reads_redis_while_a_fetcher_cache_is_warm
-    fetcher, capsule = build_fetcher(%W[#{@qname}])
+    fetcher, capsule = build_fetcher(%W[#{@qname}], PinnedGeneration)
     fetcher.queues_cmd
     pause_elsewhere(@qname)
 
@@ -283,13 +283,23 @@ class QueuePauseTest < Wurk::Test::UnitCase
     capsule&.stop
   end
 
+  # A fetcher whose view of the process-global paused generation is frozen.
+  # `Queue#pause!` bumps that counter for every fetcher in the process, which is
+  # exactly what the invalidation tests above assert — and exactly what makes a
+  # parallel sibling's pause! indistinguishable from a TTL expiry in the four
+  # tests that measure the TTL itself. Those build from here so a sibling's bump
+  # can't force the extra SMEMBERS their counts and stale reads are pinning.
+  PinnedGeneration = Class.new(Wurk::Fetcher::Reliable) do
+    def self.paused_generation = 0
+  end
+
   private
 
-  def build_fetcher(queues)
+  def build_fetcher(queues, klass = Wurk::Fetcher::Reliable)
     config  = Wurk::Configuration.new
     capsule = Wurk::Capsule.new('test', config)
     capsule.queues = queues
-    [Wurk::Fetcher::Reliable.new(capsule), capsule]
+    [klass.new(capsule), capsule]
   end
 
   def paused_members
@@ -327,8 +337,8 @@ class QueuePauseTest < Wurk::Test::UnitCase
     [fetcher, capsule, counter]
   end
 
-  def build_fetcher_with_paused_counter
-    fetcher, capsule = build_fetcher(%W[#{@qname} #{@other}])
+  def build_pinned_fetcher_with_paused_counter
+    fetcher, capsule = build_fetcher(%W[#{@qname} #{@other}], PinnedGeneration)
     counter = PausedReadCounter.new(capsule.redis_pool)
     capsule.instance_variable_set(:@redis_pool, counter)
     [fetcher, capsule, counter]

--- a/test/unit/queue_pause_test.rb
+++ b/test/unit/queue_pause_test.rb
@@ -115,9 +115,8 @@ class QueuePauseTest < Wurk::Test::UnitCase
   # F1 regression: with every queue paused, retrieve_work has nothing to
   # BLMOVE on, so it must back off a full poll interval per pass rather than
   # returning nil instantly. A caller that drives retrieve_work in a bare loop
-  # (Processor#run has no pause of its own) would otherwise turn this into a
-  # hot spin issuing one SMEMBERS per iteration as fast as the CPU allows —
-  # thousands of Redis round trips per second instead of a handful.
+  # (Processor#run has no pause of its own) would otherwise spin as fast as the
+  # CPU allows, burning a core on passes that can never return a job.
   def test_fetcher_backs_off_with_bounded_redis_commands_when_all_paused
     fetcher, capsule, counter = build_paused_fetcher_with_counter
 
@@ -125,8 +124,8 @@ class QueuePauseTest < Wurk::Test::UnitCase
 
     # Backed off at 0.05s/pass, ~1s of wall clock caps this well under 40
     # passes; a hot spin (no backoff) would blow past this by orders of
-    # magnitude. One SMEMBERS per retrieve_work pass, so the Redis command
-    # count tracks 1:1 with the loop iteration count.
+    # magnitude. Checkouts are bounded twice over — by the backoff and by
+    # PAUSED_TTL — so they can only come in under the pass count.
     assert(results.all?(&:nil?))
     assert_operator results.size, :<=, 40
     assert_operator counter.count, :<=, 40
@@ -161,6 +160,124 @@ class QueuePauseTest < Wurk::Test::UnitCase
 
     q.unpause!
 
+    assert_includes fetcher.queues_cmd, @rqname
+  ensure
+    capsule&.stop
+  end
+
+  # --- fetch-path paused cache ----------------------------------------
+
+  # The fast path has to be "no SMEMBERS at all", not "no SMEMBERS only once
+  # something is paused": an empty `paused` SET is the state of virtually every
+  # install, and re-confirming it once per fetch is the round trip per job the
+  # cache exists to delete.
+  def test_empty_paused_set_is_read_once_per_ttl_not_once_per_pass
+    fetcher, capsule, counter = build_fetcher_with_paused_counter
+
+    10.times { fetcher.queues_cmd }
+
+    assert_equal 1, counter.count
+  ensure
+    capsule&.stop
+  end
+
+  def test_paused_set_stays_cached_while_a_queue_is_paused
+    fetcher, capsule, counter = build_fetcher_with_paused_counter
+    Wurk::Queue.new(@qname).pause!
+
+    10.times { refute_includes fetcher.queues_cmd, @rqname }
+
+    assert_equal 1, counter.count
+  ensure
+    capsule&.stop
+  end
+
+  # A host app that pauses a queue from inside a job has to see its own workers
+  # stop, so a local pause expires the local copy rather than waiting out the
+  # TTL. The cache is warmed first — without the invalidation this reads stale.
+  def test_pause_in_this_process_expires_a_warm_cache_immediately
+    fetcher, capsule = build_fetcher(%W[#{@qname} #{@other}])
+
+    assert_includes fetcher.queues_cmd, @rqname
+
+    Wurk::Queue.new(@qname).pause!
+
+    refute_includes fetcher.queues_cmd, @rqname
+  ensure
+    capsule&.stop
+  end
+
+  def test_unpause_in_this_process_expires_a_warm_cache_immediately
+    fetcher, capsule = build_fetcher(%W[#{@qname}])
+    Wurk::Queue.new(@qname).pause!
+
+    assert_empty fetcher.queues_cmd
+
+    Wurk::Queue.new(@qname).unpause!
+
+    assert_includes fetcher.queues_cmd, @rqname
+  ensure
+    capsule&.stop
+  end
+
+  # A worker runs one fetcher per capsule; a pause has to expire all of them,
+  # not just whichever one happens to fetch next.
+  def test_pause_expires_every_fetcher_in_this_process
+    first, capsule_a = build_fetcher(%W[#{@qname}])
+    second, capsule_b = build_fetcher(%W[#{@qname}])
+    warm = [first.queues_cmd, second.queues_cmd]
+
+    Wurk::Queue.new(@qname).pause!
+
+    assert_equal [[@rqname], [@rqname]], warm
+    assert_equal [[], []], [first.queues_cmd, second.queues_cmd]
+  ensure
+    capsule_a&.stop
+    capsule_b&.stop
+  end
+
+  # Another process's pause is a bare SADD with no local invalidation — the
+  # cross-process case the sign-off bounds at PAUSED_TTL instead of making
+  # immediate.
+  def test_pause_from_another_process_is_invisible_until_the_cache_expires
+    fetcher, capsule = build_fetcher(%W[#{@qname}])
+
+    assert_includes fetcher.queues_cmd, @rqname
+
+    pause_elsewhere(@qname)
+
+    assert_includes fetcher.queues_cmd, @rqname
+
+    expire_cache(fetcher)
+
+    assert_empty fetcher.queues_cmd
+  ensure
+    capsule&.stop
+  end
+
+  # The half a rewound deadline can't prove: that the deadline really is one
+  # PAUSED_TTL out on the monotonic clock. With the test above, this pins "a
+  # cross-process pause lands within 2 seconds" without spending 2 seconds.
+  def test_cache_deadline_is_one_paused_ttl_out_on_the_monotonic_clock
+    fetcher, capsule = build_fetcher(%W[#{@qname}])
+    opened = monotonic_now
+    fetcher.queues_cmd
+    deadline = fetcher.instance_variable_get(:@paused_expires_at)
+
+    assert_operator deadline, :>=, opened + Wurk::Fetcher::Reliable::PAUSED_TTL
+    assert_operator deadline, :<=, monotonic_now + Wurk::Fetcher::Reliable::PAUSED_TTL
+  ensure
+    capsule&.stop
+  end
+
+  # Reporting is never served from the fetch cache: the dashboard has to show
+  # what Redis says right now, even mid-TTL.
+  def test_paused_predicate_reads_redis_while_a_fetcher_cache_is_warm
+    fetcher, capsule = build_fetcher(%W[#{@qname}])
+    fetcher.queues_cmd
+    pause_elsewhere(@qname)
+
+    assert_predicate Wurk::Queue.new(@qname), :paused?
     assert_includes fetcher.queues_cmd, @rqname
   ensure
     capsule&.stop
@@ -210,6 +327,25 @@ class QueuePauseTest < Wurk::Test::UnitCase
     [fetcher, capsule, counter]
   end
 
+  def build_fetcher_with_paused_counter
+    fetcher, capsule = build_fetcher(%W[#{@qname} #{@other}])
+    counter = PausedReadCounter.new(capsule.redis_pool)
+    capsule.instance_variable_set(:@redis_pool, counter)
+    [fetcher, capsule, counter]
+  end
+
+  # A pause written by some other process: the SET changes, this process's
+  # fetcher caches don't hear about it.
+  def pause_elsewhere(name)
+    @pool.with { |c| c.call('SADD', Wurk::Keys::PAUSED_SET, name) }
+  end
+
+  # Ages a fetcher's cached copy past PAUSED_TTL without spending PAUSED_TTL of
+  # wall clock doing it.
+  def expire_cache(fetcher)
+    fetcher.instance_variable_set(:@paused_expires_at, monotonic_now - 1)
+  end
+
   # Delegating pool that counts checkouts (one per `config.redis` block),
   # swapped in for the capsule's real pool so a test can measure Redis round
   # trips without a global monkeypatch. Mirrors WebSearchTest::RoundTripCounter.
@@ -224,6 +360,38 @@ class QueuePauseTest < Wurk::Test::UnitCase
     def with(&)
       @count += 1
       @pool.with(&)
+    end
+  end
+
+  # Same swap-in trick, counting a named command rather than checkouts: the
+  # point of the paused cache is that `SMEMBERS paused` stops happening while
+  # the fetch itself keeps happening, which a checkout count can't tell apart.
+  class PausedReadCounter
+    attr_reader :count
+
+    def initialize(pool)
+      @pool = pool
+      @count = 0
+    end
+
+    def with
+      @pool.with { |conn| yield Tap.new(conn, self) }
+    end
+
+    def record
+      @count += 1
+    end
+
+    class Tap < SimpleDelegator
+      def initialize(conn, counter)
+        super(conn)
+        @counter = counter
+      end
+
+      def call(*args, **, &)
+        @counter.record if args.first == 'SMEMBERS' && args[1] == Wurk::Keys::PAUSED_SET
+        __getobj__.call(*args, **, &)
+      end
     end
   end
 end

--- a/test/unit/redis_idempotent_call_sites_test.rb
+++ b/test/unit/redis_idempotent_call_sites_test.rb
@@ -135,16 +135,30 @@ class RedisIdempotentCallSitesTest < Wurk::Test::UnitCase
     assert_empty @main.commands
   end
 
-  # The ACK and the shutdown re-push are the other side of the same fetcher: an
-  # RPUSH replayed after a lost reply is a duplicate job, so neither may claim.
-  def test_ack_and_requeue_do_not_claim_apply_safety
+  # The shutdown re-push is the other side of the same fetcher: an RPUSH
+  # replayed after a lost reply is a duplicate job, so it must not claim.
+  def test_requeue_does_not_claim_apply_safety
     enqueue('{"jid":"b"}')
-    uow = fetcher.retrieve_work
-    uow.requeue
-    uow.acknowledge
+    fetcher.retrieve_work.requeue
 
     assert_equal [false], @main.claims_for('RPUSH')
-    assert_equal [false], @main.claims_for('LREM')
+  end
+
+  # The ACK claims, and had to: it no longer owns a checkout — it rides the
+  # next fetch's pipeline, whose LMOVE claims. The claim is sound on its own
+  # terms anyway. A replayed LREM finds the payload already gone and removes
+  # nothing, because every job JSON carries a unique jid, and the poison-pill
+  # DEL beside it is idempotent by definition. The standalone flush claims for
+  # the same reason: it is the same two commands, on the drain path, where
+  # riding out a blip is worth more than anywhere else.
+  def test_the_ack_claims_apply_safety_on_both_the_piggybacked_and_flushed_paths
+    enqueue('{"jid":"b"}')
+    enqueue('{"jid":"c"}')
+    fetcher.retrieve_work.acknowledge
+    fetcher.retrieve_work.acknowledge
+    fetcher.flush_pending_acks
+
+    assert_equal [true, true], @main.claims_for('LREM')
   end
 
   # --- reaper -------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Cache the paused-queue set per fetcher behind a 2s monotonic TTL instead of `SMEMBERS` every fetch pass
- Fold `Metrics::History` writes into an in-process accumulator, flushed every 5s (and on drain/terminate) instead of 6 synchronous Redis writes per job
- Piggyback the job ack (`LREM` + poison-pill `DEL`) onto the next fetch's pipeline instead of a synchronous round trip the moment a job finishes
- Cache per-queue derived strings (private-list key, unprefixed name) on `UnitOfWork` instead of rebuilding them per job
- Sign off and publish the three intentional semantics divergences (paused-cache TTL, metrics flush cadence, deferred ack) in `docs/reliability.md` / `docs/metrics.md`
- Re-baseline `bench/command_count.rb`'s budget to 3 commands/job (the settled floor — poison-pill `DEL` is a deliberate keeper) / 1 round trip, down from ~10 commands / 4 round trips

## Test plan
- [x] `bin/rake test` — 3059 runs, 0 failures
- [x] `bin/rake test:integration` — 44 runs, 0 failures (incl. `reaper_kill9_test`, `graceful_shutdown_test`)
- [x] `bin/rake test:parity` — 23 runs, 0 failures
- [x] `bin/rake test:ecosystem` — 182 runs, 0 failures
- [x] `COVERAGE=1 bin/rake test` — line 96.93% / branch 91.07% (≥90/90 gate)
- [x] `bin/rake bench:command_count` — 3.00 commands/job, within budget
- [x] `bundle exec rubocop bench/command_count.rb` — no new offenses vs. pre-existing bench/ baseline

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788629181&installation_model_id=11168&pr_number=370&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F370&signature=0230ee68555ace7048e2e6a0ee1631925fd032d1170a27a345ae51c7b876bed3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced Redis activity through batched metrics updates, cached paused-queue checks, and combined acknowledgement operations.
* **Reliability**
  * Improved acknowledgement handling during fetching, polling, failures, requeueing, and graceful shutdown.
  * Added safeguards to preserve pending metrics and acknowledgements when errors occur.
* **Metrics**
  * Job metrics may appear with up to a five-second delay while retaining execution-minute attribution.
* **Documentation**
  * Expanded guidance on fetch behavior, reliability tradeoffs, queue pausing, metrics, benchmarks, and operational semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->