### PR TITLE
docs(plans): beyond-Sidekiq feature plan + dashboard locale/theme/date slices

### DIFF
--- a/docs/plans/2026/08/07/101-beyond-sidekiq/00-census.md
+++ b/docs/plans/2026/08/07/101-beyond-sidekiq/00-census.md
@@ -1,0 +1,82 @@
+# 00 — Cross-ecosystem census
+
+> Part of [`overview.md`](overview.md). Depends on: none. **Reference only — no code changes.**
+
+Surveyed 2026-08-07: BullMQ + Pro, pg-boss, Bee-Queue · Oban + Pro · River, Asynq, Faktory, Machinery · Celery, Dramatiq, RQ, arq, Huey · Laravel Queues + Horizon, Symfony Messenger · Hangfire, Quartz.NET · JobRunr · Temporal, Restate, Inngest, Trigger.dev, Hatchet · Solid Queue, GoodJob, Que, Resque · SQS, Cloud Tasks, Cloudflare Queues, Azure Service Bus.
+
+Legend: ✅ shipped · 🟡 partial · ❌ absent.
+
+## Where Wurk already leads
+
+Batches + callbacks, five limiter types, leader-elected cron, unique jobs, AES-256-GCM encryption + rotation, transactional enqueue (`transaction_aware_client.rb`), outage buffering (`client/buffered.rb`), reliable BLMOVE fetch, Lua bulk enqueue, metrics + history + StatsD, queue pause, poison-pill guard, fork parallelism, K8s probes. Ahead of every surveyed system except the durable-execution tier.
+
+## Gaps, by area
+
+### Orchestration
+| Capability | Prior art | Wurk | Slice |
+|---|---|---|---|
+| Batch + completion callback | Sidekiq Pro, Hangfire, Faktory | ✅ | — |
+| DAG / parent-child flows | BullMQ `FlowProducer`, Oban Pro Workflows, Celery `chord`, Temporal child workflows | ❌ | 11 |
+| Chains (ordered, result piped) | Laravel `Bus::chain`, Celery `chain`, Oban Pro chains | ❌ | 11 (follow-on) |
+| Continuations | Hangfire `ContinueJobWith` | 🟡 one-job batch | 11 |
+| Saga / compensation | Temporal, Restate | ❌ | non-goal |
+| Durable replayable steps | Temporal, Inngest, Trigger.dev | ❌ | non-goal |
+
+### Dedup
+| Capability | Prior art | Wurk | Slice |
+|---|---|---|---|
+| until_executed / executing / both | Sidekiq Ent, Asynq, River | ✅ `Wurk::Unique` | — |
+| Unique by arg subset | River, Laravel `uniqueId` | 🟡 whole-arg hash | 09 |
+| Debounce (collapse burst, keep last) | pg-boss debounce, Inngest, BullMQ dedup TTL-extend | ❌ | 09 |
+| Throttle-to-slot (one per N sec) | pg-boss `singletonSeconds` | ❌ | 09 |
+
+### Concurrency & rate
+| Capability | Prior art | Wurk | Slice |
+|---|---|---|---|
+| Concurrent/window/bucket/leaky/points | Sidekiq Ent | ✅ | — |
+| Global per-queue concurrency | BullMQ global concurrency, Oban Pro Smart Engine | ❌ | 10 |
+| Keyed groups (tenant = concurrency+rate+priority+pause) | BullMQ Pro Groups, Hatchet | ❌ | deferred |
+| Sequential partitions in a concurrent queue | Oban Pro chains | ❌ | deferred |
+| Dynamic rate limit (worker signals back-off) | BullMQ `RateLimitError` | ❌ | deferred |
+
+### Reliability
+| Capability | Prior art | Wurk | Slice |
+|---|---|---|---|
+| Reliable fetch, crash reclaim | Sidekiq Pro, Faktory | ✅ | — |
+| Per-job timeout | Asynq, Celery `time_limit`, Dramatiq | ❌ | 08 |
+| Per-job deadline | Asynq `Deadline`, Cloud Tasks | 🟡 `expires_in` pre-execution only (`middleware/expiry.rb`) | 08 |
+| Lease renewal / stall watchdog | SQS visibility timeout, BullMQ stalled checker, River | 🟡 reclaimed at process boot only | deferred |
+| Filtered DLQ redrive | SQS redrive, pg-boss | 🟡 retry-all, no filter | deferred |
+
+### State & observability
+| Capability | Prior art | Wurk | Slice |
+|---|---|---|---|
+| Store return value | BullMQ `returnvalue`, Celery result backend, Oban Pro output | ❌ | 06 |
+| Retain completed jobs | Asynq retention, Hangfire succeeded list | ❌ | 06 |
+| Look up state by jid | sidekiq-status, BullMQ `Job.fromId` | 🟡 dashboard set scan | 06 |
+| Per-job progress | BullMQ `updateProgress`, sidekiq-status | 🟡 batches + iterables only | 06 |
+| OpenTelemetry traces | BullMQ 5.x, Temporal, JobRunr | ❌ | 05 |
+| Prometheus endpoint | AsynqMon, Hangfire exporters | ❌ | deferred |
+| Outbound webhooks / event stream | Inngest, Trigger.dev, Hatchet | 🟡 SSE for SPA only | deferred |
+| Cooperative cancellation | Celery `revoke`, BullMQ observables, Temporal | ❌ | deferred |
+
+### Polyglot & remote
+| Capability | Prior art | Wurk | Slice |
+|---|---|---|---|
+| Language-agnostic producers | Faktory (7+ client langs), BullMQ (Python/Rust/Elixir/PHP/.NET) | ❌ | 07 |
+| HTTP enqueue | Cloud Tasks, Cloudflare Queues, Inngest | ❌ | 07 |
+| Versioned admin API | SQS API, Hangfire | 🟡 dashboard JSON only | 07 |
+| HTTP consumer protocol (fetch/ack) | Faktory, Cloud Tasks push targets | ❌ | non-goal (see 07 §non-goals) |
+
+### Priority
+Per-job numeric priority inside one queue (BullMQ, Dramatiq, pg-boss, Solid Queue, River) is **deferred, not dropped**: Sidekiq queues are Redis **lists**, so it needs a parallel zset — which skews ordering against non-Wurk producers on the same queue and violates pillar 1. Ship only with a design that degrades cleanly, or not at all.
+
+## Declared non-goals
+
+- **Durable-execution engine** (Temporal/Restate replay + determinism + workflow versioning). Different failure model; not expressible in Sidekiq job JSON. Flows (slice 11) cover the 80% Rails apps reach for.
+- **SQL backend** (River/Oban/Solid Queue/pg-boss/Hangfire territory). Pillar 1 is "same Redis key schema"; a second backend halves parity confidence and competes for a user Wurk isn't targeting.
+- **Anything mutating an existing key or JSON field.**
+
+## Sources
+
+BullMQ [docs](https://docs.bullmq.io/) · [flows](https://docs.bullmq.io/guide/flows) · [Pro changelog](https://docs.bullmq.io/bullmq-pro/changelog) — Oban Pro [site](https://oban.pro/) · [releases](https://oban.pro/releases/pro) — River [site](https://riverqueue.com/) · [repo](https://github.com/riverqueue/river) — Asynq [repo](https://github.com/hibiken/asynq) · [aggregation](https://github.com/hibiken/asynq/wiki/Task-aggregation) · [unique](https://github.com/hibiken/asynq/wiki/Unique-Tasks) — Faktory [wiki](https://github.com/contribsys/faktory/wiki) — Celery [canvas](https://docs.celeryq.dev/en/stable/userguide/canvas.html) · [time limits](https://deepwiki.com/celery/celery/3.5-time-limits-and-rate-limits) — Dramatiq [guide](https://dramatiq.io/guide.html) — pg-boss [site](https://pgboss.io/) · [jobs API](https://timgit.github.io/pg-boss/api/jobs) — Laravel [queues](https://laravel.com/docs/12.x/queues) — Hangfire [overview](https://www.hangfire.io/overview.html) — Temporal [workflow execution](https://docs.temporal.io/workflow-execution) — Hatchet/Trigger.dev/Inngest [comparison](https://www.pkgpulse.com/guides/hatchet-vs-trigger-dev-v3-vs-inngest-durable-workflows-2026) — Solid Queue [repo](https://github.com/rails/solid_queue) — GoodJob [repo](https://github.com/bensheldon/good_job) — SQS [patterns](https://jayendrapatil.com/aws-sqs-simple-queue-service/) — Cloud Tasks [docs](https://cloud.google.com/tasks/docs/migrating)

--- a/docs/plans/2026/08/07/101-beyond-sidekiq/01-metrics-interrupted-job.md
+++ b/docs/plans/2026/08/07/101-beyond-sidekiq/01-metrics-interrupted-job.md
@@ -1,0 +1,62 @@
+# 01 — Interrupted IterableJob booked as a failure (#394)
+
+> Part of [`overview.md`](overview.md). Depends on: none. Independent of every other slice — land it first.
+
+Known issue: [#394](https://github.com/developerz-ai/wurk/issues/394). Carried from `docs/plans/2026/07/31/101-leak-logic-perf-fixes/status.yml` as **F13**, deliberately left for a parity determination.
+
+## Symptom
+
+One cooperatively-interrupted `IterableJob` books one spurious `<klass>|f`, then books `<klass>|p` when it resumes and completes. Dashboard failure rate inflates for any app that interrupts iterable jobs across restarts.
+
+## Why
+
+`Metrics::History#call` (`lib/wurk/metrics/history.rb:65-86`) treats *any* exception escaping `yield` as `success = false`. `InterruptHandler` self-prepends (`lib/wurk/middleware/interrupt_handler.rb:46`), so it sits **outside** `Metrics::History` — `Wurk::Job::Interrupted` propagates up *through* the metrics middleware before `InterruptHandler` (`:31`) catches it, re-pushes, and converts to `JobRetry::Skip`.
+
+`Wurk::Batch::ServerMiddleware` already models the right treatment (`lib/wurk/batch/server_middleware.rb:56`): a handled/skip exit or a cooperative interruption is **neither** success nor failure.
+
+Not affected: `Limiter::Rescheduled` — the limiter middleware is outside `Metrics::History` (`lib/wurk.rb:285-291`) and raises without ever yielding to it, so a rescheduled job isn't counted at all today. Only in play if a host app reorders the chain. Real failures are also correct: `JobRetry::Handled` comes from `retrier.local`/`global`, which wrap the chain from outside, so `Metrics::History` sees the raw exception.
+
+## Blocking decision (settle before writing code)
+
+Record the outcome in `docs/idea/parity-divergences.md` if it diverges from upstream.
+
+| Question | Options |
+|---|---|
+| Does an interrupted run book `p`/`f` at all? | neither (suggested) · `p` · `f` (today) |
+| Does it book `<klass>|ms`? | no (consistent with batch middleware's all-or-nothing) · yes (it consumed real wall-clock; omitting under-reports "time spent in FooJob") |
+
+Oracle: upstream Sidekiq `Metrics::ExecutionTracker`. `docs/target/sidekiq-free.md` does **not** pin the interrupted case — check the real implementation, not the spec doc. If upstream also counts it as a failure, fixing it is an intentional divergence and must be documented as one.
+
+## Files to change
+
+- `lib/wurk/metrics/history.rb:65-86` — `#call`: rescue `Wurk::Job::Interrupted` and re-raise without recording (per the decision above).
+- `lib/wurk/metrics/statsd.rb:145` — identical shape, same question. Sidekiq **Pro §9** parity. Fix in the same pass or the two emitters disagree.
+- `docs/idea/parity-divergences.md` — record the divergence if any.
+- `CHANGELOG.md` — `[Unreleased]`, behavior change.
+
+## Steps
+
+1. Settle the two questions above. Write the answer + reasoning at the top of this file before touching code (same pattern as `docs/plans/2026/08/06/101-faster-than-sidekiq/00-semantics-signoff.md`).
+2. `history.rb#call` — add the rescue. Suggested shape from the issue:
+   ```ruby
+   rescue Wurk::Job::Interrupted
+     raise   # neither success nor failure; recorded when the job resumes and completes
+   ```
+   Mind the existing `ensure`-based recording: the fix must prevent the record, not just re-raise past it.
+3. Mirror in `metrics/statsd.rb:145`.
+4. Confirm `Limiter::Rescheduled` behavior is unchanged (it never reaches these middlewares) and add a regression test that pins that ordering assumption — it is the thing a future chain reorder would silently break.
+
+## Tests
+
+- Unit: interrupted job through the real chain → no `|f` bucket written, `|p` written once after resume+completion.
+- Unit: genuinely failed job still books `|f` (guard against over-broad rescue).
+- Unit: `Limiter::Rescheduled` still books nothing; assert the chain order that makes it so.
+- Statsd equivalents for all three.
+- `bin/rake test TEST=test/unit/metrics_history_test.rb`, then full `bin/rake test` + `test:parity`. Coverage ≥90/90.
+
+## Done when
+
+- One interruption produces exactly one `p` and zero `f` for the class.
+- `Metrics::History` and `Metrics::Statsd` agree.
+- Decision recorded; divergence (if any) in `docs/idea/parity-divergences.md` and `CHANGELOG.md`.
+- #394 closed with the parity determination written in the issue.

--- a/docs/plans/2026/08/07/101-beyond-sidekiq/02-frontend-locale.md
+++ b/docs/plans/2026/08/07/101-beyond-sidekiq/02-frontend-locale.md
@@ -1,0 +1,58 @@
+# 02 — Locale auto-detect + user override
+
+> Part of [`overview.md`](overview.md). Depends on: none. Disjoint from backend slices — safe to run in parallel.
+
+## What exists
+
+`frontend/src/i18n/index.ts`:
+- `detectLocale()` — reads `#wurk-root[data-locale]`, falls back to `navigator.language`, then `'en'`.
+- `directionFor()` + `RTL_LANGS` — `ar`/`he`/`fa` → `dir="rtl"`.
+- `loadHostOverrides()` — reads `#wurk-i18n` JSON `<script>` for host copy overrides.
+- Bundles: `en es fr de pt-BR ja zh-CN ar`. `langKey` match is `locale.startsWith(k)`.
+- `frontend/src/main.tsx:18-19` sets `document.documentElement.dir` / `.lang` before first paint; `:31` mirrors `dir` onto the root node.
+
+So auto-detect **is already there**. Three real gaps:
+
+| Gap | Evidence |
+|---|---|
+| `data-locale` and `#wurk-i18n` are **never emitted by the engine** — the documented host-override path is unwired | `grep -rn "wurk-i18n\|data-locale" --include=*.rb` → no hits. `dashboard_controller.rb#index` injects only `window.__WURK_BASE__` (`:41-51`) |
+| No user-visible override — a browser set to `de` can't view the board in `en` | no picker anywhere in `frontend/src/components/` |
+| `startsWith` match is wrong-way-round for regional tags | `locale = "pt"` matches key `"pt-BR"`? No — `"pt".startsWith("pt-BR")` is false, so `pt` falls back to `en` instead of `pt-BR`. `"es-419"` → matches `es` correctly. Asymmetric. |
+
+## Files to change
+
+- `frontend/src/i18n/index.ts` — `detectLocale()` precedence chain; fix bundle matching; export `setLocale()`/`availableLocales`.
+- `frontend/src/main.tsx:18-19` — unchanged behavior, but locale now comes from the resolved chain.
+- `frontend/src/components/` — new `LocalePicker.tsx`, mounted in the left-rail/settings area (see `layout/` SCSS + existing nav component).
+- `app/controllers/wurk/dashboard_controller.rb:41-51` — emit `data-locale` on `#wurk-root` from `Accept-Language` (and any host-configured default), alongside the existing base-script injection. Same `js_string`-style escaping discipline.
+- `lib/wurk/web/config.rb` — host-settable default locale + allowed-locale list.
+- `frontend/src/i18n/i18n.test.ts` — extend.
+
+## Steps
+
+1. Precedence chain in `detectLocale()`, highest first:
+   1. `?locale=` query param (one-off, not persisted) — useful for support/debug.
+   2. `localStorage["wurk.locale"]` — the user's explicit pick.
+   3. `#wurk-root[data-locale]` — host/server hint (new, from `Accept-Language`).
+   4. `navigator.languages[]` — walk in order, first with a bundle wins (today only `navigator.language`).
+   5. `'en'`.
+2. Fix bundle matching: normalize to lowercase, try exact key, then base subtag → best regional bundle (`pt` → `pt-BR`, `zh` → `zh-CN`). Keep the existing "no bundle still flips RTL and falls back to en strings" behavior — it's deliberate (comment at `index.ts:22-27`).
+3. `setLocale(loc)` — persist to `localStorage`, update `document.documentElement.lang`/`dir` and `#wurk-root.dir`, then reload. Full reload is acceptable and simpler than making `t()` reactive; `merged` is computed once at module scope by design.
+4. `LocalePicker` — lists `availableLocales` with endonyms (Deutsch, 日本語, العربية), current marked. Keyboard-navigable, labeled for screen readers.
+5. Engine side: parse `Accept-Language` (quality-ordered), intersect with the shipped locale list, emit as `data-locale`. Never trust it as markup — attribute-escape.
+6. Document `#wurk-i18n` host-override emission while in here — it's referenced by `loadHostOverrides()` but nothing produces it. Either wire it from a host-configurable hash in `Wurk::Web.config`, or delete the dead path. Don't leave it half-real.
+
+## Tests
+
+- `frontend/src/i18n/i18n.test.ts`: precedence order (all five levels), `pt` → `pt-BR`, `zh` → `zh-CN`, `es-419` → `es`, unknown locale → en strings + correct `dir`, RTL for `he`/`fa` without bundles, `setLocale` persists.
+- Component test: picker renders every locale, click calls `setLocale`.
+- Engine test: `Accept-Language: de-DE,de;q=0.9,en;q=0.8` → `data-locale="de"`; unknown language → no attribute (SPA falls through to `navigator.languages`); header injection attempt is escaped.
+- `bun run test` + `tsc -b` in `frontend/`; `bin/rake test TEST=test/engine/dashboard_controller_test.rb`.
+
+## Done when
+
+- A user can override the detected language from the UI and it survives reload.
+- `Accept-Language` picks the right bundle on first paint (no flash of English).
+- `pt` and `zh` resolve to their regional bundles.
+- `#wurk-i18n` is either emitted by the engine or removed.
+- RTL behavior unchanged for `ar`/`he`/`fa`.

--- a/docs/plans/2026/08/07/101-beyond-sidekiq/03-frontend-theme.md
+++ b/docs/plans/2026/08/07/101-beyond-sidekiq/03-frontend-theme.md
@@ -1,0 +1,65 @@
+# 03 — Theme system (light / dark / system)
+
+> Part of [`overview.md`](overview.md). Depends on: none. Disjoint from backend slices.
+>
+> **Blocked on a maintainer call** — see "Decision" below. Everything else in the plan is independent of it.
+
+## What exists
+
+Dark-only, by explicit design:
+
+| Anchor | State |
+|---|---|
+| `frontend/index.html:2` | `<html lang="en" data-theme="dark">` |
+| `frontend/index.html:6-9` | `<meta name="color-scheme" content="dark">`, `theme-color` `#09090b`, **`<meta name="darkreader-lock">`** (stops Dark Reader washing it out) |
+| `frontend/src/styles/abstracts/_tokens.scss:15-45` | Obsidian zinc palette declared **unlayered on bare `:root`** so it beats daisyUI's layered theme regardless of source order |
+| `CLAUDE.md` (Dashboard §) · `docs/idea/08-dashboard.md` | "dark-only" is documented as a property of the design system |
+
+The token layer is the right shape for theming — every colour is a CSS var on `:root`, no component hardcodes one (`_tokens.scss:1-6`). The work is a palette, not a refactor.
+
+## Decision (get this before building)
+
+Light mode is a **visual-identity change**, not a feature toggle. Obsidian was authored against a near-black canvas: "luminance over hue", 1px borders and no shadows, colour reserved for status signal only. A light palette has to re-derive that hierarchy — borders and tonal surfaces carry all the structure, and they invert badly.
+
+Ask: ship light mode, or ship only "respect `prefers-color-scheme` for the *system* option and keep dark as the sole palette"? If the answer is dark-only, close this slice and keep the `darkreader-lock`.
+
+## Files to change
+
+- `frontend/src/styles/abstracts/_tokens.scss` — restructure: dark palette stays the `:root` default; add a light palette block.
+- `frontend/index.html:2,6-9` — `data-theme` set by an inline pre-paint script; `color-scheme` → `light dark`; drop/condition `darkreader-lock`.
+- `frontend/src/main.tsx:17-19` — theme applied alongside `dir`/`lang`, before render.
+- new `frontend/src/theme.ts` — resolve, persist, subscribe to system changes.
+- new `frontend/src/components/ThemeToggle.tsx` — three-state control (light / dark / system), next to `LocalePicker` (slice 02).
+- `app/controllers/wurk/dashboard_controller.rb:41-51` — optional host-configured default theme, same injection point as slice 02's `data-locale`.
+- Any component with a literal colour — audit; `_tokens.scss:1-6` claims there are none, verify rather than trust.
+
+## Steps
+
+1. Three-state model: `'light' | 'dark' | 'system'` in `localStorage["wurk.theme"]`, default `'system'`. `'system'` resolves via `matchMedia('(prefers-color-scheme: light)')` and **live-updates** on change (add the listener; don't resolve once at boot).
+2. Apply as `data-theme="light|dark"` on `<html>` — the resolved value, never `system`.
+3. **Pre-paint inline script** in `index.html` reading `localStorage` + `matchMedia` and stamping `data-theme` before the bundle loads. Without it every dark-mode user gets a white flash on each load. It must be inline (no import) and tiny.
+4. Token structure — mirrors the Artifact/theme-aware convention:
+   - bare `:root` — full dark palette (today's values, unchanged; keeps it the design default).
+   - `:root[data-theme="light"]` — light overrides for the same var names only.
+   - Do not define any colour solely inside a media query or a `[data-theme]` block; every var needs a value on bare `:root`.
+5. Light palette derivation: invert luminance, don't invert hue. Canvas `#fafafa`-ish, surfaces stepping *down* in lightness, borders darker not lighter. Status colours (`--color-error/-warning/-success`) need re-picking for contrast on light — the current values are tuned for `#09090b` and will fail WCAG AA on white. Verify every text/background pair at AA.
+6. `--color-scheme` meta + `theme-color` must track the resolved theme (mobile browser chrome).
+7. `darkreader-lock` (`index.html:9`) — keep it only while a real light theme exists to switch to; otherwise Dark Reader users lose the light option. If light mode ships, remove it.
+8. Charts: `frontend/src/components/charts/` — hand-rolled SVG. Confirm they read tokens, not literals (`charts/util.tsx` is the likely offender).
+
+## Tests
+
+- `frontend/src/theme.test.ts`: default `system`; explicit choice persists and wins over system; `matchMedia` change flips the resolved theme only in `system` mode; resolved value is never `'system'`.
+- Component test: toggle cycles all three states, updates `documentElement.dataset.theme`.
+- Visual check via `bin/rake frontend:build` + dummy app (`cd test/dummy && bin/rails s`) on both themes: dashboard, queues, retries, a chart page, a modal.
+- Contrast audit at AA for every token pair in the light palette. Record the numbers in the PR.
+- `bun run test` + `tsc -b`.
+
+## Done when
+
+- Light / dark / system all render correctly, no flash of the wrong theme on load.
+- `system` tracks OS changes live without reload.
+- Choice persists across reloads and across mounts.
+- No component hardcodes a colour; charts follow the theme.
+- AA contrast met in both palettes.
+- `CLAUDE.md` Dashboard § and `docs/idea/08-dashboard.md` no longer say "dark-only" (slice 12 carries the docs).

--- a/docs/plans/2026/08/07/101-beyond-sidekiq/04-frontend-dates.md
+++ b/docs/plans/2026/08/07/101-beyond-sidekiq/04-frontend-dates.md
@@ -1,0 +1,57 @@
+# 04 — User-relative dates & timezones
+
+> Part of [`overview.md`](overview.md). Depends on: 02 (locale resolution) for the formatting locale. Disjoint from backend slices.
+
+## What exists
+
+`frontend/src/utils.ts`:
+
+| Fn | Today | Problem |
+|---|---|---|
+| `relativeTime(epochSeconds)` | hand-rolled `s`/`m`/`h`/`d` + hardcoded English `" ago"` / `" from now"` | untranslated in all 8 locales; wrong grammar in ja/ar/de; no weeks/months/years — a 400-day-old dead job reads `400d ago` |
+| `isoTime(epochSeconds)` | `new Date(ms).toISOString()` for hover titles | always **UTC**, never the user's zone. Guarded against `NaN` (`utils.ts:26-32`) — keep that guard. |
+| `formatDuration(seconds)` | `ms`/`s`/`m`/`h`/`d` composites | English unit letters, not localized |
+| `formatKb(kb)` | `KB`/`MB`/`GB` | same |
+
+Consumers (don't miss any): `pages/Retries.tsx`, `Scheduled.tsx`, `Dead.tsx`, `Busy.tsx`, `Queues.tsx`, `Cron.tsx`, `Batches.tsx`, `BatchDetail.tsx`, `Search.tsx`, `Limiters.tsx`, `Profiles.tsx`, `Metrics.tsx`, `components/JobDetailModal.tsx`, `components/charts/*`.
+
+All timestamps arrive as **epoch float seconds** from the API (Sidekiq score format) — that stays untouched. This slice is display-only.
+
+## Files to change
+
+- `frontend/src/utils.ts` — rewrite the four formatters over `Intl`.
+- new `frontend/src/tz.ts` — resolved timezone + user override.
+- `frontend/src/i18n/*.json` — no new strings needed for relative time (`Intl.RelativeTimeFormat` handles it), but **do** add the timezone-picker labels and the "shown in <tz>" affordance.
+- new `frontend/src/components/TimezonePicker.tsx` (or fold into the settings surface built in 02/03).
+- `frontend/src/components/charts/util.tsx` — axis tick labels are dates; must use the same zone.
+- `frontend/src/utils.test.ts` — extend.
+
+## Steps
+
+1. **Locale-aware relative time.** Replace the hand-rolled branch chain with `Intl.RelativeTimeFormat(locale, { numeric: 'auto' })` — gives "yesterday"/"vor 3 Stunden"/"3時間前" for free. Pick the unit by magnitude and extend the ladder past days: second → minute → hour → day → week → month → year. Keep the `Number.isFinite` guard (`utils.ts:3-4`) — sorted-set entries do arrive without a usable timestamp and the `'—'` fallback is deliberate.
+2. **Timezone resolution**, highest precedence first:
+   1. `localStorage["wurk.tz"]` — explicit user pick.
+   2. `Intl.DateTimeFormat().resolvedOptions().timeZone` — the browser's zone (this is "relative to the user" for ~everyone).
+   3. `'UTC'`.
+   Offer `UTC` as an explicit option — ops people comparing against server logs want it, and it's why the current hardcoded UTC isn't simply a bug.
+3. **Absolute times** via `Intl.DateTimeFormat(locale, { timeZone, dateStyle, timeStyle })`. Keep an ISO/UTC rendering available in the hover title alongside the local one — losing UTC entirely would be a regression for log correlation. Keep the `RangeError` guard (`utils.ts:26-30`): `new Date(NaN).toISOString()` throws and unmounts the whole table.
+4. **Live-updating relatives.** A `5m ago` cell currently only re-renders when its query refetches. Add one shared interval signal (a single timer for the whole page, not one per cell) that ticks the relative labels. Cheap; `VirtualList.tsx` is already in play for long tables, so don't attach timers per row.
+5. `formatDuration` / `formatKb` — use `Intl.NumberFormat` with `style: 'unit'` where the unit exists (`second`, `hour`, `kilobyte`, `megabyte`). Composite forms ("21m 49s") have no `Intl` equivalent — compose two formatted parts, don't concatenate raw letters.
+6. Surface the active zone in the UI (footer or settings) so a user reading `14:03` knows whose `14:03` it is.
+7. Sweep every consumer listed above for inline date formatting that bypasses `utils.ts`.
+
+## Tests
+
+- `frontend/src/utils.test.ts`: relative output in en/de/ja/ar for past and future at each unit boundary; `NaN`/`Infinity` → `'—'`; the week/month/year ladder.
+- Timezone: fixed epoch renders differently under `America/New_York` vs `UTC` vs `Asia/Tokyo`; override beats browser zone; invalid stored zone falls back rather than throwing (`Intl` throws on a bad `timeZone`).
+- DST boundary case — a timestamp inside the ambiguous hour formats without throwing.
+- Live-tick: one timer per page, cleaned up on unmount (no leak — same discipline as the RAII pass in `docs/plans/2026/07/31/`).
+- `bun run test` + `tsc -b`.
+
+## Done when
+
+- Relative times read naturally in all 8 shipped locales, including RTL.
+- Absolute times render in the user's zone, with UTC still reachable.
+- Zone is user-overridable and persists.
+- Relative labels tick without a refetch, from one shared timer.
+- No `toISOString()` or hand-rolled date math left outside `utils.ts`/`tz.ts`.

--- a/docs/plans/2026/08/07/101-beyond-sidekiq/05-opentelemetry.md
+++ b/docs/plans/2026/08/07/101-beyond-sidekiq/05-opentelemetry.md
@@ -1,0 +1,62 @@
+# 05 — OpenTelemetry
+
+> Part of [`overview.md`](overview.md). Depends on: none.
+>
+> **Additive invariant:** not required, not loaded, not registered unless the host opts in. With OTel absent, zero new objects, zero new Redis commands, zero new JSON keys — byte-identical behavior to today.
+
+## Why
+
+BullMQ 5.x, Temporal, and JobRunr ship first-party tracing; Sidekiq needs a third-party gem. A producer span that links to the consumer span across the Redis hop is the single most-requested observability feature in every survey ([`00-census.md`](00-census.md)).
+
+## Shape
+
+A client/server middleware **pair**, in a new `lib/wurk/telemetry/`:
+
+| Side | Does |
+|---|---|
+| Client middleware | Inject W3C `traceparent` (+ `tracestate` if present) into the job hash under a single key. Start/end a `<queue> publish` producer span. |
+| Server middleware | Extract the context, open a `<klass> process` consumer span **linked** to the producer, set standard messaging attributes, record the exception on failure. |
+
+Attribute names follow the OTel **messaging** semantic conventions (`messaging.system=wurk`, `messaging.destination.name=<queue>`, `messaging.message.id=<jid>`) — do not invent a private vocabulary.
+
+## The one JSON addition
+
+`traceparent` (and optionally `tracestate`) become extra top-level keys in the job hash. This is the plan's only unavoidable payload change.
+
+- Precedent: sidekiq-cron, sidekiq-unique-jobs, sidekiq-status all add top-level keys; Sidekiq's own `Processor` ignores unknown keys.
+- Contract: a Wurk-enqueued traced job **must still run unmodified on stock Sidekiq**, and a Sidekiq-enqueued job with no `traceparent` must run here. Both directions get an integration test.
+- Needs the sign-off recorded in `docs/idea/parity-divergences.md` before merge (overview "Risks").
+- Keys appear **only** when tracing is enabled.
+
+## Files to change
+
+- new `lib/wurk/telemetry.rb`, `lib/wurk/telemetry/client_middleware.rb`, `lib/wurk/telemetry/server_middleware.rb`.
+- `lib/wurk.rb:258-306` — registration, guarded: only when the host calls the opt-in. Read the ordering comments at `:258`, `:273`, `:285` before choosing a position. The server span should wrap as much of the chain as possible → register **early** (outer), but stay inside `InterruptHandler` so an interruption isn't recorded as a span error (same trap as slice 01).
+- `lib/wurk/configuration.rb` — the opt-in accessor.
+- `wurk.gemspec` — **no** hard dependency. `opentelemetry-api` stays an optional runtime require; the middlewares no-op if the constant is missing.
+
+## Steps
+
+1. Optional-dependency guard: `require`-rescue at load, and a `Telemetry.available?` predicate. Nothing registers unless both "gem present" and "host opted in" hold.
+2. Client middleware: inject on `push` and on every `push_bulk` item. Bulk is the Lua path (`client.rb:84`, `:300`) — verify the injected key survives it and doesn't defeat the single-`verify_json` optimization from `docs/plans/2026/08/06/101-faster-than-sidekiq/04-enqueue-client.md`.
+3. Server middleware: extract, open a linked span, set attributes, `record_exception` + error status on a real failure. Treat `Wurk::Job::Interrupted`, `JobRetry::Skip`, and `Limiter::Rescheduled` as **not** errors — see `lib/wurk/batch/server_middleware.rb:56` for the canonical rescue list.
+4. Retries: a retried job carries the original `traceparent`. Decide — link to the original trace (recommended, one trace per logical job) vs. a fresh root per attempt. Document the choice.
+5. Scheduled/cron jobs: a job enqueued now and run in 6 hours has a long-dead producer span. Use a span **link**, not a parent-child edge, past some threshold. Document.
+6. Encryption interaction (`lib/wurk/encryption.rb`): `traceparent` is metadata, not an argument — it must **not** be encrypted, and must not break the encrypted-args round-trip. Test explicitly.
+
+## Tests
+
+- Unit: injection present when enabled, absent when disabled (byte-compare the payload against the non-traced one).
+- Unit: extraction + link; interrupted/skipped/rescheduled jobs produce a non-error span.
+- Integration (real Redis, real fork): traced enqueue → traced execute, parent-child/link intact across the process boundary.
+- **Drop-in:** a traced job consumed by a stock Sidekiq worker; a stock-Sidekiq job (no `traceparent`) consumed here.
+- Encryption: encrypted args + tracing enabled, both survive.
+- `rake bench` with tracing **off** — must be within noise of main. Report the numbers.
+- Full `bin/rake test`, `test:parity`, `test:ecosystem`. Coverage ≥90/90.
+
+## Done when
+
+- Enqueue and execute spans link across the Redis hop, in-process and across forks.
+- OTel gem absent or opt-in off → payload and hot path byte-identical to today, proven by test and by `rake bench`.
+- Drop-in both directions proven.
+- Retry and long-delay semantics documented; JSON addition recorded in `docs/idea/parity-divergences.md`.

--- a/docs/plans/2026/08/07/101-beyond-sidekiq/06-job-status-results.md
+++ b/docs/plans/2026/08/07/101-beyond-sidekiq/06-job-status-results.md
@@ -1,0 +1,59 @@
+# 06 — Job status, progress & results (`Wurk::Status`)
+
+> Part of [`overview.md`](overview.md). Depends on: none. **Blocks 07** (`GET /jobs/:jid`) and **11** (chains need a result to pipe).
+>
+> **Additive invariant:** opt-in per worker class. A worker that doesn't opt in writes nothing, reads nothing, allocates nothing. Default path unchanged.
+
+## Why
+
+Four census gaps in one feature ([`00-census.md`](00-census.md)): succeeded jobs vanish entirely (Asynq retention, Hangfire's succeeded list), no per-job progress outside batches/iterables (BullMQ `updateProgress`), no lookup by jid (BullMQ `Job.fromId`), no stored return value (BullMQ `returnvalue`, Celery result backend, Oban Pro output recording). Also subsumes the `sidekiq-status` gem, which the ecosystem suite already tests against (`bin/rake test:ecosystem`) — **check its expectations first; don't collide with its key names.**
+
+## Data model
+
+New keys only, under a new prefix declared in `lib/wurk/keys.rb` (follow `:15-53`):
+
+| Key | Type | Holds | TTL |
+|---|---|---|---|
+| `status:<jid>` | HASH | `state`, `queue`, `class`, `enqueued_at`, `started_at`, `finished_at`, `progress`, `total`, `message`, `result`, `error_class`, `error_message`, `attempt` | configurable, default ~30 min; longer on `complete` if retention is on |
+
+`state`: `enqueued` → `running` → `complete` \| `failed` \| `interrupted` \| `retrying` \| `dead`.
+
+**No existing key is read or written.** No score format, no queue list, no sorted set touched.
+
+## Files to change
+
+- new `lib/wurk/status.rb` (+ `lib/wurk/status/` if it grows), `lib/wurk/middleware/status.rb`, `lib/wurk/lua/status_*.lua`.
+- `lib/wurk/keys.rb` — new prefix + TTL constant.
+- `lib/wurk/worker.rb` — `wurk_options track: true` (and the `Sidekiq::Worker` alias path).
+- `lib/wurk.rb` — register the server middleware, guarded by the opt-in.
+- `lib/wurk/client.rb:71,84` — write the `enqueued` row **only** for tracked classes; must not add a round-trip to untracked enqueue (fold into the existing pipeline/Lua, don't append a command).
+- `lib/wurk.rb` — `Sidekiq::Status` alias if and only if it doesn't clash with the gem.
+
+## Steps
+
+1. Read `docs/target/sidekiq-{free,pro,ent}.md` — confirm nothing upstream owns this surface. This is a **Wurk extra**, not parity; it must not shadow a Sidekiq name with different semantics.
+2. Check the `sidekiq-status` ecosystem suite (`test/ecosystem/`) before choosing key names or a `Sidekiq::Status` alias. Coexistence beats collision.
+3. `Wurk::Status` API: `.get(jid)`, `.delete(jid)`, and inside a job `status.at(50, 100, "halfway")`, `status.message(...)`. Progress writes are HSET+EXPIRE — one round-trip, and **rate-limited/coalesced** so a tight loop calling `at()` per row can't flood Redis. Document the coalescing.
+4. Result capture: the server middleware records `perform`'s return value. Cap the serialized size hard (e.g. 8 KB) and truncate with a flag rather than storing blobs — a job returning an ActiveRecord relation must not fill Redis. JSON only (`CLAUDE.md`: never MessagePack).
+5. Terminal states: reuse the exact rescue taxonomy from `lib/wurk/batch/server_middleware.rb:56` so `interrupted`/`skipped` are not `failed` — the same trap as slice 01.
+6. Retention: `complete` rows get their own TTL knob. Off by default; `0` means "delete immediately on success" (today's behavior).
+7. Encryption: if args are encrypted (`lib/wurk/encryption.rb`), the result is likely sensitive too. Either encrypt stored results with the same key or refuse to store them for encrypted workers — pick one, document it, don't leak plaintext results beside encrypted args.
+
+## Tests
+
+- Unit: full lifecycle per state; progress coalescing; result truncation at the cap; TTL set on every write.
+- Unit: untracked worker → **zero** new Redis commands (assert via command count, the harness from `bench/command_count.rb`).
+- Unit: interrupted job → `interrupted`, not `failed`.
+- Integration: real fork, status readable from another process mid-run.
+- Ecosystem: `bin/rake test:ecosystem` still green with `sidekiq-status` installed.
+- Encryption: tracked + encrypted worker stores no plaintext result.
+- `rake bench` with tracking off — within noise.
+- Coverage ≥90/90.
+
+## Done when
+
+- `Wurk::Status.get(jid)` returns state, progress, timings, result, error for a tracked job.
+- Untracked workers are provably unchanged (command count + bench).
+- Completed-job retention is configurable, off by default.
+- No collision with `sidekiq-status`; ecosystem suite green.
+- Encrypted workers don't leak results.

--- a/docs/plans/2026/08/07/101-beyond-sidekiq/07-http-producer-api.md
+++ b/docs/plans/2026/08/07/101-beyond-sidekiq/07-http-producer-api.md
@@ -1,0 +1,114 @@
+# 07 — HTTP API: enqueue, status, swarm
+
+> Part of [`overview.md`](overview.md). Depends on: 06 (`GET /jobs/:jid` needs `Wurk::Status`). Enqueue + swarm endpoints can land before 06; gate the job-status route on it.
+>
+> **Additive invariant:** the API is **off unless a token is configured**. No token → no routes mounted, no behavior change, nothing new on the hot path. It is a producer + observer of existing Redis structures; it does not alter how jobs are stored or run.
+
+## Why
+
+Sidekiq has no supported remote enqueue path. Faktory is the only mainstream polyglot option and needs its own server process. Wurk can serve it from the engine the app already mounts — a Python or Go service enqueues into the same Redis, and a Ruby swarm runs it.
+
+## What exists (and why it isn't this)
+
+`config/routes.rb` already has a JSON API — but it is a **dashboard** API: SPA-shaped payloads, same-origin CSRF (`app/controllers/concerns/wurk/same_origin_guard.rb`), session / `Wurk::Web.use` auth, unversioned, **read + mutate only, no create**. Its shape is free to change when the SPA changes. A machine-facing API needs the opposite guarantee. Build a separate plane; reuse the serializers (`app/controllers/wurk/api/serializers.rb`) and pagination (`api/pagination.rb`), not the controller.
+
+## Surface (`/api/v1`)
+
+### Produce
+| Route | Notes |
+|---|---|
+| `POST /jobs` | one job |
+| `POST /jobs/bulk` | many — maps to the existing Lua bulk path (`client.rb:84`, `:300`) |
+| `GET /jobs/:jid` | state, progress, result, error — **needs slice 06** |
+| `DELETE /jobs/:jid` | remove from schedule/retry sets by jid (not a running-job cancel — that's a separate deferred feature) |
+
+Body is the Sidekiq job hash, nothing invented:
+```json
+{ "class": "HardWorker", "args": [1, "two"], "queue": "default", "at": 1786000000, "retry": 5 }
+```
+
+### Observe — queues & sets
+`GET /queues` · `GET /queues/:name` · `POST /queues/:name/pause` · `POST /queues/:name/unpause` · `GET /stats` · `GET /retries` · `GET /scheduled` · `GET /dead` · `GET /batches/:bid`.
+All read through the canonical inspectors (`Wurk::Stats`, `Queue`, `RetrySet`, `ScheduledSet`, `DeadSet`, `BatchSet`) — same objects the dashboard uses, so the two can never disagree.
+
+### Observe — swarm / topology
+The "how is the swarm actually working" surface. Everything below already exists in Redis or in-process; this exposes it over HTTP.
+
+| Route | Source | Returns |
+|---|---|---|
+| `GET /swarm` | `Wurk::ProcessSet` + `lib/wurk/topology.rb` | cluster roll-up: process count, child slots per host, total concurrency, queues served, leader identity (`lib/wurk/leader.rb`), rolling-restart state (`swarm/restart.rb`), quiet/stopping flags |
+| `GET /processes` | `Wurk::ProcessSet` | per-process: identity, hostname, pid, tag, concurrency, queues, busy count, RSS, `beat` age, quiet flag, version |
+| `GET /processes/:identity` | ditto | one process + its in-flight work |
+| `POST /processes/:identity/quiet` · `/stop` | same signals as the Busy page (`api_controller#quiet_process`, `#stop_process`) | TSTP / TERM; `all` targets every process |
+| `GET /busy` | `Wurk::WorkSet` | currently-executing jobs cluster-wide |
+| `GET /health` | `lib/wurk/health.rb` | the K8s liveness/readiness view, as JSON |
+| `GET /limiters` · `GET /cron` | `Wurk::Limiter`, `Wurk::Cron::LoopSet` | limiter state, cron entries + next-fire |
+
+Heartbeat staleness matters here: a process that died between beats is still in `processes` until its TTL lapses. Return `beat_age_seconds` and a derived `stale` boolean rather than making every client re-derive it.
+
+## Mounting
+
+Three ways, one implementation. `Wurk::API` is a Rack app; the engine just mounts it.
+
+**1. Inside the engine (default).** Already-mounted apps get it for free at `<mount>/api/v1` once a token is set:
+```ruby
+# config/routes.rb
+mount Wurk::Engine => "/wurk"        # API at /wurk/api/v1
+```
+
+**2. Mounted separately.** Useful to put the machine API on a different path, host, or middleware stack than the dashboard — e.g. dashboard behind Devise on the app domain, API on an internal-only route:
+```ruby
+mount Wurk::API => "/wurk-api"       # API at /wurk-api/v1, dashboard untouched
+```
+
+**3. Standalone, no Rails.** `CLAUDE.md`: standalone mode must run without the engine. `Wurk::API` is plain Rack under `lib/`, so:
+```bash
+bundle exec wurk api --port 7433     # or: run Wurk::API in any config.ru
+```
+
+Mount-agnostic like the SPA (`dashboard_controller.rb:41-51`): never hardcode `/wurk` in a URL the API emits — derive from `SCRIPT_NAME`.
+
+## Files to change
+
+- new `lib/wurk/api/` — `app.rb` (Rack router), `auth.rb`, `jobs.rb`, `queues.rb`, `swarm.rb`, `serializers.rb`.
+- `lib/wurk/engine.rb` + `config/routes.rb` — conditional mount when a token is configured.
+- `lib/wurk/cli.rb` — `wurk api` subcommand.
+- `lib/wurk/configuration.rb` — tokens, scopes, enable flag, payload caps, throttle.
+- new `clients/python/` (or a sibling repo) — one reference client.
+- `docs/api-http.md` — new; slice 12 wires it into README/site/wiki/`llms.txt`.
+
+## Steps
+
+1. **Auth first, before any route works.** Bearer tokens, scoped `enqueue` / `read` / `admin`. Compare with a constant-time check. No token configured → the app isn't mounted at all (not "mounted and 401" — don't advertise a surface that shouldn't exist). Never reuse the dashboard's session/CSRF path; `same_origin_guard` is meaningless for a machine client and would only weaken it.
+2. **Byte-identical enqueue.** Route straight through `Wurk::Client#push` / `#push_bulk` (`client.rb:71,84`) — do **not** hand-build a payload. This is the pillar-1 test: an HTTP-enqueued job must be indistinguishable from a Ruby-enqueued one, and runnable by stock Sidekiq.
+3. **Validate at the boundary.** Class name is a string from the network: enforce a strict format, cap `args` size, cap total body size, reject unknown top-level keys. A `strict_classes:` mode (allow-list of enqueueable classes) defaults **on** for `enqueue`-scoped tokens — a polyglot producer that can name any constant is remote code selection.
+4. Idempotency: `Idempotency-Key` header → server-side dedupe; composes with slice 09 once that lands. Until then, a short-TTL seen-key set.
+5. Errors as RFC-9457-ish JSON problem objects, stable machine-readable `type` strings. Versioned path (`/v1`) means the shape is a contract — write it down in `docs/api-http.md` at the same time as the code.
+6. Rate-limit per token; return `Retry-After`. Reuse `Wurk::Limiter` rather than a second limiter implementation.
+7. Swarm endpoints read `ProcessSet`/`WorkSet`/`Health` only — no new heartbeat writes, no new Redis keys, no extra beat traffic.
+8. One reference client (Python or TS), thin: enqueue, bulk, status, queues. Publish only after the surface is frozen.
+
+## Non-goals
+
+- **No consumer protocol.** Faktory-style fetch/ack over HTTP means owning lease semantics, heartbeats, and reclaim for clients Wurk can't test — it puts the reliability guarantee in third-party hands. Producers first; revisit only on real demand.
+- No GraphQL, no gRPC.
+- No new job storage. Every route reads or writes structures that already exist.
+
+## Tests
+
+- Auth: no token configured → routes absent (404, not 401). Wrong token → 401. Wrong scope → 403. Constant-time comparison asserted.
+- **Drop-in (the headline test):** enqueue over HTTP, then byte-compare the Redis payload against `Wurk::Client#push` for the same input; and an integration test where a **stock Sidekiq** worker consumes an HTTP-enqueued job.
+- Validation: oversized body, oversized args, unknown class under `strict_classes`, malformed `at`, unknown top-level key.
+- Swarm: `GET /swarm` and `/processes` against a real forked swarm (integration, real Redis — never mock, `CLAUDE.md`); stale-heartbeat process reported `stale: true`.
+- Mounting: all three modes — engine-nested, separately mounted, standalone Rack — serve the same routes and emit mount-correct URLs.
+- Read-only mode (`WURK_WEB_READ_ONLY=1`) interaction: decide and test whether it also freezes the API (it should, for `admin`-scoped writes).
+- `rake bench`: API off → within noise of main.
+
+## Done when
+
+- A non-Ruby process can enqueue, and a Wurk swarm runs the job.
+- HTTP-enqueued payload is byte-identical to the Ruby path; stock Sidekiq consumes it.
+- `GET /swarm` answers "how is the swarm working" without opening the dashboard.
+- All three mount modes work and are documented in `docs/api-http.md`.
+- No token → nothing mounted, nothing changed.
+- One client library published with a runnable example.

--- a/docs/plans/2026/08/07/101-beyond-sidekiq/08-timeout-deadline.md
+++ b/docs/plans/2026/08/07/101-beyond-sidekiq/08-timeout-deadline.md
@@ -1,0 +1,55 @@
+# 08 — Per-job timeout & deadline
+
+> Part of [`overview.md`](overview.md). Depends on: none.
+>
+> **Additive invariant:** opt-in per worker via `wurk_options`. A worker without `timeout:`/`deadline:` gets no timer, no allocation, no behavior change.
+
+## Why
+
+Asynq (`Timeout`, `Deadline`), Celery (`time_limit` / `soft_time_limit`), and Dramatiq all treat this as table stakes; Sidekiq deliberately omits it. Wurk's `expires_in` (`lib/wurk/middleware/expiry.rb`) only drops a job **before** execution — nothing bounds a job that hangs on a wedged socket after it starts.
+
+## Semantics (decide, then implement)
+
+| Option | Meaning |
+|---|---|
+| `timeout: 30` | max wall-clock for **this attempt**. Exceeded → raise in the job thread → normal retry path. |
+| `deadline: 5.minutes` | absolute cutoff from **enqueue**. Past it → don't start; if running, abandon. Not per-attempt — retries can't outlive it. |
+
+Decisions to settle before code:
+1. **Soft vs hard.** Celery distinguishes: soft raises a catchable exception (job can clean up), hard kills. Recommend soft-only. Hard-killing a Ruby thread mid-`perform` (`Thread#kill`) leaks connections and half-written state — exactly the class of bug the RAII pass in `docs/plans/2026/07/31/101-leak-logic-perf-fixes/` closed. If a hard kill is wanted, it belongs at the process level, not the thread.
+2. **Does a timeout count as a failure?** Recommend yes — it's a real failure with a real exception, unlike the interrupted case in slice 01. But say so explicitly so `Metrics::History` treatment is deliberate.
+3. **Retry interaction.** A timed-out job retries by default (`Asynq` does). A job that times out every attempt burns the retry budget and lands in the dead set — correct, but note it in docs.
+4. **Deadline expiry state.** Silently dropped (like `expires_in`, which books `stat:expired` — `lib/wurk/keys.rb:48`) or booked as failed? Reuse the `expired` stat for consistency.
+
+## Files to change
+
+- new `lib/wurk/middleware/timeout.rb`.
+- `lib/wurk/worker.rb` — accept `timeout:` / `deadline:` in `wurk_options`; validate types at declaration, not per job.
+- `lib/wurk/job_util.rb` — carry the values in the payload (only when set).
+- `lib/wurk.rb:258` — registration. Must sit **inside** `Batch`/`Expiry` and **outside** `Metrics::History`, so a timeout is measured and booked. Read the ordering comments before inserting.
+- `lib/wurk/manager.rb` / `lib/wurk/processor.rb` — the timer's home if a per-thread timer is too costly (see step 2).
+
+## Steps
+
+1. Prefer `Timeout.timeout`'s successor pattern over the stdlib `Timeout` module where possible — stdlib `Timeout` spawns a thread per call and is notorious for firing inside `ensure` blocks. Measure both; a single monotonic watchdog thread per Manager scanning in-flight deadlines is likely cheaper than N timer threads and is the shape Asynq/River use.
+2. Bound the cost: with no timeouts configured anywhere, the watchdog must not start at all.
+3. Deadline check happens twice: at fetch (before `perform`, alongside `Expiry`) and inside the watchdog for a job already running.
+4. Interaction with `IterableJob` (`lib/wurk/iterable_job.rb`): a cooperatively-interrupted job re-enqueues and resumes. A `deadline` must survive the re-enqueue (it's absolute); a `timeout` resets per attempt. Test both.
+5. Interaction with `shutdown_timeout`: on TERM, in-flight jobs get the swarm's drain budget. A job `timeout` shorter than that fires first; longer, and shutdown wins. Document which.
+
+## Tests
+
+- Unit: job exceeding `timeout` raises, retries, books a failure.
+- Unit: job past `deadline` never starts; running job past `deadline` is abandoned; `stat:expired` (or the chosen stat) increments.
+- Unit: no timeout configured → watchdog never starts, zero extra threads (assert thread count).
+- `IterableJob`: deadline survives interrupt+resume; timeout resets per attempt.
+- Integration: real fork, real Redis, a genuinely hanging job (sleep) is cut at the bound.
+- Leak check: no thread or connection leak after 1000 timed-out jobs — the RAII discipline from the previous plan applies.
+- `rake bench` with no timeouts configured → within noise.
+
+## Done when
+
+- `wurk_options timeout: 30, deadline: 5.minutes` bounds a hanging job.
+- Zero cost when unconfigured, proven by thread count + bench.
+- Soft/hard, failure-booking, retry, and shutdown interactions all documented.
+- No leaked threads or connections under sustained timeouts.

--- a/docs/plans/2026/08/07/101-beyond-sidekiq/09-debounce-throttle.md
+++ b/docs/plans/2026/08/07/101-beyond-sidekiq/09-debounce-throttle.md
@@ -1,0 +1,61 @@
+# 09 — Debounce & throttle-to-slot
+
+> Part of [`overview.md`](overview.md). Depends on: none. Extends `Wurk::Unique` — read `lib/wurk/unique.rb` before starting.
+>
+> **Additive invariant:** new opt-in policies alongside the existing `until:` values. A worker using today's `unique:` behavior sees no change; a worker using neither sees no code path at all.
+
+## Why
+
+pg-boss's two collapse policies, absent from Sidekiq and from `Wurk::Unique`. Both solve problems Rails apps hit constantly — search-index rebuilds, webhook fan-in, cache warms, "user changed something, re-derive the projection".
+
+| Policy | Behavior | Prior art |
+|---|---|---|
+| **debounce** | Collapse a burst; keep the **last** payload; fire after N seconds of quiet | pg-boss debounce, Inngest `debounce`, BullMQ dedup with TTL extension |
+| **throttle-to-slot** | At most one per N-second slot; extras dropped (or coalesced) | pg-boss `singletonSeconds` |
+
+Distinct from today's uniqueness: `Wurk::Unique` prevents a *duplicate* while one is pending/running. Debounce deliberately *delays* and *replaces*; throttle deliberately *drops*.
+
+## What exists
+
+`lib/wurk/unique.rb`:
+- `DEFAULT_UNTIL = :success`, `VALID_UNTIL = %i[success start]` (`:49-50`).
+- `lock_key(klass, queue, args)` (`:117`), `lock_key_for(job)` (`:125`), `unique_context(job)` (`:135`), `active_job_context` (`:165`), `release_if_owner(conn, key, jid)` (`:88`).
+- Host hook `sidekiq_unique_context(job)` (documented `:36-44`) lets a class narrow the key — **this is already the "unique by arg subset" escape hatch**; document it rather than building a second mechanism.
+
+## Files to change
+
+- `lib/wurk/unique.rb` — new policy values; keep `VALID_UNTIL` validation strict so a typo fails loudly.
+- new `lib/wurk/lua/debounce.lua`, `lib/wurk/lua/throttle_slot.lua`; register in `lib/wurk/lua.rb` (EVALSHA-cached once per pool — `CLAUDE.md`).
+- `lib/wurk/client.rb:71,84` — the collapse decision happens at enqueue, on the client side.
+- `lib/wurk/keys.rb` — new key prefixes for debounce/throttle state.
+- `lib/wurk/worker.rb` — `wurk_options unique: { policy: :debounce, wait: 5 }` shape.
+
+## Steps
+
+1. **Debounce must be one atomic Lua call**, not read-then-write — two concurrent producers must not both schedule. The script: upsert the pending payload under the debounce key, (re)set the scheduled-set entry to `now + wait`, extend the key TTL. Replacing the payload means the *last* enqueue wins, which is the whole point.
+2. Debounce writes into the existing `schedule` ZSET with the existing score format — **do not invent a parallel delayed structure**. A debounced job in `schedule` must be indistinguishable to any other reader, including stock Sidekiq and the dashboard.
+3. Cap the delay: a key re-extended forever never fires. Add `max_wait` (fire regardless after this long from the *first* enqueue). Without it, a busy key starves — this is the classic debounce bug.
+4. **Throttle-to-slot**: `SET key jid NX EX <slot>` semantics; on collision, drop. Decide and document whether the dropped enqueue returns `nil` (pg-boss returns no job id) or the winning jid — callers branch on this.
+5. Both policies interact with `Wurk::Unique`'s existing lock. Define precedence explicitly: a class declares **one** policy. Reject a config that sets both, at class-definition time.
+6. `push_bulk` (`client.rb:84`): decide whether policies apply per item. Recommend yes, but it turns the single Lua bulk call into a per-item decision — measure. If the cost is real, restrict policies to `push` and raise on bulk rather than silently ignoring them.
+7. ActiveJob path: `active_job_context` (`unique.rb:165`) already unwraps the wrapper class. Policies must key off the *inner* job, same as uniqueness does.
+
+## Tests
+
+- Unit: 100 rapid enqueues in a burst → exactly one job, carrying the **last** payload.
+- Unit: `max_wait` fires under continuous re-enqueue (the starvation case).
+- Unit: throttle drops within slot, admits in the next slot; documented return value.
+- Unit: policy + existing `unique:` both set → raises at class definition.
+- Unit: debounced entry in `schedule` has the canonical score format and is readable by the plain `ScheduledSet` inspector.
+- Concurrency: two processes debouncing the same key simultaneously → one job (integration, real Redis, real forks).
+- ActiveJob wrapper keys off the inner class.
+- Ecosystem: `sidekiq-unique-jobs` suite still green.
+- `rake bench`: no policy configured → within noise; with debounce → report the added enqueue cost.
+
+## Done when
+
+- Debounce collapses a burst to one job with the last payload, and can't starve.
+- Throttle admits at most one per slot with documented semantics.
+- Debounced/throttled jobs are ordinary Sidekiq-shaped entries in existing structures.
+- Conflicting config fails at definition, not at runtime.
+- Existing `Wurk::Unique` behavior and the ecosystem suite unchanged.

--- a/docs/plans/2026/08/07/101-beyond-sidekiq/10-global-concurrency.md
+++ b/docs/plans/2026/08/07/101-beyond-sidekiq/10-global-concurrency.md
@@ -1,0 +1,53 @@
+# 10 — Global per-queue concurrency
+
+> Part of [`overview.md`](overview.md). Depends on: none.
+>
+> **This is the one slice that touches the fetch hot path.** Everything else in the plan is inert when unused; this one has to prove it. If it can't be made free-when-unconfigured *and* cheap-when-configured, **defer it** — the previous plan fought from 10 Redis commands/job down to 3 (`docs/plans/2026/08/06/101-faster-than-sidekiq/08-measurements.md`) and giving that back for a feature most apps won't enable is a bad trade.
+
+## Why
+
+"At most 20 jobs from this queue running cluster-wide, whatever the worker count." Oban Pro's Smart Engine and BullMQ's global concurrency both sell this; Wurk's limiters can't express it — `Wurk::Limiter::Concurrent` is keyed per-lock, not per-queue, and gates *inside* the job (server middleware) rather than at fetch. Gating inside the job means the job is already claimed off the queue, so it either blocks a thread or reschedules — neither is a real cap.
+
+## Design constraints
+
+1. **Zero cost when unconfigured.** No config → the fetcher's code path must be identical to today's, not "identical plus a nil check per fetch". Resolve at boot, not per job.
+2. **Fold into the existing pipeline.** `lib/wurk/fetcher/reliable.rb` already pipelines BLMOVE with a piggybacked ack and a cached paused-set lookup. A concurrency gate must join that pipeline or that Lua, not add a round-trip.
+3. **Crash-safe.** A slot held by a process that was SIGKILLed must be released without operator action. Counter-based schemes leak on kill; use a TTL'd holder key per slot, refreshed by the existing heartbeat (`lib/wurk/heartbeat.rb`) — no new beat traffic.
+4. **No new fetch semantics for unconfigured queues.** Reliable BLMOVE stays the default and only fetcher (`CLAUDE.md`).
+
+## Files to change
+
+- `lib/wurk/fetcher/reliable.rb` — the gate, guarded so unconfigured queues short-circuit before any new work.
+- new `lib/wurk/lua/queue_slot.lua` — acquire/release, registered in `lib/wurk/lua.rb`.
+- `lib/wurk/keys.rb` — new slot-key prefix.
+- `lib/wurk/configuration.rb` — `global_concurrency: { "critical" => 20 }`.
+- `lib/wurk/processor.rb` — slot release on completion, RAII-style (`ensure`), matching the discipline from `docs/plans/2026/07/31/101-leak-logic-perf-fixes/`.
+- `lib/wurk/heartbeat.rb` — refresh held slots (piggyback, no extra beat).
+- Dashboard: expose per-queue cap + in-use count (`app/controllers/wurk/api_controller.rb#queues`, and the API in slice 07).
+
+## Steps
+
+1. Measure first. Add a `bench/` case for fetch under a configured cap before writing the gate, so the cost is known, not argued.
+2. Slot model: a per-queue capacity with TTL'd holders keyed by `<process identity>:<slot>`. Acquire and BLMOVE want to be one Lua script; if they can't be, acquire must at least ride the existing pipeline.
+3. **Starvation and fairness.** A capped queue with all slots held must not spin the fetcher. Back off on the capped queue while still serving other queues in the same fetch — otherwise one capped queue stalls the whole worker. This is the hard part, not the counting.
+4. Release on every exit path: success, failure, retry, interrupt, timeout (slice 08), process death (TTL). `ensure`, not a happy-path call.
+5. Interaction with rolling restart (`lib/wurk/swarm/restart.rb`): during a restart both the old and new slot hold capacity briefly. Decide whether that's tolerated (recommend yes, TTL bounded) and document it.
+6. Interaction with quiet/TSTP: a quiet process must release its slots, not sit on them while draining.
+
+## Tests
+
+- Unit: cap N, N+1 concurrent claims → the extra waits; released slot admits the waiter.
+- Integration (real forks, real Redis — never mocked): 4 processes × 5 threads against a cap of 3 → never more than 3 in flight, sustained.
+- Crash safety: SIGKILL a slot holder → capacity recovers within the TTL, no operator action.
+- Fairness: capped queue at capacity does not stall fetching from other queues.
+- Leak: 10k jobs through a capped queue → slot key count returns to zero.
+- **`rake bench` with no global concurrency configured → within noise of main, and `bench/command_count.rb` still reports 3 commands/job.** This is the gate on the whole slice.
+- `rake bench` with a cap configured → report the delta honestly; it is allowed to cost something.
+
+## Done when
+
+- A cluster-wide cap holds across processes and hosts.
+- Slots recover from SIGKILL without intervention.
+- Unconfigured path proven unchanged by command count **and** bench.
+- Capped queues don't starve other queues.
+- If any of the above can't be met: slice closed as **deferred**, with the measurements written up. That is an acceptable outcome.

--- a/docs/plans/2026/08/07/101-beyond-sidekiq/11-flows.md
+++ b/docs/plans/2026/08/07/101-beyond-sidekiq/11-flows.md
@@ -1,0 +1,73 @@
+# 11 — Flows (DAG) & chains
+
+> Part of [`overview.md`](overview.md). Depends on: 06 (chains pipe a result forward). Largest API addition in the plan — everything before it ships independently if this slips.
+>
+> **Additive invariant:** a new class alongside `Wurk::Batch`. Existing batches, callbacks, and nesting behave exactly as today. An app that never builds a flow never touches this code.
+
+## Why
+
+One API covers four prior arts at once ([`00-census.md`](00-census.md)): BullMQ `FlowProducer` parent-child, Oban Pro Workflows, Celery `chord`, Hangfire continuations. It's the most-requested capability Sidekiq Pro doesn't have — and Wurk is already 80% of the way there, because **a batch is a one-level flow**.
+
+## Build on batches, not beside them
+
+`lib/wurk/batch/` already owns: atomic creation (`buffer.rb`), success/complete/death callbacks (`callbacks.rb`, `callback_job.rb`), the "neither success nor failure" rescue taxonomy (`server_middleware.rb:56`), nesting, progress (`status.rb`), and death handling (`death_handler.rb`). A flow node is a batch whose success callback enqueues the parent. Reuse that machinery; do not write a second completion tracker — two trackers that can disagree is the failure mode here.
+
+Read `docs/target/sidekiq-pro.md` (Batches) and `docs/batches.md` before designing the API.
+
+## Shape
+
+```ruby
+Wurk::Flow.new do |f|
+  a = f.job(FetchJob, url)
+  b = f.job(FetchJob, other_url)
+  f.job(MergeJob, depends_on: [a, b])       # runs after both succeed
+end.run
+```
+
+Chains fall out of the same primitive — a linear flow where each node's result feeds the next (needs slice 06's stored return value).
+
+## Decisions to settle before code
+
+1. **Failure propagation.** A child fails permanently (lands in the dead set) — does the parent never run, run anyway, or run with a failure marker? BullMQ offers fail/continue/remove per edge. Recommend: default = parent never runs, flow marked failed; make it configurable per edge later, not now.
+2. **Partial results.** With `continue`, the parent needs to see which children succeeded. Ties to slice 06 storage and its size cap.
+3. **Depth and width limits.** "Unlimited nesting" (BullMQ's claim) plus callbacks means an accidental fan-out can bury Redis. Cap both; fail loudly at build time, not at runtime.
+4. **Dead-set interaction.** A dead child holds its parent forever. Needs a TTL/reaper, or an explicit "flow abandoned" terminal state visible in the dashboard.
+5. **Cycle detection** at build time — a DAG builder that accepts a cycle deadlocks silently.
+
+## Files to change
+
+- new `lib/wurk/flow.rb`, `lib/wurk/flow/` (node, builder, completion), `lib/wurk/lua/flow_*.lua`.
+- `lib/wurk/keys.rb` — flow key prefixes (new keys only).
+- `lib/wurk/batch/callbacks.rb` — extension point for "callback enqueues the parent node"; **do not** change existing callback semantics.
+- `lib/wurk.rb` — `Sidekiq::Flow` alias only if no upstream/ecosystem name collides. This is a Wurk extra, not parity — check first.
+- Dashboard: a flow view (graph + per-node state) — `app/controllers/wurk/api_controller.rb` + a new SPA page under `frontend/src/pages/`.
+- API: `GET /flows/:fid` in slice 07's surface.
+
+## Steps
+
+1. Write the decisions above into the top of this file first, with reasoning.
+2. Builder: construct the whole graph, validate (cycles, depth, width), then **create atomically** — a partially-created flow whose parent can never fire is worse than a rejected one. `batch/buffer.rb` already does atomic creation for the one-level case; extend that pattern.
+3. Node completion: reuse batch success callbacks. The callback resolves "are all my parent's other dependencies done?" in **one Lua call** — a read-then-decide races when two siblings finish simultaneously. This is the correctness core of the slice; test it under real concurrent forks.
+4. Chains: linear flow + slice 06's stored result as the next node's argument. Respect slice 06's result size cap — a chain passing a large payload must fail clearly, not truncate silently.
+5. Dashboard: flow graph with per-node state, reusing the existing SPA patterns (lazy-loaded route + `components/Skeleton.tsx` fallback, per `CLAUDE.md`).
+6. Kill switch: a way to abandon a stuck flow from the dashboard/API, releasing its keys.
+
+## Tests
+
+- Unit: diamond graph (A,B → C) fires C exactly once, after both.
+- **Concurrency: siblings finishing simultaneously across real forks fire the parent exactly once.** The race this slice exists to get right.
+- Failure: dead child → parent doesn't run, flow marked failed, keys reaped.
+- Build-time: cycle rejected; depth/width caps rejected; partially-built flow never persists.
+- Chains: result piped; oversized result fails clearly.
+- Nested flows and flows-inside-batches don't corrupt batch state; existing batch tests unchanged.
+- Integration: real Redis, real forks, a 3-level flow to completion.
+- `rake bench`: no flows in use → within noise.
+- Coverage ≥90/90 including the branchy completion logic.
+
+## Done when
+
+- A DAG with fan-out and fan-in executes in dependency order, parent fires exactly once.
+- Simultaneous sibling completion across processes is race-free (proven under forks, not mocked).
+- Failure, cycle, depth, and abandonment cases all have defined, tested behavior.
+- Existing `Wurk::Batch` behavior and tests are untouched.
+- Flow state visible in dashboard and API.

--- a/docs/plans/2026/08/07/101-beyond-sidekiq/12-docs-site.md
+++ b/docs/plans/2026/08/07/101-beyond-sidekiq/12-docs-site.md
@@ -1,0 +1,53 @@
+# 12 — Docs, site, README, llms.txt
+
+> Part of [`overview.md`](overview.md). Depends on: whichever slices actually shipped. **Run last.** Document only what landed — a doc for a deferred slice is worse than no doc.
+
+## Rule
+
+Every slice above is a **Wurk extra**, not Sidekiq parity. Docs must say so plainly, so a migrant can tell "this is the drop-in surface" from "this is Wurk-only, and using it ties you to Wurk". `docs/target/sidekiq-{free,pro,ent}.md` stay untouched — they are the parity spec, not a feature list.
+
+## Files to change
+
+| File | Change |
+|---|---|
+| new `docs/api-http.md` | slice 07: full route reference, **all three mount modes**, auth/scopes, error shapes, client examples. Written with the code, not after. |
+| new `docs/telemetry.md` | slice 05: setup, span/attribute names, retry + long-delay semantics |
+| new `docs/job-status.md` | slice 06: opt-in, API, retention, size caps, encryption interaction |
+| new `docs/flows.md` | slice 11: DAG + chains, failure propagation, limits |
+| `docs/unique-jobs.md` | slice 09: debounce + throttle policies; also document the existing `sidekiq_unique_context` hook (`lib/wurk/unique.rb:36-44`) — it's the supported "unique by arg subset" path and is currently undocumented |
+| `docs/retries.md` | slice 08: timeout/deadline in the failure lifecycle |
+| `docs/rate-limiting.md` | slice 10: global per-queue concurrency vs. the per-key limiters — say clearly which to reach for |
+| `docs/dashboard.md` | slices 02–04: theme, locale override, timezone |
+| `docs/configuration.md` | every new option, in the existing precedence table format |
+| `docs/metrics.md` | slice 01: what an interrupted run does and does not book |
+| `docs/idea/parity-divergences.md` | slice 01 outcome; any job-JSON key added by 05/06/08 |
+| `docs/idea/13-roadmap.md` | fold the shipped items into the roadmap; the "Stretch (post-1.0)" list is stale |
+| `README.md` | feature matrix — add a **"Wurk extras"** section distinct from the Sidekiq-tier table |
+| `CLAUDE.md` | Dashboard § still says "dark-only" — only if slice 03 shipped |
+| docs site (`docs/site/`) + wiki | mirror README; the site is published from here |
+| `llms.txt` | the machine-readable map — new features must appear or agents won't find them |
+| `CHANGELOG.md` | `[Unreleased]`, one entry per shipped slice, behavior changes called out |
+
+## Steps
+
+1. Inventory what actually landed. Check `status.yml` in this plan dir, not memory.
+2. For each shipped slice, write its doc page **before** touching README/site — the deep page is the source, the summaries link to it.
+3. Mark every extra as Wurk-only, with a one-line "what you give up if you migrate back to Sidekiq".
+4. **`CLAUDE.md` pillar 3 — no "faster than Sidekiq" claim anywhere.** This has been violated before, in `spec.summary` (published on the RubyGems page), the dashboard tagline in all 8 locales, and the site. Grep the whole repo — `README.md`, `wurk.gemspec`, `frontend/src/i18n/*.json`, `docs/site/`, `llms.txt`, `frontend/index.html` meta descriptions — before publishing. Wurk is 0.87×–1.02× (`docs/benchmarks.md`).
+5. Regenerate YARD for any new public class (`Wurk::Status`, `Wurk::Flow`, `Wurk::API`) and confirm the `Sidekiq::*` alias table in the README is still accurate.
+6. Re-run the doc-link check if one exists; otherwise spot-check every new link. The README is dense with links and a dead one ships in the gem.
+
+## Tests
+
+- `bin/rake test` (docs changes can break the engine's asset/manifest expectations if `docs/site` shares tooling).
+- Build the site locally; check new pages render and nav includes them.
+- `bin/rake release:check` — the tag ↔ `Wurk::VERSION` ↔ CHANGELOG gate. It has failed silently twice (v1.2.1, v1.5.0); run it before assuming a release is publishable.
+- Grep gate: zero "faster" claims outside `docs/benchmarks.md`'s measured context.
+
+## Done when
+
+- Every shipped slice has a docs page, linked from README and the site.
+- Extras are unambiguously distinguished from parity surface.
+- `llms.txt` and the YARD reference cover the new public classes.
+- CHANGELOG `[Unreleased]` complete, behavior changes flagged.
+- No unsupported performance claim anywhere in the repo, gem metadata, dashboard copy, or site.

--- a/docs/plans/2026/08/07/101-beyond-sidekiq/overview.md
+++ b/docs/plans/2026/08/07/101-beyond-sidekiq/overview.md
@@ -1,0 +1,69 @@
+# Beyond Sidekiq
+
+## Goal
+
+Add the features the rest of the job-queue world ships and Sidekiq does not — an HTTP producer API, OpenTelemetry, job status/results, per-job timeouts, debounce/throttle, global queue concurrency, flows — plus three dashboard gaps (locale override, light/dark theme, user-timezone dates), and fix the known [#394](https://github.com/developerz-ai/wurk/issues/394) metrics defect. Cross-ecosystem evidence for every item is in [`00-census.md`](00-census.md).
+
+## The additive invariant
+
+**Nothing here changes what already works.** Every feature is off by default and inert when unused: an app that adopts none of them runs the same code paths, writes the same bytes, and posts the same benchmark numbers as today. Concretely, each slice must show:
+
+- no existing Redis key, JSON field, or score format touched;
+- no new Redis command on the default enqueue/fetch/execute path (verify with `bench/command_count.rb`);
+- `rake bench` within noise of main **with the feature disabled**;
+- existing tests, parity suite, and ecosystem suite untouched — not adjusted to accommodate the feature.
+
+Two slices carry an asterisk and say so in their own file: **10** (global concurrency) is the only one that touches the fetch hot path and is allowed to close as *deferred* on the bench numbers; **03** (light theme) changes existing visuals and is blocked on a maintainer call. Slice **01** is a bug fix — it changes behavior on purpose.
+
+## Context
+
+- Ruby gem + mountable Rails engine, Sidekiq drop-in. **Wire-compat is sacred** (`CLAUDE.md`): no existing Redis key, JSON field, or score format changes. Where a slice adds a job-hash key (05, 06, 08), it says so and cites the precedent — third-party Sidekiq gems already add top-level keys freely, and upstream ignores unknown ones.
+- **Free pillar**: no tier, no flag gating, no license check. **Measured pillar**: anything on enqueue/fetch/execute must clear `rake bench` at ≤5%, or move off the hot path. `docs/benchmarks.md` — no "faster" claims.
+- Layer ownership table in `CLAUDE.md` is binding. User-facing → engine (`app/`, `lib/wurk/engine.rb`); non-user-facing → plain Ruby under `lib/`. **Standalone mode must run without the engine.**
+- Server middleware chain, outermost → innermost (`lib/wurk.rb:258-306`): `InterruptHandler` (prepended, `middleware/interrupt_handler.rb:46`) → `Batch` → `Expiry` → `Limiter` → `Statsd` → `Metrics::History` → perform. Ordering comments at `lib/wurk.rb:258`, `:273`, `:285` are the contract — read before inserting anything.
+- Existing JSON API (`config/routes.rb`) is **dashboard-shaped**: SPA payloads, same-origin CSRF (`concerns/wurk/same_origin_guard.rb`), session/`Wurk::Web.use` auth, unversioned, read+mutate only. **No create path.** Slice 07 adds a separate plane, not an extension of this one.
+- Dashboard: SolidJS + Vite, shell served by `app/controllers/wurk/dashboard_controller.rb#index` from `vendor/assets/dashboard/index.html`, mount-agnostic via `window.__WURK_BASE__` (`dashboard_controller.rb:41-51`). Build: `bin/rake frontend:build`. Tests: `bun run test` in `frontend/` (vitest).
+- Reference patterns to follow, don't reinvent:
+  - Additive server middleware: `lib/wurk/middleware/expiry.rb`, registration comment `lib/wurk.rb:258`.
+  - Skip-class exception treated as neither success nor failure: `lib/wurk/batch/server_middleware.rb:56`.
+  - Lua + EVALSHA cache: `lib/wurk/lua.rb`, `lib/wurk/lua/`.
+  - Redis key declaration: `lib/wurk/keys.rb:15-53`.
+  - Enqueue path to mirror byte-for-byte: `Wurk::Client#push` (`lib/wurk/client.rb:71`), `#push_bulk` (`:84`).
+  - Limiter shape for a new gate: `lib/wurk/limiter/base.rb`, `lib/wurk/limiter/server_middleware.rb`.
+
+## Plan files (execute in order)
+
+0. [`00-census.md`](00-census.md) — reference only, no code. Cross-ecosystem feature census + why each item made the cut.
+1. [`01-metrics-interrupted-job.md`](01-metrics-interrupted-job.md) — fix #394: interrupted `IterableJob` booked as a failure. Needs a parity determination first. Independent of everything else.
+2. [`02-frontend-locale.md`](02-frontend-locale.md) — locale auto-detect hardening + user override + `Accept-Language` server hint.
+3. [`03-frontend-theme.md`](03-frontend-theme.md) — light/dark/system theme system over the existing token layer.
+4. [`04-frontend-dates.md`](04-frontend-dates.md) — user-timezone + locale-aware relative and absolute dates.
+5. [`05-opentelemetry.md`](05-opentelemetry.md) — W3C trace context on enqueue, linked consumer span on execute. Opt-in middleware pair.
+6. [`06-job-status-results.md`](06-job-status-results.md) — `Wurk::Status`: per-jid state, progress, return value, timings. Unlocks 07's `GET /jobs/:jid`, 09, 11.
+7. [`07-http-producer-api.md`](07-http-producer-api.md) — versioned token-auth control plane: enqueue over HTTP, job status, **swarm/process/health inspection**, three mount modes, one client library.
+8. [`08-timeout-deadline.md`](08-timeout-deadline.md) — per-job `timeout:` / `deadline:`.
+9. [`09-debounce-throttle.md`](09-debounce-throttle.md) — two collapse policies on `Wurk::Unique`.
+10. [`10-global-concurrency.md`](10-global-concurrency.md) — cluster-wide per-queue cap. Hot path — bench gate in hand.
+11. [`11-flows.md`](11-flows.md) — `Wurk::Flow`: parent blocks on a child tree. Built on batches.
+12. [`12-docs-site.md`](12-docs-site.md) — docs, README, wiki, site, `llms.txt`, CHANGELOG for everything above.
+
+Slices 02–04 (frontend) touch files disjoint from 05–11 (backend) — safe to run in parallel per `CLAUDE.md` (same checkout, no worktrees, disjoint files). 06 blocks 07 and 11. 12 last.
+
+## Done when
+
+- Every shipped slice's own "Done when" is met.
+- `bin/rake test`, `test:parity`, `test:ecosystem` green; SimpleCov ≥90% line **and** branch on `lib/`.
+- `rake bench` gate green (no >5% regression on enqueue / fetch+execute / bulk enqueue / swarm boot / memory) **with every new feature disabled** — the default path must be unchanged — and separately measured with each enabled.
+- `bun run test` + `tsc -b` green in `frontend/`; `bin/rake frontend:build` produces a working bundle.
+- No existing Redis key or job JSON field changed. Any *added* job-hash key documented in `docs/idea/parity-divergences.md`.
+- Drop-in proof for slice 07: a job enqueued over HTTP is byte-identical to one from `Wurk::Client#push` and is consumed by a **stock Sidekiq** worker in an integration test.
+- Docs updated (slice 12) — no "faster than Sidekiq" claim added anywhere.
+
+## Risks / open questions
+
+- **#394 parity call blocks slice 01.** Upstream `Metrics::ExecutionTracker` is the oracle and `docs/target/sidekiq-free.md` doesn't pin the interrupted case. Decide: (a) does an interrupted run book `p`/`f` at all, (b) does it book `<klass>|ms`. `Metrics::Statsd` (`lib/wurk/metrics/statsd.rb:145`) has the same shape and is Pro §9 — settle both in one pass.
+- **Job-hash key additions** (05 traceparent, 06 status opt-in, 08 timeout/deadline) are the one place this plan touches the JSON. Precedent exists (sidekiq-cron, sidekiq-unique-jobs all add keys) but it needs an explicit sign-off before 05 lands, in the shape of `docs/plans/2026/08/06/101-faster-than-sidekiq/00-semantics-signoff.md`.
+- **Slice 10 is on the fetch hot path.** The last plan fought to 3 commands/job. A per-queue concurrency gate risks giving that back. If it can't be folded into the existing fetch pipeline, defer it rather than regress.
+- **Slice 07 attack surface.** An enqueue endpoint on a mounted engine is remote code execution by job class if auth is weak. Off unless a token is configured; never share the dashboard's session/CSRF model.
+- **Theme (03) is a visual-identity change.** `CLAUDE.md` and `docs/idea/08-dashboard.md` both say "dark-only"; `frontend/index.html:9` even ships a `darkreader-lock`. Confirm the maintainer wants light mode before building the palette — the token layer supports it, the design system was authored against dark.
+- Slice 11 (flows) is the largest API addition. If it slips, everything before it still ships independently.

--- a/docs/plans/2026/08/07/101-beyond-sidekiq/status.yml
+++ b/docs/plans/2026/08/07/101-beyond-sidekiq/status.yml
@@ -1,0 +1,64 @@
+plan: 101-beyond-sidekiq
+title: Beyond Sidekiq
+status: not_started
+created_by: sebi
+worked_by: ""
+owner: sebi
+percent: 0
+current_focus: "01-metrics-interrupted-job.md — needs the upstream ExecutionTracker parity call before code (issue #394)"
+slices:
+  - file: 00-census.md
+    status: complete
+    percent: 100
+  - file: 01-metrics-interrupted-job.md
+    status: not_started
+    percent: 0
+  - file: 02-frontend-locale.md
+    status: not_started
+    percent: 0
+  - file: 03-frontend-theme.md
+    status: not_started
+    percent: 0
+  - file: 04-frontend-dates.md
+    status: not_started
+    percent: 0
+  - file: 05-opentelemetry.md
+    status: not_started
+    percent: 0
+  - file: 06-job-status-results.md
+    status: not_started
+    percent: 0
+  - file: 07-http-producer-api.md
+    status: not_started
+    percent: 0
+  - file: 08-timeout-deadline.md
+    status: not_started
+    percent: 0
+  - file: 09-debounce-throttle.md
+    status: not_started
+    percent: 0
+  - file: 10-global-concurrency.md
+    status: not_started
+    percent: 0
+  - file: 11-flows.md
+    status: not_started
+    percent: 0
+  - file: 12-docs-site.md
+    status: not_started
+    percent: 0
+evidence:
+  - "00-census.md — cross-ecosystem survey completed 2026-08-07 (BullMQ/Pro, Oban Pro, River, Asynq, Faktory, Celery, Dramatiq, pg-boss, Laravel/Horizon, Hangfire, Temporal/Inngest/Trigger.dev/Hatchet, Solid Queue, GoodJob, SQS, Cloud Tasks). Sources linked in that file. No code."
+notes: >
+  Additive-only plan: every slice must be inert when unused — no change to the default
+  enqueue/fetch/execute path, no existing Redis key or JSON field touched. Slice 10
+  (global concurrency) is the sole hot-path slice and is explicitly allowed to close as
+  "deferred" if it can't clear the bench gate; that is a documented acceptable outcome,
+  not a failure. Slice 03 (light theme) is blocked on a maintainer call — CLAUDE.md and
+  docs/idea/08-dashboard.md both declare the dashboard dark-only by design.
+  Slice 01 fixes issue #394 and is independent of everything else; it needs a parity
+  determination against upstream Metrics::ExecutionTracker first, and Metrics::Statsd
+  (Pro §9) has the identical shape and must be settled in the same pass.
+  06 blocks 07 (GET /jobs/:jid) and 11 (chains need stored results). 02-04 (frontend)
+  are disjoint from 05-11 (backend) and can run in parallel in this checkout.
+  12 runs last and documents only what actually shipped.
+last_updated: 2026-08-07


### PR DESCRIPTION
Execution plan only — no code changes. `docs/plans/2026/08/07/101-beyond-sidekiq/`.

## What's in it

- **`00-census.md`** — cross-ecosystem feature census: BullMQ + Pro, Oban Pro, River, Asynq, Faktory, Celery, Dramatiq, pg-boss, Laravel/Horizon, Hangfire, Temporal/Inngest/Trigger.dev/Hatchet, Solid Queue, GoodJob, SQS, Cloud Tasks. Marks what Wurk already leads on and what's genuinely missing, with sources.
- **12 executable slices** — #394 metrics fix · dashboard locale override / theme system / user-timezone dates · OpenTelemetry · job status+results · HTTP API (enqueue, status, **swarm inspection**, three mount modes) · per-job timeout+deadline · debounce/throttle · global queue concurrency · flows (DAG) · docs.
- **`status.yml`** — tracker, `not_started`.

## The invariant

Additive-only. Every feature is off by default and inert when unused: no existing Redis key or job JSON field touched, no new Redis command on the default enqueue/fetch/execute path, `rake bench` within noise with the feature disabled, existing/parity/ecosystem tests untouched rather than adjusted.

Two slices carry an asterisk and say so in their own files:
- **10 (global concurrency)** is the only hot-path slice — explicitly allowed to close as *deferred* on the bench numbers rather than give back the 10→3 commands/job win.
- **03 (light theme)** changes existing visuals and is blocked on a maintainer call; `CLAUDE.md` and `docs/idea/08-dashboard.md` both declare the dashboard dark-only by design.

Slice **01** changes behavior on purpose — it's the parity determination for #394 (interrupted `IterableJob` booked as a failure), and `Metrics::Statsd` has the identical shape so both get settled in one pass.

Declared non-goals: a Temporal-style durable-execution engine, a SQL backend, and any change to an existing key or field.

Closes nothing yet; #394 is slice 01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788741912&installation_model_id=11168&pr_number=396&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F396&signature=b9e0901cf9250b4cfdc9ce40d7d1a443c9f44f7c183f83a4a580dbc6f5a75ed1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->