### PR TITLE
docs: stop claiming Wurk is faster than Sidekiq in docs/idea (closes #375)

### DIFF
--- a/docs/idea/00-seed.md
+++ b/docs/idea/00-seed.md
@@ -1,16 +1,16 @@
 # Wurk — Seed
 
-100% API-compatible drop-in replacement for Sidekiq + Sidekiq Pro + Sidekiq Enterprise. Free forever. Meaningfully faster. Like AOSP for Sidekiq.
+100% API-compatible drop-in replacement for Sidekiq + Sidekiq Pro + Sidekiq Enterprise. Free forever. Like AOSP for Sidekiq.
 
 ## The pitch in one sentence
 
-**Same Sidekiq API, includes all Pro + Enterprise features for free, runs faster.**
+**Same Sidekiq API, includes all Pro + Enterprise features for free.**
 
 ## Three pillars (all must be true)
 
 1. **100% drop-in.** Same Ruby API, same Redis wire format, same DSL. Migration is a one-line gem swap. Third-party gems built on Sidekiq (sidekiq-cron, sidekiq-unique-jobs, sidekiq-scheduler, sidekiq-status, etc.) work unchanged. We prove this in CI by running each ecosystem gem's own test suite against Wurk.
 2. **Free.** Pro + Enterprise feature parity built in. No license tiers, no paid features.
-3. **Faster.** Real multi-process parallelism via fork. Optimized Redis path. Precompiled assets. Hot loops tuned. Every release benchmarked against stock Sidekiq; regressions block merge.
+3. **Measured.** Real multi-process parallelism via fork. Optimized Redis path. Precompiled assets. Hot loops tuned. Two benchmark suites, and only one of them gates: `rake bench` compares Wurk against its own past self and blocks merge on a >5% regression; `rake bench:vs_sidekiq` compares against stock Sidekiq and gates nothing. Wurk is **not** currently faster than stock Sidekiq — it runs at roughly 0.45x-0.86x depending on workload shape. See `docs/benchmarks.md` for the numbers and the reproduction command.
 
 ## Shape
 

--- a/docs/idea/00-seed.md
+++ b/docs/idea/00-seed.md
@@ -10,7 +10,7 @@
 
 1. **100% drop-in.** Same Ruby API, same Redis wire format, same DSL. Migration is a one-line gem swap. Third-party gems built on Sidekiq (sidekiq-cron, sidekiq-unique-jobs, sidekiq-scheduler, sidekiq-status, etc.) work unchanged. We prove this in CI by running each ecosystem gem's own test suite against Wurk.
 2. **Free.** Pro + Enterprise feature parity built in. No license tiers, no paid features.
-3. **Measured.** Real multi-process parallelism via fork. Optimized Redis path. Precompiled assets. Hot loops tuned. Two benchmark suites, and only one of them gates: `rake bench` compares Wurk against its own past self and blocks merge on a >5% regression; `rake bench:vs_sidekiq` compares against stock Sidekiq and gates nothing. Wurk is **not** currently faster than stock Sidekiq — it runs at roughly 0.45x-0.86x depending on workload shape. See `docs/benchmarks.md` for the numbers and the reproduction command.
+3. **Measured.** Real multi-process parallelism via fork. Optimized Redis path. Precompiled assets. Hot loops tuned. Two benchmark suites, and only one of them gates: `rake bench` compares Wurk against its own past self and blocks merge on a >5% regression; `rake bench:vs_sidekiq` compares against stock Sidekiq and gates nothing. Wurk is **not** currently faster than stock Sidekiq — it runs at roughly 0.45×–0.86× depending on workload shape and process configuration. See `docs/benchmarks.md` for the numbers and the reproduction command.
 
 ## Shape
 

--- a/docs/idea/01-overview.md
+++ b/docs/idea/01-overview.md
@@ -10,13 +10,13 @@ Not "Sidekiq-compatible enough." Bit-for-bit on the public surface.
 
 **100% API-compatible with Sidekiq + Pro + Enterprise, free forever.**
 
-That's the entire pitch. Every other claim in this project supports one of those two.
+That's the entire pitch. Every other claim in this project exists to support it — including the third pillar below, which is how the first two are kept honest rather than a selling point of its own.
 
 ## The three pillars (must all be true)
 
 1. **100% drop-in.** Swap one gem line. Existing jobs, batches, limiters, cron entries, Redis data — all continue to work untouched. Third-party gems built on Sidekiq's API (sidekiq-cron, sidekiq-unique-jobs, sidekiq-scheduler, sidekiq-status, etc.) work against Wurk with no changes. We test this in CI — see 14-ecosystem-compat.md.
 2. **Free.** Pro features (batches, reliable fetch, queue pause, statsd, search). Enterprise features (rate limiters, cron, unique jobs, encryption, historical metrics, swarm, rolling restart, leader election). No license fees, ever.
-3. **Measured and optimized.** Real multi-process parallelism. Optimized Redis path with BLMOVE, Lua bulk ops, pipelining. Per-fork connection pools. Hot-path allocations minimized. Two benchmark suites, and only one of them gates: `rake bench` compares Wurk against its own past self and blocks merge on a >5% regression; `rake bench:vs_sidekiq` compares against stock Sidekiq and gates nothing, so a green CI says nothing about Sidekiq. Wurk is **not** currently faster than stock Sidekiq — roughly 0.45x-0.86x depending on workload shape. See 06-performance.md and `docs/benchmarks.md`.
+3. **Measured and optimized.** Real multi-process parallelism. Optimized Redis path with BLMOVE, Lua bulk ops, pipelining. Per-fork connection pools. Hot-path allocations minimized. Two benchmark suites, and only one of them gates: `rake bench` compares Wurk against its own past self and blocks merge on a >5% regression; `rake bench:vs_sidekiq` compares against stock Sidekiq and gates nothing, so a green CI says nothing about Sidekiq. Wurk is **not** currently faster than stock Sidekiq — roughly 0.45×–0.86× depending on workload shape and process configuration. See 06-performance.md and `docs/benchmarks.md`.
 
 ## Who it's for
 

--- a/docs/idea/01-overview.md
+++ b/docs/idea/01-overview.md
@@ -8,15 +8,15 @@ Not "Sidekiq-compatible enough." Bit-for-bit on the public surface.
 
 ## The value prop (one sentence)
 
-**100% API-compatible with Sidekiq + Pro + Enterprise, free forever, and meaningfully faster.**
+**100% API-compatible with Sidekiq + Pro + Enterprise, free forever.**
 
-That's the entire pitch. Every other claim in this project supports one of those three.
+That's the entire pitch. Every other claim in this project supports one of those two.
 
 ## The three pillars (must all be true)
 
 1. **100% drop-in.** Swap one gem line. Existing jobs, batches, limiters, cron entries, Redis data — all continue to work untouched. Third-party gems built on Sidekiq's API (sidekiq-cron, sidekiq-unique-jobs, sidekiq-scheduler, sidekiq-status, etc.) work against Wurk with no changes. We test this in CI — see 14-ecosystem-compat.md.
 2. **Free.** Pro features (batches, reliable fetch, queue pause, statsd, search). Enterprise features (rate limiters, cron, unique jobs, encryption, historical metrics, swarm, rolling restart, leader election). No license fees, ever.
-3. **Faster and optimized.** Real multi-process parallelism. Optimized Redis path with BLMOVE, Lua bulk ops, pipelining. Per-fork connection pools. Hot-path allocations minimized. Faster than stock Sidekiq on enqueue, fetch, and total throughput. CI enforces this — regressions block merge. See 06-performance.md.
+3. **Measured and optimized.** Real multi-process parallelism. Optimized Redis path with BLMOVE, Lua bulk ops, pipelining. Per-fork connection pools. Hot-path allocations minimized. Two benchmark suites, and only one of them gates: `rake bench` compares Wurk against its own past self and blocks merge on a >5% regression; `rake bench:vs_sidekiq` compares against stock Sidekiq and gates nothing, so a green CI says nothing about Sidekiq. Wurk is **not** currently faster than stock Sidekiq — roughly 0.45x-0.86x depending on workload shape. See 06-performance.md and `docs/benchmarks.md`.
 
 ## Who it's for
 

--- a/docs/idea/06-performance.md
+++ b/docs/idea/06-performance.md
@@ -1,6 +1,8 @@
-# Performance — Why Wurk Is Faster
+# Performance — How Wurk Is Measured
 
-Speed is a pillar, not a side effect. Wurk must beat stock Sidekiq on every benchmark we ship.
+Speed is measured, not claimed. Wurk is **not** currently faster than stock Sidekiq: it runs at roughly 0.45x-0.86x depending on workload shape, because reliable fetch and per-job metrics cost extra Redis round-trips. The numbers, the method, and the reproduction command live in `docs/benchmarks.md`.
+
+The optimizations below are real and worth keeping — they are why the gap is not larger — but they have not added up to beating stock Sidekiq, and this document does not claim they have.
 
 ## Redis path
 
@@ -55,6 +57,10 @@ Every release must run, and must not regress on:
 
 The benchmark job runs in CI on Blacksmith. Results uploaded as artifacts. PR comment shows delta vs main. Greater than 5% regression flags the PR.
 
-## Promise
+## What actually gates a merge
 
-Wurk is at least as fast as stock Sidekiq on every benchmark, and ideally meaningfully faster on enqueue and bulk paths. If a release can't claim this, the release waits.
+`rake bench` is the regression gate: it compares Wurk against **its own past self** on enqueue, fetch+execute, bulk enqueue, swarm boot, and memory. A regression greater than 5% on any of those blocks the merge.
+
+`rake bench:vs_sidekiq` is the comparison suite against stock Sidekiq. It gates nothing. A green CI run says nothing about how Wurk compares to Sidekiq — only that Wurk has not got slower than it was.
+
+There is deliberately no "must beat Sidekiq to release" rule. One previously stood here and was not followed — v1.5.0 shipped on 2026-08-06 while slower — so it is removed rather than left as a policy releases ignore. Closing the gap is tracked as ordinary performance work, and `docs/benchmarks.md` is the place the current numbers are published.

--- a/docs/idea/06-performance.md
+++ b/docs/idea/06-performance.md
@@ -1,6 +1,6 @@
 # Performance — How Wurk Is Measured
 
-Speed is measured, not claimed. Wurk is **not** currently faster than stock Sidekiq: it runs at roughly 0.45x-0.86x depending on workload shape, because reliable fetch and per-job metrics cost extra Redis round-trips. The numbers, the method, and the reproduction command live in `docs/benchmarks.md`.
+Speed is measured, not claimed. Wurk is **not** currently faster than stock Sidekiq: it runs at roughly 0.45×–0.86× depending on workload shape and process configuration, because reliable fetch and per-job metrics cost extra Redis round-trips. The numbers, the method, and the reproduction command live in `docs/benchmarks.md`.
 
 The optimizations below are real and worth keeping — they are why the gap is not larger — but they have not added up to beating stock Sidekiq, and this document does not claim they have.
 
@@ -61,6 +61,6 @@ The benchmark job runs in CI on Blacksmith. Results uploaded as artifacts. PR co
 
 `rake bench` is the regression gate: it compares Wurk against **its own past self** on enqueue, fetch+execute, bulk enqueue, swarm boot, and memory. A regression greater than 5% on any of those blocks the merge.
 
-`rake bench:vs_sidekiq` is the comparison suite against stock Sidekiq. It gates nothing. A green CI run says nothing about how Wurk compares to Sidekiq — only that Wurk has not got slower than it was.
+`rake bench:vs_sidekiq` is the comparison suite against stock Sidekiq. It gates nothing. A green CI run says nothing about how Wurk compares to Sidekiq — only that Wurk has not regressed by more than 5% against its own baseline on the measured metrics. A 4% regression still passes.
 
 There is deliberately no "must beat Sidekiq to release" rule. One previously stood here and was not followed — v1.5.0 shipped on 2026-08-06 while slower — so it is removed rather than left as a policy releases ignore. Closing the gap is tracked as ordinary performance work, and `docs/benchmarks.md` is the place the current numbers are published.


### PR DESCRIPTION
## What

Brings `docs/idea/` in line with `docs/benchmarks.md`. Seven claims across three files said Wurk is faster than stock Sidekiq; it is not.

## Why

#366 swept the README, `docs/benchmarks.md`, `docs/site/index.html` and `docs/site/llms.txt`. `docs/idea/` was missed, and it is public. CLAUDE.md pillar 3 is explicit that the "faster" claim does not go back until the numbers support it, and `docs/benchmarks.md:3` states plainly that Wurk is **not** currently faster — roughly 0.45x-0.86x depending on workload shape.

Two of the lines were more than stale. `01-overview.md` and `00-seed.md` both told the reader that **CI enforces a comparison against stock Sidekiq** and blocks merge on it. It does not, and never did:

- `rake bench` is the regression gate — Wurk against its own past self, >5% blocks merge.
- `rake bench:vs_sidekiq` is the comparison suite and gates nothing.

`docs/benchmarks.md:10` marks that second row "No" under gating. So a contributor reading `docs/idea` would have had the wrong model of what a green CI means.

## Changes

- `docs/idea/00-seed.md` — drops "Meaningfully faster" from the summary and "runs faster" from the one-sentence pitch; pillar 3 becomes **Measured** and states which suite gates and which does not.
- `docs/idea/01-overview.md` — same treatment for the value prop and pillar 3. Also fixes the now-dangling "one of those three" to "those two", since the pitch lost a clause.
- `docs/idea/06-performance.md` — retitled "Why Wurk Is Faster" to "How Wurk Is Measured", replaced the opening "must beat stock Sidekiq on every benchmark" with the measured position, and replaced the `## Promise` section with `## What actually gates a merge`.

The optimizations documented in `06-performance.md` are left intact and described as real — they are why the gap is not larger. Only the claims about the outcome changed.

## The removed release policy

`06-performance.md` said: *"If a release can't claim this, the release waits."* We did not follow it — v1.5.0 shipped on 2026-08-06 while slower. Leaving a policy in the tree that releases ignore is worse than either enforcing or dropping it, so this PR drops it and documents the real gate. If the intent is to reinstate it as a genuine release rule, that is a deliberate decision worth its own issue rather than something to restore silently.

## Verification

Docs-only; no code paths touched. Re-grepped `docs/idea/` for speed claims after the edit — the only remaining hits are the corrected lines (which now contain "not currently faster"), `08-dashboard.md`'s note about the SolidJS dashboard being faster than Sidekiq's ERB+jQuery (frontend responsiveness, not job throughput), `11-testing-ci.md` on Blacksmith runners being faster than `ubuntu-latest`, and path references to the `101-faster-than-sidekiq` plan directory. All four are accurate and out of scope; I called them out as such in #375.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788676092&installation_model_id=11168&pr_number=382&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F382&signature=a0654827bde8f4f4f42ec07281f129607ca74c8fa25348b08f86d4b3b5d3a49b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project materials to accurately describe current performance relative to Sidekiq.
  * Added measured performance ranges and clarified that benchmark comparisons are informational.
  * Documented that regression checks track performance against the project’s own history.
  * Removed claims and requirements stating that the project must outperform Sidekiq.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->