### PR TITLE
fix: close leaks + resource lifecycle races (RAII pass)

### DIFF
--- a/app/controllers/concerns/wurk/stream_concurrency_guard.rb
+++ b/app/controllers/concerns/wurk/stream_concurrency_guard.rb
@@ -7,28 +7,45 @@ module Wurk
   # we 503 with Retry-After — the SPA's EventSource reconnects (and its polling
   # fallback honors Retry-After) once a slot frees. Per-process is the right
   # scope: it's this process's own thread pool we're protecting.
+  #
+  # Slots are held as thread references rather than tallied in a counter so the
+  # cap can heal itself. A stream whose thread is killed mid-flight never
+  # reaches the `ensure` below (Puma hard-reaps worker threads past
+  # `force_shutdown_after`, and a thread killed inside an uninterruptible read
+  # can skip its ensure), which a counter would record as a slot held by nobody
+  # — ten of those and `/api/stream` 503s for the life of the process. A dead
+  # holder is instead evicted by the next acquire.
   module StreamConcurrencyGuard
     extend ActiveSupport::Concern
 
     MAX_CONCURRENT_STREAMS = 10
     RETRY_AFTER_SECONDS = 3
 
-    @open = 0
+    @holders = []
     @lock = Mutex.new
 
     class << self
-      # Reserve a stream slot; false when the cap is already reached.
+      # Reserve a stream slot for the calling thread; false when the cap is
+      # already reached by threads that are still alive.
       def acquire
         @lock.synchronize do
-          return false if @open >= MAX_CONCURRENT_STREAMS
+          @holders.keep_if(&:alive?)
+          return false if @holders.size >= MAX_CONCURRENT_STREAMS
 
-          @open += 1
+          @holders << Thread.current
           true
         end
       end
 
+      # Drops one slot held by the calling thread. Acquire and release always
+      # bracket a single block on one thread (`#with_stream_slot`), so a call
+      # from a thread holding nothing is a no-op rather than a slot taken away
+      # from whoever is actually streaming.
       def release
-        @lock.synchronize { @open -= 1 if @open.positive? }
+        @lock.synchronize do
+          index = @holders.rindex(Thread.current)
+          @holders.delete_at(index) if index
+        end
       end
     end
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -402,7 +402,11 @@ Setting `config.redis[:size]` pins **the main pool only**; the fetch pool
 always tracks `concurrency` and the web pool always tracks `web_pool_size`.
 
 Redis connections are **never shared across forks**: the swarm parent calls
-`reset_redis_pools!` before forking and each child rebuilds lazily.
+`reset_redis_pools!` before forking and each child rebuilds lazily. A graceful
+shutdown releases them too — `Launcher#stop` resets the pools in its teardown
+tail, so a host that outlives Wurk (Puma, a rake task, a test) gets its sockets
+back instead of holding one main + one fetch pool per capsule open forever. The
+next checkout rebuilds, so a stop/start cycle is safe.
 
 ### Transient-failure handling
 

--- a/lib/wurk/capsule.rb
+++ b/lib/wurk/capsule.rb
@@ -30,8 +30,15 @@ module Wurk
       @mode = :strict
       @weights = { 'default' => 0 }
       @fetcher = nil
-      @redis_pool = nil
-      @fetch_redis_pool = nil
+      # One mutable Hash rather than two ivars: the pools are the only part of a
+      # capsule that legitimately changes after Configuration#freeze! — fork
+      # closes them, Launcher#stop releases them, an embedded host that boots
+      # again rebuilds them. `Object#freeze` is shallow, so the Hash stays
+      # writable and freezing a capsule keeps meaning "no more configuration"
+      # instead of "these sockets are yours forever". Before this, a reset on a
+      # frozen capsule disconnected the pool and then raised FrozenError on the
+      # memo, leaving `redis_pool` answering with a shut-down pool for good.
+      @pools = {}
       @client_chain = nil
       @server_chain = nil
     end
@@ -121,7 +128,7 @@ module Wurk
     MIN_POOL_SIZE = 10
 
     def redis_pool
-      @redis_pool ||= build_pool(size: main_pool_size, name: "#{@name}-main")
+      @pools[:main] ||= build_pool(size: main_pool_size, name: "#{@name}-main")
     end
 
     # Dedicated pool for the reliable fetcher's blocking BLMOVE: one slot per
@@ -129,18 +136,17 @@ module Wurk
     # fetch at once. Keeping fetch off the main pool is what lets an idle worker
     # hold zero main-pool connections again.
     def fetch_redis_pool
-      @fetch_redis_pool ||= build_pool(size: @concurrency, name: "#{@name}-fetch")
+      @pools[:fetch] ||= build_pool(size: @concurrency, name: "#{@name}-fetch")
     end
 
-    # Disconnect and drop cached pools. Called by Wurk::Swarm just before
-    # fork (parent side: close inherited sockets) and just after fork
-    # (child side: rebuild lazily). Connection_pool#shutdown is terminal,
-    # so dropping the reference is required — `redis_pool` will rebuild.
+    # Disconnect and drop cached pools. Called by Wurk::Swarm just before fork
+    # (parent side: close inherited sockets), just after fork (child side:
+    # rebuild lazily), and by Launcher#stop (release what this process held).
+    # Connection_pool#shutdown is terminal, so dropping the reference is
+    # required — `redis_pool` will rebuild.
     def reset_redis_pools!
-      @redis_pool&.disconnect!
-      @redis_pool = nil
-      @fetch_redis_pool&.disconnect!
-      @fetch_redis_pool = nil
+      @pools.each_value(&:disconnect!)
+      @pools.clear
     end
 
     def redis(idempotent: false, &)

--- a/lib/wurk/client/buffered.rb
+++ b/lib/wurk/client/buffered.rb
@@ -119,6 +119,13 @@ module Wurk
             @overflow_mode = nil
             @buffer_client_factory = nil
           end
+          # Stop before dropping: an unstopped drainer thread survives with
+          # its factory nil'd out from under it and ticks forever against
+          # nothing, leaking the thread and everything its closure retains.
+          install_mutex.synchronize do
+            @drainer&.stop
+            @drainer = nil
+          end
         end
 
         # Fork hook, called from the `Process._fork` prepend below and from

--- a/lib/wurk/fetcher/reaper.rb
+++ b/lib/wurk/fetcher/reaper.rb
@@ -3,6 +3,7 @@
 require_relative '../component'
 require_relative '../keys'
 require_relative '../middleware/poison_pill'
+require_relative '../timer_loop'
 
 module Wurk
   class Fetcher
@@ -91,13 +92,22 @@ module Wurk
         @thread
       end
 
+      # Bounded at TimerLoop::JOIN_TIMEOUT like every other periodic component.
+      # The full-keyspace sweep is exactly the tick that outlasts a stop: it
+      # SCANs the whole `queue:*|*` keyspace and drains what it finds, so on a
+      # large or slow Redis it can still be running when shutdown lands. Waiting
+      # it out held the entire process's teardown open past the swarm parent's
+      # SHUTDOWN_GRACE — which SIGKILLs the child mid-drain, the one outcome
+      # this component exists to recover from. A straggler is left running
+      # instead — and still referenced, like every other periodic component, so
+      # a restart after a timed-out stop can't spawn a second sweep loop
+      # alongside it. Its own tick_once rescues and reports.
       def stop
         @mutex.synchronize do
           @done = true
           @sleeper.signal
         end
-        @thread&.join
-        @thread = nil
+        @thread = nil if @thread&.join(TimerLoop::JOIN_TIMEOUT)
       end
 
       def running?

--- a/lib/wurk/heartbeat.rb
+++ b/lib/wurk/heartbeat.rb
@@ -190,7 +190,7 @@ module Wurk
 
     def cpu_model
       if ::File.exist?('/proc/cpuinfo')
-        line = ::File.foreach('/proc/cpuinfo').find { |l| l.start_with?('model name') }
+        line = ::File.open('/proc/cpuinfo') { |f| f.find { |l| l.start_with?('model name') } }
         line&.split(':', 2)&.last&.strip
       else
         model = `sysctl -n machdep.cpu.brand_string 2>/dev/null`.strip
@@ -202,7 +202,7 @@ module Wurk
 
     def memory_total_kb
       if ::File.exist?('/proc/meminfo')
-        line = ::File.foreach('/proc/meminfo').find { |l| l.start_with?('MemTotal') }
+        line = ::File.open('/proc/meminfo') { |f| f.find { |l| l.start_with?('MemTotal') } }
         line.to_s[/\d+/].to_i
       else
         `sysctl -n hw.memsize 2>/dev/null`.to_i / 1024

--- a/lib/wurk/launcher.rb
+++ b/lib/wurk/launcher.rb
@@ -15,6 +15,7 @@ require_relative 'metrics/flusher'
 require_relative 'history'
 require_relative 'fetcher/reaper'
 require_relative 'timer_loop'
+require_relative 'shutdown_gate'
 
 module Wurk
   # Top-level supervisor inside each worker process. Owns the Manager pool
@@ -60,6 +61,7 @@ module Wurk
       # beating would never publish quiet=true and would expire out of the live
       # set (#236). Only #stop ends the beat, by terminating @beat_timer.
       @done = false
+      @shutdown_gate = ShutdownGate.new
       @beat_timer = TimerLoop.new(BEAT_PAUSE)
       @managers = build_managers
       build_loops
@@ -131,20 +133,35 @@ module Wurk
       fire_event(:quiet, reverse: true)
     end
 
-    # Graceful shutdown. Deadline is monotonic so wall-clock skew can't
-    # extend it. Managers stop in parallel threads so a slow capsule
-    # doesn't block its siblings — and each drain is guarded, because a
-    # capsule that blows up mid-drain (Redis down during bulk_requeue) used
-    # to surface out of `join` and skip the whole teardown tail, leaving the
+    # Graceful shutdown, single-shot: several requests can be in flight at once
+    # (a dashboard-queued TERM, the embedded host's own `Embedded#stop`, a
+    # Manager that can no longer hold its concurrency), so the first caller
+    # drains and the rest wait it out — see ShutdownGate. Deadline is monotonic
+    # so wall-clock skew can't extend it. Managers stop in parallel threads so a
+    # slow capsule doesn't block its siblings — and each drain is guarded,
+    # because a capsule that blows up mid-drain (Redis down during bulk_requeue)
+    # used to surface out of `join` and skip the whole teardown tail, leaving the
     # leader lock held, the process listed as live, and its port open.
+    #
+    # The joins get one shared budget of `deadline + TimerLoop::JOIN_TIMEOUT`,
+    # not an open-ended wait. Manager#stop is meant to run a little past the
+    # deadline — on expiry it bulk_requeues the in-flight UnitsOfWork, kills the
+    # threads and gives them a ~3s window to run their `ensure` blocks — but
+    # past that it is wedged (a `fetcher.terminate` / `bulk_requeue` parked on a
+    # Redis that stopped answering), and every further second spent waiting
+    # comes out of the teardown tail below, which the swarm parent only allows
+    # `shutdown_timeout + Swarm::SHUTDOWN_GRACE` for before it SIGKILLs us
+    # mid-drain.
     def stop
