### PR TITLE
perf: redis-client eager dispatch + checkout trims (Redis layer)

### DIFF
--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -209,7 +209,7 @@ module Wurk
     end
 
     def redis(idempotent: false, &)
-      PoolCheckout.with(redis_pool, idempotent, &)
+      PoolCheckout.trusted(redis_pool, idempotent, &)
     end
 
     # --- Web dashboard Redis pool ----------------------------------------

--- a/lib/wurk/fetcher/reliable.rb
+++ b/lib/wurk/fetcher/reliable.rb
@@ -469,11 +469,12 @@ module Wurk
         timeout = poll_interval
         # Dedicated fetch pool, not the main one: a parked BLMOVE holds its slot
         # for the whole block window, so routing it here keeps idle fetchers from
-        # starving the main pool's background loops (#101). Extend the socket
-        # read-timeout one second past BLMOVE's own server-side timeout so the
-        # connection's read timeout can't fire while BLMOVE is legitimately blocked.
+        # starving the main pool's background loops (#101). redis-client's
+        # connection_timeout helper (connection_mixin.rb:87-93) adds config.read_timeout
+        # to the blocking call timeout, ensuring the socket read timeout won't fire
+        # while BLMOVE is legitimately blocked.
         job = config.fetch_redis(idempotent: true) do |conn|
-          conn.blocking_call(timeout + 1, 'BLMOVE', public_q, priv, 'RIGHT', 'LEFT', timeout)
+          conn.blocking_call(timeout, 'BLMOVE', public_q, priv, 'RIGHT', 'LEFT', timeout)
         end
         job ? unit_of_work(public_q, priv, name, job) : nil
       end

--- a/lib/wurk/pool_checkout.rb
+++ b/lib/wurk/pool_checkout.rb
@@ -25,5 +25,15 @@ module Wurk
 
       pool.with(idempotent: true, &)
     end
+
+    # Same apply-safety forwarding as .with, minus the is_a? probe. Only for
+    # call sites whose pool is always this process's own {RedisPool} — never a
+    # host-supplied `pool:` kwarg — so the polymorphic check has nothing to
+    # decide.
+    def self.trusted(pool, idempotent, &)
+      return pool.with(&) unless idempotent
+
+      pool.with(idempotent: true, &)
+    end
   end
 end

--- a/lib/wurk/redis_client_adapter.rb
+++ b/lib/wurk/redis_client_adapter.rb
@@ -37,7 +37,7 @@ module Wurk
 
       # The Redis commands Sidekiq itself uses — defined eagerly so the
       # common ones skip method_missing. Same list as upstream.
