### PR TITLE
perf(client): enqueue/bulk/batch hot-path trims + verification

### DIFF
--- a/lib/wurk/client.rb
+++ b/lib/wurk/client.rb
@@ -26,6 +26,20 @@ module Wurk
     SCHEDULED_BATCH_SIZE      = 100
     SPREAD_INTERVAL_FLOOR     = 5
 
+    # Batched (`bid`) payloads per EVALSHA pipeline. Ours, not Sidekiq's — it
+    # has no batches. Sized to DEFAULT_BATCH_SIZE so no existing caller's
+    # round-trip count moves: `push_bulk` already hands #raw_push at most that
+    # many payloads, so its batched pipeline stays exactly one round trip.
+    #
+    # The cap is for the one path that isn't pre-sliced: `autoflush = true`
+    # buffers a whole `Batch#jobs` block, so #flush_batched can be handed an
+    # unbounded payload set. Unsliced that is one pipeline holding every
+    # command and every reply in memory at once, and — Lua being atomic and
+    # single-threaded — one uninterrupted server-side sweep that blocks every
+    # other client for its duration. Same reasoning as the LIMIT on
+    # RELIABLE_SCHEDULE_PROMOTE.
+    BATCH_PIPELINE_SLICE      = 1_000
+
     # Thread-local slot holding the payloads of the current push whose Redis
     # write is confirmed applied. {Client::Buffered} subtracts them from the set
     # it re-buffers when a *later* phase of the same push loses the connection,
@@ -328,6 +342,27 @@ module Wurk
       push_batched_pipelined(conn, batched, now) unless batched.empty?
     end
 
+    # One pipeline per BATCH_PIPELINE_SLICE payloads, each marked delivered the
+    # moment its reply is in — same contract as push_plain_group, and for the
+    # same reason: a slice that Redis already accepted must stay out of the
+    # reliable_push ledger, or a later slice's failure would report it as
+    # undelivered.
+    def push_batched_pipelined(conn, batched, now)
+      batched.each_slice(BATCH_PIPELINE_SLICE) do |slice|
+        eval_batched_slice(conn) { |pipe, eval_method| push_batched(pipe, slice, now, eval_method: eval_method) }
+        mark_delivered(slice)
+      end
+    end
+
+    # Same slicing and NOSCRIPT recovery as push_batched_pipelined, for the
+    # scheduled batched path (BATCH_SCHEDULE instead of BATCH_PUSH).
+    def push_batched_scheduled_pipelined(conn, batched)
+      batched.each_slice(BATCH_PIPELINE_SLICE) do |slice|
+        eval_batched_slice(conn) { |pipe, eval_method| push_batched_scheduled(pipe, slice, eval_method: eval_method) }
+        mark_delivered(slice)
+      end
+    end
+
     # Outside of test boots and `SCRIPT FLUSH` the rescue branch is dead
     # code; the eager `script_load_all` after fork keeps the script cache
     # hot for the life of the connection. The retry uses EVAL (source-embedded)
@@ -335,24 +370,18 @@ module Wurk
     # NOSCRIPT a second time under heavy CI load (WorkerTest 3.4/7.2 flake).
     # `script_load_all` still primes the cache so the *next* pipeline returns
     # to the EVALSHA fast path.
-    def push_batched_pipelined(conn, batched, now)
-      conn.pipelined { |pipe| push_batched(pipe, batched, now) }
+    #
+    # Replaying the slice is safe precisely because every command in it is the
+    # same script: a flushed cache NOSCRIPTs all of them and applies none.
+    # Recovery is per slice, so the slices already acknowledged above are never
+    # re-sent. Mirrors Fetcher::Reliable#requeue_pipelined.
+    def eval_batched_slice(conn)
+      conn.pipelined { |pipe| yield(pipe, :eval_cached) }
     rescue RedisClient::CommandError => e
       raise unless e.message.to_s.start_with?('NOSCRIPT')
 
       Wurk::Lua::Loader.script_load_all(conn)
-      conn.pipelined { |pipe| push_batched(pipe, batched, now, eval_method: :eval_with_source) }
-    end
-
-    # Same NOSCRIPT-recovery shape as push_batched_pipelined, for the scheduled
-    # batched path (BATCH_SCHEDULE instead of BATCH_PUSH).
-    def push_batched_scheduled_pipelined(conn, batched)
-      conn.pipelined { |pipe| push_batched_scheduled(pipe, batched) }
-    rescue RedisClient::CommandError => e
-      raise unless e.message.to_s.start_with?('NOSCRIPT')
-
-      Wurk::Lua::Loader.script_load_all(conn)
-      conn.pipelined { |pipe| push_batched_scheduled(pipe, batched, eval_method: :eval_with_source) }
+      conn.pipelined { |pipe| yield(pipe, :eval_with_source) }
     end
 
     # One pipeline per queue, marked delivered the moment its reply is in.
@@ -402,11 +431,15 @@ module Wurk
 
     # Batched jobs route through BATCH_PUSH: increments b-<bid> total+pending,
     # SADDs jid into the live set, registers the queue, LPUSHes the payload —
-    # all atomically. One Redis round-trip per job (no pipeline grouping)
-    # because the lua needs per-job KEYS bound. Acceptable cost: batch
-    # enqueue is not the hot path; correctness is. `eval_method` is the
+    # all atomically. The Lua binds per-job KEYS, so grouping N jobs into one
+    # EVALSHA isn't available; they ride one pipeline instead (the `conn` here
+    # is always the pipeline #push_batched_pipelined opened), so the cost is
+    # N commands and one round trip, not N round trips. `eval_method` is the
     # Wurk::Lua::Loader entry point (`:eval_cached` for the hot EVALSHA path,
-    # `:eval_with_source` for the EVAL-source retry).
+    # `:eval_with_source` for the EVAL-source retry) — neither reads the reply,
+    # which is what makes the pipelined form legal: `eval_cached`'s inline
+    # NOSCRIPT rescue can't fire against a buffered call, so recovery is the
+    # caller's finalize-time rescue.
     def push_batched(conn, payloads, now, eval_method: :eval_cached)
       payloads.each do |j|
         j['enqueued_at'] = now
@@ -425,9 +458,9 @@ module Wurk
     # total/pending increment registers the job in its batch at creation, and
     # the ZADD defers it onto `schedule`. Payload is stripped of `at`/
     # `enqueued_at` exactly like push_scheduled — `enqueued_at` is stamped fresh
