### PR TITLE
fix(engine): send Cache-Control for dashboard assets (closes #377)

### DIFF
--- a/lib/wurk/engine.rb
+++ b/lib/wurk/engine.rb
@@ -35,6 +35,15 @@ module Wurk
       IMMUTABLE_CACHE_CONTROL = 'public, max-age=31536000, immutable'
       REVALIDATE_CACHE_CONTROL = 'public, no-cache'
 
+      # Only a served body gets a cache directive. Rack::Files answers more than
+      # file reads: OPTIONS with 200 + Allow, 405 for any other verb
+      # (`ALLOWED_VERBS = %w[GET HEAD OPTIONS]`), and 416 for an unsatisfiable
+      # Range. 405 is cacheable by default (RFC 9110 §15.5.6), so stamping it
+      # `immutable` would let a shared proxy serve "method not allowed" for a
+      # year to everyone behind it.
+      CACHEABLE_METHODS = %w[GET HEAD].freeze
+      CACHEABLE_STATUSES = [200, 206, 304].freeze
+
       def initialize(app, root:)
         @app   = app
         @files = ::Rack::Files.new(root)
@@ -50,17 +59,26 @@ module Wurk
         response = @files.call(inner)
         return @app.call(env) if response[0] == 404
 
-        # This mount is inserted at index 0 of the HOST app's stack (see the
-        # initializer below), so Rack::ETag and Rack::ConditionalGet never see
-        # these responses — without this the dashboard's fingerprinted bundle
-        # shipped with no cache directive at all and was refetched every load.
+        stamp_cache_control(response, env, stripped)
+        response
+      end
+
+      private
+
+      # This mount is inserted at index 0 of the HOST app's stack (see the
+      # initializer below), so Rack::ETag and Rack::ConditionalGet never see
+      # these responses — without this the dashboard's fingerprinted bundle
+      # shipped with no cache directive at all and was refetched every load.
+      def stamp_cache_control(response, env, stripped)
+        return unless CACHEABLE_METHODS.include?(env[::Rack::REQUEST_METHOD])
+        return unless CACHEABLE_STATUSES.include?(response[0])
+
         response[1]['cache-control'] ||=
           if stripped.start_with?(FINGERPRINTED_PREFIX)
             IMMUTABLE_CACHE_CONTROL
           else
             REVALIDATE_CACHE_CONTROL
           end
-        response
       end
     end
 

--- a/lib/wurk/engine.rb
+++ b/lib/wurk/engine.rb
@@ -25,6 +25,16 @@ module Wurk
     class AssetMount
       PREFIX = '/wurk-assets'
 
+      # Vite fingerprints everything it emits into `assets/`
+      # (`Dashboard-cGKycyd0.js`), so the bytes behind one of those URLs can
+      # never change — cache them for a year and never revalidate. The rest of
+      # the bundle (index.html, the favicons, wurk-manifest.json,
+      # .vite/manifest.json) keeps a stable name across builds, so it must be
+      # revalidated or a client would pin a stale dashboard shell forever.
+      FINGERPRINTED_PREFIX = '/assets/'
+      IMMUTABLE_CACHE_CONTROL = 'public, max-age=31536000, immutable'
+      REVALIDATE_CACHE_CONTROL = 'public, no-cache'
+
       def initialize(app, root:)
         @app   = app
         @files = ::Rack::Files.new(root)
@@ -38,7 +48,19 @@ module Wurk
         stripped = path.delete_prefix(PREFIX)
         inner[::Rack::PATH_INFO] = stripped.empty? ? '/' : stripped
         response = @files.call(inner)
-        response[0] == 404 ? @app.call(env) : response
+        return @app.call(env) if response[0] == 404
+
+        # This mount is inserted at index 0 of the HOST app's stack (see the
+        # initializer below), so Rack::ETag and Rack::ConditionalGet never see
+        # these responses — without this the dashboard's fingerprinted bundle
+        # shipped with no cache directive at all and was refetched every load.
+        response[1]['cache-control'] ||=
+          if stripped.start_with?(FINGERPRINTED_PREFIX)
+            IMMUTABLE_CACHE_CONTROL
+          else
+            REVALIDATE_CACHE_CONTROL
+          end
+        response
       end
     end
 

--- a/test/engine/static_assets_test.rb
+++ b/test/engine/static_assets_test.rb
@@ -126,7 +126,11 @@ class StaticAssetsTest < Wurk::Test::EngineCase
 
     options "/wurk-assets/assets/#{File.basename(asset)}"
 
-    refute_includes last_response.headers['cache-control'].to_s, 'immutable'
+    # Rack::Files answers OPTIONS with 200 + Allow (rack/files.rb:69). The
+    # contract is no cache directive at all, not merely "not immutable" —
+    # asserting nil would fail if OPTIONS ever picked up `public, no-cache`.
+    assert_equal 200, last_response.status
+    assert_nil last_response.headers['cache-control']
   end
 
   def test_unknown_asset_falls_through_with_404

--- a/test/engine/static_assets_test.rb
+++ b/test/engine/static_assets_test.rb
@@ -80,6 +80,32 @@ class StaticAssetsTest < Wurk::Test::EngineCase
     assert_equal 200, last_response.status
   end
 
+  # AssetMount sits at index 0 of the HOST middleware stack, so Rack::ETag and
+  # Rack::ConditionalGet never see these responses. Without an explicit
+  # directive the fingerprinted bundle shipped with no Cache-Control at all and
+  # browsers refetched or revalidated it on every dashboard load.
+  def test_fingerprinted_asset_is_cached_immutably
+    asset = Dir.glob(ASSETS_DIR.join('assets', '*.js')).first
+    skip 'no built JS asset to probe' unless asset
+
+    get "/wurk-assets/assets/#{File.basename(asset)}"
+
+    assert_equal 200, last_response.status
+    assert_equal 'public, max-age=31536000, immutable', last_response.headers['cache-control']
+  end
+
+  # index.html keeps the same name across builds, so caching it immutably would
+  # pin a client to a stale dashboard shell forever. It must revalidate.
+  def test_non_fingerprinted_asset_must_revalidate
+    skip 'index.html missing' unless ASSETS_DIR.join('index.html').exist?
+
+    get '/wurk-assets/index.html'
+
+    assert_equal 200, last_response.status
+    assert_equal 'public, no-cache', last_response.headers['cache-control']
+    refute_includes last_response.headers['cache-control'].to_s, 'immutable'
+  end
+
   def test_unknown_asset_falls_through_with_404
     get '/wurk-assets/assets/does-not-exist-xyz.js'
 

--- a/test/engine/static_assets_test.rb
+++ b/test/engine/static_assets_test.rb
@@ -106,6 +106,29 @@ class StaticAssetsTest < Wurk::Test::EngineCase
     refute_includes last_response.headers['cache-control'].to_s, 'immutable'
   end
 
+  # Rack::Files answers more than file reads: OPTIONS (200 + Allow) and 405 for
+  # any other verb. 405 is cacheable by default (RFC 9110 §15.5.6), so caching
+  # one immutably would let a shared proxy serve "method not allowed" for a year
+  # to every client behind it.
+  def test_rejected_verb_gets_no_cache_control
+    asset = Dir.glob(ASSETS_DIR.join('assets', '*.js')).first
+    skip 'no built JS asset to probe' unless asset
+
+    post "/wurk-assets/assets/#{File.basename(asset)}"
+
+    assert_equal 405, last_response.status
+    assert_nil last_response.headers['cache-control']
+  end
+
+  def test_options_request_is_not_cached_immutably
+    asset = Dir.glob(ASSETS_DIR.join('assets', '*.js')).first
+    skip 'no built JS asset to probe' unless asset
+
+    options "/wurk-assets/assets/#{File.basename(asset)}"
+
+    refute_includes last_response.headers['cache-control'].to_s, 'immutable'
+  end
+
   def test_unknown_asset_falls_through_with_404
     get '/wurk-assets/assets/does-not-exist-xyz.js'
 


### PR DESCRIPTION
## What

The dashboard's precompiled bundle now ships a `Cache-Control` header. Fingerprinted assets are cached immutably for a year; everything else revalidates.

## Why

`Wurk::Engine::AssetMount` is inserted at **index 0 of the host application's** middleware stack (`engine.rb`), so `Rack::ETag` and `Rack::ConditionalGet` never see its responses. The result, measured against `test/dummy`:

```
$ curl -sI http://127.0.0.1:3111/wurk-assets/assets/ArgsValue-CYjrqKnf.js
HTTP/1.1 200 OK
last-modified: Fri, 07 Aug 2026 03:00:52 GMT
content-type: text/javascript
          <- no cache-control, no etag

$ curl -sI http://127.0.0.1:3111/wurk          # normal route, full stack
HTTP/1.1 200 OK
etag: W/"a6fad56eb9aae34da111f130acd59f1b"
cache-control: max-age=0, private, must-revalidate
```

Those filenames are already content-hashed, which is the textbook case for `immutable`. Instead they carried no directive at all, so browsers fell back to heuristic caching and revalidated the whole bundle on every dashboard load.

## The trap this avoids

The obvious one-line fix — passing a headers hash to `Rack::Files.new` — would apply one policy to everything the mount serves. That is wrong here. Of the files in the bundle, only the contents of `assets/` are fingerprinted:

| Fingerprinted (`assets/`) | Stable names |
|---|---|
| `Dashboard-cGKycyd0.js`, 42 others | `index.html`, `favicon.png`, `favicon-16.png`, `favicon-32.png`, `apple-touch-icon.png`, `og-image.png`, `wurk-logo.webp`, `wurk-manifest.json`, `.vite/manifest.json` |

Caching `index.html` immutably would pin a client to a stale dashboard shell indefinitely, with no way to recover short of a hard refresh. So the header is chosen per path:

- `/wurk-assets/assets/*` -> `public, max-age=31536000, immutable`
- everything else -> `public, no-cache`

Assigned with `||=`, so an explicitly-set upstream header still wins.

## Scope

This fixes the caching half of #377 only. The placement question — index 0 also skips the host's `HostAuthorization`, `ContentSecurityPolicy`, `Rack::Sendfile`, `RequestId`, and `ActionDispatch::SSL` when a host sets `force_ssl` — is deliberately left open on the issue. Moving the mount is a behaviour change affecting every host app and deserves its own decision rather than riding along here.

## Verification

- Two new tests in `test/engine/static_assets_test.rb`, asserting the immutable header on a fingerprinted asset and `public, no-cache` (explicitly not `immutable`) on `index.html`. They exercise the real Rails middleware stack via rack-test, not the class in isolation.
- `bin/rake test TEST=test/engine/static_assets_test.rb` — 13 runs, 28 assertions, 0 failures, 0 errors.
- Full `bin/rake test` — 3139 runs, 6942 assertions, 0 failures, 0 errors, 6 skips.
- `bundle exec rubocop lib/wurk/engine.rb` — no offenses, matching baseline. The test file reports 28 offenses both before and after this change, so it adds none.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788676641&installation_model_id=11168&pr_number=384&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F384&signature=597fa0f0fcd9ac7a2f5112a4c911954559b47348a5c5f8c16cc707f6a081f475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser and CDN caching for static assets.
  * Fingerprinted assets now support one-year immutable caching.
  * Stable assets, such as `index.html`, now revalidate on each request.
  * Cache headers are applied only to successful, cacheable GET and HEAD requests.
  * Unsupported methods do not receive misleading cache directives.
  * Missing assets continue to return the expected 404 response.
  * Existing cache-control settings are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->