-      deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + (@config[:timeout] || 25)
-      quiet
-      stoppers = @managers.map { |m| Thread.new { teardown_step('manager') { m.stop(deadline) } } }
-      fire_event(:shutdown, reverse: true)
-      stoppers.each(&:join)
-    ensure
-      release_components
+      @shutdown_gate.run do
+        deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + (@config[:timeout] || 25)
+        quiet
+        stoppers = @managers.map { |m| Thread.new { teardown_step('manager') { m.stop(deadline) } } }
+        fire_event(:shutdown, reverse: true)
+        @shutdown_gate.join_within(stoppers, deadline + TimerLoop::JOIN_TIMEOUT)
+      ensure
+        release_components
+      end
     end
 
     def stopping?
@@ -206,12 +223,14 @@ module Wurk
       %i[stop_heartbeat clear_heartbeat].each { |step| teardown_step(step) { send(step) } }
       # Unguarded: fire_event already reports and skips past a raising hook.
       fire_event(:exit, reverse: true)
-      # Embedded only: a swarm child or standalone process exits right after
-      # #stop anyway, so disconnecting here would just make every unit test
-      # that inspects Redis post-stop rebuild a pool for no reason. Embedded
-      # hosts (Puma, a rake task) keep running and can `run` again later —
-      # without this a stop-then-run cycle doubles the live socket set.
-      teardown_step('redis-pools') { @config.reset_redis_pools! } if @embedded
+      # Unconditional. A swarm child or standalone process exits right after
+      # #stop, so for those it only closes sockets the kernel was about to close
+      # anyway — but every other driver survives us: an embedded host (Puma, a
+      # rake task) that boots a fresh Launcher later, and anything driving
+      # Launcher directly. Skipping those leaked one main + one fetch pool per
+      # capsule, live, for the life of the host. Idempotent: `reset_redis_pools!`
+      # drops the memo, so the next checkout rebuilds.
+      teardown_step('redis-pools') { @config.reset_redis_pools! }
     ensure
       # In an ensure of its own, not merely a guarded step: a leaked TCPServer
       # FD survives even a non-StandardError unwind (a second TERM landing
@@ -356,8 +375,15 @@ module Wurk
     # concurrency. Standalone hands off to the installed TERM trap; embedded
     # owns no traps, so it drains in place — on its own thread, because callers
     # may be a thread `stop` itself joins (the heartbeat) or kills (a Processor).
+    #
+    # That thread is spawned once and retained by the gate: every later request
+    # rides the same drain instead of leaving another unreferenced `stop`
+    # running behind it. Returned so a caller that can afford to wait (a test,
+    # a host teardown) has something to join.
     def request_shutdown
-      @embedded ? Thread.new { stop } : redeliver('TERM')
+      return redeliver('TERM') unless @embedded
+
+      @shutdown_gate.runner { safe_thread('launcher-stop') { stop } }
     end
 
     # Separate method so tests can stub it — really sending TERM/TSTP would

--- a/lib/wurk/leader.rb
+++ b/lib/wurk/leader.rb
@@ -5,6 +5,7 @@ require 'socket'
 require_relative 'component'
 require_relative 'lua'
 require_relative 'pool_checkout'
+require_relative 'timer_loop'
 
 module Wurk
   # Cluster leader election via Redis `SET NX EX`. Single-leader-per-cluster
@@ -148,14 +149,20 @@ module Wurk
       @thread
     end
 
+    # Bounded at TimerLoop::JOIN_TIMEOUT like every other periodic component: a
+    # tick parked on a wedged Redis (the campaign is a `SET NX EX`, so it waits
+    # out the socket timeouts) must not hold the whole process's teardown open —
+    # the swarm parent SIGKILLs a child that overruns its shutdown grace. The
+    # CAS release below runs either way; the loop's own trailing release makes
+    # a straggler's second attempt a no-op. A straggler also stays referenced,
+    # so a restart after a timed-out stop can't campaign twice in parallel.
     def stop
       thread = @mutex.synchronize do
         @done = true
         @sleeper.signal
         @thread
       end
-      thread&.join
-      @mutex.synchronize { @thread = nil }
+      @mutex.synchronize { @thread = nil } if thread.nil? || thread.join(TimerLoop::JOIN_TIMEOUT)
       release
     end
 

--- a/lib/wurk/middleware/poison_pill.rb
+++ b/lib/wurk/middleware/poison_pill.rb
@@ -129,11 +129,32 @@ module Wurk
       # Register a callback fired when a poison pill is detected. Callbacks
       # receive a single Hash `{jid:, klass:, count:, queue:}` — matches
       # Sidekiq Pro's documented shape so consumers can drop in unchanged.
+      #
+      # Dedups by callable identity — an initializer that re-runs (Rails
+      # code reloading, a re-required file) and hands back the *same* stored
+      # Proc each time won't accumulate duplicate closures (and the bindings
+      # they retain). A fresh block literal per call still registers
+      # separately, same as before. Returns a {Registration} the caller can
+      # `#remove!` to deregister explicitly.
       def on_poison(&block)
         raise ArgumentError, 'block required' unless block
 
-        callbacks << block
-        block
+        callbacks << block unless callbacks.any? { |cb| cb.equal?(block) }
+        Registration.new(callbacks, block)
+      end
+
+      # Handle returned by {on_poison}. Removing it is idempotent and safe
+      # even after a {reset!} discarded the underlying list.
+      class Registration
+        def initialize(list, callback)
+          @list = list
+          @callback = callback
+        end
+
+        def remove!
+          @list.delete(@callback)
+          nil
+        end
       end
 
       def callbacks

--- a/lib/wurk/processor.rb
+++ b/lib/wurk/processor.rb
@@ -139,6 +139,19 @@ module Wurk
         @lock.synchronize { @work.delete(tid) }
       end
 
+      # RAII: publish for the duration of the block, always retract. The write
+      # lives *inside* this method's ensure frame on purpose — with the `set`
+      # one line above a `begin`, an async raise landing in that gap (a host
+      # timeout's `Thread#raise`, say) escapes the ensure and strands the
+      # entry for the life of the process: the payload String stays reachable
+      # and every heartbeat reports the thread as busy.
+      def track(tid, hash)
+        set(tid, hash)
+        yield
+      ensure
+        delete(tid)
+      end
+
       def dup
         @lock.synchronize { @work.dup }
       end
@@ -303,17 +316,14 @@ module Wurk
     # Heartbeat can mirror it into Redis (`<identity>:work`), and increments
     # PROCESSED/FAILURE counters around the inner block.
     def stats(jobstr, queue)
-      id = tid
       run_at = ::Process.clock_gettime(::Process::CLOCK_REALTIME, :second)
-      WORK_STATE.set(id, queue: queue, payload: jobstr, run_at: run_at)
-      begin
+      WORK_STATE.track(tid, queue: queue, payload: jobstr, run_at: run_at) do
         yield
       rescue Exception # rubocop:disable Lint/RescueException
         FAILURE.incr
         raise
       ensure
         PROCESSED.incr
-        WORK_STATE.delete(id)
       end
     end
   end

--- a/lib/wurk/shutdown_gate.rb
+++ b/lib/wurk/shutdown_gate.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Wurk
+  # The two rules a process teardown obeys: it runs exactly once, and it never
+  # waits on a thread without a bound. Same reason TimerLoop exists — the
+  # mutex/clock dance was going to be hand-rolled in the caller, so it lives in
+  # one place with a name instead.
+  #
+  # A worker process can have several shutdown requests in flight at once — a
+  # dashboard-queued TERM, an embedded host calling `stop`, a Manager that can
+  # no longer hold its concurrency — and running the teardown twice double-fires
+  # the `:exit` hooks and tears the Redis pool down under the thread still using
+  # it.
+  #
+  #   @gate = Wurk::ShutdownGate.new
+  #   def stop = @gate.run { ...teardown... }
+  #
+  # The first caller runs the block; the rest block until it returns and then get
+  # nil. `Queue#close` releases every waiter at once and makes every later call
+  # return immediately, so a `stop` landing after the teardown finished is a
+  # no-op rather than a second one.
+  #
+  # The lock is only ever held for the bookkeeping, never across the teardown —
+  # a caller that must not block (a dying Processor thread, the heartbeat the
+  # teardown is about to join) has to be able to ask for a shutdown that is
+  # already under way without deadlocking against it.
+  class ShutdownGate
+    def initialize
+      @mutex = ::Mutex.new
+      @owner = nil
+      @runner = nil
+      @done = ::Queue.new
+    end
+
+    def run
+      return await unless claim
+
+      begin
+        yield
+      ensure
+        @done.close
+      end
+    end
+
+    # Memoizes the one background thread a caller uses to reach #run from
+    # somewhere it cannot block. Spawned once: a second request rides the first
+    # teardown instead of leaving another unreferenced one running behind it.
+    def runner
+      @mutex.synchronize { @runner ||= yield }
+    end
+
+    # Join every thread inside one shared monotonic `budget` (an absolute
+    # CLOCK_MONOTONIC instant), so N wedged threads cost the budget once rather
+    # than N times. A non-positive remainder polls without waiting, which is the
+    # right answer once the budget is spent: the straggler is left to the process
+    # exit rather than holding the whole teardown open behind it.
+    def join_within(threads, budget)
+      threads.each { |t| t.join([budget - ::Process.clock_gettime(::Process::CLOCK_MONOTONIC), 0].max) }
+    end
+
+    private
+
+    def claim
+      @mutex.synchronize do
+        return false if @owner
+
+        @owner = Thread.current
+        true
+      end
+    end
+
+    # The owner re-entering (a `:shutdown` hook that calls `stop`) cannot wait on
+    # a teardown it is inside of, so it returns instead of deadlocking.
+    def await
+      @done.pop unless @mutex.synchronize { @owner } == Thread.current
+      nil
+    end
+  end
+end

--- a/lib/wurk/swarm.rb
+++ b/lib/wurk/swarm.rb
@@ -54,6 +54,12 @@ module Wurk
     SUPERVISOR_POOL_SIZE = 1
     SUPERVISOR_POOL_NAME = 'swarm-supervisor'
 
+    # Poll budget for the post-SIGKILL reap sweep (250ms). Deliberately far
+    # shorter than any drain deadline — it runs after the fleet is already dead
+    # and races a kernel teardown measured in microseconds.
+    HARD_KILL_REAP_ATTEMPTS = 25
+    HARD_KILL_REAP_INTERVAL = 0.01
+
     # Children each hard_shutdown after their own drain deadline (bulk_requeue
     # + a 3s ensure window + heartbeat cleanup); the parent must not SIGKILL
     # them mid-tail, so its own wait always extends past theirs by this much.
@@ -375,18 +381,29 @@ module Wurk
     end
 
     # Reap every exited child this tick (not one), so a fleet-wide death
-    # recovers in parallel rather than one child per SUPERVISE_TICK. ECHILD
-    # (momentarily no children — all crashed and awaiting backoff) is not a stop
-    # condition: the swarm only stops on an explicit TERM/INT.
+    # recovers in parallel rather than one child per SUPERVISE_TICK.
+    #
+    # Waits on the KNOWN pids, one by one — never `wait2(-1)`. Embedded
+    # (`RailsBoot.boot_swarm`) the supervisor shares a process with the host
+    # app, and a wildcard wait consumes the exit status of ANY child: a Puma
+    # worker, a `system`/`Open3`/`spawn` subprocess. The host's own
+    # `Process.wait` then fails with ECHILD and its subprocess bookkeeping
+    # breaks. A pid the swarm did not fork is never its business.
     def reap_children
-      loop do
-        pid, status = ::Process.wait2(-1, ::Process::WNOHANG)
-        break unless pid
+      child_pids.each { |pid| reap_child(pid) }
+    end
 