-    # at promotion, never while the job sits scheduled (spec §7.1). One Redis
-    # round-trip per job because the Lua binds per-job KEYS; scheduled batch
-    # enqueue is not the hot path.
+    # at promotion, never while the job sits scheduled (spec §7.1). Per-job
+    # KEYS again, so one EVALSHA per job — pipelined by
+    # #push_batched_scheduled_pipelined into one round trip per slice.
     def push_batched_scheduled(conn, payloads, eval_method: :eval_cached)
       payloads.each do |j|
         Wurk::Lua::Loader.public_send(

--- a/lib/wurk/client.rb
+++ b/lib/wurk/client.rb
@@ -450,7 +450,13 @@ module Wurk
     # evict them, and the drain that does land one counts it then — so booking
     # them here would inflate the counter on an outage and double-count every
     # payload that later replays.
+    #
+    # Resolve the client once for the whole batch and bail before touching a
+    # payload: unconfigured is the common case, and the tags below cost two
+    # Strings and an Array per job for `increment` to immediately drop.
     def emit_enqueued(payloads, buffered = nil)
+      return if Wurk::Metrics::Statsd.safe_client.nil?
+
       payloads = reject_by_identity(payloads, buffered) if buffered && !buffered.empty?
       payloads.each do |p|
         Wurk::Metrics::Statsd.increment(

--- a/lib/wurk/client.rb
+++ b/lib/wurk/client.rb
@@ -369,18 +369,35 @@ module Wurk
     # Cost is a round trip per distinct queue. The single-queue push — every
     # `perform_async`, every same-class `push_bulk` — still writes exactly the
     # one SADD + LPUSH pipeline it did before.
+    #
+    # `uniform_queue` short-circuits the common case (one job, or many jobs
+    # all destined for the same queue) without paying for the `group_by`
+    # Hash + per-group Array allocations; only a genuinely mixed-queue batch
+    # falls through to grouping.
     def push_plain(conn, payloads, now)
-      payloads.group_by { |j| j['queue'] }.each do |queue, jobs|
-        serialized = jobs.map do |j|
-          j['enqueued_at'] = now
-          Wurk.dump_json(j)
-        end
-        conn.pipelined do |pipe|
-          pipe.call('SADD', 'queues', queue)
-          pipe.call('LPUSH', "queue:#{queue}", *serialized)
-        end
-        mark_delivered(jobs)
+      queue = uniform_queue(payloads)
+      return push_plain_group(conn, queue, payloads, now) if queue
+
+      payloads.group_by { |j| j['queue'] }.each { |q, jobs| push_plain_group(conn, q, jobs, now) }
+    end
+
+    def uniform_queue(payloads)
+      first = payloads[0]['queue']
+      return first if payloads.size == 1
+
+      first if payloads.all? { |j| j['queue'] == first }
+    end
+
+    def push_plain_group(conn, queue, jobs, now)
+      serialized = jobs.map do |j|
+        j['enqueued_at'] = now
+        Wurk.dump_json(j)
       end
+      conn.pipelined do |pipe|
+        pipe.call('SADD', 'queues', queue)
+        pipe.call('LPUSH', "queue:#{queue}", *serialized)
+      end
+      mark_delivered(jobs)
     end
 
     # Batched jobs route through BATCH_PUSH: increments b-<bid> total+pending,

--- a/lib/wurk/client.rb
+++ b/lib/wurk/client.rb
@@ -138,7 +138,21 @@ module Wurk
 
     private
 
+    # #push and #push_bulk verify at different points and both match Sidekiq
+    # exactly: push walks the payload the chain handed back (sidekiq
+    # client.rb:101 — normalize → middleware → verify → raw_push), bulk walks it
+    # inside the innermost block (sidekiq client.rb:165). Push used to do both,
+    # and since `strict_args_mode` defaults to :raise the second full recursive
+    # args walk was never skipped.
+    #
+    # Bulk keeps its walk inside the block on purpose: a client middleware that
+    # halts the job there short-circuits the walk, and hoisting it out would
+    # raise on args that middleware was about to drop.
     def invoke_chain(normed)
+      @chain.invoke(normed['class'], normed, normed['queue'], pool) { normed }
+    end
+
+    def invoke_chain_verified(normed)
       @chain.invoke(normed['class'], normed, normed['queue'], pool) do
         verify_json(normed)
         normed
@@ -191,7 +205,7 @@ module Wurk
         item = base.merge('args' => job_args)
         item['at'] = ats[idx] if ats
         normed = normalize_item(item)
-        invoke_chain(normed)
+        invoke_chain_verified(normed)
       end
     end
 

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -87,7 +87,16 @@ module Wurk
     #   config.dogstatsd = -> { Datadog::Statsd.new('host', 8125) }
     #
     # Spec: docs/target/sidekiq-pro.md §9.1.
-    attr_accessor :dogstatsd
+    attr_reader :dogstatsd
+
+    # Assignment drops Statsd's resolved-client memo. That memo caches the
+    # "nothing configured" answer too (so the no-client emit path allocates
+    # nothing), which means a builder wired up after the first emit would
+    # otherwise never be picked up.
+    def dogstatsd=(builder)
+      @dogstatsd = builder
+      Wurk::Metrics::Statsd.reset!
+    end
 
     def initialize(options = {})
       @options = deep_dup_defaults.merge(options)

--- a/lib/wurk/job_util.rb
+++ b/lib/wurk/job_util.rb
@@ -140,32 +140,52 @@ module Wurk
       end
     end
 
+    JSON_NATIVE = ->(_val) {}
+
+    # Dispatch table for the args walk, ported from Sidekiq (job_util.rb:80-111).
+    # Keyed by `val.class` under `compare_by_identity`, so every node costs one
+    # identity lookup + one call instead of the ladder of `Module#===` checks a
+    # `case/when` compiles to — the entry node is always the args Array, which
+    # sat behind six failing `===` probes.
+    #
+    # Identity lookup means a *subclass* of a JSON-native type misses the table
+    # and falls to the default lambda, i.e. is reported unsafe: an
+    # ActiveSupport::SafeBuffer arg raises where a bare String does not. That is
+    # Sidekiq's behavior and the drop-in contract, not an oversight. Hash keys
+    # are the one exception — they are checked with `is_a?`, so a String
+    # subclass key is accepted, again matching Sidekiq.
+    RECURSIVE_JSON_UNSAFE = { # rubocop:disable Style/MutableConstant -- frozen below, after the two setup calls
+      Integer => JSON_NATIVE,
+      Float => JSON_NATIVE,
+      TrueClass => JSON_NATIVE,
+      FalseClass => JSON_NATIVE,
+      NilClass => JSON_NATIVE,
+      String => JSON_NATIVE,
+      Array => lambda { |val|
+        val.each do |e|
+          bad = RECURSIVE_JSON_UNSAFE[e.class].call(e)
+          return bad unless bad.nil?
+        end
+        nil
+      },
+      Hash => lambda { |val|
+        val.each do |k, v|
+          return k unless k.is_a?(String)
+
+          bad = RECURSIVE_JSON_UNSAFE[v.class].call(v)
+          return bad unless bad.nil?
+        end
+        nil
+      }
+    }
+    RECURSIVE_JSON_UNSAFE.default = ->(val) { val }
+    RECURSIVE_JSON_UNSAFE.compare_by_identity
+    RECURSIVE_JSON_UNSAFE.freeze
+    private_constant :JSON_NATIVE, :RECURSIVE_JSON_UNSAFE
+
     # Returns the first offending value, or nil when the tree is JSON-native.
     def json_unsafe(obj)
-      case obj
-      when String, Integer, Float, TrueClass, FalseClass, NilClass then nil
-      when Array then json_unsafe_array(obj)
-      when Hash then json_unsafe_hash(obj)
-      else obj
-      end
-    end
-
-    def json_unsafe_array(arr)
-      arr.each do |v|
-        bad = json_unsafe(v)
-        return bad unless bad.nil?
-      end
-      nil
-    end
-
-    def json_unsafe_hash(hash)
-      hash.each do |k, v|
-        return k unless k.is_a?(String)
-
-        bad = json_unsafe(v)
-        return bad unless bad.nil?
-      end
-      nil
+      RECURSIVE_JSON_UNSAFE[obj.class].call(obj)
     end
   end
 end

--- a/lib/wurk/metrics/statsd.rb
+++ b/lib/wurk/metrics/statsd.rb
@@ -35,6 +35,15 @@ module Wurk
       METRIC_PREFIX = 'sidekiq.'
       DEFAULT_SAMPLE_RATE = 1.0
 
+      # Unresolved state of the {.client} memo, distinct from a resolved nil.
+      UNSET = :unset
+      private_constant :UNSET
+
+      # Seeded in the class body (not `class << self`, where `self` is the
+      # singleton class) so {.client} is a bare ivar read with no `defined?`
+      # guard on the hot path.
+      @client = UNSET
+
       class << self
         attr_accessor :options
 
@@ -91,19 +100,35 @@ module Wurk
         # Resolves the live client: invokes the configured `dogstatsd` proc
         # exactly once per process and memoizes. Returns nil when no proc
         # is configured, so callers get a clean no-op without raising.
+        #
+        # The *unconfigured* answer is memoized too, which is what makes the
+        # no-client path free: Client#emit_enqueued asks once per payload, so
+        # re-reading `Wurk.configuration` here would cost a config lookup per
+        # job on every bulk push. Both invalidation points call {.reset!}.
         def client
-          return @client if defined?(@client) && !@client.nil?
+          memo = @client
+          return memo unless UNSET.equal?(memo)
 
           builder = Wurk.configuration.respond_to?(:dogstatsd) ? Wurk.configuration.dogstatsd : nil
-          return nil if builder.nil?
-
           @client = builder.respond_to?(:call) ? builder.call : builder
         end
 
-        # Test/lifecycle hook. Reset between specs and after fork so the
-        # parent's socket doesn't bleed into children.
+        # {.client} without the raise: a builder proc that blows up is reported
+        # through the error handler and treated as "no client", so misconfigured
+        # metrics can never fail the work they were measuring. Callers on a
+        # hot path use this to skip building anything the emit would drop.
+        def safe_client
+          client
+        rescue StandardError => e
+          handle_error(e)
+          nil
+        end
+
+        # Test/lifecycle hook. Reset between specs, after fork so the parent's
+        # socket doesn't bleed into children, and on every `config.dogstatsd=`
+        # — a memoized nil would otherwise hide a client configured later.
         def reset!
-          @client = nil
+          @client = UNSET
         end
 
         private
@@ -118,8 +143,7 @@ module Wurk
       end
 
       def call(_worker, job, queue) # rubocop:disable Metrics/AbcSize
-        client = safe_client
-        return yield if client.nil?
+        return yield if self.class.safe_client.nil?
 
         klass = job['class']
         opts  = per_job_options(klass, job, queue)
@@ -145,16 +169,6 @@ module Wurk
       end
 
       private
-
-      # Wraps `self.class.client` so a misconfigured builder proc never turns
-      # a metrics-init failure into a job failure. Returns nil on error (the
-      # caller falls through to a plain `yield`).
-      def safe_client
-        self.class.client
-      rescue StandardError => e
-        self.class.send(:handle_error, e)
-        nil
-      end
 
       # Per-spec §9.2: caller-supplied proc may override tags / sample_rate
       # on a per-job basis. The job's own `dd_rate` field, when present,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -161,6 +161,12 @@ module Wurk
     # the reader see 0 instead of the identity it just registered.
     PROCESSES_MUTEX = Mutex.new
 
+    # Suite-wide mutex for tests that mutate Wurk's process-global state
+    # (`@strict_args_mode`, `@default_job_options`, `@testing_mode`, `@server`).
+    # Shared by every such class — a class-local mutex would let JobUtilTest's
+    # `strict_args!(false)` land inside ClientVerifyJsonTest's `assert_raises`.
+    GLOBAL_STATE_MUTEX = Mutex.new
+
     # Suite-wide mutex for tests that read/write the in-process
     # `Wurk::Processor::{PROCESSED, FAILURE, EXPIRED}` counters and then
     # assert on their value. Without it, the LauncherTest flush_stats

--- a/test/unit/client_batch_pipeline_test.rb
+++ b/test/unit/client_batch_pipeline_test.rb
@@ -134,13 +134,64 @@ class ClientBatchPipelineTest < Wurk::Test::UnitCase
     assert_equal (SLICE + 1).to_s, batch_field('total')
   end
 
+  # --- identical Redis state: pipelined vs per-job (Plan 04/S8) -----------
+  #
+  # The pipeline only changes how many round trips the N EVALSHA calls ride
+  # in — the Lua script and its per-job KEYS/ARGV are untouched. Runs the
+  # exact same private #push_batched twice against disjoint bid/queue
+  # namespaces: once wrapped in `pipelined` (today's path), once against a
+  # bare connection so each EVALSHA is its own round trip (the pre-#313
+  # per-job path). Diffs the resulting batch hash, live-jid set, and queued
+  # payloads — normalized for the namespace names, which differ by design so
+  # the two runs don't collide.
+  def test_pipelined_batch_push_matches_per_job_redis_state
+    now             = Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
+    pipelined_bid   = "#{@bid}-pl"
+    per_job_bid     = "#{@bid}-pj"
+    pipelined_queue = "#{@queue}-pl"
+    per_job_queue   = "#{@queue}-pj"
+    client          = Wurk::Client.new(pool: @pool)
+
+    @pool.with do |conn|
+      conn.pipelined do |pipe|
+        client.send(:push_batched, pipe, payloads(5, bid: pipelined_bid, queue: pipelined_queue), now)
+      end
+    end
+    @pool.with do |conn|
+      client.send(:push_batched, conn, payloads(5, bid: per_job_bid, queue: per_job_queue), now)
+    end
+
+    assert_equal batch_state(pipelined_bid, pipelined_queue), batch_state(per_job_bid, per_job_queue)
+  ensure
+    cleanup_namespace(pipelined_bid, pipelined_queue)
+    cleanup_namespace(per_job_bid, per_job_queue)
+  end
+
   private
 
-  def payloads(count, at: nil)
+  def payloads(count, at: nil, bid: @bid, queue: @queue)
     Array.new(count) do |i|
-      job = { 'class' => @class_name, 'args' => [i], 'queue' => @queue,
-              'jid' => format('%024x', i), 'bid' => @bid }
+      job = { 'class' => @class_name, 'args' => [i], 'queue' => queue,
+              'jid' => format('%024x', i), 'bid' => bid }
       at ? job.merge('at' => at) : job
+    end
+  end
+
+  def batch_state(bid, queue)
+    @pool.with do |conn|
+      {
+        total: conn.call('HGET', "b-#{bid}", 'total'),
+        pending: conn.call('HGET', "b-#{bid}", 'pending'),
+        jids: conn.call('SMEMBERS', "b-#{bid}-jids").sort,
+        jobs: conn.call('LRANGE', "queue:#{queue}", 0, -1).map { |s| JSON.parse(s).except('queue', 'bid') }
+      }
+    end
+  end
+
+  def cleanup_namespace(bid, queue)
+    @pool.with do |conn|
+      conn.call('DEL', "queue:#{queue}", "b-#{bid}", "b-#{bid}-jids")
+      conn.call('SREM', 'queues', queue)
     end
   end
 

--- a/test/unit/client_batch_pipeline_test.rb
+++ b/test/unit/client_batch_pipeline_test.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'json'
+
+# Plan 04/S6. Batched (`bid`) enqueue rides one pipeline, not one round trip
+# per job, and that pipeline is capped at Client::BATCH_PIPELINE_SLICE payloads
+# so an `autoflush = true` Batch#jobs block can't hand #flush_batched an
+# unbounded command set.
+#
+# Round trips are counted by wrapping the connection and tallying `pipelined`
+# calls: every command these paths emit is buffered into a pipeline, so
+# pipelines opened == round trips spent. Real Redis throughout — the EVAL-source
+# NOSCRIPT retry has to genuinely apply, or "no duplicates" would pass
+# vacuously.
+class ClientBatchPipelineTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  SLICE = Wurk::Client::BATCH_PIPELINE_SLICE
+
+  def setup
+    super
+    @pool       = Wurk.configuration.redis_pool
+    @queue      = "bp-q-#{Process.pid}-#{object_id}"
+    @class_name = "BatchPipelineJob@#{Process.pid}-#{object_id}"
+    @bid        = "BP-#{Process.pid}-#{object_id}"
+  end
+
+  def teardown
+    @probe&.close
+    @pool.with do |c|
+      c.call('DEL', "queue:#{@queue}", "b-#{@bid}", "b-#{@bid}-jids")
+      c.call('SREM', 'queues', @queue)
+      mine = mine_in_schedule(c)
+      c.call('ZREM', 'schedule', *mine) unless mine.empty?
+    end
+  ensure
+    Thread.current[Wurk::Client::DELIVERED_KEY] = nil
+    super
+  end
+
+  # --- round trips: N jobs, one pipeline -----------------------------------
+
+  def test_batched_push_spends_one_round_trip_for_a_whole_slice
+    client = Wurk::Client.new(pool: probe_pool)
+
+    client.flush_batched(payloads(4))
+
+    assert_equal 1, @probe.pipelines, 'four BATCH_PUSH EVALSHAs must ride one pipeline, not four round trips'
+    assert_equal 4, llen
+  end
+
+  def test_scheduled_batched_push_spends_one_round_trip_for_a_whole_slice
+    client = Wurk::Client.new(pool: probe_pool)
+
+    client.send(:raw_push, payloads(4, at: future_seconds(600)))
+
+    assert_equal 1, @probe.pipelines, 'four BATCH_SCHEDULE EVALSHAs must ride one pipeline'
+    assert_equal 4, scheduled_members.size
+  end
+
+  # --- the cap: one pipeline per slice, nothing lost or doubled ------------
+
+  def test_batched_push_opens_a_second_pipeline_past_the_slice_cap
+    client = Wurk::Client.new(pool: probe_pool)
+
+    client.flush_batched(payloads(SLICE + 1))
+
+    assert_equal 2, @probe.pipelines
+    assert_equal SLICE + 1, llen, 'every payload in every slice must land exactly once'
+    assert_equal (SLICE + 1).to_s, batch_field('total')
+  end
+
+  def test_scheduled_batched_push_opens_a_second_pipeline_past_the_slice_cap
+    client = Wurk::Client.new(pool: probe_pool)
+
+    client.send(:raw_push, payloads(SLICE + 1, at: future_seconds(600)))
+
+    assert_equal 2, @probe.pipelines
+    assert_equal SLICE + 1, scheduled_members.size
+  end
+
+  # `enqueued_at` is stamped once per push (push_immediate computes `now`
+  # before the split), so slicing must not restamp the later slices — the
+  # whole push has to share one arrival timestamp, as it did unsliced.
+  def test_every_slice_shares_the_pushs_single_enqueued_at_stamp
+    Wurk::Client.new(pool: probe_pool).flush_batched(payloads(SLICE + 1))
+
+    stamps = queued.map { |j| j['enqueued_at'] }.uniq
+
+    assert_equal 1, stamps.size
+  end
+
+  # --- delivery ledger ------------------------------------------------------
+
+  # A slice Redis acknowledged must be in the ledger before the next one goes
+  # out; otherwise Client::Buffered reports an already-written batched payload
+  # as undelivered when a later slice loses the socket.
+  def test_an_acknowledged_slice_is_marked_delivered_before_the_next_one_goes_out
+    client = Wurk::Client.new(pool: probe_pool(drop_after: 1))
+    jobs   = payloads(SLICE + 1)
+    Thread.current[Wurk::Client::DELIVERED_KEY] = []
+
+    assert_raises(RedisClient::ConnectionError) { client.flush_batched(jobs) }
+
+    # By identity, not by value: the ledger's whole point is that Buffered can
+    # subtract the very Hash objects this push handed to Redis.
+    assert_equal jobs.first(SLICE).map(&:object_id),
+                 Thread.current[Wurk::Client::DELIVERED_KEY].map(&:object_id),
+                 'exactly the acknowledged slice, and nothing from the one that never got a reply'
+  end
+
+  def test_nothing_is_marked_delivered_when_the_first_slice_never_lands
+    client = Wurk::Client.new(pool: probe_pool(drop_after: 0))
+    Thread.current[Wurk::Client::DELIVERED_KEY] = []
+
+    assert_raises(RedisClient::ConnectionError) { client.flush_batched(payloads(2)) }
+
+    assert_empty Thread.current[Wurk::Client::DELIVERED_KEY]
+  end
+
+  # --- NOSCRIPT recovery is per slice --------------------------------------
+
+  # A flushed script cache NOSCRIPTs every EVALSHA in the pipeline and applies
+  # none, so replaying that slice through source-embedded EVAL is safe — but
+  # only that slice. Replaying the whole push would double the slice that
+  # already landed.
+  def test_noscript_replays_only_the_failing_slice
+    client = Wurk::Client.new(pool: probe_pool(noscript_on: 2))
+
+    client.flush_batched(payloads(SLICE + 1))
+
+    assert_equal SLICE + 1, llen, 'the acknowledged slice must not be re-sent by the reload retry'
+    assert_equal (SLICE + 1).to_s, batch_field('total')
+  end
+
+  private
+
+  def payloads(count, at: nil)
+    Array.new(count) do |i|
+      job = { 'class' => @class_name, 'args' => [i], 'queue' => @queue,
+              'jid' => format('%024x', i), 'bid' => @bid }
+      at ? job.merge('at' => at) : job
+    end
+  end
+
+  def future_seconds(delta)
+    Process.clock_gettime(Process::CLOCK_REALTIME) + delta
+  end
+
+  def probe_pool(drop_after: nil, noscript_on: nil)
+    @probe = ProbeConn.new(Wurk::Test.redis_url, drop_after: drop_after, noscript_on: noscript_on)
+    pool   = Object.new
+    probe  = @probe
+    pool.define_singleton_method(:with) { |&blk| blk.call(probe) }
+    pool
+  end
+
+  def llen
+    @pool.with { |c| c.call('LLEN', "queue:#{@queue}") }
+  end
+
+  def queued
+    @pool.with { |c| c.call('LRANGE', "queue:#{@queue}", 0, -1) }.map { |s| JSON.parse(s) }
+  end
+
+  def batch_field(field)
+    @pool.with { |c| c.call('HGET', "b-#{@bid}", field) }
+  end
+
+  def scheduled_members
+    @pool.with { |c| mine_in_schedule(c) }
+  end
+
+  def mine_in_schedule(conn)
+    conn.call('ZRANGE', 'schedule', 0, -1).select do |member|
+      JSON.parse(member)['class'] == @class_name
+    rescue JSON::ParserError
+      false
+    end
+  end
+
+  # One real connection that counts the pipelines opened on it and can fault a
+  # chosen one. `drop_after` lands that many pipelines and then behaves like a
+  # dead socket; `noscript_on` fails the Nth pipeline the way a flushed script
+  # cache does — at finalize, never to eval_cached's inline rescue — so the
+  # client's reload-and-replay branch runs against real Redis.
+  #
+  # A real SCRIPT FLUSH is not an option: the EVALSHA cache is server-wide and
+  # shared across the parallel_fork workers' isolated DBs.
+  class ProbeConn
+    attr_reader :pipelines
+
+    def initialize(url, drop_after: nil, noscript_on: nil)
+      @real        = RedisClient.config(url: url).new_client
+      @drop_after  = drop_after
+      @noscript_on = noscript_on
+      @pipelines   = 0
+    end
+
+    def pipelined(&)
+      @pipelines += 1
+      raise RedisClient::ConnectionError, 'simulated mid-push drop' if @drop_after && @pipelines > @drop_after
+
+      if @noscript_on == @pipelines
+        @noscript_on = nil
+        raise RedisClient::CommandError, 'NOSCRIPT No matching script. Use EVAL.'
+      end
+
+      @real.pipelined(&)
+    end
+
+    def call(*, &) = @real.call(*, &)
+
+    def close = @real.close
+  end
+end

--- a/test/unit/client_buffered_fork_test.rb
+++ b/test/unit/client_buffered_fork_test.rb
@@ -23,8 +23,11 @@ class ClientBufferedForkTest < Wurk::Test::UnitCase
   # state" — what a child observes after fork.
   FOREIGN_PID = -1
 
+  # Statsd singletons are process-global too (see #test_statsd_memo_resets_on_fork
+  # below) — serialize against every other test class that rewrites them
+  # (MetricsStatsdTest, ClientBufferedTest, ...), not just against this one.
   def run(*args, &)
-    MUTEX.synchronize { super }
+    Wurk::Test::STATSD_MUTEX.synchronize { MUTEX.synchronize { super } }
   end
 
   def setup
@@ -157,6 +160,53 @@ class ClientBufferedForkTest < Wurk::Test::UnitCase
 
     assert(eventually? { queued_args == [['post-fork']] },
            'the re-armed drainer never flushed the buffer through the default pool')
+  end
+
+  # --- statsd memo: fork + reconfigure (Plan 04/S8) -----------------------
+  #
+  # `Swarm::ChildBoot#reconnect_after_fork` calls `Buffered.reset_after_fork!`
+  # and `Statsd.reset!` in the same breath (lib/wurk/swarm/child_boot.rb) —
+  # the dogstatsd client is memoized at the class level, so without the reset
+  # every forked child would share the parent's UDP socket and thread-locals
+  # instead of building its own. Proven alongside the Buffered fork tests
+  # above because production pairs the two resets; a regression in either
+  # leaves a forked child holding process-global state it must not.
+  def test_statsd_memo_resets_on_fork
+    invocations = 0
+    prev = Wurk.configuration.instance_variable_get(:@dogstatsd)
+    Wurk.configuration.instance_variable_set(:@dogstatsd, lambda {
+      invocations += 1
+      Object.new
+    })
+    Wurk::Metrics::Statsd.reset!
+    Wurk::Metrics::Statsd.client # parent process resolves + memoizes once
+
+    Wurk::Metrics::Statsd.reset! # mirrors reconnect_after_fork's post-fork reset
+    Wurk::Metrics::Statsd.client
+
+    assert_equal 2, invocations, 'the child must rebuild its own client instead of inheriting the parent memo'
+  ensure
+    Wurk.configuration.instance_variable_set(:@dogstatsd, prev)
+    Wurk::Metrics::Statsd.reset!
+  end
+
+  # `Configuration#dogstatsd=` also drops the memo (configuration.rb) — a host
+  # app that wires up statsd after boot must not have the earlier "no client"
+  # answer stick around from the first emit.
+  def test_statsd_memo_resets_on_reconfigure
+    prev = Wurk.configuration.dogstatsd
+    first  = Object.new
+    second = Object.new
+    Wurk.configuration.dogstatsd = first
+
+    assert_same first, Wurk::Metrics::Statsd.client
+
+    Wurk.configuration.dogstatsd = second
+
+    assert_same second, Wurk::Metrics::Statsd.client, 'dogstatsd= must drop the stale memo, not just future assignments'
+  ensure
+    Wurk.configuration.dogstatsd = prev
+    Wurk::Metrics::Statsd.reset!
   end
 
   private

--- a/test/unit/client_buffered_test.rb
+++ b/test/unit/client_buffered_test.rb
@@ -552,19 +552,33 @@ class ClientBufferedTest < Wurk::Test::UnitCase
 
   # Statsd singletons are process-global — serialize against every other test
   # class that also rewrites `Wurk::Metrics::Statsd.increment`.
-  def with_statsd_capture
+  def with_statsd_capture(&)
     Wurk::Test::STATSD_MUTEX.synchronize do
       calls = []
-      Wurk::Metrics::Statsd.singleton_class.alias_method(:__increment_real, :increment)
-      Wurk::Metrics::Statsd.define_singleton_method(:increment) { |metric, **| calls << metric }
-      begin
-        yield
-        calls
-      ensure
-        Wurk::Metrics::Statsd.singleton_class.send(:alias_method, :increment, :__increment_real)
-        Wurk::Metrics::Statsd.singleton_class.send(:remove_method, :__increment_real)
-      end
+      with_stand_in_client { with_increment_stub(calls, &) }
+      calls
     end
+  end
+
+  # The capture stubs `increment` rather than the client, but
+  # `Client#emit_enqueued` resolves the client first and skips the whole emit
+  # when none is wired up — so one has to stand in for the block's duration.
+  # The stub means it is never actually called; any object will do.
+  def with_stand_in_client
+    prev = Wurk.configuration.dogstatsd
+    Wurk.configuration.dogstatsd = Object.new
+    yield
+  ensure
+    Wurk.configuration.dogstatsd = prev
+  end
+
+  def with_increment_stub(calls)
+    Wurk::Metrics::Statsd.singleton_class.alias_method(:__increment_real, :increment)
+    Wurk::Metrics::Statsd.define_singleton_method(:increment) { |metric, **| calls << metric }
+    yield
+  ensure
+    Wurk::Metrics::Statsd.singleton_class.send(:alias_method, :increment, :__increment_real)
+    Wurk::Metrics::Statsd.singleton_class.send(:remove_method, :__increment_real)
   end
 
   def base_item(overrides = {})

--- a/test/unit/client_push_test.rb
+++ b/test/unit/client_push_test.rb
@@ -2,6 +2,7 @@
 
 require_relative '../test_helper'
 require 'json'
+require 'stringio'
 
 # Drives Wurk::Client against real Redis. Asserts on the canonical Sidekiq
 # wire shape — keys, JID format, ms timestamps — and on the validation
@@ -227,6 +228,78 @@ class ClientPushTest < Wurk::Test::UnitCase
     end
   end
 
+  # --- verify_json: exactly once per push (Plan 04/S8) --------------------
+  #
+  # #push used to walk the payload's args twice (once inside the client
+  # middleware chain, once again on the returned payload); #push_bulk still
+  # walks once per job, inside the chain. A spy on the public `verify_json`
+  # method counts real invocations against real Redis, so a regression that
+  # reintroduces the second walk — or drops the only one — trips a count
+  # mismatch instead of just costing allocations silently.
+  def test_push_calls_verify_json_exactly_once
+    calls = 0
+    @client.define_singleton_method(:verify_json) do |item|
+      calls += 1
+      super(item)
+    end
+
+    @client.push(base_item)
+
+    assert_equal 1, calls
+  end
+
+  def test_push_bulk_calls_verify_json_exactly_once_per_job
+    calls = 0
+    @client.define_singleton_method(:verify_json) do |item|
+      calls += 1
+      super(item)
+    end
+
+    @client.push_bulk(base_item('args' => [[1], [2], [3]]))
+
+    assert_equal 3, calls
+  end
+
+  # --- verify_json: :warn/:raise mode matrix -------------------------------
+  #
+  # Both entry points route unsafe args through the same JobUtil#verify_json,
+  # so :raise must raise identically from push and push_bulk, and :warn must
+  # let both through unraised (job still lands on the wire) while logging the
+  # same message shape. Pins the matrix so a future divergence between the
+  # two push paths — e.g. push_bulk regaining its own verify call with a
+  # different mode read — shows up as a failing cell, not a shrug.
+  def test_push_raises_on_unsafe_args_in_raise_mode
+    with_strict_mode(:raise) do
+      err = assert_raises(ArgumentError) { @client.push(base_item('args' => [:sym])) }
+      assert_match(/native JSON/, err.message)
+    end
+  end
+
+  def test_push_bulk_raises_on_unsafe_args_in_raise_mode
+    with_strict_mode(:raise) do
+      err = assert_raises(ArgumentError) { @client.push_bulk(base_item('args' => [[:sym]])) }
+      assert_match(/native JSON/, err.message)
+    end
+  end
+
+  def test_push_warns_without_raising_on_unsafe_args_in_warn_mode
+    with_strict_mode(:warn) do
+      log = capture_log { @client.push(base_item('args' => [:sym])) }
+
+      assert_match(/native JSON/, log)
+      assert_equal [['sym']], queued_args
+    end
+  end
+
+  def test_push_bulk_warns_without_raising_on_unsafe_args_in_warn_mode
+    with_strict_mode(:warn) do
+      log = capture_log { @client.push_bulk(base_item('args' => [[:sym]])) }
+
+      assert_match(/native JSON/, log)
+      assert_equal [['sym']], queued_args
+    end
+  end
+
   # --- pool routing ------------------------------------------------------
 
   def test_class_via_overrides_pool_in_block
@@ -319,6 +392,26 @@ class ClientPushTest < Wurk::Test::UnitCase
     rescue JSON::ParserError
       next
     end
+  end
+
+  def with_strict_mode(mode)
+    Wurk::Test::GLOBAL_STATE_MUTEX.synchronize do
+      original = Wurk.strict_args_mode
+      Wurk.strict_args!(mode)
+      yield
+    ensure
+      Wurk.strict_args!(original)
+    end
+  end
+
+  def capture_log
+    io = StringIO.new
+    saved = Wurk.configuration.logger
+    Wurk.configuration.logger = ::Logger.new(io)
+    yield
+    io.string
+  ensure
+    Wurk.configuration.logger = saved
   end
 
   def fake_pool(&hook)

--- a/test/unit/client_verify_json_test.rb
+++ b/test/unit/client_verify_json_test.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'stringio'
+require 'logger'
+
+# Pins where and how often Wurk::Client walks a job's args.
+#
+# `verify_json` recurses the whole args tree and `strict_args_mode` defaults to
+# `:raise`, so an extra call is an extra full walk on every enqueue — #push used
+# to do it twice. Both paths now match Sidekiq exactly: #push verifies the
+# payload the client chain returned (sidekiq client.rb:101), #push_bulk verifies
+# inside the innermost block (sidekiq client.rb:165), which is what keeps a
+# halting middleware from paying for a walk it is about to discard.
+#
+# `:warn` mode is the observable proof — the double walk logged the same warning
+# twice per push.
+#
+# Real Redis, per-test queue namespace. Takes GLOBAL_STATE_MUTEX for the whole
+# class: the mode matrix flips `Wurk.strict_args_mode`, which JobUtilTest also
+# owns.
+class ClientVerifyJsonTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def run(*)
+    Wurk::Test::GLOBAL_STATE_MUTEX.synchronize { super }
+  end
+
+  def setup
+    super
+    @queue      = "cv-q-#{Process.pid}-#{object_id}"
+    @class_name = "ClientVerifyJob@#{Process.pid}-#{object_id}"
+    @pool       = Wurk.configuration.redis_pool
+    @events     = []
+  end
+
+  def teardown
+    @pool.with do |conn|
+      conn.call('DEL', "queue:#{@queue}")
+      conn.call('SREM', 'queues', @queue)
+    end
+  ensure
+    super
+  end
+
+  # --- #push ---------------------------------------------------------------
+
+  def test_push_verifies_exactly_once
+    client(RecordingMiddleware).push(item)
+
+    assert_equal 1, @events.count(:verify)
+  end
+
+  def test_push_verifies_after_the_client_middleware_chain
+    client(RecordingMiddleware).push(item)
+
+    assert_equal %i[before after verify], @events
+  end
+
+  def test_push_skips_verification_when_middleware_halts
+    assert_nil client(HaltingMiddleware).push(item)
+    assert_equal %i[halt], @events
+    assert_equal(0, queue_depth)
+  end
+
+  def test_push_raises_on_complex_args_without_enqueueing
+    with_strict_mode(:raise) do
+      err = assert_raises(ArgumentError) { client(RecordingMiddleware).push(item(args: [:sym])) }
+
+      assert_match(/native JSON/, err.message)
+    end
+
+    assert_equal(0, queue_depth)
+  end
+
+  def test_push_warns_once_per_complex_arg_and_still_enqueues
+    log = with_strict_mode(:warn) { capture_log { client(RecordingMiddleware).push(item(args: [:sym])) } }
+
+    assert_equal 1, log.scan('native JSON').size
+    assert_equal(1, queue_depth)
+  end
+
+  # --- #push_bulk ----------------------------------------------------------
+
+  def test_push_bulk_verifies_exactly_once_per_job
+    client(RecordingMiddleware).push_bulk('class' => @class_name, 'queue' => @queue, 'args' => [[1], [2], [3]])
+
+    assert_equal 3, @events.count(:verify)
+  end
+
+  def test_push_bulk_verifies_inside_the_client_middleware_chain
+    client(RecordingMiddleware).push_bulk('class' => @class_name, 'queue' => @queue, 'args' => [[1]])
+
+    assert_equal %i[before verify after], @events
+  end
+
+  def test_push_bulk_skips_verification_when_middleware_halts
+    client(HaltingMiddleware).push_bulk('class' => @class_name, 'queue' => @queue, 'args' => [[1]])
+
+    assert_equal %i[halt], @events
+    assert_equal(0, queue_depth)
+  end
+
+  def test_push_bulk_raises_on_complex_args_without_enqueueing
+    with_strict_mode(:raise) do
+      assert_raises(ArgumentError) do
+        client(RecordingMiddleware).push_bulk('class' => @class_name, 'queue' => @queue, 'args' => [[1], [:sym]])
+      end
+    end
+
+    assert_equal(0, queue_depth)
+  end
+
+  def test_push_bulk_warns_once_per_complex_arg
+    log = with_strict_mode(:warn) do
+      capture_log do
+        client(RecordingMiddleware).push_bulk('class' => @class_name, 'queue' => @queue, 'args' => [[:a], [:b]])
+      end
+    end
+
+    assert_equal 2, log.scan('native JSON').size
+  end
+
+  private
+
+  def client(middleware)
+    chain = Wurk::Middleware::Chain.new(Wurk.configuration)
+    chain.add(middleware, @events)
+    RecordingClient.new(pool: @pool, chain: chain, events: @events)
+  end
+
+  def item(args: [1])
+    { 'class' => @class_name, 'args' => args, 'queue' => @queue }
+  end
+
+  def queue_depth = @pool.with { |conn| conn.call('LLEN', "queue:#{@queue}") }
+
+  def with_strict_mode(mode)
+    original = Wurk.strict_args_mode
+    Wurk.strict_args!(mode)
+    yield
+  ensure
+    Wurk.strict_args!(original)
+  end
+
+  def capture_log
+    io    = StringIO.new
+    saved = Wurk.configuration.logger
+    Wurk.configuration.logger = ::Logger.new(io)
+    yield
+    io.string
+  ensure
+    Wurk.configuration.logger = saved
+  end
+
+  # Records every args walk. Subclassing beats stubbing here — the override sits
+  # exactly where JobUtil's method would, so it counts calls from both paths
+  # without caring which one made them.
+  class RecordingClient < Wurk::Client
+    def initialize(events:, **)
+      super(**)
+      @events = events
+    end
+
+    def verify_json(item)
+      @events << :verify
+      super
+    end
+  end
+
+  class RecordingMiddleware
+    def initialize(events) = @events = events
+
+    def call(_worker, _job, _queue, _redis)
+      @events << :before
+      result = yield
+      @events << :after
+      result
+    end
+  end
+
+  class HaltingMiddleware
+    def initialize(events) = @events = events
+
+    def call(_worker, _job, _queue, _redis)
+      @events << :halt
+      nil
+    end
+  end
+end

--- a/test/unit/client_verify_json_test.rb
+++ b/test/unit/client_verify_json_test.rb
@@ -51,6 +51,9 @@ class ClientVerifyJsonTest < Wurk::Test::UnitCase
     assert_equal 1, @events.count(:verify)
   end
 
+  # Deliberately the mirror image of the #push_bulk order below: #push runs the
+  # walk on the payload the chain returned (`invoke_chain` + verify), bulk runs
+  # it in the innermost block (`invoke_chain_verified`). Both match Sidekiq.
   def test_push_verifies_after_the_client_middleware_chain
     client(RecordingMiddleware).push(item)
 
@@ -88,6 +91,8 @@ class ClientVerifyJsonTest < Wurk::Test::UnitCase
     assert_equal 3, @events.count(:verify)
   end
 
+  # Inside the chain, unlike #push above — a halting middleware must be able to
+  # short-circuit the walk on args it is about to drop.
   def test_push_bulk_verifies_inside_the_client_middleware_chain
     client(RecordingMiddleware).push_bulk('class' => @class_name, 'queue' => @queue, 'args' => [[1]])
 

--- a/test/unit/job_util_test.rb
+++ b/test/unit/job_util_test.rb
@@ -4,22 +4,16 @@ require_relative '../test_helper'
 require 'date'
 require 'stringio'
 
-module WurkGlobalStateLock
-  # One process-wide mutex serializing every test that mutates Wurk's
-  # process-global state (`@default_job_options`, `@strict_args_mode`,
-  # `@testing_mode`, `@server`). Without this, parallel classes holding
-  # separate locks could interleave and corrupt shared state.
-  MUTEX = Mutex.new
-end
-
 class JobUtilTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  STRICT_MUTEX = WurkGlobalStateLock::MUTEX
+  STRICT_MUTEX = Wurk::Test::GLOBAL_STATE_MUTEX
 
   Host = Struct.new(:placeholder) do
     include Wurk::JobUtil
   end
+
+  class StringLike < String; end
 
   # Sidekiq's public API names this `get_sidekiq_options` — wire-compat sacred.
   class StubWorker
@@ -157,6 +151,34 @@ class JobUtilTest < Wurk::Test::UnitCase
     end
   end
 
+  # The walk dispatches on `val.class` through a compare_by_identity table, so a
+  # subclass of a JSON-native type misses and is reported unsafe. Sidekiq
+  # (job_util.rb:80-111) behaves identically — an ActiveSupport::SafeBuffer arg
+  # raises there too — and the oracle is the contract.
+  def test_verify_json_rejects_a_string_subclass_value
+    with_strict_mode(:raise) do
+      err = assert_raises(ArgumentError) { @host.verify_json({ 'class' => 'X', 'args' => [StringLike.new('hi')] }) }
+
+      assert_match(/StringLike/, err.message)
+    end
+  end
+
+  # Hash keys are the documented exception: Sidekiq checks them with `String ===`,
+  # not the identity table, so a String subclass key stays acceptable.
+  def test_verify_json_accepts_a_string_subclass_hash_key
+    with_strict_mode(:raise) do
+      @host.verify_json({ 'class' => 'X', 'args' => [{ StringLike.new('k') => 'v' }] })
+    end
+  end
+
+  def test_verify_json_reports_the_first_offender_in_order
+    with_strict_mode(:raise) do
+      err = assert_raises(ArgumentError) { @host.verify_json({ 'class' => 'X', 'args' => [1, :first, Date.today] }) }
+
+      assert_match(/:first is a Symbol/, err.message)
+    end
+  end
+
   # --- normalize_item --------------------------------------------------
 
   def test_normalize_item_assigns_jid_as_24_hex
@@ -271,7 +293,7 @@ end
 class WurkTopLevelTest < Wurk::Test::UnitCase
   parallelize_me!
 
-  STATE_MUTEX = WurkGlobalStateLock::MUTEX
+  STATE_MUTEX = Wurk::Test::GLOBAL_STATE_MUTEX
 
   def test_shutdown_is_an_interrupt
     assert_operator Wurk::Shutdown, :<, Interrupt

--- a/test/unit/job_util_test.rb
+++ b/test/unit/job_util_test.rb
@@ -267,6 +267,51 @@ class JobUtilTest < Wurk::Test::UnitCase
     refute item.key?('pool')
   end
 
+  # --- normalize_item: byte-identical payload shape (Plan 04/S8) -------
+  #
+  # Pins #normalize_item's output shape against the merge trim in
+  # #normalize_item / #wrap_options (Plan 04/S7 — merge only when wrapping
+  # actually applies): fewer intermediate Hash#merge calls must never change
+  # which keys land in the final payload or their values. Six representative
+  # shapes exercise every branch: bare class default, per-class
+  # `get_sidekiq_options`, an explicit key overriding both, a `wrapped`
+  # class (whose own options are shadowed once outer class defaults already
+  # set `queue`/`retry` — verified against the real implementation, not
+  # hand-derived), tags + `retry_for` coercion, and `at` + `expires_in`
+  # stamping. `created_at` is excluded — it is a clock read, not merge output.
+  def test_normalize_item_payload_shape_is_unchanged_for_representative_jobs
+    jid = 'a' * 24
+    cases = {
+      plain_default: { 'class' => 'X', 'args' => [1, 2] },
+      per_class_options: { 'class' => StubWorker, 'args' => [] },
+      explicit_override: { 'class' => StubWorker, 'args' => [], 'queue' => 'override', 'retry' => false },
+      wrapped_class: { 'class' => 'ActiveJob::Adapter', 'wrapped' => StubWorker, 'args' => [1] },
+      with_tags_and_retry_for: { 'class' => 'X', 'args' => [], 'tags' => ['a'], 'retry_for' => '30' },
+      with_expires_in_and_at: { 'class' => 'X', 'args' => [], 'at' => 2_000_000_000, 'expires_in' => 60 }
+    }
+
+    actual = cases.to_h do |name, item|
+      item = item.merge('jid' => jid)
+      [name, @host.normalize_item(item).except('created_at')]
+    end
+
+    expected = {
+      plain_default: { 'retry' => true, 'queue' => 'default', 'class' => 'X', 'args' => [1, 2], 'jid' => jid },
+      per_class_options: { 'queue' => 'critical', 'retry' => 5, 'class' => 'JobUtilTest::StubWorker',
+                           'args' => [], 'jid' => jid },
+      explicit_override: { 'queue' => 'override', 'retry' => false, 'class' => 'JobUtilTest::StubWorker',
+                           'args' => [], 'jid' => jid },
+      wrapped_class: { 'queue' => 'default', 'retry' => true, 'class' => 'ActiveJob::Adapter',
+                       'wrapped' => StubWorker, 'args' => [1], 'jid' => jid },
+      with_tags_and_retry_for: { 'retry' => true, 'queue' => 'default', 'class' => 'X', 'args' => [],
+                                 'tags' => ['a'], 'retry_for' => 30, 'jid' => jid },
+      with_expires_in_and_at: { 'retry' => true, 'queue' => 'default', 'class' => 'X', 'args' => [],
+                                'at' => 2_000_000_000, 'expires_in' => 60, 'jid' => jid, 'expiry' => 2_000_000_060.0 }
+    }
+
+    assert_equal expected, actual
+  end
+
   # --- now_in_millis ---------------------------------------------------
 
   def test_now_in_millis_returns_integer

--- a/test/unit/metrics_emissions_test.rb
+++ b/test/unit/metrics_emissions_test.rb
@@ -70,6 +70,29 @@ class MetricsEmissionsTest < Wurk::Test::UnitCase
     assert_nil @fake.calls.find { |c| c[1] == 'sidekiq.jobs.enqueued' }
   end
 
+  # With nothing configured the emit must not read the payload at all — no tag
+  # strings built per job for an increment that gets dropped. A payload that
+  # raises on `[]` pins that deterministically, without counting allocations.
+  def test_emit_enqueued_reads_nothing_without_a_client
+    Wurk.configuration.dogstatsd = nil
+
+    assert_nil Wurk::Client.new.send(:emit_enqueued, [tripwire_payload])
+  end
+
+  def test_emit_enqueued_reads_payloads_when_a_client_is_configured
+    assert_raises(RuntimeError) { Wurk::Client.new.send(:emit_enqueued, [tripwire_payload]) }
+  end
+
+  # The guard resolves the client inline, so a builder that raises would take
+  # the enqueue down with it if it weren't swallowed.
+  def test_push_survives_a_raising_dogstatsd_builder
+    Wurk.configuration.dogstatsd = -> { raise 'boom' }
+
+    assert Wurk::Client.new.push('class' => 'MyJob', 'queue' => @ns, 'args' => [])
+  ensure
+    cleanup_queue
+  end
+
   def test_push_bulk_emits_one_jobs_enqueued_per_payload
     Wurk::Client.new.push_bulk('class' => 'MyJob', 'queue' => @ns, 'args' => [[1], [2], [3]])
 
@@ -182,5 +205,13 @@ class MetricsEmissionsTest < Wurk::Test::UnitCase
 
   def cleanup_queue
     Wurk.redis { |c| c.call('UNLINK', "queue:#{@ns}") }
+  end
+
+  # A payload that reports any read of itself, so "allocated nothing" is
+  # assertable as "never indexed" instead of an allocation count.
+  def tripwire_payload
+    Class.new(Hash) do
+      def [](_key) = raise('emit_enqueued must not read payloads with no statsd client')
+    end.new
   end
 end

--- a/test/unit/metrics_statsd_test.rb
+++ b/test/unit/metrics_statsd_test.rb
@@ -107,6 +107,57 @@ class MetricsStatsdTest < Wurk::Test::UnitCase
     assert_equal 1, fake.calls.size
   end
 
+  # --- client memo --------------------------------------------------------
+
+  # The memo is tri-state: "unresolved" is distinct from a resolved nil, so an
+  # unconfigured process stops re-reading config on every emit. Assigning
+  # behind the writer's back is how a test can observe the cached nil at all.
+  def test_client_memoizes_the_unconfigured_answer
+    Wurk.configuration.dogstatsd = nil
+
+    assert_nil Wurk::Metrics::Statsd.client
+
+    Wurk.configuration.instance_variable_set(:@dogstatsd, FakeClient.new)
+
+    assert_nil Wurk::Metrics::Statsd.client, 'unconfigured answer must be cached, not re-resolved per call'
+  end
+
+  def test_dogstatsd_assignment_drops_the_memo
+    Wurk.configuration.dogstatsd = nil
+
+    assert_nil Wurk::Metrics::Statsd.client
+
+    fake = FakeClient.new
+    Wurk.configuration.dogstatsd = fake
+
+    assert_same fake, Wurk::Metrics::Statsd.client
+  end
+
+  # Swarm children call reset! after fork so they build their own socket
+  # instead of inheriting the parent's (Swarm::ChildBoot).
+  def test_reset_re_invokes_the_builder
+    invocations = 0
+    Wurk.configuration.dogstatsd = lambda {
+      invocations += 1
+      FakeClient.new
+    }
+
+    Wurk::Metrics::Statsd.client
+    Wurk::Metrics::Statsd.reset!
+    Wurk::Metrics::Statsd.client
+
+    assert_equal 2, invocations
+  end
+
+  # Hot-path callers reach for the client directly to skip work; a builder that
+  # blows up must degrade to "no client", never propagate into their caller.
+  def test_safe_client_swallows_a_raising_builder
+    Wurk.configuration.dogstatsd = -> { raise 'boom' }
+
+    assert_raises(RuntimeError) { Wurk::Metrics::Statsd.client }
+    assert_nil Wurk::Metrics::Statsd.safe_client
+  end
+
   # --- #115: Pro drop-in statsd setup snippet (spec §9.1) -----------------
 
   def test_server_statsd_alias_and_verbatim_snippet


### PR DESCRIPTION
## Summary
PR 4 of the "faster than Sidekiq" plan (`docs/plans/2026/08/06/101-faster-than-sidekiq`) — enqueue, bulk, and batch client hot-path trims, plus the closing verification slice.

- `verify_json` runs exactly once per push (was twice); statsd emit path is free when unconfigured (tri-state memo + early-return before any allocation)
- `normalize_item`/`wrap_options` merge only when wrapping actually applies; `push_plain` gets a single-queue fast path skipping the `group_by` allocation
- Batched (`bid`) enqueue is pipelined and capped at `BATCH_PIPELINE_SLICE` (1000) instead of one round trip per job
- Verification (this commit, no `lib/` changes): `verify_json`-once spy, a `:warn`/`:raise` mode matrix, a byte-for-byte `normalize_item` payload pin across 6 representative job shapes, a pipelined-vs-per-job Redis state diff for batched enqueue, and statsd-memo-resets-on-fork/reconfigure coverage — every new assertion mutation-checked against the pre-fix `lib/` code

## Test plan
- [x] `bin/rake test` — 3123 runs, 0 failures (+18 vs previous PR in this group)
- [x] `bin/rake test:parity` — 23/0
- [x] `COVERAGE=1 bin/rake test` — 96.96% line / 91.06% branch (≥90/90 gate)
- [x] `bundle exec rubocop` — clean on touched files, no new offenses vs baseline
- [x] `bin/rake bench:enqueue`, `bin/rake bench:bulk_enqueue` — ran clean, within established RTT-bound noise (no `lib/` change in this commit to attribute a delta to)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788667328&installation_model_id=11168&pr_number=379&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F379&signature=a8438592c4ae62bb3743d90a97f80735e3c4f7f7e2b458427f6de8d721c4d8ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Large bulk and scheduled job submissions are processed in smaller batches for improved reliability.
  - Queue handling is optimized for both single-queue and mixed-queue submissions.
  - JSON argument validation now consistently supports strict warning or error modes.

- **Bug Fixes**
  - Middleware halting behavior is preserved during job submission.
  - Transient Redis script and connection failures recover without duplicating deliveries.
  - Metrics failures or missing StatsD configuration no longer interrupt job pushes.
  - StatsD configuration changes now take effect reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->