### PR TITLE
feat: dashboard locale override (negotiation, picker, tests)

### DIFF
--- a/app/controllers/wurk/dashboard_controller.rb
+++ b/app/controllers/wurk/dashboard_controller.rb
@@ -3,6 +3,7 @@
 require 'json'
 require 'net/http'
 require 'uri'
+require 'wurk/web'
 
 module Wurk
   # Serves the SPA shell. Everything else is JSON from ApiController.
@@ -25,15 +26,28 @@ module Wurk
     VITE_ASSET_BASE = "#{::Wurk::Engine::AssetMount::PREFIX}/".freeze # "/wurk-assets/"
     VITE_DEV_URL = "#{VITE_DEV_HOST}#{VITE_ASSET_BASE}".freeze
     INDEX_REL_PATH = ['vendor', 'assets', 'dashboard', 'index.html'].freeze
+    # The SPA mount point, matched without its closing `>` so the locale hint
+    # appends to whatever attributes the shell already carries.
+    ROOT_DIV = '<div id="wurk-root"'
 
     def index
-      render layout: false, html: inject_mount_base(spa_html).html_safe
+      render layout: false, html: decorate_shell(spa_html).html_safe
     end
 
     private
 
+    def decorate_shell(html)
+      inject_locale_hint(inject_head(html))
+    end
+
     def spa_html
       ENV['WURK_VITE_DEV'] == '1' ? fetch_vite_dev_shell : read_built_index
+    end
+
+    # Block form deliberately: a string replacement would interpret `\0`/`\&`
+    # backreferences inside the host-configured JSON these scripts carry.
+    def inject_head(html)
+      html.sub('</head>') { "#{mount_base_script}#{host_translations_script}</head>" }
     end
 
     # The SPA is mount-agnostic: it reads window.__WURK_BASE__ to build every API
@@ -41,20 +55,45 @@ module Wurk
     # the host mounts the engine at /wurk, /sidekiq, or /admin/jobs. script_name
     # is the mount prefix ("/sidekiq"), or "" at the app root. Injected into every
     # served shell (built and Vite-dev) so a non-/wurk mount needs no rebuild.
-    def inject_mount_base(html)
-      html.sub('</head>', "#{mount_base_script}</head>")
-    end
-
     def mount_base_script
       base = request.script_name.to_s.chomp('/')