-        on_child_exit(pid, status)
-      end
+    # ECHILD on a pid the swarm forked means someone else already reaped it —
+    # an embedded host with its own wildcard reaper is exactly the mirror of the
+    # bug above. Retire the slot with an unknown status rather than skip it: the
+    # child is gone either way, and leaving the entry in the table wedges the
+    # slot forever (never respawned because it still looks alive, never reaped
+    # because there is nothing left to reap).
+    def reap_child(pid)
+      reaped, status = ::Process.wait2(pid, ::Process::WNOHANG)
+      on_child_exit(pid, status) if reaped
     rescue Errno::ECHILD
-      nil
+      on_child_exit(pid, nil)
     end
 
     def on_child_exit(pid, status)
@@ -396,7 +413,7 @@ module Wurk
         return if @restart.claim_exit(pid)
 
         if @stopping
-          logger.info { "swarm: child #{pid} exited (status=#{status.exitstatus})" }
+          logger.info { "swarm: child #{pid} exited (status=#{status&.exitstatus})" }
         else
           schedule_respawn(pid, status, meta)
         end
@@ -411,7 +428,7 @@ module Wurk
       idx = meta[:index]
       delay = @respawn_backoff.fail(idx, lifetime: monotonic - meta[:spawned_at])
       logger.warn do
-        "swarm: child #{pid} died (status=#{status.exitstatus}); respawning slot #{idx} in #{delay}s"
+        "swarm: child #{pid} died (status=#{status&.exitstatus}); respawning slot #{idx} in #{delay}s"
       end
     end
 
@@ -495,11 +512,42 @@ module Wurk
     # Kill and forget atomically: a child landing in the table between the walk
     # and the clear would be dropped from it without ever being signalled —
     # untracked and still alive.
+    #
+    # SIGKILL only schedules the teardown; the pid stays a zombie until someone
+    # waits on it, and this is the swarm's last reap — `shutdown` has already
+    # left the supervise loop behind. Standalone the exiting process hands its
+    # zombies to init, but embedded (`RailsBoot.boot_swarm`) the host lives on
+    # and carries one zombie per straggler for the rest of its life. The sweep
+    # runs on the pids taken under the lock but outside it: it sleeps, and the
+    # child table is never held across a sleep.
     def hard_kill_stragglers
-      @lock.synchronize do
-        @children.each_key { |pid| safe_kill(pid, 'KILL') }
+      killed = @lock.synchronize do
+        pids = @children.keys
+        pids.each { |pid| safe_kill(pid, 'KILL') }
         @children.clear
+        pids
       end
+      reap_killed(killed)
+    end
+
+    # Bounded and best-effort: SIGKILL is asynchronous, so poll rather than
+    # block on a pid that may be wedged in uninterruptible sleep. A straggler
+    # still unreaped when the budget runs out is dropped exactly as before —
+    # the drain must not stall on it.
+    def reap_killed(pids)
+      pending = pids
+      HARD_KILL_REAP_ATTEMPTS.times do
+        pending = pending.reject { |pid| reaped?(pid) }
+        break if pending.empty?
+
+        sleep HARD_KILL_REAP_INTERVAL
+      end
+    end
+
+    def reaped?(pid)
+      !::Process.wait2(pid, ::Process::WNOHANG).nil?
+    rescue Errno::ECHILD
+      true
     end
 
     # Has the child written its first heartbeat yet? One non-blocking SISMEMBER,

--- a/lib/wurk/web/config.rb
+++ b/lib/wurk/web/config.rb
@@ -196,15 +196,19 @@ module Wurk
       end
 
       # Builds the host-middleware chain wrapping `inner`, memoized against
-      # the middleware list it was built from — `middlewares` is the live
-      # array (upstream surface), so direct mutation after the first request
-      # triggers a rebuild instead of silently serving the stale chain.
-      # Production builds exactly once at boot; the per-request comparison is
-      # an == over a handful of entries.
+      # `[inner, middlewares]` — `middlewares` is the live array (upstream
+      # surface), so direct mutation after the first request triggers a
+      # rebuild instead of silently serving the stale chain. Keying on
+      # `inner` too matters for the same reason: memoizing on the
+      # middleware list alone pins whichever `inner` app the *first* caller
+      # passed, forever — a second mount (e.g. per-test Rack app, or a
+      # second engine mount) would silently get served the first one's app.
+      # Production builds exactly once at boot; the per-request comparison
+      # is an == over a handful of entries plus one object identity check.
       def rack_app(inner)
-        return @rack_app if @rack_app && @rack_app_stack == @middlewares
+        return @rack_app if @rack_app && @rack_app_key == [inner, @middlewares]
 
-        @rack_app_stack = @middlewares.dup
+        @rack_app_key = [inner, @middlewares.dup]
         stack = @middlewares
         @rack_app = ::Rack::Builder.new do
           stack.each { |middleware, args, block| use(middleware, *args, &block) }

--- a/test/engine/stream_concurrency_guard_test.rb
+++ b/test/engine/stream_concurrency_guard_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require_relative '../engine_test_helper'
+
+# Pins the self-healing half of the SSE concurrency cap (#101). A stream whose
+# thread is killed mid-flight never runs the `ensure` in #with_stream_slot, so
+# the guard has to reclaim the slot on its own — otherwise MAX_CONCURRENT_STREAMS
+# such deaths 503 `/api/stream` for the rest of the process's life.
+class StreamConcurrencyGuardTest < Wurk::Test::EngineCase
+  parallelize_me!
+
+  GUARD = ::Wurk::StreamConcurrencyGuard
+  CAP = GUARD::MAX_CONCURRENT_STREAMS
+
+  # Slots are thread-scoped, so this drops everything this test thread holds
+  # however the test exited; slots held by dead threads clean themselves up.
+  def teardown
+    CAP.times { GUARD.release }
+  ensure
+    super
+  end
+
+  def test_dead_holder_frees_its_slot
+    fill_cap_with_dead_holders
+
+    assert GUARD.acquire, 'a slot whose holder died must be reclaimed'
+  end
+
+  def test_every_dead_holder_is_reclaimed_not_just_one
+    fill_cap_with_dead_holders
+
+    assert_equal CAP, CAP.times.count { GUARD.acquire }, 'all leaked slots must come back'
+    refute GUARD.acquire, 'the cap must still hold once the reclaimed slots are taken'
+  end
+
+  # The cap only self-heals for holders that are gone; a live stream keeps its
+  # slot, which is the whole point of the bound.
+  def test_live_holders_keep_their_slots
+    gate = Queue.new
+    ready = Queue.new
+    threads = Array.new(CAP) do
+      Thread.new do
+        ready << GUARD.acquire
+        gate.pop
+      end
+    end
+
+    CAP.times { assert ready.pop, 'each parked thread should get a slot' }
+
+    refute GUARD.acquire, 'live holders must still count against the cap'
+  ensure
+    CAP.times { gate << :go }
+    threads&.each(&:join)
+  end
+
+  # Acquire/release bracket one block on one thread; a release from anywhere
+  # else must not take a slot away from the thread that is streaming.
+  def test_release_from_another_thread_leaves_the_slot_with_its_owner
+    assert GUARD.acquire
+    Thread.new { GUARD.release }.join
+
+    assert_equal(CAP - 1, (CAP - 1).times.count { GUARD.acquire })
+    refute GUARD.acquire, 'a foreign release must not free the slot its owner still holds'
+  end
+
+  def test_release_without_a_slot_does_not_widen_the_cap
+    3.times { GUARD.release }
+
+    assert_equal(CAP, CAP.times.count { GUARD.acquire })
+    refute GUARD.acquire, 'stray releases must not hand out extra capacity'
+  end
+
+  # The user-visible fix: every slot leaked by a hard-reaped thread, yet the
+  # next request still streams instead of 503ing forever.
+  def test_stream_still_serves_after_every_slot_leaked
+    fill_cap_with_dead_holders
+
+    get '/wurk/api/stream?max_duration=0&tick=0'
+
+    assert_equal 200, last_response.status, "non-200: #{last_response.body[0, 300]}"
+    assert_includes last_response.body, 'event: stats'
+  end
+
+  private
+
+  # Reproduces the leak: each thread takes a slot and dies without releasing.
+  def fill_cap_with_dead_holders
+    threads = Array.new(CAP) { Thread.new { GUARD.acquire } }
+    threads.each(&:join)
+
+    assert threads.all? { |thread| thread.value == true }, 'setup should have filled every slot'
+  end
+end

--- a/test/integration/swarm_boot_test.rb
+++ b/test/integration/swarm_boot_test.rb
@@ -87,12 +87,12 @@ end
 # assert a child runs it. NEVER mock Redis here.
 #
 # `install_signals: false` so the swarm doesn't poison the test process's
-# SIGTERM/INT handlers. The supervisor thread calls Process.wait(-1, …), and
-# the leader-order probe observes `dear-leader` — a key no @ns can namespace —
-# so these tests must never overlap. They can't, on either axis. Within the
-# class: `Wurk::Test::UnitCase` overrides `parallelize_me!` with a no-op, so
-# the marker below leaves test_order at :random (serial), and parallel_fork
-# re-extends any genuinely parallel suite with Minitest::Unparallelize anyway.
+# SIGTERM/INT handlers. The leader-order probe observes `dear-leader` — a key
+# no @ns can namespace — so these tests must never overlap. They can't, on
+# either axis. Within the class: `Wurk::Test::UnitCase` overrides
+# `parallelize_me!` with a no-op, so the marker below leaves test_order at
+# :random (serial), and parallel_fork re-extends any genuinely parallel suite
+# with Minitest::Unparallelize anyway.
 # Across classes: parallel_fork deals whole suites round-robin to NCPU forked
 # workers that each run their slice sequentially on their own Redis logical DB.
 # A mutex would guard neither axis — there is no concurrent reader to contend

--- a/test/integration/swarm_supervision_test.rb
+++ b/test/integration/swarm_supervision_test.rb
@@ -16,6 +16,12 @@ class SwarmSupervisionTest < Wurk::Test::UnitCase
   POLL_INTERVAL = 0.1
   SHUTDOWN_TIMEOUT = 5
 
+  # A host subprocess exits with a status only the host could care about; each
+  # round gives the supervise loop several ticks to steal it.
+  HOST_SUBPROCESS_ROUNDS = 3
+  HOST_SUBPROCESS_STATUS = 7
+  STRAGGLER_LIFETIME = 300
+
   def setup
     super
     @ns = "swarmsup-#{::Process.pid}-#{object_id}"
@@ -129,8 +135,8 @@ class SwarmSupervisionTest < Wurk::Test::UnitCase
   # inside the child — where `@children` lists that child's SIBLINGS. Unguarded
   # it TERMs them, then stalls the entire shutdown timeout on PIDs it can never
   # reap, then SIGKILLs whatever survived. Forking the supervisor reproduces
-  # that inherited object graph exactly. No supervise thread here: its
-  # `Process.wait(-1, …)` would race us for the drainer's exit status.
+  # that inherited object graph exactly. No supervise thread needed — the drain
+  # under test runs entirely inside the fork.
   def test_shutdown_from_a_forked_child_leaves_the_fleet_alone
     swarm = Wurk::Swarm.new(topology: topology_n(2), config: @config, shutdown_timeout: SHUTDOWN_TIMEOUT)
 
@@ -177,6 +183,51 @@ class SwarmSupervisionTest < Wurk::Test::UnitCase
       end
       stop_supervisor_thread(supervisor, 10)
     end