-      USED_COMMANDS = %w[bitfield bitfield_ro del exists expire flushdb
+      USED_COMMANDS = %w[bitfield bitfield_ro blmove del exists expire flushdb
                          get hdel hget hgetall hincrby hlen hmget hset hsetnx incr incrby
                          lindex llen lmove lpop lpush lrange lrem mget mset ping pttl
                          publish rpop rpush sadd scard script set sismember smembers

--- a/lib/wurk/redis_pool.rb
+++ b/lib/wurk/redis_pool.rb
@@ -190,9 +190,9 @@ module Wurk
     # redials a closed socket lazily), so a busy fetcher can't leak checkouts.
     def run(conn, idempotent)
       attempts = 0
+      odometer = conn.round_trips
       begin
         attempts += 1
-        odometer = conn.round_trips
         yield conn
       rescue RedisClient::Error => e
         plan = retry_plan(e, attempts, idempotent, conn.round_trips != odometer)
@@ -204,6 +204,7 @@ module Wurk
 
         safe_close(conn)
         sleep(backoff_delay(attempts)) if plan == :backoff
+        odometer = conn.round_trips
         retry
       end
     end

--- a/test/unit/fetcher_reliable_test.rb
+++ b/test/unit/fetcher_reliable_test.rb
@@ -611,17 +611,18 @@ class FetcherReliableTest < Wurk::Test::UnitCase
     @fetcher.send(:blmove, @public_queue)
     t = Wurk::Fetcher::Reliable::TIMEOUT
 
-    assert_equal [t + 1, 'BLMOVE', @public_queue, private_queue, 'RIGHT', 'LEFT', t], args
+    assert_equal [t, 'BLMOVE', @public_queue, private_queue, 'RIGHT', 'LEFT', t], args
   end
 
-  # config.fetch_poll_interval overrides the block timeout (and the socket
-  # read-timeout stays one second past it).
+  # config.fetch_poll_interval overrides the block timeout. redis-client's
+  # connection_timeout helper (connection_mixin.rb:87-93) adds config.read_timeout
+  # to the socket read timeout, so manual padding is unnecessary.
   def test_blmove_honors_config_fetch_poll_interval
     @config.fetch_poll_interval = 0.25
     args = captured_blmove_args
     @fetcher.send(:blmove, @public_queue)
 
-    assert_equal [1.25, 'BLMOVE', @public_queue, private_queue, 'RIGHT', 'LEFT', 0.25], args
+    assert_equal [0.25, 'BLMOVE', @public_queue, private_queue, 'RIGHT', 'LEFT', 0.25], args
   end
 
   # blmove must draw from the dedicated fetch pool, never the main pool, so a

--- a/test/unit/pool_checkout_test.rb
+++ b/test/unit/pool_checkout_test.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# PoolCheckout is the seam every `#redis`-style wrapper checks out through.
+# `.with` must tolerate a foreign, non-Wurk::RedisPool object (any
+# ConnectionPool-shaped `def with; yield conn; end`) by dropping the
+# `idempotent:` claim rather than raising ArgumentError on an unknown kwarg.
+# `.trusted` skips that duck-type probe entirely — only safe for call sites
+# whose pool is always this process's own RedisPool.
+class PoolCheckoutTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @pool = Wurk::RedisPool.new(size: 2, url: Wurk::Test.redis_url)
+  end
+
+  def teardown
+    @pool&.disconnect!
+    super
+  end
+
+  # A pool that does NOT accept `idempotent:` — the shape a host might supply
+  # via Sidekiq::Client#redis_pool= or a bare round-trip-counting decorator.
+  class ForeignPool
+    def with
+      yield :foreign_conn
+    end
+  end
+
+  # --- .with: Wurk::RedisPool + idempotent: true ---
+
+  def test_with_forwards_idempotent_true_to_a_real_redis_pool
+    result = Wurk::PoolCheckout.with(@pool, true) { |conn| conn.call('PING') }
+
+    assert_equal 'PONG', result
+  end
+
+  def test_with_forwards_idempotent_false_to_a_real_redis_pool
+    result = Wurk::PoolCheckout.with(@pool, false) { |conn| conn.call('PING') }
+
+    assert_equal 'PONG', result
+  end
+
+  # --- .with: foreign-pool fallback (must not ArgumentError on the kwarg) ---
+
+  def test_with_drops_idempotent_true_for_a_foreign_pool
+    result = Wurk::PoolCheckout.with(ForeignPool.new, true) { |conn| conn }
+
+    assert_equal :foreign_conn, result
+  end
+
+  def test_with_idempotent_false_never_touches_the_kwarg_for_a_foreign_pool
+    result = Wurk::PoolCheckout.with(ForeignPool.new, false) { |conn| conn }
+
+    assert_equal :foreign_conn, result
+  end
+
+  def test_with_foreign_pool_does_not_raise_argument_error
+    Wurk::PoolCheckout.with(ForeignPool.new, true) { |conn| conn }
+  rescue ArgumentError => e
+    flunk("PoolCheckout.with must never hand a foreign pool an unknown kwarg: #{e.message}")
+  end
+
+  # A pool that DOES understand `idempotent:` but isn't a Wurk::RedisPool
+  # subclass still only receives the kwarg when idempotent: true is asked for
+  # — the is_a? probe gates the call shape, not just the value.
+  class DuckTypedPool
+    attr_reader :last_kwargs
+
+    def with(**kwargs)
+      @last_kwargs = kwargs
+      yield :duck_conn
+    end
+  end
+
+  def test_with_never_calls_idempotent_kwarg_on_non_redis_pool_even_if_supported
+    duck = DuckTypedPool.new
+    Wurk::PoolCheckout.with(duck, true) { |conn| conn }
+
+    assert_equal({}, duck.last_kwargs, 'PoolCheckout only trusts RedisPool with the kwarg, not any duck-typed pool')
+  end
+
+  # --- .trusted: skips the is_a? probe, same forwarding otherwise ---
+
+  def test_trusted_forwards_idempotent_true_to_a_real_redis_pool
+    result = Wurk::PoolCheckout.trusted(@pool, true) { |conn| conn.call('PING') }
+
+    assert_equal 'PONG', result
+  end
+
+  def test_trusted_forwards_idempotent_false_to_a_real_redis_pool
+    result = Wurk::PoolCheckout.trusted(@pool, false) { |conn| conn.call('PING') }
+
+    assert_equal 'PONG', result
+  end
+
+  def test_trusted_raises_for_a_foreign_pool_given_idempotent_true
+    assert_raises(ArgumentError) do
+      Wurk::PoolCheckout.trusted(ForeignPool.new, true) { |conn| conn }
+    end
+  end
+
+  def test_trusted_does_not_raise_for_a_foreign_pool_given_idempotent_false
+    result = Wurk::PoolCheckout.trusted(ForeignPool.new, false) { |conn| conn }
+
+    assert_equal :foreign_conn, result
+  end
+
+  # --- subclass parity: a RedisPool subclass is still trusted by .with ---
+
+  class SubclassPool < Wurk::RedisPool; end
+
+  def test_with_forwards_idempotent_true_to_a_redis_pool_subclass
+    sub = SubclassPool.new(size: 1, url: Wurk::Test.redis_url)
+    result = Wurk::PoolCheckout.with(sub, true) { |conn| conn.call('PING') }
+
+    assert_equal 'PONG', result
+  ensure
+    sub&.disconnect!
+  end
+end

--- a/test/unit/redis_client_adapter_test.rb
+++ b/test/unit/redis_client_adapter_test.rb
@@ -86,6 +86,68 @@ class RedisClientAdapterTest < Wurk::Test::UnitCase
     end
   end
 
+  # Every hot command in USED_COMMANDS must resolve as a real defined method,
+  # not fall through method_missing — respond_to? without include_private
+  # reports method_missing's own presence (it's public-ish via
+  # respond_to_missing?'s super) the same as any other method, so this checks
+  # the *public* instance method table directly instead.
+  def test_used_commands_are_eagerly_defined_not_dispatched_via_method_missing
+    defined = Wurk::RedisClientAdapter::CompatMethods.instance_methods(false)
+
+    Wurk::RedisClientAdapter::CompatMethods::USED_COMMANDS.each do |name|
+      assert_includes defined, name.to_sym, "#{name} must be an eagerly defined method, not method_missing-dispatched"
+    end
+  end
+
+  # respond_to? alone can't distinguish "really defined" from "answered by
+  # respond_to_missing?", so also spy on method_missing itself: a USED_COMMANDS
+  # entry must never reach it. Uses a fake `call`-recording host (not real
+  # Redis) so this can call every command — including destructive ones like
+  # flushdb/unlink/del — without touching the shared per-worker test DB.
+  class DispatchSpyHost
+    include Wurk::RedisClientAdapter::CompatMethods
+
+    attr_reader :calls, :method_missing_hits
+
+    def initialize
+      @calls = []
+      @method_missing_hits = []
+    end
+
+    def call(*args, **_kwargs, &)
+      @calls << args.first
+      nil
+    end
+
+    def method_missing(*args, &)
+      @method_missing_hits << args.first
+      super
+    rescue NoMethodError
+      nil
+    end
+    ruby2_keywords :method_missing
+
+    def respond_to_missing?(_name, _include_private = false)
+      true
+    end
+  end
+
+  def test_used_commands_never_reach_method_missing
+    host = DispatchSpyHost.new
+
+    Wurk::RedisClientAdapter::CompatMethods::USED_COMMANDS.each do |name|
+      host.public_send(name)
+    end
+
+    assert_equal Wurk::RedisClientAdapter::CompatMethods::USED_COMMANDS, host.calls,
+                 'every USED_COMMANDS entry must reach #call directly'
+    assert_empty host.method_missing_hits, 'no USED_COMMANDS entry may pass through method_missing'
+  end
+
+  def test_blmove_is_eagerly_defined_not_dispatched_via_method_missing
+    assert_includes Wurk::RedisClientAdapter::CompatMethods.instance_methods(false), :blmove
+  end
+
   # --- round-trip odometer (RedisPool's replay guard reads this) ---
 
   def test_round_trips_counts_call_and_pipelined


### PR DESCRIPTION
## Summary
- Add `blmove` to the eagerly defined redis-client command set (fetcher's hot-path blocking call no longer risks `method_missing`).
- Shave per-checkout frames: `PoolCheckout.trusted` skips the `is_a?(RedisPool)` duck-type probe for the one call site (`Configuration#redis`) that's never foreign; `RedisPool#run` snapshots the round-trip odometer once on the non-retried path.
- Drop the duplicated blocking read-timeout padding on BLMOVE — redis-client's own `connection_timeout` already adds `read_timeout` on top, so the manual `+ 1` was stacking (5.5s instead of the intended single pad).
- Close the test gap: new `test/unit/pool_checkout_test.rb` covers both arms of `PoolCheckout.with` (real `RedisPool` + idempotent forwarding, and the foreign-pool fallback that must drop the kwarg instead of `ArgumentError`) plus `.trusted`'s narrower contract; extended `redis_client_adapter_test.rb` to pin that every `USED_COMMANDS` entry is eagerly defined and never reaches `method_missing`.

## Test plan
- [x] `bin/rake test` — 3137/0, 7 skips
- [x] `bin/rake test:parity` — 23/0
- [x] `bin/rake test:ecosystem` — 182/0
- [x] `COVERAGE=1 bin/rake test` — line 96.96% / branch 91.07% (≥90/90 gate)
- [x] `test/integration/redis_outage_recovery_test.rb` green (replay-safety proof the odometer serves)
- [x] `bin/rake bench:fetch_execute` / `bin/rake bench:enqueue` — within established RTT-bound noise, no regression
- [x] rubocop clean on changed files
- [x] new tests mutation-checked against pre-change lib code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788669662&installation_model_id=11168&pr_number=380&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F380&signature=3ac89f4fec7258d9998d7a819943e6d9f2f46fe31c982508f8a1d8a59bbf92f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->