### PR TITLE
ci: reconcile bun.lock on Dependabot frontend PRs (closes #373)

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -1,58 +1,42 @@
 name: dependabot lockfile
 
-# Dependabot cannot maintain `frontend/bun.lock` (#373).
+# Dependabot bumps frontend/package.json but cannot maintain frontend/bun.lock
+# (#373): its npm ecosystem understands package-lock.json / yarn.lock /
+# pnpm-lock.yaml, not bun's lockfile. So every frontend dependency PR arrives
+# with a bumped package.json and a stale bun.lock, and CI's
+# `bun install --frozen-lockfile` (the frontend job, the three Ruby matrix legs,
+# and coverage all build the SPA) goes red before a test runs. #300, #304, #371
+# and #372 each needed a human to push a "regenerate bun.lock" commit; this does
+# that step instead.
 #
-# Its `npm` ecosystem understands package-lock.json / yarn.lock / pnpm-lock.yaml,
-# not bun's lockfile, so every frontend dependency PR arrives with a bumped
-# `frontend/package.json` and an untouched `frontend/bun.lock`. CI then runs
-# `bun install --frozen-lockfile` in five jobs (the frontend job, the three Ruby
-# matrix legs, and coverage — the Ruby jobs build the SPA too), and all five go
-# red on a one-line dependency mismatch before a single test runs.
-#
-# This has never worked. #300 and #304 look like Dependabot updated the lockfile,
-# but their commit lists show a human pushing a "regenerate bun.lock" commit on
-# top. #334 and #341 were closed unmerged; #371 and #372 needed the same manual
-# regeneration. This workflow does that step instead of a person.
-#
-# WHY `pull_request_target`:
-#   A Dependabot-triggered `pull_request` run gets a read-only GITHUB_TOKEN and
-#   no secrets, so it cannot push the fix back. `pull_request_target` runs in the
-#   base repo's context with a writable token.
-#
-# WHY THAT IS SAFE HERE:
-#   The usual `pull_request_target` hazard is executing untrusted PR code with a
-#   write token. This job never executes PR code:
-#     * `bun install --lockfile-only` resolves registry metadata and writes
-#       bun.lock. It does not install packages and it does not run scripts.
-#       Bun additionally never runs dependency lifecycle scripts at all
-#       (`--ignore-scripts` covers only the project's own).
-#     * The workflow definition itself is read from the BASE branch under
-#       `pull_request_target`, so a PR cannot alter these steps.
-#     * `github.actor == 'dependabot[bot]'` gates the whole job, and Dependabot
-#       branches can only be created by Dependabot.
-#   No build, no test, no `bun run` — the only thing this job can produce is a
-#   lockfile.
+# WHY `pull_request` (NOT `pull_request_target`):
+#   A Dependabot-authored `pull_request_target` run gets a READ-ONLY token with
+#   no secrets — GitHub strips write access precisely when
+#   github.event.pull_request.user.login == 'dependabot[bot]', so it could never
+#   push. A plain `pull_request` run also starts read-only, but the `permissions:`
+#   key raises it to `contents: write` (the same mechanism dependabot-automerge.yml
+#   already relies on), which is what lets the push below land on the PR branch.
+#   Fork PRs cannot abuse this: GitHub caps fork tokens at read-only regardless of
+#   `permissions:`, and the `if:` gate runs the write step only for Dependabot's
+#   own same-repo branches. No PR code executes — `bun install --lockfile-only`
+#   only resolves registry metadata into bun.lock, and bun runs no dependency
+#   lifecycle scripts.
 #
 # KNOWN LIMITATION:
-#   The push below uses GITHUB_TOKEN, and GitHub deliberately does not start new
-#   workflow runs for commits pushed with it. So the lockfile lands on the PR but
-#   the red checks stay red until someone re-runs them (or Dependabot pushes
-#   again). That is still the whole manual step removed — nobody has to clone,
-#   install, commit and push. Swapping `token:` for a PAT with `contents: write`
-#   would close the last gap and make the PR go green unattended.
+#   The push uses GITHUB_TOKEN, and GitHub does not start new workflow runs for
+#   its commits, so the red checks stay red until someone re-runs them. That is
+#   still the whole manual clone/install/commit/push removed. To also re-trigger
+#   CI unattended, push with a PAT stored as a Dependabot secret (those ARE
+#   exposed to `pull_request` runs) in place of GITHUB_TOKEN.
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  pull_request:
     paths:
       - "frontend/package.json"
 
 permissions:
   contents: write
 
-# Keyed on the PR number, not github.ref: under `pull_request_target` github.ref
-# is the BASE branch, so every open Dependabot PR would share one group and
-# cancel the others.
 concurrency:
   group: dependabot-lockfile-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -60,20 +44,16 @@ concurrency:
 jobs:
   reconcile:
     name: reconcile bun.lock
-    # Matches dependabot-automerge.yml. The PR author is the right check —
-    # `github.actor` is whoever triggered the run, which on a `synchronize` can
-    # be someone other than Dependabot.
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Check out the PR's head so the lockfile is regenerated against the
-          # bumped package.json. Credentials are persisted here on purpose —
-          # the push step below needs them.
+          # Check out the PR branch itself (not the default merge ref) so the
+          # push lands back on it. Dependabot branches live in this repo, so
+          # there is no fork to target. Persisted credentials feed the push.
           ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.14"

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -1,0 +1,98 @@
+name: dependabot lockfile
+
+# Dependabot cannot maintain `frontend/bun.lock` (#373).
+#
+# Its `npm` ecosystem understands package-lock.json / yarn.lock / pnpm-lock.yaml,
+# not bun's lockfile, so every frontend dependency PR arrives with a bumped
+# `frontend/package.json` and an untouched `frontend/bun.lock`. CI then runs
+# `bun install --frozen-lockfile` in five jobs (the frontend job, the three Ruby
+# matrix legs, and coverage — the Ruby jobs build the SPA too), and all five go
+# red on a one-line dependency mismatch before a single test runs.
+#
+# This has never worked. #300 and #304 look like Dependabot updated the lockfile,
+# but their commit lists show a human pushing a "regenerate bun.lock" commit on
+# top. #334 and #341 were closed unmerged; #371 and #372 needed the same manual
+# regeneration. This workflow does that step instead of a person.
+#
+# WHY `pull_request_target`:
+#   A Dependabot-triggered `pull_request` run gets a read-only GITHUB_TOKEN and
+#   no secrets, so it cannot push the fix back. `pull_request_target` runs in the
+#   base repo's context with a writable token.
+#
+# WHY THAT IS SAFE HERE:
+#   The usual `pull_request_target` hazard is executing untrusted PR code with a
+#   write token. This job never executes PR code:
+#     * `bun install --lockfile-only` resolves registry metadata and writes
+#       bun.lock. It does not install packages and it does not run scripts.
+#       Bun additionally never runs dependency lifecycle scripts at all
+#       (`--ignore-scripts` covers only the project's own).
+#     * The workflow definition itself is read from the BASE branch under
+#       `pull_request_target`, so a PR cannot alter these steps.
+#     * `github.actor == 'dependabot[bot]'` gates the whole job, and Dependabot
+#       branches can only be created by Dependabot.
+#   No build, no test, no `bun run` — the only thing this job can produce is a
+#   lockfile.
+#
+# KNOWN LIMITATION:
+#   The push below uses GITHUB_TOKEN, and GitHub deliberately does not start new
+#   workflow runs for commits pushed with it. So the lockfile lands on the PR but
+#   the red checks stay red until someone re-runs them (or Dependabot pushes
+#   again). That is still the whole manual step removed — nobody has to clone,
+#   install, commit and push. Swapping `token:` for a PAT with `contents: write`
+#   would close the last gap and make the PR go green unattended.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "frontend/package.json"
+
+permissions:
+  contents: write
+
+# Keyed on the PR number, not github.ref: under `pull_request_target` github.ref
+# is the BASE branch, so every open Dependabot PR would share one group and
+# cancel the others.
+concurrency:
+  group: dependabot-lockfile-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  reconcile:
+    name: reconcile bun.lock
+    # Matches dependabot-automerge.yml. The PR author is the right check —
+    # `github.actor` is whoever triggered the run, which on a `synchronize` can
+    # be someone other than Dependabot.
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Check out the PR's head so the lockfile is regenerated against the
+          # bumped package.json. Credentials are persisted here on purpose —
+          # the push step below needs them.
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.14"
+      - name: regenerate bun.lock
+        run: bun install --lockfile-only
+        working-directory: frontend
+      - name: commit and push if it changed
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- frontend/bun.lock; then
+            echo "bun.lock already matches package.json — nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add frontend/bun.lock
+          git commit -m "chore(deps): reconcile bun.lock
+
+          Dependabot bumps frontend/package.json but cannot maintain
+          frontend/bun.lock, so \`bun install --frozen-lockfile\` fails in every
+          job that builds the SPA. Regenerated automatically (#373)."
+          git push


### PR DESCRIPTION
## What

Adds `.github/workflows/dependabot-lockfile.yml`, which regenerates `frontend/bun.lock` on Dependabot's frontend dependency PRs so they can go green without a human.

## Why

Dependabot's `npm` ecosystem maintains package-lock.json / yarn.lock / pnpm-lock.yaml. It does not produce bun's lockfile. So every frontend dependency PR arrives with a bumped `frontend/package.json` and an untouched `frontend/bun.lock`, and five checks go red on the mismatch before a single test runs — the frontend job plus the three Ruby matrix legs and coverage, because those build the SPA too:

```
(cd frontend && bun install --frozen-lockfile)
error: lockfile had changes, but lockfile is frozen
```

**This has never worked.** I originally filed #373 saying Dependabot used to maintain the lockfile and regressed; that was wrong and I corrected it on the issue. #300 and #304 look like Dependabot updated `bun.lock`, but their commit lists tell the real story:

```
dependabot[bot] | chore(deps): bump @solidjs/router
sebi            | chore(deps): regenerate bun.lock for @solidjs/router 0.16.2
```

#334 and #341 were closed unmerged. #371 and #372 needed the same manual regeneration this week. The step was always a person; this workflow does it instead.

## Why `pull_request_target`, and why it is safe here

A Dependabot-triggered `pull_request` run gets a read-only `GITHUB_TOKEN` and no secrets, so it cannot push a fix back. `pull_request_target` runs in the base repo context with a writable token.

The usual hazard with that trigger is running untrusted PR code with write access. This job cannot:

- `bun install --lockfile-only` resolves registry metadata and writes `bun.lock`. It installs nothing and runs no scripts. Bun additionally never runs *dependency* lifecycle scripts at all — `--ignore-scripts` covers only the project's own.
- There is no build, no test, no `bun run`. The only artifact the job can produce is a lockfile.
- Under `pull_request_target` the workflow definition is read from the **base** branch, so a PR cannot edit these steps.
- The job is gated on `github.event.pull_request.user.login == 'dependabot[bot]'`, matching `dependabot-automerge.yml`. That is deliberately the PR **author**, not `github.actor`, which on a `synchronize` can be someone else.

## Known limitation, stated up front

The push uses `GITHUB_TOKEN`, and GitHub deliberately does not start new workflow runs for commits pushed with it. So the lockfile lands on the PR but the existing red checks stay red until someone re-runs them. That still removes the entire manual step — nobody clones, installs, commits and pushes. Swapping the checkout `token:` for a PAT with `contents: write` would close the last gap and let the PR go green unattended; that needs a secret, so it is left as a follow-up rather than assumed.

## Alternative considered

Dropping `package-ecosystem: npm` for `/frontend` from `dependabot.yml` would also stop the broken PRs, and I floated it in the issue. Rejected: it gives up automated frontend dependency updates — including security ones — on a gem whose dashboard ships to users. Fixing the lane beats deleting it.

## Verification

Simulated a Dependabot PR on a clean tree by bumping only `frontend/package.json`:

```
=== frozen install now fails (the bug) ===
error: lockfile had changes, but lockfile is frozen
=== reconcile with --lockfile-only ===
Saved bun.lock (270 packages) [9.00ms]
=== frozen install now passes ===
8 packages installed [73.00ms]
```

`YAML.load_file` parses the workflow; the job's `if`, concurrency key and step list were asserted from the parsed document.

One thing I could **not** verify: the workflow wiring itself. `pull_request_target` workflows run from the base branch, so this only exercises for real once merged, on the next Dependabot frontend PR. The reconcile command it runs is the part proven above.

## Note on the concurrency key

Keyed on `github.event.pull_request.number` rather than `github.ref`. Under `pull_request_target`, `github.ref` is the *base* branch, so the `${{ github.workflow }}-${{ github.ref }}` pattern used in `test.yml` would put every open Dependabot PR in one group and have them cancel each other.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788676800&installation_model_id=11168&pr_number=385&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F385&signature=cb0fa989063868c1ae807a68934ca86e7b7aa507bfebee2d5a428053cb8052fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated lockfile reconciliation for qualifying dependency update pull requests.
  * Lockfile changes are regenerated and committed automatically when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->