+  end
+
+  # --- reaping ownership ----------------------------------------------------
+
+  # Embedded (`RailsBoot.boot_swarm`) the supervise loop ticks on a background
+  # thread of the host's own process, so a wildcard `wait2(-1)` there consumes
+  # the exit status of ANY child — a Puma worker, a `system`/`Open3`
+  # subprocess — and the host's own `Process.wait` then fails with ECHILD.
+  # Forking a stranger child while the loop ticks reproduces exactly that.
+  def test_supervise_leaves_the_hosts_own_subprocesses_to_the_host
+    swarm = Wurk::Swarm.new(topology: topology_n(1), config: @config, shutdown_timeout: SHUTDOWN_TIMEOUT)
+    supervisor = nil
+
+    begin
+      swarm.boot(install_signals: false)
+      supervisor = Thread.new { swarm.supervise }
+
+      assert_host_subprocesses_survive_the_supervisor
+    ensure
+      begin
+        swarm.shutdown(timeout: SHUTDOWN_TIMEOUT)
+      rescue StandardError
+        nil
+      end
+      stop_supervisor_thread(supervisor, 10)
+    end
+  end
+
+  # SIGKILL only schedules the teardown; the pid stays a zombie until someone
+  # waits on it, and `hard_kill_stragglers` is the last reap the swarm will ever
+  # do — `shutdown` has already left the supervise loop behind. Standalone the
+  # exiting process hands its zombies to init; embedded, the host lives on and
+  # keeps one per straggler for the rest of its life.
+  def test_hard_kill_stragglers_reaps_the_pids_it_killed
+    swarm = Wurk::Swarm.new(topology: topology_n(1), config: @config, shutdown_timeout: SHUTDOWN_TIMEOUT)
+    straggler = ::Process.fork { sleep STRAGGLER_LIFETIME }
+    register_straggler(swarm, straggler)
+
+    swarm.send(:hard_kill_stragglers)
+
+    assert_empty swarm.children
+    assert_fully_reaped(straggler)
+  ensure
+    ::Process.kill('KILL', straggler) if straggler && pid_alive?(straggler)
+    reap(straggler) if straggler
   end
 
   # --- orphan self-termination ---------------------------------------------
@@ -250,6 +301,48 @@ class SwarmSupervisionTest < Wurk::Test::UnitCase
     assert supervisor.join(SHUTDOWN_TIMEOUT + 5), 'supervise must return once it observes the drain request'
     assert_empty swarm.children, 'the supervise thread must have drained the fleet'
     assert(children.all? { |pid| wait_until_dead(pid, 5) }, "children #{children.inspect} survived the drain")
+  end
+
+  # Children the swarm never forked: the test owns them, and only the test may
+  # reap them. `exit!` skips this suite's at_exit hooks, the same as a real
+  # child gets.
+  def assert_host_subprocesses_survive_the_supervisor
+    HOST_SUBPROCESS_ROUNDS.times do
+      pid = ::Process.fork { exit!(HOST_SUBPROCESS_STATUS) }
+      sleep Wurk::Swarm::SUPERVISE_TICK * 3
+      status = reap_host_subprocess(pid)
+
+      assert status, "the supervisor reaped the host's subprocess #{pid} (ECHILD)"
+      assert_equal HOST_SUBPROCESS_STATUS, status.exitstatus
+    end
+  end
+
+  def reap_host_subprocess(pid)
+    _, status = ::Process.wait2(pid)
+    status
+  rescue Errno::ECHILD
+    nil
+  end
+
+  # A straggler exactly as the drain leaves one behind: tracked, about to be
+  # SIGKILLed, and no supervise loop left to wait on it. A real fleet can't
+  # produce one on demand — its children drain well inside the deadline.
+  def register_straggler(swarm, pid)
+    swarm.instance_variable_set(:@owner_pid, ::Process.pid)
+    swarm.instance_variable_get(:@children)[pid] =
+      { slot: topology_n(1).assignments.first, index: 0, spawned_at: monotonic_now }
+  end
+
+  # ECHILD is the unambiguous proof: not merely dead — waited on. A zombie still
+  # answers `wait2` (with a status) and still answers `kill(0)`.
+  def assert_fully_reaped(pid)
+    outcome = begin
+      ::Process.wait2(pid, ::Process::WNOHANG)
+    rescue Errno::ECHILD
+      :reaped
+    end
+
+    assert_equal :reaped, outcome, "straggler #{pid} was left behind: #{outcome.inspect}"
   end
 
   def assert_old_child_survives(swarm, original)

--- a/test/support/swarm_teardown.rb
+++ b/test/support/swarm_teardown.rb
@@ -5,8 +5,8 @@ require 'English'
 # Cleanup for the `Thread.new { swarm.supervise }` pattern every real-fork
 # integration test uses. `Wurk::Swarm#shutdown` never joins the supervise loop
 # and `Thread#kill` is asynchronous, so a plain `join(t) || kill` can return
-# while the supervisor is still parked in `Process.wait(-1, …)` — where it
-# steals the exit status of the *next* test's children.
+# while the supervisor is still ticking — forking respawns and signalling
+# children into the middle of the next test.
 module SwarmTeardown
   KILL_GRACE = 5
 
@@ -18,7 +18,7 @@ module SwarmTeardown
     return if supervisor.join(KILL_GRACE)
 
     message = "supervisor thread survived shutdown + kill + #{KILL_GRACE}s join; " \
-              'it is still reaping children and will corrupt later tests'
+              'it is still supervising and will spawn children into later tests'
     # Called from an `ensure`: $ERROR_INFO is the exception already on its way
     # out, and replacing a real assertion failure with this one hides the cause.
     raise message if $ERROR_INFO.nil?

--- a/test/unit/capsule_test.rb
+++ b/test/unit/capsule_test.rb
@@ -430,6 +430,15 @@ class CapsuleTest < Wurk::Test::UnitCase
     assert_same obj, @capsule.lookup(:thing)
   end
 
+  # The only `lib/` caller of Configuration#lookup, and it passes no default
+  # class — `@directory[name] ||= nil` still *writes* on a miss, so a frozen
+  # directory turned the first post-boot resolution into a FrozenError.
+  def test_lookup_miss_survives_a_frozen_config
+    @config.freeze!
+
+    assert_nil @capsule.lookup(:never_registered)
+  end
+
   def test_logger_delegates_to_config
     custom = ::Logger.new(IO::NULL)
     @config.logger = custom

--- a/test/unit/capsule_test.rb
+++ b/test/unit/capsule_test.rb
@@ -11,8 +11,8 @@ class CapsuleTest < Wurk::Test::UnitCase
   end
 
   def teardown
-    @capsule.instance_variable_get(:@redis_pool)&.disconnect!
-    @capsule.instance_variable_get(:@fetch_redis_pool)&.disconnect!
+    @capsule.instance_variable_get(:@pools)[:main]&.disconnect!
+    @capsule.instance_variable_get(:@pools)[:fetch]&.disconnect!
   rescue ConnectionPool::PoolShuttingDownError
     # already torn down
   ensure
@@ -142,8 +142,8 @@ class CapsuleTest < Wurk::Test::UnitCase
   def test_prepare_materializes_lazy_pools
     @capsule.prepare!
 
-    refute_nil @capsule.instance_variable_get(:@redis_pool)
-    refute_nil @capsule.instance_variable_get(:@fetch_redis_pool)
+    refute_nil @capsule.instance_variable_get(:@pools)[:main]
+    refute_nil @capsule.instance_variable_get(:@pools)[:fetch]
   end
 
   # --- prepare_shared! (the half a swarm parent runs pre-fork) ----------
@@ -165,8 +165,8 @@ class CapsuleTest < Wurk::Test::UnitCase
     @capsule.prepare_shared!
 
     assert_nil @capsule.fetcher
-    assert_nil @capsule.instance_variable_get(:@redis_pool)
-    assert_nil @capsule.instance_variable_get(:@fetch_redis_pool)
+    assert_nil @capsule.instance_variable_get(:@pools)[:main]
+    assert_nil @capsule.instance_variable_get(:@pools)[:fetch]
   end
 
   def test_prepare_completes_what_prepare_shared_left
@@ -175,8 +175,8 @@ class CapsuleTest < Wurk::Test::UnitCase
     @capsule.prepare!
 
     assert_instance_of Wurk::Fetcher::Reliable, @capsule.fetcher
-    refute_nil @capsule.instance_variable_get(:@redis_pool)
-    refute_nil @capsule.instance_variable_get(:@fetch_redis_pool)
+    refute_nil @capsule.instance_variable_get(:@pools)[:main]
+    refute_nil @capsule.instance_variable_get(:@pools)[:fetch]
   end
 
   def test_prepare_shared_returns_self
@@ -390,6 +390,22 @@ class CapsuleTest < Wurk::Test::UnitCase
     cap = Wurk::Capsule.new('untouched', @config)
 
     cap.reset_redis_pools! # must not raise
+  end
+
+  # Every capsule is frozen from Launcher#run onward, and #stop releases pools
+  # after that. With the pools in ivars the reset disconnected the pool and then
+  # raised FrozenError on the memo, so `redis_pool` answered with a shut-down
+  # pool for the rest of the process's life — freezing a capsule means "no more
+  # configuration", not "these sockets are yours forever".
+  def test_reset_redis_pools_works_on_a_frozen_capsule
+    @capsule.prepare!
+    before = @capsule.redis_pool
+    @capsule.freeze
+
+    @capsule.reset_redis_pools!
+
+    refute_same before, @capsule.redis_pool, 'a frozen capsule must still rebuild its pool'
+    assert_equal('PONG', @capsule.redis { |c| c.call('PING') })
   end
 
   # --- fetcher slot ------------------------------------------------------

--- a/test/unit/child_boot_test.rb
+++ b/test/unit/child_boot_test.rb
@@ -175,7 +175,7 @@ class ChildBootTest < Wurk::Test::UnitCase
   def test_validate_redis_costs_a_single_round_trip
     conn = RoundTripCountingConn.new
     capsule = @config.default_capsule
-    capsule.instance_variable_set(:@redis_pool, StubPool.new(conn))
+    capsule.instance_variable_get(:@pools)[:main] = StubPool.new(conn)
 
     @boot.send(:validate_redis!)
 
@@ -212,7 +212,7 @@ class ChildBootTest < Wurk::Test::UnitCase
   def record_capsule_commands
     sent = []
     capsule = @config.default_capsule
-    capsule.instance_variable_set(:@redis_pool, Wurk::Test::RecordingPool.new(capsule.redis_pool, sent))
+    capsule.instance_variable_get(:@pools)[:main] = Wurk::Test::RecordingPool.new(capsule.redis_pool, sent)
     yield
     sent
   ensure

--- a/test/unit/client_buffered_test.rb
+++ b/test/unit/client_buffered_test.rb
@@ -441,6 +441,22 @@ class ClientBufferedTest < Wurk::Test::UnitCase
     refute_predicate Wurk::Client, :reliable_push_drainer_running?
   end
 