-      %(<script>window.__WURK_BASE__ = #{js_string(base)};</script>\n  )
+      %(<script>window.__WURK_BASE__ = #{json_literal(base)};</script>\n  )
     end
 
-    # JSON-quote the mount prefix as a literal inside <script>, escaping the
-    # sequences that could otherwise break out of the tag. The mount is
+    # Host copy overrides (Wurk::Web.config.translations), read once at SPA boot
+    # by loadHostOverrides() in frontend/src/i18n/index.ts and deep-merged over
+    # the shipped bundle for the locale in use.
+    def host_translations_script
+      overrides = ::Wurk::Web.config.translations
+      return '' unless overrides.is_a?(::Hash) && !overrides.empty?
+
+      %(<script type="application/json" id="wurk-i18n">#{json_literal(overrides)}</script>\n  )
+    end
+
+    # First-paint language hint, third in the SPA's precedence chain (`?locale=`
+    # and a stored pick both outrank it), so it only decides the render for a
+    # visitor who has never chosen. The negotiator returns a tag from the host's
+    # offered list or nothing — request text never reaches the attribute — and
+    # no hint at all is the right answer for an unrecognized language: the SPA
+    # then falls through to navigator.languages.
+    def inject_locale_hint(html)
+      locale = negotiated_locale
+      return html unless locale
+
+      html.sub(ROOT_DIV) { %(#{ROOT_DIV} data-locale="#{::ERB::Util.html_escape(locale)}") }
+    end
+
+    def negotiated_locale
+      config = ::Wurk::Web.config
+      header = request.get_header('HTTP_ACCEPT_LANGUAGE')
+      ::Wurk::Web::LocaleNegotiator.call(header, offered: config.offered_locales) || config.default_locale
+    end
+
+    # JSON-encode a value as a literal inside <script>, escaping the sequences
+    # that could otherwise break out of the tag. Both payloads are
     # host-configured, not request input, but the injection stays safe regardless.
-    def js_string(str)
-      str.to_json.gsub(/[<>&]/) { |c| format('\u%04x', c.ord) }
+    def json_literal(value)
+      value.to_json.gsub(/[<>&]/) { |c| format('\u%04x', c.ord) }
     end
 
     def fetch_vite_dev_shell

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -708,6 +708,42 @@ end
 (`""`, `"0"`, `"false"`, `"no"`, `"off"` mean off). Authorization hooks, Rack
 middleware, and CSRF are covered in [authentication.md](authentication.md).
 
+### Language
+
+The dashboard ships copy for `en es fr de pt-BR ja zh-CN ar` and picks one per
+visitor, highest source first:
+
+1. `?locale=` on the URL — one-off, not persisted (handy in a support link).
+2. The visitor's own pick from the language menu (`localStorage`).
+3. The server hint: the engine negotiates the request's `Accept-Language`
+   against `offered_locales` and renders it as `data-locale` on the shell, so
+   the first paint is already in the right language.
+4. `navigator.languages`, first entry wurk ships a bundle for.
+5. English.
+
+```ruby
+Wurk.configure_server do |config|
+  # Narrow what the server will negotiate, or widen it with a locale you
+  # supply copy for yourself. Defaults to every bundled locale.
+  config.web.offered_locales = %w[en de he]
+  # Hint used when Accept-Language asks for nothing offered. Leave nil and the
+  # browser's own preference list decides instead.
+  config.web.default_locale = "de"
+  # Override any string in the shipped bundles, keyed by locale. Deep-merged,
+  # so untouched keys keep their translation.
+  config.web.translations = {
+    "en" => { "nav" => { "queues" => "Pipelines" } },
+    "he" => { "nav" => { "dashboard" => "לוח בקרה" } }
+  }
+end
+```
+
+A locale with no bundle (`he` above) still lays the board out right-to-left and
+falls back to English for keys you don't translate — which is what makes
+serving a language wurk doesn't ship possible without a gem release.
+`offered_locales` is unrelated to `config.web.locales`, the locale-*directory*
+list third-party web extensions append to.
+
 ---
 
 ## Health checks

--- a/frontend/src/components/LocalePicker.test.tsx
+++ b/frontend/src/components/LocalePicker.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@solidjs/testing-library';
+import LocalePicker from './LocalePicker';
+import { availableLocales, setLocale, t } from '../i18n';
+
+// Only setLocale is stubbed: it persists and then reloads, and jsdom has no
+// navigation. Everything else (t, availableLocales, the resolved locale) stays
+// real so the picker is exercised against the actual bundle registry.
+vi.mock('../i18n', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../i18n')>()),
+  setLocale: vi.fn(),
+}));
+
+const label = (name: string) => t('nav.language_current', { name });
+
+function open() {
+  render(() => <LocalePicker />);
+  const trigger = screen.getByRole('button', { name: label('English') });
+  fireEvent.click(trigger);
+  return trigger;
+}
+
+const items = () => screen.getAllByRole('menuitemradio');
+
+beforeEach(() => vi.mocked(setLocale).mockClear());
+
+describe('LocalePicker', () => {
+  it('labels the trigger with the resolved language and opens nothing until asked', () => {
+    render(() => <LocalePicker />);
+    const trigger = screen.getByRole('button', { name: label('English') });
+
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('lists every shipped locale by endonym with the current one marked', () => {
+    const trigger = open();
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('menu')).toHaveAccessibleName(t('nav.language'));
+    expect(items()).toHaveLength(availableLocales.length);
+    expect(items().map((el) => el.textContent)).toEqual([
+      'English',
+      'Español',
+      'Français',
+      'Deutsch',
+      'Português (Brasil)',
+      '日本語',
+      '简体中文',
+      'العربية',
+    ]);
+    // jsdom resolves navigator.language ("en-US") to the en bundle.
+    expect(screen.getByRole('menuitemradio', { name: 'English' })).toHaveAttribute('aria-checked', 'true');
+    expect(items().filter((el) => el.getAttribute('aria-checked') === 'true')).toHaveLength(1);
+  });
+
+  it('names every shipped bundle, never falling back to a raw tag', () => {
+    open();
+    // A row rendering its own code means ENDONYMS is missing that locale.
+    items().forEach((el, i) => expect(el.textContent).not.toBe(availableLocales[i]));
+  });
+
+  it('tags each entry with its own lang so a screen reader pronounces the endonym', () => {
+    open();
+    expect(items().map((el) => el.getAttribute('lang'))).toEqual([...availableLocales]);
+  });
+
+  it('reports the pick to setLocale and closes', () => {
+    open();
+    fireEvent.click(screen.getByRole('menuitemradio', { name: '日本語' }));
+
+    expect(vi.mocked(setLocale)).toHaveBeenCalledWith('ja');
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('still reports a pick of the language already showing', () => {
+    // Persisting is the point: this is how a ?locale= support link becomes the
+    // user's stored choice.
+    open();
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'English' }));
+    expect(vi.mocked(setLocale)).toHaveBeenCalledWith('en');
+  });
+
+  it('opens onto the current entry and wraps arrow keys in both directions', () => {
+    open();
+    const last = availableLocales.length - 1;
+    expect(document.activeElement).toBe(items()[0]);
+
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowUp' });
+    expect(document.activeElement).toBe(items()[last]);
+
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(items()[0]);
+
+    fireEvent.keyDown(document.activeElement!, { key: 'End' });
+    expect(document.activeElement).toBe(items()[last]);
+
+    fireEvent.keyDown(document.activeElement!, { key: 'Home' });
+    expect(document.activeElement).toBe(items()[0]);
+  });
+
+  it('opens from the keyboard on either arrow', () => {
+    render(() => <LocalePicker />);
+    const trigger = screen.getByRole('button', { name: label('English') });
+
+    fireEvent.keyDown(trigger, { key: 'ArrowUp' });
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  it.each(['Escape', 'Tab'])('closes on %s, returning focus to the trigger', (key) => {
+    const trigger = open();
+    fireEvent.keyDown(document.activeElement!, { key });
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('closes on an outside press without reporting a pick', () => {
+    open();
+    fireEvent.pointerDown(document.body);
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    expect(vi.mocked(setLocale)).not.toHaveBeenCalled();
+  });
+
+  it('closes when the rail scrolls out from under the anchored panel', () => {
+    open();
+    fireEvent.scroll(window);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/LocalePicker.test.tsx
+++ b/frontend/src/components/LocalePicker.test.tsx
@@ -22,6 +22,22 @@ function open() {
 
 const items = () => screen.getAllByRole('menuitemradio');
 
+// jsdom measures every element as a zero rect, so placement is the one
+// behaviour that has to be handed a real one. Viewport is jsdom's 768px tall.
+function openAt(top: number, height = 36) {
+  render(() => <LocalePicker />);
+  const trigger = screen.getByRole('button', { name: label('English') });
+  vi.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({
+    top,
+    bottom: top + height,
+    left: 20,
+    right: 84,
+    height,
+  } as DOMRect);
+  fireEvent.click(trigger);
+  return screen.getByRole('menu');
+}
+
 beforeEach(() => vi.mocked(setLocale).mockClear());
 
 describe('LocalePicker', () => {
@@ -128,5 +144,35 @@ describe('LocalePicker', () => {
     open();
     fireEvent.scroll(window);
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('opens upward from a trigger in the rail footer', () => {
+    const menu = openAt(700);
+
+    expect(menu.style.bottom).toBe('76px');
+    expect(menu.style.top).toBe('');
+    expect(menu.style.maxHeight).toBe('684px');
+  });
+
+  it('flips below the trigger when there is no room above', () => {
+    // A short viewport or the mobile drawer can put the footer near the top;
+    // opening upward there would strand the entries off-screen.
+    const menu = openAt(10);
+
+    expect(menu.style.top).toBe('54px');
+    expect(menu.style.bottom).toBe('');
+    expect(menu.style.maxHeight).toBe('706px');
+  });
+
+  it.each([0, 40, 120, 400, 740, 760])('keeps the panel on screen from %ipx', (top) => {
+    const { style } = openAt(top);
+    const height = parseFloat(style.maxHeight);
+    // Whichever edge it is pinned to, the panel grows away from it — so both
+    // ends have to land inside the viewport.
+    const edge = parseFloat(style.bottom || style.top);
+
+    expect(height).toBeGreaterThan(0);
+    expect(edge).toBeGreaterThanOrEqual(0);
+    expect(edge + height).toBeLessThanOrEqual(window.innerHeight);
   });
 });

--- a/frontend/src/components/LocalePicker.tsx
+++ b/frontend/src/components/LocalePicker.tsx
@@ -21,13 +21,16 @@ const ENDONYMS: Record<string, string> = {
 /** Gap between the trigger and the panel, and the panel's viewport margin. */
 const GAP = 8;
 
-/** Floor for the panel height, so a trigger near the viewport top still lists. */
+/** Room the panel wants; short of it, `open()` takes the roomier side. */
 const MIN_PANEL = 160;
 
 interface Anchor {
   /** Distance from the viewport's inline-start edge (right edge under RTL). */
   start: number;
-  bottom: number;
+  /** Whether the panel hangs above the trigger; below it when false. */
+  up: boolean;
+  /** Distance from the viewport edge the panel is pinned to. */
+  offset: number;
   maxHeight: number;
 }
 
@@ -59,10 +62,21 @@ export default function LocalePicker() {
     // which would otherwise clip it to 64px in the collapsed rail. Anchored to
     // the trigger's inline-start edge — the viewport's right edge under RTL.
     const rtl = document.documentElement.dir === 'rtl';
+    // Room left on each side of the trigger once both gaps are spent: one
+    // between panel and trigger, one between panel and viewport edge.
+    const above = r.top - GAP * 2;
+    const below = window.innerHeight - r.bottom - GAP * 2;
+    // Upward is the natural direction — the trigger sits in the rail's footer —
+    // but a trigger high in the viewport would push a fixed panel off the top
+    // edge, where its own scrollbar can't bring the clipped entries back.
+    const up = above >= MIN_PANEL || above >= below;
     setAnchor({
       start: rtl ? window.innerWidth - r.right : r.left,
-      bottom: window.innerHeight - r.top + GAP,
-      maxHeight: Math.max(r.top - GAP * 2, MIN_PANEL),
+      up,
+      offset: up ? window.innerHeight - r.top + GAP : r.bottom + GAP,
+      // Never taller than the side it opened onto: entries past the viewport
+      // edge are unreachable, entries past the panel's edge only need a scroll.
+      maxHeight: Math.max(up ? above : below, 0),
     });
     // Solid renders the panel synchronously with the write above, so its refs
     // are already assigned here.
@@ -114,7 +128,7 @@ export default function LocalePicker() {
   };
 
   const onTriggerKeyDown = (e: KeyboardEvent) => {
-    // The panel opens upward, so both arrows are natural "open it" keys.
+    // The panel lands on whichever side has room, so both arrows open it.
     if (isOpen() || (e.key !== 'ArrowUp' && e.key !== 'ArrowDown')) return;
     e.preventDefault();
     open();
@@ -168,7 +182,7 @@ export default function LocalePicker() {
               class="locale-menu"
               style={{
                 'inset-inline-start': `${pos().start}px`,
-                bottom: `${pos().bottom}px`,
+                ...(pos().up ? { bottom: `${pos().offset}px` } : { top: `${pos().offset}px` }),
                 'max-height': `${pos().maxHeight}px`,
               }}
               onKeyDown={onPanelKeyDown}

--- a/frontend/src/components/LocalePicker.tsx
+++ b/frontend/src/components/LocalePicker.tsx
@@ -1,0 +1,202 @@
+import { For, Show, createEffect, createSignal, onCleanup } from 'solid-js';
+import { Portal } from 'solid-js/web';
+import { availableLocales, bundleFor, locale, setLocale, t } from '../i18n';
+
+// Endonyms: every language named in itself, never translated — a menu that
+// offers "German" to someone who can't read English is useless. Keyed by the
+// bundle codes in `i18n/index.ts`; a bundle added there without an entry here
+// falls back to its raw tag, and LocalePicker.test.tsx fails on the gap rather
+// than letting a bare "pt-BR" ship.
+const ENDONYMS: Record<string, string> = {
+  en: 'English',
+  es: 'Español',
+  fr: 'Français',
+  de: 'Deutsch',
+  'pt-BR': 'Português (Brasil)',
+  ja: '日本語',
+  'zh-CN': '简体中文',
+  ar: 'العربية',
+};
+
+/** Gap between the trigger and the panel, and the panel's viewport margin. */
+const GAP = 8;
+
+/** Floor for the panel height, so a trigger near the viewport top still lists. */
+const MIN_PANEL = 160;
+
+interface Anchor {
+  /** Distance from the viewport's inline-start edge (right edge under RTL). */
+  start: number;
+  bottom: number;
+  maxHeight: number;
+}
+
+/**
+ * Language menu for the nav rail's footer. The locale is baked in at module
+ * load (`Nav.tsx`'s LINKS call `t()` once), so picking one reloads the page —
+ * `setLocale()` owns that, see `i18n/index.ts`.
+ */
+export default function LocalePicker() {
+  // The resolved locale can't change without a reload, so these are constants,
+  // not signals. A locale with no bundle ("he") marks nothing and labels the
+  // trigger with its raw tag.
+  const active = bundleFor(locale);
+  const currentLabel = ENDONYMS[active ?? ''] ?? locale;
+
+  let trigger!: HTMLButtonElement;
+  let panel: HTMLDivElement | undefined;
+  const items: HTMLButtonElement[] = [];
+
+  // The anchor doubles as the open flag — one source of truth, so an open menu
+  // can never be un-positioned.
+  const [anchor, setAnchor] = createSignal<Anchor | null>(null);
+  const isOpen = () => anchor() !== null;
+  const activeIndex = () => Math.max(0, availableLocales.indexOf(active ?? ''));
+
+  const open = () => {
+    const r = trigger.getBoundingClientRect();
+    // Fixed + portaled so the panel escapes the rail's `overflow: hidden`,
+    // which would otherwise clip it to 64px in the collapsed rail. Anchored to
+    // the trigger's inline-start edge — the viewport's right edge under RTL.
+    const rtl = document.documentElement.dir === 'rtl';
+    setAnchor({
+      start: rtl ? window.innerWidth - r.right : r.left,
+      bottom: window.innerHeight - r.top + GAP,
+      maxHeight: Math.max(r.top - GAP * 2, MIN_PANEL),
+    });
+    // Solid renders the panel synchronously with the write above, so its refs
+    // are already assigned here.
+    items[activeIndex()]?.focus();
+  };
+
+  const close = (refocus: boolean) => {
+    setAnchor(null);
+    if (refocus) trigger.focus();
+  };
+
+  const choose = (code: string) => {
+    close(false);
+    // Re-picking the language that's already showing is not a no-op: arriving
+    // on a ?locale= support link and clicking that language is how the pick
+    // becomes the persisted one.
+    setLocale(code);
+  };
+
+  const focusItem = (i: number) => items[i]?.focus();
+
+  const onPanelKeyDown = (e: KeyboardEvent) => {
+    const last = availableLocales.length - 1;
+    const cur = items.findIndex((el) => el === document.activeElement);
+    switch (e.key) {
+      case 'ArrowDown':
+        focusItem(cur >= last ? 0 : cur + 1);
+        break;
+      case 'ArrowUp':
+        focusItem(cur <= 0 ? last : cur - 1);
+        break;
+      case 'Home':
+        focusItem(0);
+        break;
+      case 'End':
+        focusItem(last);
+        break;
+      case 'Escape':
+      // Tab out of a portaled panel would land focus at the end of <body>,
+      // nowhere near the rail, so it returns to the trigger instead; the next
+      // Tab then continues from there through the rest of the nav.
+      case 'Tab':
+        close(true);
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+  };
+
+  const onTriggerKeyDown = (e: KeyboardEvent) => {
+    // The panel opens upward, so both arrows are natural "open it" keys.
+    if (isOpen() || (e.key !== 'ArrowUp' && e.key !== 'ArrowDown')) return;
+    e.preventDefault();
+    open();
+  };
+
+  createEffect(() => {
+    if (!isOpen()) return;
+    const onPointerDown = (e: Event) => {
+      const target = e.target as Node;
+      if (!panel?.contains(target) && !trigger.contains(target)) close(false);
+    };
+    // The rail scrolls its own overflow, so the trigger can move out from under
+    // a positioned panel. Close rather than chase it.
+    const onViewportChange = () => close(false);
+    document.addEventListener('pointerdown', onPointerDown, true);
+    window.addEventListener('scroll', onViewportChange, true);
+    window.addEventListener('resize', onViewportChange);
+    onCleanup(() => {
+      document.removeEventListener('pointerdown', onPointerDown, true);
+      window.removeEventListener('scroll', onViewportChange, true);
+      window.removeEventListener('resize', onViewportChange);
+    });
+  });
+
+  return (
+    <>
+      <button
+        ref={trigger}
+        type="button"
+        class="wurk-navlink locale-picker__trigger"
+        aria-haspopup="menu"
+        aria-expanded={isOpen()}
+        aria-label={t('nav.language_current', { name: currentLabel })}
+        title={t('nav.language')}
+        onClick={() => (isOpen() ? close(false) : open())}
+        onKeyDown={onTriggerKeyDown}
+      >
+        <i class="fa-solid fa-language wurk-navlink__icon" aria-hidden="true" />
+        <span class="nav-label">
+          <bdi>{currentLabel}</bdi>
+        </span>
+      </button>
+
+      <Show when={anchor()}>
+        {(pos) => (
+          <Portal>
+            <div
+              ref={panel}
+              role="menu"
+              aria-label={t('nav.language')}
+              class="locale-menu"
+              style={{
+                'inset-inline-start': `${pos().start}px`,
+                bottom: `${pos().bottom}px`,
+                'max-height': `${pos().maxHeight}px`,
+              }}
+              onKeyDown={onPanelKeyDown}
+            >
+              <For each={availableLocales}>
+                {(code, i) => (
+                  <button
+                    ref={(el) => (items[i()] = el)}
+                    type="button"
+                    role="menuitemradio"
+                    aria-checked={code === active}
+                    class="locale-menu__item"
+                    // `lang` so a screen reader pronounces the endonym in its own
+                    // language; `<bdi>` keeps an RTL name from reordering the row.
+                    lang={code}
+                    onClick={() => choose(code)}
+                  >
+                    <bdi>{ENDONYMS[code] ?? code}</bdi>
+                    <Show when={code === active}>
+                      <i class="fa-solid fa-check" aria-hidden="true" />
+                    </Show>
+                  </button>
+                )}
+              </For>
+            </div>
+          </Portal>
+        )}
+      </Show>
+    </>
+  );
+}

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -3,6 +3,7 @@ import { For, Show } from 'solid-js';
 import { t } from '../i18n';
 import { useMeta } from '../hooks/useMeta';
 import { useSSE } from '../hooks/useSSE';
+import LocalePicker from './LocalePicker';
 import logoUrl from '../assets/wurk-logo.png';
 
 interface NavProps {
@@ -241,6 +242,10 @@ export default function Nav(props: NavProps) {
           />
           <span class="nav-label">{t('nav.collapse')}</span>
         </button>
+
+        {/* The rail footer is the dashboard's only non-route control area, so the
+            language menu lives here next to the collapse toggle. */}
+        <LocalePicker />
 
         {/* Footer: link out to the source repo. Pinned to the bottom because the
             nav list above is flex:1. Muted by default; hover lifts like a nav item. */}

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -15,6 +15,8 @@
     "extensions": "الإضافات",
     "collapse": "طيّ",
     "expand": "توسيع",
+    "language": "اللغة",
+    "language_current": "اللغة: {name}",
     "status_active": "حالة النظام: نشط",
     "status_inactive": "حالة النظام: غير متصل"
   },

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -15,6 +15,8 @@
     "extensions": "Erweiterungen",
     "collapse": "Einklappen",
     "expand": "Ausklappen",
+    "language": "Sprache",
+    "language_current": "Sprache: {name}",
     "status_active": "Systemstatus: Aktiv",
     "status_inactive": "Systemstatus: Getrennt"
   },

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -15,6 +15,8 @@
     "extensions": "Extensions",
     "collapse": "Collapse",
     "expand": "Expand",
+    "language": "Language",
+    "language_current": "Language: {name}",
     "status_active": "System Status: Active",
     "status_inactive": "System Status: Disconnected"
   },

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -15,6 +15,8 @@
     "extensions": "Extensiones",
     "collapse": "Contraer",
     "expand": "Expandir",
+    "language": "Idioma",
+    "language_current": "Idioma: {name}",
     "status_active": "Estado del sistema: Activo",
     "status_inactive": "Estado del sistema: Desconectado"
   },

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -15,6 +15,8 @@
     "extensions": "Extensions",
     "collapse": "Réduire",
     "expand": "Développer",
+    "language": "Langue",
+    "language_current": "Langue : {name}",
     "status_active": "État du système : Actif",
     "status_inactive": "État du système : Déconnecté"
   },

--- a/frontend/src/i18n/i18n.test.ts
+++ b/frontend/src/i18n/i18n.test.ts
@@ -306,25 +306,75 @@ describe('resolved bundle', () => {
   });
 });
 
+// The engine emits this block from Wurk::Web.config.translations, keyed by
+// locale — the server's data-locale hint is only third in the precedence chain,
+// so the entry has to be picked in the browser against the rendered locale.
+function mountOverrides(payload: unknown): void {
+  const el = document.createElement('script');
+  el.id = 'wurk-i18n';
+  el.type = 'application/json';
+  el.textContent = typeof payload === 'string' ? payload : JSON.stringify(payload);
+  document.head.appendChild(el);
+}
+
 describe('host overrides', () => {
+  beforeEach(clearLocaleEnvironment);
   afterEach(() => {
+    clearLocaleEnvironment();
     document.getElementById('wurk-i18n')?.remove();
     vi.resetModules();
   });
 
-  it('deep-merges a #wurk-i18n script tag over the base bundle', async () => {
-    const el = document.createElement('script');
-    el.id = 'wurk-i18n';
-    el.type = 'application/json';
+  it('deep-merges the entry for the rendered locale over the bundle', async () => {
+    mountRoot('de');
     // Override one leaf; siblings and untouched branches must survive the merge.
-    el.textContent = JSON.stringify({ nav: { dashboard: 'Control Center' } });
-    document.head.appendChild(el);
+    mountOverrides({ de: { nav: { dashboard: 'Kontrollzentrum' } } });
 
     // The bundle reads the override at module-eval time, so re-evaluate it with
     // the script tag present.
     vi.resetModules();
     const mod = await import('./index');
-    expect(mod.t('nav.dashboard')).toBe('Control Center');
-    expect(mod.t('nav.queues')).toBe('Queues');
+    expect(mod.t('nav.dashboard')).toBe('Kontrollzentrum');
+    expect(mod.t('nav.queues')).toBe(de.nav.queues);
+  });
+
+  it('matches the entry the same way the bundle was matched', async () => {
+    mountRoot('es-419');
+    mountOverrides({ es: { nav: { dashboard: 'Centro de Control' } } });
+
+    vi.resetModules();
+    const mod = await import('./index');
+    expect(mod.t('nav.dashboard')).toBe('Centro de Control');
+  });
+
+  it('leaves the bundle alone when nothing is keyed for the locale', async () => {
+    mountRoot('de');
+    mountOverrides({ en: { nav: { dashboard: 'Control Center' } } });
+
+    vi.resetModules();
+    const mod = await import('./index');
+    expect(mod.t('nav.dashboard')).toBe(de.nav.dashboard);
+  });
+
+  // The point of the hook: a host can serve a locale this build ships no
+  // bundle for by supplying the copy itself.
+  it('supplies copy for a locale with no bundle', async () => {
+    mountRoot('he');
+    mountOverrides({ he: { nav: { dashboard: 'לוח בקרה' } } });
+
+    vi.resetModules();
+    const mod = await import('./index');
+    expect(mod.dir).toBe('rtl');
+    expect(mod.t('nav.dashboard')).toBe('לוח בקרה');
+    expect(mod.t('nav.queues')).toBe('Queues'); // untranslated keys still fall back to en
+  });
+
+  it('falls back to the shipped copy when the block is malformed', async () => {
+    mountRoot('de');
+    mountOverrides('not json');
+
+    vi.resetModules();
+    const mod = await import('./index');
+    expect(mod.t('nav.dashboard')).toBe(de.nav.dashboard);
   });
 });

--- a/frontend/src/i18n/i18n.test.ts
+++ b/frontend/src/i18n/i18n.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect, afterEach, vi } from 'vitest';
-import { t, directionFor } from './index';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import {
+  t,
+  directionFor,
+  bundleFor,
+  detectLocale,
+  applyLocale,
+  setLocale,
+  availableLocales,
+} from './index';
 import en from './en.json';
 import es from './es.json';
 import fr from './fr.json';
@@ -103,6 +111,199 @@ describe('locale parity', () => {
       });
     });
   }
+});
+
+describe('bundleFor()', () => {
+  it('matches an exact key, case-insensitively', () => {
+    expect(bundleFor('de')).toBe('de');
+    expect(bundleFor('pt-BR')).toBe('pt-BR');
+    expect(bundleFor('PT-br')).toBe('pt-BR');
+  });
+
+  it('falls back to the base subtag', () => {
+    expect(bundleFor('es-419')).toBe('es');
+    expect(bundleFor('en-GB')).toBe('en');
+    expect(bundleFor('ar-EG')).toBe('ar');
+  });
+
+  // The previous `locale.startsWith(key)` match was backwards for regional
+  // bundles — "pt".startsWith("pt-BR") is false, so a browser set to plain
+  // Portuguese silently rendered English.
+  it('promotes a bare subtag to its regional bundle', () => {
+    expect(bundleFor('pt')).toBe('pt-BR');
+    expect(bundleFor('zh')).toBe('zh-CN');
+    expect(bundleFor('pt-PT')).toBe('pt-BR');
+    expect(bundleFor('zh-Hant-TW')).toBe('zh-CN');
+  });
+
+  it('reports nothing for a locale this build does not ship', () => {
+    expect(bundleFor('he')).toBeUndefined();
+    expect(bundleFor('fa-IR')).toBeUndefined();
+  });
+
+  it('resolves every advertised locale to itself', () => {
+    expect(availableLocales.length).toBeGreaterThan(0);
+    for (const code of availableLocales) expect(bundleFor(code)).toBe(code);
+  });
+});
+
+// Every locale source lives on a global, so each test owns the whole
+// environment and hands it back clean.
+function clearLocaleEnvironment(): void {
+  history.replaceState({}, '', '/');
+  localStorage.clear();
+  document.getElementById('wurk-root')?.remove();
+  // Drops the own-property stub, revealing jsdom's real prototype getter.
+  delete (navigator as unknown as Record<string, unknown>).languages;
+  delete (navigator as unknown as Record<string, unknown>).language;
+  document.documentElement.removeAttribute('lang');
+  document.documentElement.removeAttribute('dir');
+}
+
+function stubLanguages(langs: string[]): void {
+  Object.defineProperty(navigator, 'languages', { value: langs, configurable: true });
+  Object.defineProperty(navigator, 'language', { value: langs[0] ?? '', configurable: true });
+}
+
+function mountRoot(dataLocale?: string): HTMLElement {
+  const el = document.createElement('div');
+  el.id = 'wurk-root';
+  if (dataLocale !== undefined) el.dataset.locale = dataLocale;
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('detectLocale()', () => {
+  beforeEach(clearLocaleEnvironment);
+  afterEach(clearLocaleEnvironment);
+
+  it('prefers ?locale= over every persisted or detected source', () => {
+    history.replaceState({}, '', '/?locale=fr');
+    localStorage.setItem('wurk.locale', 'de');
+    mountRoot('ja');
+    stubLanguages(['es']);
+    expect(detectLocale()).toBe('fr');
+  });
+
+  it('prefers the stored pick over the server hint', () => {
+    localStorage.setItem('wurk.locale', 'de');
+    mountRoot('ja');
+    stubLanguages(['es']);
+    expect(detectLocale()).toBe('de');
+  });
+
+  it('prefers the server hint over browser preferences', () => {
+    mountRoot('ja');
+    stubLanguages(['es']);
+    expect(detectLocale()).toBe('ja');
+  });
+
+  it('walks navigator.languages in order', () => {
+    stubLanguages(['zh-CN', 'es']);
+    expect(detectLocale()).toBe('zh-CN');
+  });
+
+  // A passive browser preference we ship nothing for is skipped rather than
+  // honoured, so a Hebrew browser doesn't get an RTL board of English strings.
+  it('skips browser preferences with no bundle', () => {
+    stubLanguages(['he', 'de']);
+    expect(detectLocale()).toBe('de');
+  });
+
+  it('honours an explicit pick with no bundle', () => {
+    localStorage.setItem('wurk.locale', 'he');
+    stubLanguages(['de']);
+    expect(detectLocale()).toBe('he');
+  });
+
+  it('ends at en', () => {
+    stubLanguages([]);
+    expect(detectLocale()).toBe('en');
+  });
+
+  it('ignores malformed tags from every source', () => {
+    history.replaceState({}, '', '/?locale=%3Cscript%3E');
+    localStorage.setItem('wurk.locale', 'not a locale');
+    mountRoot('');
+    stubLanguages(['de']);
+    expect(detectLocale()).toBe('de');
+  });
+});
+
+describe('applyLocale()', () => {
+  beforeEach(clearLocaleEnvironment);
+  afterEach(clearLocaleEnvironment);
+
+  it('mirrors lang and dir onto the document and the root node', () => {
+    const root = mountRoot();
+    applyLocale('ar-EG');
+    expect(document.documentElement.lang).toBe('ar-EG');
+    expect(document.documentElement.dir).toBe('rtl');
+    expect(root.dir).toBe('rtl');
+  });
+
+  it('is a no-op on the root node when it is absent', () => {
+    applyLocale('de');
+    expect(document.documentElement.dir).toBe('ltr');
+  });
+});
+
+describe('setLocale()', () => {
+  beforeEach(clearLocaleEnvironment);
+  afterEach(clearLocaleEnvironment);
+
+  // jsdom's Location is unforgeable, so `reload`/`assign` can't be stubbed and
+  // the reload itself is out of reach here (it logs "Not implemented" and is a
+  // no-op). What's pinned is the observable contract: the pick is persisted and
+  // mirrored before the page turns over.
+  it('persists the pick and mirrors it onto the document', () => {
+    const root = mountRoot();
+    setLocale('ar');
+    expect(localStorage.getItem('wurk.locale')).toBe('ar');
+    expect(document.documentElement.lang).toBe('ar');
+    expect(document.documentElement.dir).toBe('rtl');
+    expect(root.dir).toBe('rtl');
+  });
+
+  it('rejects a malformed tag instead of persisting it', () => {
+    setLocale('not a locale');
+    expect(localStorage.getItem('wurk.locale')).toBeNull();
+    expect(document.documentElement.hasAttribute('lang')).toBe(false);
+  });
+});
+
+describe('resolved bundle', () => {
+  beforeEach(clearLocaleEnvironment);
+  afterEach(() => {
+    clearLocaleEnvironment();
+    vi.resetModules();
+  });
+
+  it('serves the regional bundle for a bare subtag', async () => {
+    mountRoot('pt');
+    vi.resetModules();
+    const mod = await import('./index');
+    expect(mod.locale).toBe('pt');
+    expect(mod.t('nav.dashboard')).toBe('Painel');
+  });
+
+  it('serves the base bundle for an unshipped region', async () => {
+    mountRoot('es-419');
+    vi.resetModules();
+    const mod = await import('./index');
+    expect(mod.t('nav.dashboard')).toBe('Panel');
+  });
+
+  // Deliberate: a bundle-less locale still flips direction and falls back to en
+  // strings, so a host can override copy without shipping a translation file.
+  it('flips RTL with English strings when nothing ships for the locale', async () => {
+    mountRoot('he');
+    vi.resetModules();
+    const mod = await import('./index');
+    expect(mod.locale).toBe('he');
+    expect(mod.dir).toBe('rtl');
+    expect(mod.t('nav.dashboard')).toBe('Dashboard');
+  });
 });
 
 describe('host overrides', () => {

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -52,18 +52,25 @@ function normalizeTag(raw: string | null | undefined): string | undefined {
 }
 
 /**
- * The bundle key serving `loc`, or undefined when this build ships nothing for
- * it: exact match (case-insensitively), then the base subtag ("es-419" -> "es"),
- * then the first regional bundle sharing that base ("pt" -> "pt-BR").
+ * The key in `keys` serving `loc`, or undefined when none does: exact match
+ * (case-insensitively), then the base subtag ("es-419" -> "es"), then the first
+ * regional key sharing that base ("pt" -> "pt-BR"). Wurk::Web::LocaleNegotiator
+ * walks the same three rungs server-side — they have to agree, or the hint the
+ * engine emits resolves to a bundle it didn't intend.
  */
-export function bundleFor(loc: string): string | undefined {
+function matchTag(keys: readonly string[], loc: string): string | undefined {
   const lower = loc.toLowerCase();
   const base = lower.split('-')[0];
   return (
-    availableLocales.find((k) => k.toLowerCase() === lower) ??
-    availableLocales.find((k) => k.toLowerCase() === base) ??
-    availableLocales.find((k) => k.toLowerCase().split('-')[0] === base)
+    keys.find((k) => k.toLowerCase() === lower) ??
+    keys.find((k) => k.toLowerCase() === base) ??
+    keys.find((k) => k.toLowerCase().split('-')[0] === base)
   );
+}
+
+/** The bundle key serving `loc`, or undefined when this build ships nothing for it. */
+export function bundleFor(loc: string): string | undefined {
+  return matchTag(availableLocales, loc);
 }
 
 function fromQuery(): string | undefined {
@@ -140,10 +147,21 @@ export function setLocale(loc: string): void {
   else window.location.assign(url.href);
 }
 
-function loadHostOverrides(): DeepPartial<Translations> {
+/**
+ * Host copy overrides for `loc`, from the `#wurk-i18n` block the engine emits
+ * out of `Wurk::Web.config.translations`. That payload is keyed by locale
+ * rather than flat because the server's `data-locale` hint is not the last
+ * word — a `?locale=` link or a stored pick outranks it — so the entry has to
+ * be selected here, against the locale actually rendered, using the same match
+ * that chose the bundle underneath it.
+ */
+function loadHostOverrides(loc: string): DeepPartial<Translations> {
   try {
     const el = document.getElementById('wurk-i18n');
-    return el ? (JSON.parse(el.textContent ?? '{}') as DeepPartial<Translations>) : {};
+    if (!el) return {};
+    const byLocale = JSON.parse(el.textContent ?? '{}') as Record<string, DeepPartial<Translations>>;
+    const key = matchTag(Object.keys(byLocale), loc);
+    return key ? (byLocale[key] ?? {}) : {};
   } catch {
     return {};
   }
@@ -173,7 +191,7 @@ export const locale = detectLocale();
 export const dir = directionFor(locale);
 const langKey = bundleFor(locale) ?? 'en';
 const base = deepMerge(en, (LOCALES[langKey] ?? {}) as DeepPartial<typeof en>);
-const merged = deepMerge(base, loadHostOverrides());
+const merged = deepMerge(base, loadHostOverrides(locale));
 
 export function t(path: string, vars?: Record<string, string | number>): string {
   const parts = path.split('.');

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -10,6 +10,10 @@ import ar from './ar.json';
 type Translations = typeof en;
 type DeepPartial<T> = { [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K] };
 
+// Declaration order is load-bearing: a locale naming only a base subtag ("pt",
+// "zh") resolves to the first bundle declared for that base, so shipping a
+// second regional bundle for an existing base changes what the bare subtag
+// picks. Order deliberately, don't append blindly.
 const LOCALES: Record<string, DeepPartial<Translations>> = {
   en,
   es,
@@ -21,6 +25,12 @@ const LOCALES: Record<string, DeepPartial<Translations>> = {
   ar,
 };
 
+/** Locale codes with a bundle in this build, in declaration (menu) order. */
+export const availableLocales: readonly string[] = Object.freeze(Object.keys(LOCALES));
+
+const STORAGE_KEY = 'wurk.locale';
+const QUERY_KEY = 'locale';
+
 // Languages written right-to-left. The detected locale's base subtag (e.g. the
 // "ar" of "ar-EG") drives both `dir` and the matched bundle below. Bundles are
 // optional: a locale with no bundle still flips to RTL and falls back to en
@@ -31,6 +41,105 @@ export function directionFor(loc: string): 'rtl' | 'ltr' {
   return RTL_LANGS.includes(loc.toLowerCase().split('-')[0]) ? 'rtl' : 'ltr';
 }
 
+// Every locale source is untrusted input — a query param, a localStorage value
+// a previous build wrote, or a server-rendered attribute. Reject anything that
+// isn't BCP-47-shaped rather than letting it reach `documentElement.lang`.
+const TAG_RE = /^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$/;
+
+function normalizeTag(raw: string | null | undefined): string | undefined {
+  const tag = raw?.trim();
+  return tag && TAG_RE.test(tag) ? tag : undefined;
+}
+
+/**
+ * The bundle key serving `loc`, or undefined when this build ships nothing for
+ * it: exact match (case-insensitively), then the base subtag ("es-419" -> "es"),
+ * then the first regional bundle sharing that base ("pt" -> "pt-BR").
+ */
+export function bundleFor(loc: string): string | undefined {
+  const lower = loc.toLowerCase();
+  const base = lower.split('-')[0];
+  return (
+    availableLocales.find((k) => k.toLowerCase() === lower) ??
+    availableLocales.find((k) => k.toLowerCase() === base) ??
+    availableLocales.find((k) => k.toLowerCase().split('-')[0] === base)
+  );
+}
+
+function fromQuery(): string | undefined {
+  return normalizeTag(new URLSearchParams(window.location.search).get(QUERY_KEY));
+}
+
+function fromStorage(): string | undefined {
+  // localStorage throws SecurityError / QuotaExceededError in private mode and
+  // sandboxed iframes — same guard the nav-collapsed preference uses.
+  try {
+    return normalizeTag(localStorage.getItem(STORAGE_KEY));
+  } catch {
+    return undefined;
+  }
+}
+
+function fromRoot(): string | undefined {
+  return normalizeTag(document.getElementById('wurk-root')?.dataset.locale);
+}
+
+// Browser preferences are a passive signal, not a choice, so only a locale we
+// actually ship counts here. Honouring an unshipped one would flip a Hebrew
+// browser's board to RTL with English strings for a user who never asked; the
+// explicit sources above are taken verbatim precisely so that stays possible.
+function fromNavigator(): string | undefined {
+  const prefs = navigator.languages?.length ? navigator.languages : [navigator.language];
+  for (const pref of prefs) {
+    const tag = normalizeTag(pref);
+    if (tag && bundleFor(tag)) return tag;
+  }
+  return undefined;
+}
+
+/** Highest-precedence locale source that yields a usable tag. */
+export function detectLocale(): string {
+  return fromQuery() ?? fromStorage() ?? fromRoot() ?? fromNavigator() ?? 'en';
+}
+
+/** Mirror a locale onto the document: `lang`, and `dir` on both html and root. */
+export function applyLocale(loc: string): void {
+  const direction = directionFor(loc);
+  document.documentElement.lang = loc;
+  document.documentElement.dir = direction;
+  const root = document.getElementById('wurk-root');
+  if (root) root.dir = direction;
+}
+
+/**
+ * Record an explicit locale pick and reload into it. The reload is deliberate:
+ * `merged` resolves once at module scope by design, so no consumer of `t()`
+ * has to become reactive to a language change.
+ */
+export function setLocale(loc: string): void {
+  const tag = normalizeTag(loc);
+  if (!tag) return;
+
+  let persisted = false;
+  try {
+    localStorage.setItem(STORAGE_KEY, tag);
+    persisted = true;
+  } catch {
+    // Storage disabled — the query param below carries the pick instead.
+  }
+
+  applyLocale(tag);
+
+  const url = new URL(window.location.href);
+  // A leftover ?locale= from a support link out-ranks storage, so it has to go
+  // once the pick is persisted; when it couldn't be, it becomes the carrier.
+  if (persisted) url.searchParams.delete(QUERY_KEY);
+  else url.searchParams.set(QUERY_KEY, tag);
+
+  if (url.href === window.location.href) window.location.reload();
+  else window.location.assign(url.href);
+}
+
 function loadHostOverrides(): DeepPartial<Translations> {
   try {
     const el = document.getElementById('wurk-i18n');
@@ -38,12 +147,6 @@ function loadHostOverrides(): DeepPartial<Translations> {
   } catch {
     return {};
   }
-}
-
-function detectLocale(): string {
-  const el = document.getElementById('wurk-root');
-  if (el?.dataset.locale) return el.dataset.locale;
-  return navigator.language || 'en';
 }
 
 function deepMerge<T extends object>(base: T, override: DeepPartial<T>): T {
@@ -68,7 +171,7 @@ function deepMerge<T extends object>(base: T, override: DeepPartial<T>): T {
 
 export const locale = detectLocale();
 export const dir = directionFor(locale);
-const langKey = Object.keys(LOCALES).find((k) => locale.startsWith(k)) ?? 'en';
+const langKey = bundleFor(locale) ?? 'en';
 const base = deepMerge(en, (LOCALES[langKey] ?? {}) as DeepPartial<typeof en>);
 const merged = deepMerge(base, loadHostOverrides());
 

--- a/frontend/src/i18n/ja.json
+++ b/frontend/src/i18n/ja.json
@@ -15,6 +15,8 @@
     "extensions": "拡張機能",
     "collapse": "折りたたむ",
     "expand": "展開",
+    "language": "言語",
+    "language_current": "言語: {name}",
     "status_active": "システム状態: 稼働中",
     "status_inactive": "システム状態: 切断"
   },

--- a/frontend/src/i18n/pt-BR.json
+++ b/frontend/src/i18n/pt-BR.json
@@ -15,6 +15,8 @@
     "extensions": "Extensões",
     "collapse": "Recolher",
     "expand": "Expandir",
+    "language": "Idioma",
+    "language_current": "Idioma: {name}",
     "status_active": "Status do sistema: Ativo",
     "status_inactive": "Status do sistema: Desconectado"
   },

--- a/frontend/src/i18n/zh-CN.json
+++ b/frontend/src/i18n/zh-CN.json
@@ -15,6 +15,8 @@
     "extensions": "扩展",
     "collapse": "折叠",
     "expand": "展开",
+    "language": "语言",
+    "language_current": "语言：{name}",
     "status_active": "系统状态：运行中",
     "status_inactive": "系统状态：已断开"
   },

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -11,12 +11,12 @@ import '@fontsource/jetbrains-mono/500.css';
 import './tailwind.css';
 import './styles/main.scss';
 import App from './App';
-import { dir, locale, t } from './i18n';
+import { applyLocale, locale, t } from './i18n';
 
-// Set text direction + language from the detected locale before first paint so
-// the whole SPA (and its logical-property CSS) lays out RTL for ar/he/fa.
-document.documentElement.dir = dir;
-document.documentElement.lang = locale;
+// Set text direction + language from the resolved locale before first paint so
+// the whole SPA (and its logical-property CSS) lays out RTL for ar/he/fa. This
+// module is deferred, so #wurk-root already exists and gets its `dir` here too.
+applyLocale(locale);
 
 // When this SPA is loaded inside the Extension page's embed iframe (see
 // pages/Extension.tsx), the host did NOT mount real content at the extension's
@@ -28,7 +28,6 @@ const embedded =
 
 const root = document.getElementById('wurk-root');
 if (root) {
-  root.dir = dir;
   // Solid's render takes a component factory (a function returning JSX), not an
   // element — it establishes the reactive root that owns the whole app.
   render(

--- a/frontend/src/styles/abstracts/_variables.scss
+++ b/frontend/src/styles/abstracts/_variables.scss
@@ -39,5 +39,8 @@ $z-layers: (
   'sticky-corner': 3,
   'nav': 100,
   'hamburger': 200,
+  // Menus anchored to the nav must clear it and the hamburger; they are portaled
+  // to <body>, so they can't rely on being nested inside the rail's stacking.
+  'popover': 250,
   'toast': 300,
 );

--- a/frontend/src/styles/base/_motion.scss
+++ b/frontend/src/styles/base/_motion.scss
@@ -13,6 +13,7 @@
   .table-wrapper,
   .search-empty,
   .toast,
+  .locale-menu,
   .live-dot {
     animation: none;
   }

--- a/frontend/src/styles/components/_locale-picker.scss
+++ b/frontend/src/styles/components/_locale-picker.scss
@@ -1,0 +1,67 @@
+// ── Locale picker ────────────────────────────────────────────────────────────
+// The rail-footer language menu. The panel is portaled to <body> and positioned
+// `fixed` from the trigger's rect (LocalePicker.tsx) because the nav clips its
+// overflow — an in-flow panel would be cut to 64px in the collapsed rail. Only
+// the panel's own chrome lives here; the trigger reuses `.wurk-navlink` so the
+// collapsed-rail rules in Nav.tsx (round glyph, centred, rail-width box) apply
+// to it unchanged.
+
+@use '../abstracts' as *;
+
+// Chained with `.wurk-navlink` deliberately: Nav.tsx declares that class in an
+// inline <style> that ships after this stylesheet, so a single-class rule here
+// would lose the tie and inherit nav-item (not footer-control) colouring.
+.wurk-navlink.locale-picker__trigger {
+  width: calc(100% - #{to-rem(16)});
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: to-rem(13);
+  text-align: start;
+  cursor: pointer;
+}
+
+.locale-menu {
+  position: fixed;
+  z-index: z('popover');
+  min-width: to-rem(180);
+  max-width: to-rem(260);
+  overflow-y: auto;
+  padding: to-rem(4);
+  @include surface(var(--surface-strong), var(--border-strong));
+  box-shadow: 0 to-rem(10) to-rem(28) oklch(0 0 0 / 0.45);
+  animation: fade-up duration('base') easing('emphasized');
+}
+
+.locale-menu__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: to-rem(12);
+  width: 100%;
+  padding: to-rem(7) to-rem(10);
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text);
+  font-family: inherit;
+  font-size: to-rem(13);
+  text-align: start;
+  cursor: pointer;
+  @include transition(background color);
+
+  &:hover {
+    background: var(--surface-hover);
+    color: var(--accent);
+  }
+
+  &:focus-visible {
+    @include focus-ring;
+  }
+
+  &[aria-checked='true'] {
+    color: var(--accent);
+    font-weight: 600;
+  }
+}

--- a/frontend/src/styles/main.scss
+++ b/frontend/src/styles/main.scss
@@ -36,6 +36,7 @@
 @use 'components/chips';
 @use 'components/skeleton';
 @use 'components/toast';
+@use 'components/locale-picker';
 
 // — Layout —
 @use 'layout/shell';

--- a/lib/wurk/web.rb
+++ b/lib/wurk/web.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'web/config'
+require_relative 'web/locale_negotiator'
 require_relative 'web/pool_scope'
 require_relative 'web/search'
 require_relative 'web/enterprise'

--- a/lib/wurk/web/config.rb
+++ b/lib/wurk/web/config.rb
@@ -67,6 +67,13 @@ module Wurk
         batches limiters cron search
       ].freeze
 
+      # Locale tags the shipped SPA bundle carries copy for, in menu order.
+      # Mirrors `availableLocales` in frontend/src/i18n/index.ts — the pair is
+      # pinned by WebConfigTest, since a bundle added on one side only would
+      # make the server negotiate a locale the SPA can't render (or refuse one
+      # it can).
+      BUNDLED_LOCALES = %w[en es fr de pt-BR ja zh-CN ar].freeze
+
       # Host-app Rack middleware stacked in front of the dashboard, newest
       # last. Each entry is `[middleware, args, block]`. The LIVE array, like
       # Sidekiq::Web::Config#middlewares — callers mutate it directly
@@ -75,13 +82,7 @@ module Wurk
       attr_reader :middlewares
 
       def initialize
-        @options = OPTIONS.dup
-        @authorization = nil
-        @read_only = env_read_only?
-        @read_only_message = nil
-        @middlewares = []
-        @rack_app = nil
-        init_extensions!
+        reset!
       end
 
       def_delegators :@options, :[], :[]=, :fetch, :key?, :has_key?, :merge!, :dig
@@ -105,6 +106,29 @@ module Wurk
       # host explain *why* it's read-only — e.g. the public demo sets
       # "This is a public demo — actions are disabled."
       attr_accessor :read_only_message
+
+      # Dashboard language. `offered_locales` is the set the server negotiates
+      # a request's `Accept-Language` against before emitting the SPA's
+      # `data-locale` hint (see Wurk::Web::LocaleNegotiator): it starts as the
+      # locales the bundle ships and may be narrowed, or widened with one the
+      # host supplies copy for through `translations`. `default_locale` is the
+      # hint used when the header asks for nothing offered — nil emits no hint
+      # at all, leaving the browser's own preference list to decide.
+      #
+      # Not to be confused with `locales` above: that is the extension
+      # renderer's locale-*directory* list, a separate i18n system for
+      # server-rendered third-party tabs.
+      attr_accessor :offered_locales, :default_locale
+
+      # Host copy overrides for the dashboard, keyed by locale tag and
+      # deep-merged over the shipped bundle by the SPA:
+      #
+      #   c.translations = { 'en' => { 'nav' => { 'queues' => 'Pipelines' } } }
+      #
+      # Keyed rather than flat because the negotiated hint is not the last
+      # word — a `?locale=` link or a stored pick outranks it — so the entry
+      # has to be chosen in the browser, against the locale actually rendered.
+      attr_accessor :translations
 
       # Registers a `(env, method, path) -> truthy/falsey` block. Re-calling
       # overwrites; the spec exposes a single hook, not a chain.
@@ -236,6 +260,7 @@ module Wurk
         @middlewares = []
         @rack_app = nil
         init_extensions!
+        init_locales!
       end
 
       # Returns true when no block is registered, otherwise the block's
@@ -261,6 +286,14 @@ module Wurk
         @custom_job_info_rows = []
         @app_url = nil
         @assets_path = nil
+      end
+
+      def init_locales!
+        # Dup'd like `tabs`: hosts narrow the list in place (`delete`) as often
+        # as they replace it, and a frozen default would raise on the first.
+        @offered_locales = BUNDLED_LOCALES.dup
+        @default_locale = nil
+        @translations = {}
       end
 
       def job_info_pair(row, job)

--- a/lib/wurk/web/locale_negotiator.rb
+++ b/lib/wurk/web/locale_negotiator.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Wurk
+  class Web
+    # Picks the dashboard locale to hint at from a request's `Accept-Language`.
+    #
+    # The hint is emitted as `#wurk-root[data-locale]` and sits third in the
+    # SPA's precedence chain (`?locale=` > stored pick > this > browser
+    # preferences), so it only decides the first paint for a visitor who has
+    # never chosen — which is what removes the flash of English.
+    #
+    # Matching mirrors `bundleFor()` in frontend/src/i18n/index.ts rung for
+    # rung: exact tag, then the header tag's base subtag, then the first
+    # offered locale sharing that base ("pt" -> "pt-BR"). Diverging would emit
+    # a hint the SPA then resolves to a different bundle.
+    module LocaleNegotiator
+      # Quality weight of a single `Accept-Language` entry. Case-insensitive
+      # because the parameter name is (RFC 9110 §5.6.6), even though every
+      # browser sends a lowercase `q`.
+      QUALITY_RE = /;\s*q\s*=\s*([0-9.]+)/i
+
+      module_function
+
+      # The best `offered` locale for `header`, or nil when it asks for none of
+      # them. `offered` is host-configured (`Wurk::Web.config.offered_locales`)
+      # and the return value is always one of its entries, never header text —
+      # that is what keeps request input out of the emitted attribute, and why
+      # a malformed tag needs no separate validation: it simply matches nothing.
+      def call(header, offered:)
+        preferred_tags(header).each do |tag|
+          hit = match(tag, offered)
+          return hit if hit
+        end
+        nil
+      end
+
+      # Tags in descending quality, ties keeping header order. `q=0` means "not
+      # acceptable" and is dropped. `*` is dropped too: a wildcard states no
+      # preference, so there is nothing to hint — the host's `default_locale`
+      # and the browser's own list already cover that visitor.
+      def preferred_tags(header)
+        entries = header.to_s.split(',').filter_map { |entry| parse_entry(entry) }
+        # sort_by.with_index keeps the sort stable: Ruby's sort_by is not, and
+        # equal-quality tags have to stay in the order the client listed them.
+        entries.sort_by.with_index { |(_, quality), i| [-quality, i] }.map(&:first)
+      end
+
+      def parse_entry(entry)
+        tag = entry.split(';').first.to_s.strip
+        return if tag.empty? || tag == '*'
+
+        quality = entry[QUALITY_RE, 1]&.to_f || 1.0
+        [tag, quality] if quality.positive?
+      end
+
+      def match(tag, offered)
+        lower = tag.downcase
+        base = lower.split('-').first
+        offered.find { |loc| loc.downcase == lower } ||
+          offered.find { |loc| loc.downcase == base } ||
+          offered.find { |loc| loc.downcase.split('-').first == base }
+      end
+
+      private_class_method :preferred_tags, :parse_entry, :match
+    end
+  end
+end

--- a/test/engine/dashboard_locale_test.rb
+++ b/test/engine/dashboard_locale_test.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require_relative '../engine_test_helper'
+
+# The two host/server i18n hooks the SPA shell carries: the `data-locale`
+# first-paint hint negotiated from Accept-Language, and the `#wurk-i18n` copy
+# overrides read by loadHostOverrides(). Mutates the global `Wurk::Web.config`,
+# so cannot run in parallel with other classes that share the same singleton.
+#
+# Asserts against the real shipped shell rather than a stub, for the reason
+# spelled out in DashboardRoutesTest: stubbing that file races concurrent
+# readers in other runner processes.
+class DashboardLocaleTest < Wurk::Test::EngineCase
+  INDEX = ::Wurk::Engine.root.join('vendor', 'assets', 'dashboard', 'index.html')
+  I18N_SCRIPT = %r{<script type="application/json" id="wurk-i18n">(.*?)</script>}m
+
+  def setup
+    super
+    skip 'dashboard build missing (run `bin/rake frontend:build`)' unless INDEX.exist?
+    Wurk::Web.reset_config!
+  end
+
+  def teardown
+    Wurk::Web.reset_config!
+    super
+  end
+
+  def test_accept_language_becomes_the_root_locale_hint
+    get_shell('de-DE,de;q=0.9,en;q=0.8')
+
+    assert_includes last_response.body, '<div id="wurk-root" data-locale="de">'
+  end
+
+  def test_quality_order_decides_the_hint
+    get_shell('de;q=0.4,ja;q=0.9')
+
+    assert_includes last_response.body, 'data-locale="ja"'
+  end
+
+  # No hint is the right answer for a language wurk ships nothing for: the SPA
+  # falls through to navigator.languages instead of being pinned to English.
+  def test_unoffered_language_emits_no_hint
+    get_shell('he-IL,he;q=0.9')
+
+    assert_includes last_response.body, '<div id="wurk-root">'
+    refute_includes last_response.body, 'data-locale'
+  end
+
+  def test_missing_header_emits_no_hint
+    get '/wurk'
+
+    assert_equal 200, last_response.status
+    refute_includes last_response.body, 'data-locale'
+  end
+
+  def test_default_locale_answers_when_the_header_matches_nothing
+    Wurk::Web.configure { |c| c.default_locale = 'ja' }
+    get_shell('he-IL')
+
+    assert_includes last_response.body, 'data-locale="ja"'
+  end
+
+  def test_accept_language_outranks_the_host_default
+    Wurk::Web.configure { |c| c.default_locale = 'ja' }
+    get_shell('fr-CA,fr;q=0.9')
+
+    assert_includes last_response.body, 'data-locale="fr"'
+  end
+
+  def test_narrowed_offered_list_stops_negotiating_the_rest
+    Wurk::Web.configure { |c| c.offered_locales = %w[en] }
+    get_shell('de-DE,de;q=0.9')
+
+    refute_includes last_response.body, 'data-locale'
+  end
+
+  # A host that supplies its own copy for an unshipped locale widens the list;
+  # the bundle underneath stays English (deliberate — see i18n/index.ts).
+  def test_widened_offered_list_negotiates_a_host_supplied_locale
+    Wurk::Web.configure { |c| c.offered_locales = Wurk::Web::Config::BUNDLED_LOCALES + ['he'] }
+    get_shell('he-IL,he;q=0.9')
+
+    assert_includes last_response.body, 'data-locale="he"'
+  end
+
+  # The negotiator only ever returns a tag from the host's own list, so a
+  # hostile header can neither be echoed into the attribute nor break out of it.
+  def test_hostile_header_reaches_no_attribute
+    get_shell('"><script>alert(1)</script>')
+
+    assert_equal 200, last_response.status
+    refute_includes last_response.body, 'alert(1)'
+    refute_includes last_response.body, 'data-locale'
+  end
+
+  def test_no_i18n_block_without_host_translations
+    get '/wurk'
+
+    refute_includes last_response.body, 'wurk-i18n'
+  end
+
+  def test_host_translations_are_emitted_as_a_locale_keyed_json_block
+    overrides = { 'en' => { 'nav' => { 'queues' => 'Pipelines' } } }
+    Wurk::Web.configure { |c| c.translations = overrides }
+    get '/wurk'
+
+    assert_equal overrides, JSON.parse(last_response.body[I18N_SCRIPT, 1])
+  end
+
+  # JSON-escaping the angle brackets is what keeps a `</script>` inside host
+  # copy from closing the block early.
+  def test_host_translations_cannot_break_out_of_the_script_tag
+    Wurk::Web.configure do |c|
+      c.translations = { 'en' => { 'nav' => { 'queues' => '</script><script>alert(1)</script>' } } }
+    end
+    get '/wurk'
+
+    refute_includes last_response.body, '<script>alert(1)'
+    assert_equal '</script><script>alert(1)</script>',
+                 JSON.parse(last_response.body[I18N_SCRIPT, 1]).dig('en', 'nav', 'queues')
+  end
+
+  def test_mount_base_still_injected_alongside_the_i18n_block
+    Wurk::Web.configure { |c| c.translations = { 'en' => { 'nav' => { 'queues' => 'Pipelines' } } } }
+    get_shell('de')
+
+    assert_includes last_response.body, '<script>window.__WURK_BASE__ = "/wurk";</script>'
+    assert_includes last_response.body, 'data-locale="de"'
+    assert_match I18N_SCRIPT, last_response.body
+  end
+
+  private
+
+  def get_shell(accept_language)
+    get '/wurk', {}, 'HTTP_ACCEPT_LANGUAGE' => accept_language
+  end
+end

--- a/test/unit/web_config_test.rb
+++ b/test/unit/web_config_test.rb
@@ -355,6 +355,52 @@ class WebConfigTest < Wurk::Test::UnitCase
     assert_includes paths, 'expiry'
   end
 
+  def test_locale_settings_default_to_the_shipped_bundles
+    cfg = Wurk::Web.config
+
+    assert_equal Wurk::Web::Config::BUNDLED_LOCALES, cfg.offered_locales
+    assert_nil cfg.default_locale
+    assert_empty cfg.translations
+  end
+
+  def test_locale_settings_are_configurable
+    Wurk::Web.configure do |c|
+      c.offered_locales = %w[en de he]
+      c.default_locale = 'de'
+      c.translations = { 'en' => { 'nav' => { 'queues' => 'Pipelines' } } }
+    end
+    cfg = Wurk::Web.config
+
+    assert_equal %w[en de he], cfg.offered_locales
+    assert_equal 'de', cfg.default_locale
+    assert_equal 'Pipelines', cfg.translations.dig('en', 'nav', 'queues')
+  end
+
+  def test_reset_clears_locale_settings
+    cfg = Wurk::Web.config
+    cfg.offered_locales = %w[fr]
+    cfg.default_locale = 'fr'
+    cfg.translations = { 'fr' => {} }
+    cfg.reset!
+
+    assert_equal Wurk::Web::Config::BUNDLED_LOCALES, cfg.offered_locales
+    assert_nil cfg.default_locale
+    assert_empty cfg.translations
+  end
+
+  # The server negotiates Accept-Language against BUNDLED_LOCALES, but the SPA
+  # decides what it can actually render from its own bundle imports. A bundle
+  # added on one side only would emit a hint the dashboard can't honour, so pin
+  # the two lists together at the source of truth: the JSON files themselves.
+  def test_bundled_locales_match_the_shipped_translation_files
+    dir = File.expand_path('../../frontend/src/i18n', __dir__)
+    skip 'frontend sources absent (installed gem)' unless File.directory?(dir)
+
+    shipped = Dir.children(dir).grep(/\.json\z/).map { |f| File.basename(f, '.json') }
+
+    assert_equal shipped.sort, Wurk::Web::Config::BUNDLED_LOCALES.sort
+  end
+
   private
 
   def with_env(key, value)

--- a/test/unit/web_locale_negotiator_test.rb
+++ b/test/unit/web_locale_negotiator_test.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Accept-Language -> the `data-locale` hint the dashboard shell carries.
+# Pure function over a header string and the host's offered list, so nothing
+# global is touched here.
+class WebLocaleNegotiatorTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  OFFERED = Wurk::Web::Config::BUNDLED_LOCALES
+
+  def test_exact_tag_wins
+    assert_equal 'de', negotiate('de')
+    assert_equal 'pt-BR', negotiate('pt-BR')
+  end
+
+  def test_match_is_case_insensitive_and_returns_the_offered_spelling
+    assert_equal 'pt-BR', negotiate('PT-br')
+    assert_equal 'de', negotiate('DE')
+  end
+
+  def test_region_falls_back_to_the_base_subtag
+    assert_equal 'es', negotiate('es-419')
+    assert_equal 'en', negotiate('en-GB')
+  end
+
+  # Same rung as bundleFor()'s regional promotion: a browser asking for plain
+  # Portuguese gets the one Portuguese bundle wurk ships.
+  def test_bare_subtag_is_promoted_to_a_regional_locale
+    assert_equal 'pt-BR', negotiate('pt')
+    assert_equal 'zh-CN', negotiate('zh')
+    assert_equal 'zh-CN', negotiate('zh-Hant-TW')
+  end
+
+  def test_highest_quality_entry_wins_regardless_of_position
+    assert_equal 'fr', negotiate('en;q=0.8,fr;q=0.9')
+  end
+
+  def test_ties_keep_header_order
+    assert_equal 'fr', negotiate('fr,de')
+    assert_equal 'de', negotiate('de,fr')
+    assert_equal 'de', negotiate('de;q=0.9,fr;q=0.9')
+  end
+
+  def test_real_browser_header
+    assert_equal 'de', negotiate('de-DE,de;q=0.9,en;q=0.8')
+  end
+
+  # q=0 is "not acceptable" — the header explicitly rules that language out.
+  def test_zero_quality_is_rejected
+    assert_equal 'en', negotiate('de;q=0,en')
+    assert_nil negotiate('de;q=0')
+  end
+
+  def test_whitespace_and_uppercase_quality_parameters_parse
+    assert_equal 'fr', negotiate(' en ; Q=0.4 , fr ; q=0.8 ')
+  end
+
+  # A wildcard states no preference, so there is no hint to give; the host
+  # default and the browser's own list cover that visitor instead.
+  def test_wildcard_is_not_a_preference
+    assert_nil negotiate('*')
+    assert_nil negotiate('he,*;q=0.5')
+  end
+
+  def test_unoffered_language_yields_nothing
+    assert_nil negotiate('he-IL,he;q=0.9')
+    assert_nil negotiate('de', offered: %w[en])
+  end
+
+  def test_blank_header_yields_nothing
+    assert_nil negotiate(nil)
+    assert_nil negotiate('')
+    assert_nil negotiate(',,')
+  end
+
+  # The return value is always an entry of `offered`, so header text can never
+  # reach the emitted attribute even when the header is hostile.
+  def test_header_text_is_never_echoed_back
+    assert_nil negotiate('"><script>alert(1)</script>')
+    assert_nil negotiate('de<script>')
+  end
+
+  # Widening the list is how a host serves a locale wurk ships no bundle for,
+  # paired with `translations` copy for it.
+  def test_offered_list_is_the_whole_vocabulary
+    assert_equal 'he', negotiate('he-IL', offered: OFFERED + ['he'])
+    assert_equal 'en', negotiate('de-DE,de;q=0.9,en;q=0.8', offered: %w[en fr])
+  end
+
+  private
+
+  def negotiate(header, offered: OFFERED)
+    Wurk::Web::LocaleNegotiator.call(header, offered: offered)
+  end
+end


### PR DESCRIPTION
## Summary
- Rewrites dashboard locale resolution (`bundleFor`'s reversed match, five-rung precedence: `?locale=` > stored pick > server hint > navigator > en)
- Adds the SolidJS `LocalePicker` nav-rail menu (no prior settings surface existed)
- Emits the server `data-locale` first-paint hint via `Wurk::Web::LocaleNegotiator` (mirrors the SPA's match algorithm) and wires up the previously-dead `#wurk-i18n` host-copy-override path (`Wurk::Web.config.translations`)
- Full test coverage across all layers: `frontend/src/i18n/i18n.test.ts`, `LocalePicker.test.tsx`, `test/unit/web_locale_negotiator_test.rb`, `test/engine/dashboard_locale_test.rb`

## Test plan
- [x] `cd frontend && bun run test` — 174 passed
- [x] `npx tsc --noEmit` — clean
- [x] `bun run lint` (oxlint) — clean
- [x] `bin/rake test` — 3269 runs, 0 failures
- [x] `bundle exec rubocop` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788799325&installation_model_id=11168&pr_number=399&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F399&signature=33e48aaa7b994b827123be224af72aaa8877762608b368dcd30c0ca050c0c9c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a language selector to the dashboard navigation.
  * Added support for English, Spanish, French, German, Brazilian Portuguese, Japanese, Simplified Chinese, and Arabic.
  * Automatically selects languages using browser preferences, saved settings, or server-provided locale negotiation.
  * Added support for custom translations, right-to-left layouts, regional fallback, and English fallback.
  * Improved accessibility, keyboard navigation, responsive positioning, and reduced-motion behavior.

* **Documentation**
  * Added configuration guidance for dashboard languages, locale selection, translations, and RTL support.

* **Bug Fixes**
  * Safely handles translation data and unsupported or malformed locale information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->