### PR TITLE
build: rake test builds the dashboard SPA when it is missing (closes #376)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,12 @@ Frontend unit + integration tests (Vitest, SolidJS Testing Library) run with
 | Benchmarks | `bin/rake bench` |
 | Lint | `bundle exec rubocop` |
 
+The engine tests render the dashboard shell, which needs the precompiled SPA.
+That bundle is built rather than committed, so a fresh clone has none — the
+first `bin/rake test` builds it once (roughly 4s) and says so. Later runs skip
+it. If you change anything under `frontend/src`, rebuild explicitly with
+`bin/rake frontend:build`; the automatic build only covers "no bundle at all".
+
 Test layers:
 
 - **unit** — plain Ruby classes in isolation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,10 +11,15 @@ cd wurk
 bin/setup          # gem + frontend (bun) deps + dummy app db:prepare
 ```
 
-You'll need a local **Redis ≥ 7.0** running (tests use real Redis, never a mock).
-[**bun**](https://bun.sh) is only needed if you touch the dashboard frontend
-(`frontend/`, a SolidJS SPA); the precompiled bundle is committed under
-`vendor/assets/`, so consumers run neither Node nor bun.
+You'll need a local **Redis ≥ 7.0** running (tests use real Redis, never a mock)
+and [**bun**](https://bun.sh). Bun is not only for frontend work: the engine
+tests render the dashboard shell, so the SolidJS SPA under `frontend/` has to be
+built before they can run. `vendor/assets/dashboard/` is gitignored rather than
+committed, so a fresh clone has no bundle — `bin/setup` installs the frontend
+deps, and the first `bin/rake test` builds the bundle itself.
+
+Consumers of the published gem run neither Node nor bun: the bundle is baked
+into `vendor/assets/` at release time and ships inside the gem.
 
 `bin/setup` installs the dummy app's gems into a **project-local** path
 (`test/dummy/vendor/bundle`) so a read-only or permission-locked global gem home

--- a/Rakefile
+++ b/Rakefile
@@ -150,7 +150,35 @@ namespace :frontend do
   task :dev do
     sh "bun", "run", "dev", chdir: FRONTEND_DIR
   end
+
+  # Build the SPA only when it isn't there yet.
+  #
+  # The dashboard controller raises when the precompiled index.html is missing,
+  # so the engine tests need a bundle on disk. The bundle is built, not
+  # committed (.gitignore), which means a *fresh clone* has none and `rake test`
+  # died with two errors before running a single engine test. CI never saw it:
+  # the workflow runs `rake frontend:build` first. The contributor following
+  # CONTRIBUTING step 3 is exactly who hit it.
+  #
+  # Conditional on purpose. An unconditional prerequisite would re-run the ~4s
+  # install+vite build on every `rake test`, including in CI where the workflow
+  # has already built it in a separate `bundle exec rake` invocation (so Rake's
+  # once-per-run memo doesn't help). Someone changing frontend code still
+  # rebuilds explicitly with `rake frontend:build`; this only rescues the
+  # "there is nothing at all" case.
+  task :ensure_build do
+    next if File.exist?(File.join(DASHBOARD_BUNDLE_DIR, "index.html"))
+
+    puts "frontend: precompiled SPA missing — building it once (rake frontend:build)"
+    Rake::Task["frontend:build"].invoke
+  end
 end
+
+# Engine tests render the dashboard shell, so they need the built SPA present.
+# Attached here rather than inside the TestTask blocks so the dependency reads
+# next to the task that satisfies it.
+task test: "frontend:ensure_build"
+task "test:engine" => "frontend:ensure_build"
 
 namespace :release do
   desc "Pre-release gate: tag matches version, bundle present, version matches CHANGELOG, clean tree, tests green"

--- a/bin/setup
+++ b/bin/setup
@@ -7,14 +7,17 @@ echo "==> bundle install (gem)"
 bundle check >/dev/null 2>&1 || bundle install
 
 if [ -d frontend ]; then
-  # bun is only needed to touch the dashboard frontend (CONTRIBUTING.md); the
-  # precompiled bundle ships in vendor/assets/. Skip gracefully rather than
-  # hard-fail under `set -e` for contributors without bun.
+  # bun is required to run the suite, not just to work on the frontend: the
+  # engine tests render the dashboard shell, vendor/assets/dashboard is
+  # gitignored, and `rake test` builds it via `frontend:build` when missing.
+  # (The bundle ships inside the released gem, so gem *consumers* need neither
+  # Node nor bun.) Still skip gracefully rather than hard-fail under `set -e` —
+  # setup should finish and say what is missing rather than abort halfway.
   if command -v bun >/dev/null 2>&1; then
     echo "==> frontend deps (bun)"
     (cd frontend && bun install)
   else
-    echo "==> skipping frontend deps (bun not installed; only needed if you touch frontend/)"
+    echo "==> skipping frontend deps (bun not installed — install it before \`rake test\`, which builds the dashboard bundle)"
   fi
 fi
 


### PR DESCRIPTION
## What

`bin/rake test` now builds the precompiled dashboard bundle when it is absent, so a fresh clone can run its own test suite.

## Why

On a clean clone the suite failed with 2 errors before running a single engine test:

```
ExtensionsTest#test_unregistered_name_falls_through_to_the_spa_shell
CsrfSameOriginTest#test_every_safe_route_succeeds_with_same_origin_header

RuntimeError: Wurk dashboard: precompiled SPA index.html missing at
  <repo>/vendor/assets/dashboard/index.html. Run `bin/rake frontend:build`.
```

`vendor/assets/dashboard/*` is gitignored (`.gitignore:43-44`, only `.keep` is tracked), so no clone has the bundle. CI is green because the workflow runs `bundle exec rake frontend:build` before the suite (`test.yml` lines 133 and 229). The gap is local-only — which is exactly where a new contributor is.

`CONTRIBUTING.md:90` compounds it: step 3 says to run `bin/rake test`, `test:parity`, `test:ecosystem` and `rubocop`, with no mention of `frontend:build`. The only reference to it (`CONTRIBUTING.md:36`) is a parenthetical about sanity-checking the shipped artifact. So the documented first-run path produced two errors.

## Changes

- `Rakefile` — adds `frontend:ensure_build`, a prerequisite of `test` and `test:engine`. It returns immediately when `vendor/assets/dashboard/index.html` exists; otherwise it prints why and invokes `frontend:build`.
- `CONTRIBUTING.md` — documents the behaviour under "Running the tests", including that the automatic build only covers "no bundle at all" and that frontend changes still need an explicit `bin/rake frontend:build`.

## Why conditional rather than an unconditional prerequisite

An unconditional `task test: "frontend:build"` would re-run the ~4s install + vite build on **every** `rake test`. That includes CI, where the workflow already built the bundle in a separate `bundle exec rake` invocation — Rake's once-per-run memoisation does not span processes, so it would be a straight 4s tax on three jobs. Building only when nothing is there fixes the reported failure without charging anyone who already has a bundle.

The trade-off is explicit: a *stale* bundle is not rebuilt. That matches the previous contract (the tests never checked freshness, only presence) and is called out in CONTRIBUTING.

## Verification

Simulated a fresh clone by deleting the bundle while keeping the tracked `.keep`:

- `bin/rake test:engine` — prints `frontend: precompiled SPA missing — building it once`, builds in 3.85s, then **179 runs, 530 assertions, 0 failures, 0 errors**.
- Second `bin/rake test:engine` — zero rebuild messages, confirming the skip path.
- Full `bin/rake test` — **3137 runs, 6936 assertions, 0 failures, 0 errors, 6 skips**.
- `bundle exec rubocop Rakefile` — 96 offenses, up from 87 on `origin/main`. All 9 additions are `Style/StringLiterals` (double-quoted strings), which is what the entire Rakefile already uses; matching the file beat matching a config the file has never satisfied. Rubocop is not a CI gate in `test.yml` and the repo carries 680 offenses across 382 files today, so this changes nothing about the gate. An earlier revision of this description claimed the lint was clean — it is not, and that claim was wrong.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788676311&installation_model_id=11168&pr_number=383&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F383&signature=97fdbc23f95c86ed516abca06e6da04444406c0f0cab9e47653ac2608f95546f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance explaining the dashboard build requirement for engine tests.
  * Documented when to rebuild the dashboard after making frontend changes.

* **Tests**
  * Full test runs now automatically prepare the dashboard when needed.
  * Existing builds are reused to avoid unnecessary rebuilds.
  * Frontend changes can be incorporated by explicitly running the documented build command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->