+  # Regression: reset! used to swap the buffer/cap/overflow-mode/factory
+  # ivars but leave `@drainer` running — the thread survived reset! and
+  # kept ticking against a client_factory that was never nil'd directly
+  # but whose captured pool/state reset! had just discarded, i.e. a
+  # surviving thread retaining stale closure state indefinitely.
+  def test_reset_stops_a_running_drainer
+    Wurk::Client.reliable_push_drainer(interval: 0.02)
+
+    assert_predicate Wurk::Client, :reliable_push_drainer_running?
+
+    Wurk::Client::Buffered.reset!
+
+    refute_predicate Wurk::Client, :reliable_push_drainer_running?
+    assert_nil Wurk::Client::Buffered.instance_variable_get(:@drainer)
+  end
+
   # rubocop:disable Metrics/AbcSize
   def test_drainer_drains_buffer_against_recovering_pool
     pool = togglable_pool

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -411,6 +411,14 @@ class ConfigurationTest < Wurk::Test::UnitCase
     assert_same instance, @config.lookup(:auto)
   end
 
+  # `h[k] ||= v` desugars to `h[k] || h[k] = v`, so *every* miss writes — a
+  # nil default class doesn't spare a frozen directory the FrozenError.
+  def test_lookup_miss_without_a_default_class_survives_freeze
+    @config.freeze!
+
+    assert_nil @config.lookup(:never_registered)
+  end
+
   # Only `lookup`'s own memo write survives the freeze; the host-facing half
   # of the registry stays closed.
   def test_register_still_refuses_writes_after_freeze

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -814,8 +814,8 @@ class ConfigurationTest < Wurk::Test::UnitCase
     @config.prepare_for_fork!
     cap = @config.default_capsule
 
-    assert_nil cap.instance_variable_get(:@redis_pool)
-    assert_nil cap.instance_variable_get(:@fetch_redis_pool)
+    assert_nil cap.instance_variable_get(:@pools)[:main]
+    assert_nil cap.instance_variable_get(:@pools)[:fetch]
     assert_nil cap.fetcher
   end
 

--- a/test/unit/fetcher_reaper_test.rb
+++ b/test/unit/fetcher_reaper_test.rb
@@ -473,6 +473,32 @@ class FetcherReaperTest < Wurk::Test::UnitCase
     refute_predicate reaper, :running?, 'a signalled, done loop must break and the thread join'
   end
 
+  # The full-keyspace sweep is exactly the tick that outlasts a stop, and waiting
+  # it out held the whole process teardown open past the swarm parent's shutdown
+  # grace — which SIGKILLs the child mid-drain, the outcome this reaper exists to
+  # recover from. Bounded at TimerLoop::JOIN_TIMEOUT like every other periodic
+  # component.
+  def test_stop_bounds_the_join_of_a_sweep_that_will_not_finish
+    reaper = Wurk::Fetcher::Reaper.new(@config, interval: 60, lock_key: "#{Wurk::Fetcher::Reaper::LOCK_KEY}:#{@ns}-wedged")
+    wedged = never_joins_thread
+    reaper.instance_variable_set(:@thread, wedged)
+
+    reaper.stop
+
+    assert_equal [Wurk::TimerLoop::JOIN_TIMEOUT], wedged.joins, 'the join must carry a timeout'
+    assert_same wedged, reaper.instance_variable_get(:@thread),
+                'a straggler stays referenced so a restart cannot spawn a second sweep loop'
+  end
+
+  def test_stop_clears_the_thread_once_the_sweep_joins
+    reaper = Wurk::Fetcher::Reaper.new(@config, interval: 60, lock_key: "#{Wurk::Fetcher::Reaper::LOCK_KEY}:#{@ns}-joins")
+    reaper.start
+
+    reaper.stop
+
+    assert_nil reaper.instance_variable_get(:@thread)
+  end
+
   # A short interval lets wait_next time out while @done is still false, so the
   # loop falls through to tick_once (run_loop's `break if done?` ELSE side, plus
   # wait_next's `unless @done` THEN side: it actually waited).
@@ -570,6 +596,19 @@ class FetcherReaperTest < Wurk::Test::UnitCase
   # as live (the `processes` SET is global to the worker's Redis DB).
   def unowned_pid
     @unowned_pid ||= 990_000 + (object_id % 9_000)
+  end
+
+  # Stands in for a sweep still SCANning when the stop lands: `join` records the
+  # timeout it was given and reports "not finished" (nil), exactly as a real
+  # thread that outlives the bound does. Cheaper and more precise than waiting a
+  # real JOIN_TIMEOUT out.
+  def never_joins_thread
+    thread = Object.new
+    joins = []
+    thread.define_singleton_method(:joins) { joins }
+    thread.define_singleton_method(:alive?) { true }
+    thread.define_singleton_method(:join) { |timeout| joins << timeout and nil }
+    thread
   end
 
   def wait_until(timeout: 5.0)

--- a/test/unit/heartbeat_test.rb
+++ b/test/unit/heartbeat_test.rb
@@ -107,6 +107,34 @@ class HeartbeatTest < Wurk::Test::UnitCase
     assert_nil hb.send(:cores, raising_etc)
   end
 
+  # Regression: File.foreach(path).find { } never closes the underlying
+  # File — the Enumerator (and its FD) is abandoned until GC finalizes it.
+  # cpu_model/memory_total_kb must read via File.open with a block so the
+  # FD closes deterministically on return, not on the next GC pass.
+  # Minitest 6 dropped minitest/mock; a singleton override on the ::File
+  # class object is the stub.
+  def test_cpu_model_does_not_use_file_foreach
+    skip 'no /proc/cpuinfo on this platform' unless ::File.exist?('/proc/cpuinfo')
+
+    hb = build_heartbeat
+    with_file_foreach_disabled do
+      result = hb.send(:cpu_model)
+
+      assert_kind_of String, result if result
+    end
+  end
+
+  def test_memory_total_kb_does_not_use_file_foreach
+    skip 'no /proc/meminfo on this platform' unless ::File.exist?('/proc/meminfo')
+
+    hb = build_heartbeat
+    with_file_foreach_disabled do
+      result = hb.send(:memory_total_kb)
+
+      assert_operator result, :>, 0
+    end
+  end
+
   def test_beat_writes_info_tag_and_embedded_default
     hb = build_heartbeat
 
@@ -404,6 +432,14 @@ class HeartbeatTest < Wurk::Test::UnitCase
 
   def read_info
     Wurk.load_json(@pool.with { |c| c.call('HGET', @identity, 'info') })
+  end
+
+  def with_file_foreach_disabled
+    original = ::File.method(:foreach)
+    ::File.define_singleton_method(:foreach) { |*| raise 'must not use File.foreach — abandons the FD until GC' }
+    yield
+  ensure
+    ::File.define_singleton_method(:foreach, original)
   end
 
   def read_beat_fields

--- a/test/unit/launcher_test.rb
+++ b/test/unit/launcher_test.rb
@@ -24,16 +24,22 @@ class LauncherTest < Wurk::Test::UnitCase
     cap.concurrency = 2
     # No manual fetcher wiring — Launcher#run defaults it now (regression #35).
     @config[:tag] = @ns
-    @pool = cap.redis_pool
     @cleanup_keys = []
     @threads = []
+  end
+
+  # Resolved per call, never captured: #stop disconnects the capsule's pools and
+  # drops the memo, so a reference taken in setup would be a shut-down pool by
+  # the time teardown swept its keys.
+  def pool
+    @config.default_capsule.redis_pool
   end
 
   def teardown
     # Before the key sweep, not after: a heartbeat thread left running would
     # SADD its identity back in behind us.
     @threads.each(&:kill)
-    @pool.with do |c|
+    pool.with do |c|
       @cleanup_keys.each do |k|
         c.call('SREM', Wurk::Keys::PROCESSES, k) if k.start_with?("host-#{@ns}")
         c.call('UNLINK', k)
@@ -580,10 +586,11 @@ class LauncherTest < Wurk::Test::UnitCase
     assert reset, 'embedded #stop must disconnect the Redis pools'
   end
 
-  # A8: a swarm child or standalone process exits right after #stop anyway —
-  # disconnecting here would just force every subsequent Redis touch (this
-  # test's own teardown included) to silently rebuild a pool for nothing.
-  def test_stop_leaves_redis_pools_connected_when_not_embedded
+  # A8: not just embedded. Anything driving Launcher directly — a rake task, a
+  # test — survives #stop too, and leaked one main + one fetch pool per capsule
+  # for the life of the host. A swarm child pays nothing for the release; it
+  # was about to exit anyway.
+  def test_stop_disconnects_redis_pools_when_not_embedded
     @config[:timeout] = 0
     launcher = Wurk::Launcher.new(@config)
     silence_managers(launcher)
@@ -592,7 +599,76 @@ class LauncherTest < Wurk::Test::UnitCase
 
     launcher.stop
 
-    refute reset, 'non-embedded #stop must not disconnect the Redis pools'
+    assert reset, 'non-embedded #stop must disconnect the Redis pools too'
+  end
+
+  # The release has to survive the freeze #run performs: a capsule frozen at
+  # boot could disconnect its pool but not drop the memo, so `redis_pool` kept
+  # answering with a shut-down pool and the next boot could never reconnect.
+  def test_stop_leaves_the_capsule_able_to_rebuild_its_pools
+    @config[:timeout] = 0
+    launcher = build_isolated_launcher
+    silence_boot(launcher)
+    silence_beat(launcher)
+    track(launcher_identity(launcher))
+    launcher.run(async_beat: false)
+    before = @config.default_capsule.redis_pool
+
+    launcher.stop
+
+    rebuilt = @config.default_capsule.redis_pool
+
+    refute_same before, rebuilt, 'a stopped capsule must rebuild its pool, not hand back the shut-down one'
+    assert_equal('PONG', rebuilt.with { |c| c.call('PING') })
+  end
+
+  # A wedged capsule — a `fetcher.terminate`/`bulk_requeue` parked on a Redis
+  # that stopped answering — used to hold the whole teardown open, which is what
+  # the swarm parent SIGKILLs a child for. The join budget ends it.
+  def test_stop_does_not_wait_forever_on_a_wedged_manager
+    join_budget_of(0.3)
+    gate = Queue.new
+    launcher = launcher_with_wedged_managers(gate)
+
+    elapsed = time_of { launcher.stop }
+
+    assert_operator elapsed, :<, 2, "stop must not block on a wedged manager (took #{elapsed}s)"
+    assert_predicate launcher, :stopping?
+  ensure
+    gate << true
+  end
+
+  # One shared budget: the teardown tail past this point has its own work to do
+  # inside the parent's shutdown grace, so N wedged capsules must not each cost
+  # a full JOIN_TIMEOUT.
+  def test_stop_shares_one_join_budget_across_capsules
+    @config.capsule('extra') { |c| c.concurrency = 1 }
+    join_budget_of(1)
+    gate = Queue.new
+    launcher = launcher_with_wedged_managers(gate)
+
+    assert_equal 2, launcher.managers.size
+    elapsed = time_of { launcher.stop }
+
+    assert_operator elapsed, :<, 1.7, "one budget for both capsules, not one each (took #{elapsed}s)"
+  ensure
+    2.times { gate << true }
+  end
+
+  # Every shutdown request past the first used to spawn its own unretained
+  # `stop`, so N TERMs meant N teardowns racing through #release_components.
+  def test_repeated_shutdown_requests_drain_once_when_embedded
+    @config[:timeout] = 0
+    launcher = build_isolated_launcher(embedded: true)
+    silence_managers(launcher)
+    track(launcher_identity(launcher))
+    drains = Queue.new
+    launcher.define_singleton_method(:release_components) { drains << true }
+
+    stoppers = request_shutdown_concurrently(launcher, 4)
+
+    assert_equal 1, drains.size, 'concurrent TERMs must share one drain'
+    assert_equal 1, stoppers.uniq.size, 'every request must get the same retained stopper'
   end
 
   # Branch coverage: #stop's safe-nav teardown of the cron poller, metrics
