### PR TITLE
ci: pin Node alongside Bun for the frontend jobs (closes #378)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,6 +113,18 @@ jobs:
         if: env.RUN == 'true'
         with:
           bun-version: "1.3.14"
+      # Pin Node too. Bun runs the scripts, but vitest executes test files in
+      # Node worker threads and Vite's toolchain resolves against Node — so an
+      # unpinned Node is a silent, moving dependency of every frontend run. It
+      # is what broke the jsdom 30 bump (#372): the runner image's Node was
+      # below jsdom 30's floor, `undici` loaded without
+      # `webidl.util.markAsUncloneable`, and all 17 vitest workers failed to
+      # boot. Floor comes from jsdom's `engines.node`; mirrored in
+      # frontend/package.json so a local `bun install` warns on a mismatch.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: env.RUN == 'true'
+        with:
+          node-version: "24"
       # Cache Bun's global download cache so `bun install --frozen-lockfile`
       # (run here directly in `frontend`, and via `rake frontend:build` in the
       # test/coverage legs) reuses tarballs instead of re-fetching them each run.
@@ -211,6 +223,10 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.14"
+      # See the `test` job for why Node is pinned alongside Bun.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
       # Cache Bun's global download cache so `bun install --frozen-lockfile`
       # (run here directly in `frontend`, and via `rake frontend:build` in the
       # test/coverage legs) reuses tarballs instead of re-fetching them each run.
@@ -286,6 +302,11 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.14"
+      # See the `test` job for why Node is pinned alongside Bun. This is the
+      # job that actually runs vitest, so it is the one the pin exists for.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
       # Cache Bun's global download cache so `bun install --frozen-lockfile`
       # (run here directly in `frontend`, and via `rake frontend:build` in the
       # test/coverage legs) reuses tarballs instead of re-fetching them each run.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.1",
   "type": "module",
+  "engines": {
+    "node": ">=24.15.0"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build --outDir ../vendor/assets/dashboard --emptyOutDir",


### PR DESCRIPTION
## What

Pins Node in the three CI jobs that run the frontend toolchain, and declares the supported floor in `frontend/package.json`.

## Why

vitest runs its test files in **Node worker threads**, so the frontend toolchain executes on Node even though Bun drives the scripts. `test.yml` set up Bun (`bun-version: "1.3.14"`, pinned exactly) but never Node — so the Node running our tests was whatever the Blacksmith runner image happened to ship. That is an unpinned dependency of every frontend run that moves without appearing in any diff.

It is the live blocker on #372. jsdom raised its floor between the two versions:

| package | `engines.node` |
|---------|----------------|
| jsdom 29.1.1 (current) | `^20.19.0 \|\| ^22.13.0 \|\| >=24.0.0` |
| jsdom 30.0.1 (#372) | `^22.22.2 \|\| ^24.15.0 \|\| >=26.0.0` |

The runner's Node clears 29 and not 30, so `undici` 8.10.0 loads without `webidl.util.markAsUncloneable` and every vitest worker fails to boot — 17 unhandled errors, zero tests run, ~770ms:

```
Error: [vitest-pool]: Failed to start threads worker for .../Metrics.test.tsx
Caused by: TypeError: webidl.util.markAsUncloneable is not a function
  ❯ new CacheStorage node_modules/undici/lib/web/cache/cachestorage.js:20:17
  ❯ Object.<anonymous> node_modules/jsdom/lib/api.js:12:33
```

Without a pin, the next dependency to raise its Node floor lands the same failure, reported against the dependency rather than the real cause.

## Changes

- `.github/workflows/test.yml` — `actions/setup-node` pinned to Node 24 in `test`, `coverage`, and `frontend`, placed next to the existing `setup-bun` step in each and carrying the `if: env.RUN == 'true'` guard where the surrounding job uses one. SHA-pinned with a version comment, matching the other actions in this workflow.
- `frontend/package.json` — adds `engines.node: ">=24.15.0"`. There was no `engines` field, so nothing in the repo stated which Node the frontend supports; now a local `bun install` warns on a mismatch instead of the difference only surfacing as a CI failure.

## Verification

- `bun install --frozen-lockfile` passes with the `engines` field added and does **not** modify `bun.lock` (`Checked 194 installs across 262 packages (no changes)`). This matters: a lockfile change here would have reintroduced #373.
- `test.yml` parses (`YAML.load_file`).
- jsdom 30 confirmed green on Node v24.15.0 — exactly its floor — via a clean `rm -rf node_modules && bun install --frozen-lockfile` on #372's branch: 17 files, **138/138 tests pass**. The pass/fail split there was purely the Node version, not the dependency tree.

## Follow-up

#372 should go green on a rerun once this lands — its lockfile is already reconciled. #373 (Dependabot cannot produce `bun.lock`) is a separate defect on the same lane and is not addressed here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788675941&installation_model_id=11168&pr_number=381&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F381&signature=a042179c477b19ea58148d091859c50af0cbe067fc67a54c5bcddde7ad26a02f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized project tooling on Node.js version 24.
  * Added a minimum Node.js version requirement of 24.15.0 for the frontend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->