### PR TITLE
test: prime the script cache in ClientBatchPipelineTest (closes #386)

### DIFF
--- a/test/unit/client_batch_pipeline_test.rb
+++ b/test/unit/client_batch_pipeline_test.rb
@@ -21,6 +21,17 @@ class ClientBatchPipelineTest < Wurk::Test::UnitCase
   def setup
     super
     @pool       = Wurk.configuration.redis_pool
+    # Prime the server-wide EVALSHA cache, exactly as ChildBoot does per fork.
+    # Nothing else in the suite guarantees it: the cache only warms as a side
+    # effect of some earlier test's inline NOSCRIPT recovery, and with
+    # `parallelize_me!` plus a random --seed whether that happened before this
+    # file runs is luck. Cold, two things break here — the raw `conn.pipelined`
+    # in the per-job-parity test bypasses `eval_batched_slice`, so its NOSCRIPT
+    # has no rescue and errors the test; and in the round-trip tests the
+    # recovery fires and spends a `script_load_all` plus a replay pipeline,
+    # turning `assert_equal 1, @probe.pipelines` into 3. Same one-liner the
+    # limiter and lua suites already use in their own setup.
+    @pool.with { |c| Wurk::Lua::Loader.script_load_all(c) }
     @queue      = "bp-q-#{Process.pid}-#{object_id}"
     @class_name = "BatchPipelineJob@#{Process.pid}-#{object_id}"
     @bid        = "BP-#{Process.pid}-#{object_id}"


### PR DESCRIPTION
## What

Primes the server-wide EVALSHA cache in `ClientBatchPipelineTest#setup`, the way five limiter suites and `lua_test.rb` already do. Fixes the flake filed as #386, which has now failed CI on two unrelated PRs today (#384 and #383).

## Why

The file assumed a warm script cache and never primed one. In production `ChildBoot` calls `script_load_all` once per fork. In the suite nothing does — the cache only warms as a side effect of some earlier test's inline NOSCRIPT recovery, and with `parallelize_me!` plus a random `--seed`, whether that happened before this file runs is luck.

Cold, it breaks **two** different ways, which is why #386 presented as three unrelated failures:

**1. A raw pipeline with no rescue.** `test_pipelined_batch_push_matches_per_job_redis_state` deliberately drives `conn.pipelined` directly, to compare pipelined against per-job Redis state. That bypasses `Client#eval_batched_slice`, which is where the NOSCRIPT recovery lives. `client.rb` states the trap outright:

> A `NOSCRIPT` from EVALSHA surfaces only at pipeline finalize — never to `eval_cached`'s inline rescue

So the error escapes and the test errors out. That is the failure on #383:

```
Error: ClientBatchPipelineTest#test_pipelined_batch_push_matches_per_job_redis_state:
RedisClient::NoScriptError: NOSCRIPT No matching script. Please use EVAL. (redis://localhost:6379/1)
```

**2. Inflated round-trip counts.** The other tests assert on how many pipelines were opened. Cold, `eval_batched_slice`'s recovery fires and spends a `script_load_all` plus a replay pipeline — so `assert_equal 1, @probe.pipelines` sees 3. That is the `Expected: 1, Actual: 3` failure on #384.

Both are the same missing precondition.

## The fix

```ruby
@pool.with { |c| Wurk::Lua::Loader.script_load_all(c) }
```

Already the established pattern here — `limiter_{bucket,concurrent,leaky,points,window}_test.rb` and `lua_test.rb` each call exactly this in their own `setup`. The EVALSHA cache is server-wide, so priming one pooled connection covers every parallel worker regardless of which logical DB it owns, and `teardown`'s `FLUSHDB` clears keys rather than scripts, so it stays warm.

`test_noscript_replays_only_the_failing_slice` is unaffected — it simulates NOSCRIPT through a `ProbeConn` double rather than through real cache state, so it still exercises the recovery path exactly as before.

## Verification

Reproduced the flake **deterministically** by flushing the server-wide cache first, rather than waiting for CI to lose the race:

```
$ redis-cli SCRIPT FLUSH && bin/rake test TEST=test/unit/client_batch_pipeline_test.rb
   without this change: 9 runs, 2 failures   (Expected: 2, Actual: 4)
   with this change:    9 runs, 18 assertions, 0 failures, 0 errors

$ redis-cli SCRIPT FLUSH && bin/rake test
   3137 runs, 6936 assertions, 0 failures, 0 errors, 6 skips
```

Test-only change; no `lib/` code touched. The production NOSCRIPT recovery in `eval_batched_slice` is correct as written and is deliberately left alone — this fixes the test's missing precondition, not the behaviour under test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788678793&installation_model_id=11168&pr_number=387&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F387&signature=acb0791f3a5f459bfcc528181a200ffaca2244232986031518a58f91652aa090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup reliability by preloading required Redis scripts before each test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->