@@ -809,7 +885,7 @@ class LauncherTest < Wurk::Test::UnitCase
 
       launcher.flush_stats
 
-      processed, failed, expired = @pool.with do |c|
+      processed, failed, expired = pool.with do |c|
         c.call('MGET', Wurk::Keys::STAT_PROCESSED, 'stat:failed', Wurk::Keys::STAT_EXPIRED)
       end
 
@@ -827,7 +903,7 @@ class LauncherTest < Wurk::Test::UnitCase
     track(launcher_identity(launcher))
 
     launcher.heartbeat
-    member = @pool.with { |c| c.call('SISMEMBER', Wurk::Keys::PROCESSES, launcher_identity(launcher)) }
+    member = pool.with { |c| c.call('SISMEMBER', Wurk::Keys::PROCESSES, launcher_identity(launcher)) }
 
     assert_equal 1, member
   end
@@ -838,7 +914,7 @@ class LauncherTest < Wurk::Test::UnitCase
     track(launcher_identity(launcher))
 
     launcher.heartbeat
-    ttl = @pool.with { |c| c.call('TTL', launcher_identity(launcher)).to_i }
+    ttl = pool.with { |c| c.call('TTL', launcher_identity(launcher)).to_i }
 
     assert_operator ttl, :>, 0
     assert_operator ttl, :<=, 60
@@ -902,15 +978,13 @@ class LauncherTest < Wurk::Test::UnitCase
     track(launcher_identity(launcher))
     redelivered = []
     launcher.define_singleton_method(:redeliver) { |s| redelivered << s }
-    sig_key = "#{launcher_identity(launcher)}-signals"
-    @pool.with { |c| c.call('LPUSH', sig_key, 'TSTP') }
-    @cleanup_keys << sig_key
+    sig_key = queue_signal(launcher, 'TSTP')
 
     launcher.heartbeat
 
     assert_equal ['TSTP'], redelivered
     refute_predicate launcher, :stopping?, 'the trap, not the beat, owns the state change'
-    drained = @pool.with { |c| c.call('LPOP', sig_key) }
+    drained = pool.with { |c| c.call('LPOP', sig_key) }
 
     assert_nil drained
   end
@@ -920,9 +994,7 @@ class LauncherTest < Wurk::Test::UnitCase
     track(launcher_identity(launcher))
     redelivered = []
     launcher.define_singleton_method(:redeliver) { |s| redelivered << s }
-    sig_key = "#{launcher_identity(launcher)}-signals"
-    @pool.with { |c| c.call('LPUSH', sig_key, 'TERM') }
-    @cleanup_keys << sig_key
+    queue_signal(launcher, 'TERM')
 
     launcher.heartbeat
 
@@ -935,9 +1007,7 @@ class LauncherTest < Wurk::Test::UnitCase
   def test_heartbeat_dispatches_tstp_directly_when_embedded
     launcher = build_isolated_launcher(embedded: true)
     track(launcher_identity(launcher))
-    sig_key = "#{launcher_identity(launcher)}-signals"
-    @pool.with { |c| c.call('LPUSH', sig_key, 'TSTP') }
-    @cleanup_keys << sig_key
+    queue_signal(launcher, 'TSTP')
 
     launcher.heartbeat
 
@@ -949,9 +1019,7 @@ class LauncherTest < Wurk::Test::UnitCase
     track(launcher_identity(launcher))
     stopped = Queue.new
     launcher.define_singleton_method(:stop) { stopped << true }
-    sig_key = "#{launcher_identity(launcher)}-signals"
-    @pool.with { |c| c.call('LPUSH', sig_key, 'TERM') }
-    @cleanup_keys << sig_key
+    queue_signal(launcher, 'TERM')
 
     launcher.heartbeat
 
@@ -1005,9 +1073,7 @@ class LauncherTest < Wurk::Test::UnitCase
     launcher.instance_variable_get(:@config).logger.define_singleton_method(:warn) do |*_a, &blk|
       warned << blk.call
     end
-    sig_key = "#{launcher_identity(launcher)}-signals"
-    @pool.with { |c| c.call('LPUSH', sig_key, 'BOGUS') }
-    @cleanup_keys << sig_key
+    queue_signal(launcher, 'BOGUS')
 
     launcher.heartbeat
 
@@ -1038,7 +1104,7 @@ class LauncherTest < Wurk::Test::UnitCase
 
     launcher.heartbeat
 
-    info = Wurk.load_json(@pool.with { |c| c.call('HGET', launcher_identity(launcher), 'info') })
+    info = Wurk.load_json(pool.with { |c| c.call('HGET', launcher_identity(launcher), 'info') })
 
     assert info['embedded']
   end
@@ -1069,7 +1135,7 @@ class LauncherTest < Wurk::Test::UnitCase
     @cleanup_keys << work_key
 
     launcher.heartbeat
-    ttl = @pool.with { |c| c.call('TTL', work_key).to_i }
+    ttl = pool.with { |c| c.call('TTL', work_key).to_i }
 
     assert_operator ttl, :>, 0
   ensure
@@ -1080,12 +1146,12 @@ class LauncherTest < Wurk::Test::UnitCase
     launcher = build_isolated_launcher
     track(launcher_identity(launcher))
     work_key = "#{launcher_identity(launcher)}:work"
-    @pool.with { |c| c.call('HSET', work_key, 'stale-tid', '{}') }
+    pool.with { |c| c.call('HSET', work_key, 'stale-tid', '{}') }
     @cleanup_keys << work_key
     Wurk::Processor::WORK_STATE.clear
 
     launcher.heartbeat
-    exists = @pool.with { |c| c.call('EXISTS', work_key) }
+    exists = pool.with { |c| c.call('EXISTS', work_key) }
 
     assert_equal 0, exists
   end
@@ -1096,6 +1162,48 @@ class LauncherTest < Wurk::Test::UnitCase
   # BOOT_RECLAIM_JOIN_TIMEOUT, and (when `seconds` is given) shortens it for
   # the duration of the block. Without the lock a shortened bound would leak
   # into the sibling test running concurrently under parallelize_me!.
+  # Shrinks #stop's manager-join budget (`deadline + TimerLoop::JOIN_TIMEOUT`,
+  # where the deadline is `now + config[:timeout]`) by moving the deadline into
+  # the past. The constant itself is process-global and shared with every other
+  # periodic component, so a parallel run must not swap it.
+  # LPUSHes `sig` onto the launcher's dashboard signal list and registers the
+  # key for cleanup. Returns the key for the tests that assert it drained.
+  def queue_signal(launcher, sig)
+    key = "#{launcher_identity(launcher)}-signals"
+    pool.with { |c| c.call('LPUSH', key, sig) }
+    @cleanup_keys << key
+    key
+  end
+
+  # A launcher whose every Manager#stop parks on `gate` — a capsule wedged on a
+  # Redis that stopped answering, which is what the join budget exists to bound.
+  def launcher_with_wedged_managers(gate)
+    launcher = Wurk::Launcher.new(@config)
+    silence_managers(launcher)
+    launcher.managers.each { |m| m.define_singleton_method(:stop) { |_d| gate.pop } }
+    launcher
+  end
+
+  # Fires `count` concurrent shutdown requests, then one more once they have
+  # landed, and returns every stopper thread they were handed.
+  def request_shutdown_concurrently(launcher, count)
+    threads = Array.new(count) { track_thread(Thread.new { launcher.send(:request_shutdown) }) }
+    stoppers = threads.map { |t| t.join(5) && t.value }
+    last = launcher.send(:request_shutdown)
+    last.join(5)
+    stoppers << last
+  end
+
+  def join_budget_of(seconds)
+    @config[:timeout] = seconds - Wurk::TimerLoop::JOIN_TIMEOUT
+  end
+
+  def time_of
+    started = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+    yield
+    ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) - started
+  end
+
   def with_boot_reclaim_join_timeout(seconds = nil)
     BOOT_RECLAIM_TIMEOUT_LOCK.synchronize do
       return yield unless seconds
@@ -1137,11 +1245,11 @@ class LauncherTest < Wurk::Test::UnitCase
   end
 
   def published(identity, field)
-    @pool.with { |c| c.call('HGET', identity, field) }
+    pool.with { |c| c.call('HGET', identity, field) }
   end
 
   def listed?(identity)
-    @pool.with { |c| c.call('SISMEMBER', Wurk::Keys::PROCESSES, identity) }
+    pool.with { |c| c.call('SISMEMBER', Wurk::Keys::PROCESSES, identity) }
   end
 
   def track(key)
@@ -1291,7 +1399,7 @@ class LauncherTest < Wurk::Test::UnitCase
   # redis-client returns HGETALL as either a Hash or a flat Array
   # depending on version; normalize to a Hash for assertion.
   def work_hash(work_key)
-    raw = @pool.with { |c| c.call('HGETALL', work_key) }
+    raw = pool.with { |c| c.call('HGETALL', work_key) }
     raw.is_a?(Hash) ? raw : Hash[*raw]
   end
 
@@ -1302,7 +1410,7 @@ class LauncherTest < Wurk::Test::UnitCase
   end
 
   def read_daily_ttls(day)
-    @pool.with do |c|
+    pool.with do |c|
       [
         c.call('TTL', "#{Wurk::Keys::STAT_PROCESSED}:#{day}").to_i,
         c.call('TTL', "stat:failed:#{day}").to_i,
@@ -1312,10 +1420,10 @@ class LauncherTest < Wurk::Test::UnitCase
   end
 
   def read_info(launcher)
-    Wurk.load_json(@pool.with { |c| c.call('HGET', launcher_identity(launcher), 'info') })
+    Wurk.load_json(pool.with { |c| c.call('HGET', launcher_identity(launcher), 'info') })
   end
 
   def read_beat_fields(launcher)
-    @pool.with { |c| c.call('HMGET', launcher_identity(launcher), 'concurrency', 'busy', 'beat', 'quiet', 'rss') }
+    pool.with { |c| c.call('HMGET', launcher_identity(launcher), 'concurrency', 'busy', 'beat', 'quiet', 'rss') }
   end
 end

--- a/test/unit/leader_test.rb
+++ b/test/unit/leader_test.rb
@@ -554,6 +554,23 @@ class LeaderTest < Wurk::Test::UnitCase
     refute_predicate ldr, :running?
   end
 
+  # A campaign parked on a wedged Redis (`SET NX EX` waiting out its socket
+  # timeouts) must not hold the whole process teardown open — the swarm parent
+  # SIGKILLs a child that overruns its shutdown grace. Bounded at
+  # TimerLoop::JOIN_TIMEOUT like every other periodic component.
+  def test_stop_bounds_the_join_of_a_tick_that_will_not_finish
+    ldr = build_leader
+    wedged = never_joins_thread
+    ldr.instance_variable_set(:@thread, wedged)
+
+    ldr.stop
+
+    assert_equal [Wurk::TimerLoop::JOIN_TIMEOUT], wedged.joins, 'the join must carry a timeout'
+    assert_same wedged, ldr.instance_variable_get(:@thread),
+                'a straggler stays referenced so a restart cannot campaign twice in parallel'
+    assert_nil(Wurk.redis { |c| c.call('GET', @key) }, 'the CAS release runs even when the join times out')
+  end
+
   def test_stop_releases_and_clears_thread
     ldr = build_leader(renew_interval: 0.05, follower_interval: 0.05)
     ldr.start
@@ -766,6 +783,19 @@ class LeaderTest < Wurk::Test::UnitCase
     ldr = Wurk::Leader.new(key: @key, initial_wait: 0, **)
     @leaders << ldr
     ldr
+  end
+
+  # Stands in for a campaign tick still parked on Redis when the stop lands:
+  # `join` records the timeout it was given and reports "not finished" (nil),
+  # exactly as a real thread that outlives the bound does. Cheaper and more
+  # precise than waiting a real JOIN_TIMEOUT out.
+  def never_joins_thread
+    thread = Object.new
+    joins = []
+    thread.define_singleton_method(:joins) { joins }
+    thread.define_singleton_method(:alive?) { true }
+    thread.define_singleton_method(:join) { |timeout| joins << timeout and nil }
+    thread
   end
 
   # Run the block in `count` threads released from a common barrier, so they

--- a/test/unit/middleware_poison_pill_test.rb
+++ b/test/unit/middleware_poison_pill_test.rb
@@ -256,6 +256,42 @@ class MiddlewarePoisonPillTest < Wurk::Test::UnitCase
     assert_raises(ArgumentError) { Wurk::Middleware::PoisonPill.on_poison }
   end
 
+  # Re-running an initializer that hands back the same stored Proc each time
+  # (Rails code reloading, a re-required file) must not accumulate duplicate
+  # closures — each registration retains its own binding, so unbounded
+  # re-registration is an unbounded retention leak.
+  def test_on_poison_dedups_by_callback_identity
+    calls = 0
+    callback = proc { calls += 1 }
+    3.times { Wurk::Middleware::PoisonPill.on_poison(&callback) }
+    json = payload_json
+    3.times { Wurk::Middleware::PoisonPill.track!(json, queue: @queue) }
+
+    assert_equal 1, calls, 'the same Proc registered repeatedly must fire once per poison, not N times'
+  end
+
+  # A fresh block literal per call is a distinct callable and must still
+  # register separately (dedup is by identity, not by "already registered
+  # something").
+  def test_on_poison_does_not_dedup_distinct_blocks
+    calls = 0
+    2.times { Wurk::Middleware::PoisonPill.on_poison { calls += 1 } }
+    json = payload_json
+    3.times { Wurk::Middleware::PoisonPill.track!(json, queue: @queue) }
+
+    assert_equal 2, calls
+  end
+
+  def test_on_poison_returns_removable_registration
+    calls = 0
+    registration = Wurk::Middleware::PoisonPill.on_poison { calls += 1 }
+    registration.remove!
+    json = payload_json
+    3.times { Wurk::Middleware::PoisonPill.track!(json, queue: @queue) }
+
+    assert_equal 0, calls, 'a removed registration must not fire'
+  end
+
   # --- super_fetch! recovery callback (Pro §3.1: |jobstr, pill|) -----------
 
   def test_super_fetch_callback_fires_with_job_string_and_nil_pill_on_recovery

--- a/test/unit/processor_test.rb
+++ b/test/unit/processor_test.rb
@@ -12,6 +12,15 @@ class ProcessorTest < Wurk::Test::UnitCase
   # fires without StandardError/Shutdown swallowing it earlier in the stack.
   class FatalBoom < Exception; end
 
+  # Stands in for an async raise delivered the instant after the entry is
+  # published — the seam `SharedWorkState#track` has to cover.
+  class RaisingWorkState < Wurk::Processor::SharedWorkState
+    def set(tid, hash)
+      super
+      raise FatalBoom, 'async raise right after the write'
+    end
+  end
+
   def setup
     super
     @queue_name = "pt-#{Process.pid}-#{object_id}"
@@ -556,6 +565,19 @@ class ProcessorTest < Wurk::Test::UnitCase
     assert_equal 0, Wurk::Processor::WORK_STATE.size
   end
 
+  # The retract has to survive the failure path too: `stats` re-raises through
+  # the retrier, and a stranded entry there would pin the payload of every job
+  # that ever raised.
+  def test_work_state_cleared_when_perform_raises
+    klass = define_worker_raising(RuntimeError, 'boom')
+    payload = enqueue(class: klass.name, args: [], retry: true)
+
+    @processor.process_one
+    take_retry_entry_for(payload['jid'])
+
+    refute_includes Wurk::Processor::WORK_STATE.dup.keys, @processor.tid
+  end
+
   # `stats` keys WORK_STATE with `tid` (memoized per thread, `component_test.rb`
   # covers the memo itself) — two jobs run back-to-back on the same thread must
   # publish under the identical key, not a fresh one per job.
@@ -652,6 +674,41 @@ class ProcessorTest < Wurk::Test::UnitCase
     s.set('b', x: 2)
 
     assert_equal %w[a], snap.keys
+  end
+
+  # --- SharedWorkState#track (RAII) ------------------------------------
+
+  def test_track_publishes_for_the_duration_of_the_block
+    s = Wurk::Processor::SharedWorkState.new
+    seen = s.track('tid-1', queue: 'q', payload: 'p', run_at: 1) { s.dup }
+
+    assert_equal({ queue: 'q', payload: 'p', run_at: 1 }, seen['tid-1'])
+    assert_equal 0, s.size
+  end
+
+  def test_track_returns_the_block_value
+    s = Wurk::Processor::SharedWorkState.new
+
+    assert_equal :done, s.track('tid-1', queue: 'q') { :done }
+  end
+
+  # Non-StandardError, so nothing between here and the ensure can swallow it.
+  def test_track_clears_when_the_block_raises
+    s = Wurk::Processor::SharedWorkState.new
+
+    assert_raises(FatalBoom) { s.track('tid-1', queue: 'q') { raise FatalBoom, 'boom' } }
+    assert_equal 0, s.size
+  end
+
+  # The window `track` exists to close: with the publish one line above a
+  # `begin`, a raise landing between the write and the ensure frame — an
+  # async `Thread#raise` from a host timeout, say — stranded the entry for the
+  # life of the process (payload String retained, heartbeat `busy` inflated).
+  def test_track_clears_when_a_raise_lands_right_after_the_write
+    s = RaisingWorkState.new
+
+    assert_raises(FatalBoom) { s.track('tid-1', queue: 'q') { flunk 'block must not run' } }
+    assert_equal 0, s.size
   end
 
   # --- compat ---------------------------------------------------------

--- a/test/unit/queue_pause_test.rb
+++ b/test/unit/queue_pause_test.rb
@@ -333,14 +333,14 @@ class QueuePauseTest < Wurk::Test::UnitCase
     Wurk::Queue.new(@qname).pause!
     Wurk::Queue.new(@other).pause!
     counter = RedisCallCounter.new(capsule.redis_pool)
-    capsule.instance_variable_set(:@redis_pool, counter)
+    capsule.instance_variable_get(:@pools)[:main] = counter
     [fetcher, capsule, counter]
   end
 
   def build_pinned_fetcher_with_paused_counter
     fetcher, capsule = build_fetcher(%W[#{@qname} #{@other}], PinnedGeneration)
     counter = PausedReadCounter.new(capsule.redis_pool)
-    capsule.instance_variable_set(:@redis_pool, counter)
+    capsule.instance_variable_get(:@pools)[:main] = counter
     [fetcher, capsule, counter]
   end
 

--- a/test/unit/shutdown_gate_test.rb
+++ b/test/unit/shutdown_gate_test.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# The two rules a teardown obeys: it runs exactly once, and it never waits on a
+# thread without a bound.
+class ShutdownGateTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def setup
+    super
+    @gate = Wurk::ShutdownGate.new
+    @threads = []
+  end
+
+  def teardown
+    @threads.each { |t| t.kill.join(1) }
+  ensure
+    super
+  end
+
+  # --- run: single-shot -------------------------------------------------
+
+  def test_run_yields_to_the_first_caller
+    ran = 0
+
+    @gate.run { ran += 1 }
+
+    assert_equal 1, ran
+  end
+
+  def test_run_yields_only_once_across_sequential_calls
+    ran = 0
+
+    3.times { @gate.run { ran += 1 } }
+
+    assert_equal 1, ran
+  end
+
+  # N concurrent TERMs used to mean N teardowns racing each other through the
+  # same components. Exactly one must win, however many arrive together.
+  def test_concurrent_callers_yield_exactly_once
+    ran = Queue.new
+    release = Queue.new
+    winner = claim_and_hold(ran, release)
+
+    losers = Array.new(4) { spawn_thread { @gate.run { ran << true } } }
+    release << true
+    [winner, *losers].each { |t| t.join(5) }
+
+    assert_equal 1, ran.size
+  end
+
+  # A caller that asked for the shutdown must not return while the process is
+  # still up — otherwise an embedded host's `stop` hands control back mid-drain.
+  def test_a_later_caller_blocks_until_the_teardown_finishes
+    finished = false
+    release = Queue.new
+    entered = Queue.new
+    owner = spawn_thread do
+      @gate.run do
+        entered << true
+        release.pop
+        finished = true
+      end
+    end
+    entered.pop
+
+    waiter = spawn_thread { @gate.run { nil } }
+
+    refute waiter.join(0.1), 'a second caller must not return while the teardown is still running'
+    release << true
+    owner.join(5)
+    waiter.join(5)
+
+    assert finished
+  end
+
+  def test_a_caller_after_the_teardown_returns_immediately
+    @gate.run { nil }
+
+    assert spawn_thread { @gate.run { flunk 'must not re-run the teardown' } }.join(5)
+  end
+
+  # The owner re-entering (a `:shutdown` hook that calls stop) cannot wait on a
+  # teardown it is inside of.
+  def test_the_owner_re_entering_does_not_deadlock
+    reentered = false
+
+    @gate.run do
+      @gate.run { flunk 'a re-entrant call must not run the teardown again' }
+      reentered = true
+    end
+
+    assert reentered
+  end
+
+  def test_waiters_are_released_when_the_teardown_raises
+    owner = spawn_thread do
+      @gate.run { raise 'teardown blew up' }
+    rescue RuntimeError
+      :raised
+    end
+
+    assert_equal :raised, owner.value, 'the failure belongs to the caller that owns the teardown'
+    assert spawn_thread { @gate.run { nil } }.join(5), 'a failed teardown must still release its waiters'
+  end
+
+  def test_run_returns_nil_to_a_caller_that_did_not_claim
+    @gate.run { :whatever }
+
+    assert_nil(@gate.run { :whatever })
+  end
+
+  # --- runner -----------------------------------------------------------
+
+  def test_runner_spawns_once_and_hands_the_same_thread_back
+    spawned = 0
+    first = @gate.runner { spawn_thread { spawned += 1 } }
+    second = @gate.runner { spawn_thread { spawned += 1 } }
+    first.join(5)
+
+    assert_same first, second
+    assert_equal 1, spawned
+  end
+
+  # --- join_within ------------------------------------------------------
+
+  def test_join_within_returns_once_every_thread_is_done
+    threads = Array.new(3) { spawn_thread { nil } }
+
+    @gate.join_within(threads, monotonic + 5)
+
+    threads.each { |t| refute_predicate t, :alive? }
+  end
+
+  # One shared budget, not one per thread: N wedged capsules must cost the
+  # budget once, not N times.
+  def test_join_within_shares_one_budget_across_every_thread
+    gate = Queue.new
+    threads = Array.new(3) { spawn_thread { gate.pop } }
+
+    started = monotonic
+    @gate.join_within(threads, started + 0.3)
+    elapsed = monotonic - started
+
+    assert_operator elapsed, :<, 1.5, "one shared budget, got #{elapsed}s for 3 wedged threads"
+    threads.each { |t| assert_predicate t, :alive?, 'a wedged thread is left running, not killed' }
+  ensure
+    3.times { gate << true }
+  end
+
+  def test_join_within_does_not_wait_when_the_budget_is_already_spent
+    gate = Queue.new
+    thread = spawn_thread { gate.pop }
+
+    started = monotonic
+    @gate.join_within([thread], monotonic - 10)
+
+    assert_operator monotonic - started, :<, 0.5, 'a spent budget must poll, not wait'
+  ensure
+    gate << true
+  end
+
+  private
+
+  # Claims the gate on a background thread and parks inside the teardown until
+  # `release` is fed, so the assertions run against a drain that is in flight.
+  def claim_and_hold(ran, release)
+    entered = Queue.new
+    thread = spawn_thread do
+      @gate.run do
+        entered << true
+        ran << true
+        release.pop
+      end
+    end
+    entered.pop
+    thread
+  end
+
+  def monotonic
+    ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+  end
+
+  def spawn_thread(&)
+    thread = Thread.new(&)
+    thread.report_on_exception = false
+    @threads << thread
+    thread
+  end
+end

--- a/test/unit/swarm_reaping_test.rb
+++ b/test/unit/swarm_reaping_test.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Which PIDs the supervisor may wait on, and what it must never leave behind.
+# Both halves only bite when the supervisor shares a process with a host app
+# (`RailsBoot.boot_swarm` runs the supervise loop on a background thread of the
+# web process): a wildcard `wait2(-1)` steals the host's own subprocess exit
+# statuses, and a SIGKILLed straggler nobody waits on stays a zombie for the
+# life of a host that outlives the swarm.
+#
+# Fork-free — `fork_child` hands back fake PIDs and `Process.wait2` is stubbed —
+# so the wiring is asserted deterministically. Real-fork proof:
+# test/integration/swarm_supervision_test.rb.
+class SwarmReapingTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  SLOTS = 3
+
+  Status = ::Struct.new(:exitstatus)
+
+  # Fake PIDs, so kills are recorded rather than delivered: 40_001 may well name
+  # a real, unrelated process on this box.
+  class ReapTestSwarm < Wurk::Swarm
+    attr_reader :killed
+
+    def initialize(**kwargs)
+      super
+      @fake_pid = 40_000
+      @killed = []
+    end
+
+    private
+
+    def fork_child(_slot, _idx)
+      @fake_pid += 1
+    end
+
+    def safe_kill(pid, sig)
+      @killed << [pid, sig]
+    end
+  end
+
+  def setup
+    super
+    @config = Wurk::Configuration.new
+    @config.logger = ::Logger.new(IO::NULL)
+  end
+
+  # --- reap only what the swarm forked -----------------------------------
+
+  def test_reap_children_waits_only_on_pids_the_swarm_forked
+    swarm = boot_swarm
+    waited = []
+
+    with_stubbed_wait2(still_running(waited)) { swarm.send(:reap_children) }
+
+    assert_equal swarm.children.keys.sort, waited.sort,
+                 'the supervisor must wait on its own children by pid, never on -1'
+  end
+
+  # The per-pid wait still has to feed the crash-respawn scheduler the exit it
+  # observed — the wildcard form used to be what delivered the pid.
+  def test_reap_children_routes_an_observed_exit_to_the_respawn_scheduler
+    swarm = boot_swarm
+    dead, meta = swarm.children.first
+
+    with_stubbed_wait2(exits(dead, 9)) { swarm.send(:reap_children) }
+
+    refute_includes swarm.children.keys, dead
+    assert respawn_pending?(swarm, meta[:index]), 'an observed crash must arm the slot for respawn'
+  end
+
+  # ECHILD on a pid the swarm forked means someone else already reaped it — an
+  # embedded host running its own wildcard reaper is the exact mirror of the bug
+  # this suite pins. Skipping it would wedge the slot forever: never respawned
+  # (it still looks alive), never reaped (there is nothing left to reap).
+  def test_reap_children_retires_a_slot_another_reaper_already_took
+    swarm = boot_swarm
+    stolen, meta = swarm.children.first
+
+    with_stubbed_wait2(echild_for(stolen)) { swarm.send(:reap_children) }
+
+    refute_includes swarm.children.keys, stolen, 'a pid reaped elsewhere must not stay in the child table'
+    assert respawn_pending?(swarm, meta[:index]), 'the slot it held must be refilled'
+  end
+
+  # --- leave no zombie behind ---------------------------------------------
+
+  def test_hard_kill_stragglers_reaps_what_it_killed_before_forgetting
+    swarm = boot_swarm
+    stragglers = swarm.children.keys
+    waited = []
+
+    with_stubbed_wait2(reaps_everything(waited)) { swarm.send(:hard_kill_stragglers) }
+
+    assert_equal stragglers.sort, swarm.killed.map(&:first).sort
+    assert_equal stragglers.sort, waited.sort, 'a SIGKILLed straggler left unwaited stays a zombie'
+    assert_empty swarm.children
+  end
+
+  # SIGKILL is asynchronous, so the sweep retries — but a pid wedged in
+  # uninterruptible sleep must not hold the drain open. The budget is spent and
+  # the table cleared regardless.
+  def test_hard_kill_stragglers_gives_up_on_a_pid_that_never_reaps
+    swarm = boot_swarm
+    attempts = 0
+    never_reaps = lambda do |_pid, _flags|
+      attempts += 1
+      nil
+    end
+
+    with_stubbed_wait2(never_reaps) { swarm.send(:hard_kill_stragglers) }
+
+    assert_equal SLOTS * Wurk::Swarm::HARD_KILL_REAP_ATTEMPTS, attempts, 'the sweep must be bounded'
+    assert_empty swarm.children, 'an unreapable straggler must still be forgotten'
+  end
+
+  private
+
+  def topology
+    Wurk::Topology.flat(count: SLOTS, queues: ['default'], concurrency: 1)
+  end
+
+  def boot_swarm
+    swarm = ReapTestSwarm.new(topology: topology, config: @config)
+    swarm.boot(install_signals: false)
+    swarm
+  end
+
+  def respawn_pending?(swarm, idx)
+    swarm.instance_variable_get(:@respawn_backoff).pending?(idx)
+  end
+
+  # --- Process.wait2 stand-ins (pid, flags) -> nil | [pid, status] ---------
+
+  def still_running(log)
+    lambda do |pid, _flags|
+      log << pid
+      nil
+    end
+  end
+
+  def exits(dead, code)
+    ->(pid, _flags) { pid == dead ? [pid, Status.new(code)] : nil }
+  end
+
+  def echild_for(stolen)
+    lambda do |pid, _flags|
+      raise Errno::ECHILD if pid == stolen
+
+      nil
+    end
+  end
+
+  def reaps_everything(log)
+    lambda do |pid, _flags|
+      log << pid
+      [pid, Status.new(nil)]
+    end
+  end
+
+  # Minitest 6 dropped minitest/mock; this hand-rolled stub swaps Process.wait2
+  # for `replacement`, mirroring swarm_test.rb's fork stub. `parallelize_me!` is
+  # a no-op (test_helper.rb), so this class's tests run serially in their own
+  # forked worker and nothing else in the process waits while it is installed.
+  def with_stubbed_wait2(replacement)
+    sc = ::Process.singleton_class
+    original = ::Process.method(:wait2)
+    sc.define_method(:wait2) { |*args| replacement.call(*args) }
+    yield
+  ensure
+    sc.define_method(:wait2) { |*a| original.call(*a) }
+  end
+end

--- a/test/unit/swarm_test.rb
+++ b/test/unit/swarm_test.rb
@@ -242,7 +242,7 @@ class SwarmTest < Wurk::Test::UnitCase
 
     swarm.send(:heartbeat_seen?, 999_999)
 
-    assert_nil @config.default_capsule.instance_variable_get(:@redis_pool),
+    assert_nil @config.default_capsule.instance_variable_get(:@pools)[:main],
                'the heartbeat probe reopened the parent capsule pool that boot had closed'
   end
 

--- a/test/unit/web_config_test.rb
+++ b/test/unit/web_config_test.rb
@@ -84,6 +84,43 @@ class WebConfigTest < Wurk::Test::UnitCase
     refute Wurk::Web.config.authorized?({}, 'GET', '/api/stats')
   end
 
+  # --- rack_app memoization -----------------------------------------------
+
+  def test_rack_app_caches_for_the_same_inner_and_middlewares
+    inner = ->(_env) { [200, {}, ['ok']] }
+
+    first = Wurk::Web.config.rack_app(inner)
+    second = Wurk::Web.config.rack_app(inner)
+
+    assert_same first, second
+  end
+
+  def test_rack_app_rebuilds_when_middlewares_change
+    inner = ->(_env) { [200, {}, ['ok']] }
+    first = Wurk::Web.config.rack_app(inner)
+    Wurk::Web.configure { |c| c.use(Wurk::Web::Authorization) }
+    second = Wurk::Web.config.rack_app(inner)
+
+    refute_same first, second
+  end
+
+  # Regression: memoizing on the middleware list alone pins whichever
+  # `inner` the *first* caller passed, forever — a second mount (a second
+  # test's Rack app, a second engine mount) would silently get served the
+  # first one's app instead of its own.
+  def test_rack_app_rebuilds_when_inner_changes
+    first_inner = ->(_env) { [200, {}, ['first']] }
+    second_inner = ->(_env) { [200, {}, ['second']] }
+
+    first_app = Wurk::Web.config.rack_app(first_inner)
+    second_app = Wurk::Web.config.rack_app(second_inner)
+
+    refute_same first_app, second_app
+    _status, _headers, body = second_app.call(rack_env('GET', '/'))
+
+    assert_equal ['second'], body
+  end
+
   # --- Rack middleware --------------------------------------------------
 
   def test_middleware_returns_200_when_authorized


### PR DESCRIPTION
## Summary
- Stop the supervisor from reaping the host app's own subprocesses (`Swarm#reap_children`/`hard_kill_stragglers` now wait only on tracked pids)
- Bound every shutdown join (reaper, leader, launcher stoppers, embedded TERM handling) and always release Redis pools on `Launcher#stop`, not just when embedded
- Close the `Processor::WORK_STATE` publish window (RAII `track`) and the `Configuration#lookup` frozen-`@directory` `FrozenError` trap
- Fix four low-severity retention leaks: `on_poison` dedup + removable registration, `Heartbeat` FD leak (`File.foreach` → `File.open`), `Web::Config#rack_app` stale-memo, `Client::Buffered#reset!` orphaning its drainer thread
- Make the SSE concurrency guard self-healing: thread-identity-scoped slots instead of a counter, so a hard-reaped stream thread doesn't permanently 503 `/api/stream`
- Every fix carries its own proving regression test (mutation-checked against the pre-fix code), including both branches where a fix added one

## Test plan
- [x] `bin/rake test` — 3219 runs, 0 failures, 7 skips
- [x] `bin/rake test:parity` — 23/0
- [x] `bin/rake test:ecosystem` — 182/0
- [x] `COVERAGE=1 bin/rake test` — line 97.01%, branch 90.98% (≥90/90 gate)
- [x] All 7 `rake bench` gate labels intact (checked per-commit across the group)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788703670&installation_model_id=11168&pr_number=392&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F392&signature=25f444782758cc2339971387fbcbc6a21f4f62ec380b04c604b36613ad1b107a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->