### PR TITLE
feat(dashboard): Intl-based locale/timezone-aware date and number formatting

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { Show } from 'solid-js';
 import { useMeta } from './hooks/useMeta';
 import { basePath } from './basePath';
 import { t } from './i18n';
+import { useLiveTick } from './tick';
 import Nav from './components/Nav';
 import { PageSkeleton } from './components/Skeleton';
 import ErrorBoundary from './components/ErrorBoundary';
@@ -68,6 +69,11 @@ const NAV_COLLAPSED_KEY = 'wurk-nav-collapsed';
 // every route. Solid Router renders the matched route into `props.children`,
 // which lives inside the <Suspense> so lazy chunks fall back to the skeleton.
 function Layout(props: ParentProps) {
+  // The shell outlives every route, so owning the tick here gives the relative
+  // labels on whichever page is mounted one interval between them — rather than
+  // one per page, or one per cell in a table of hundreds.
+  useLiveTick();
+
   const [navOpen, setNavOpen] = createSignal(false);
   // Desktop-only: pin the rail collapsed (icons) or expanded (full), persisted
   // so the choice survives reloads.

--- a/frontend/src/components/AnimatedNumber.tsx
+++ b/frontend/src/components/AnimatedNumber.tsx
@@ -1,4 +1,5 @@
 import { useCountUp } from '../hooks/useCountUp';
+import { formatNumber } from '../utils';
 
 interface AnimatedNumberProps {
   value: number;
@@ -9,5 +10,5 @@ interface AnimatedNumberProps {
 // exactly on the target.
 export function AnimatedNumber(props: AnimatedNumberProps) {
   const display = useCountUp(() => props.value);
-  return <>{Math.round(display()).toLocaleString()}</>;
+  return <>{formatNumber(Math.round(display()))}</>;
 }

--- a/frontend/src/components/JobDetailModal.tsx
+++ b/frontend/src/components/JobDetailModal.tsx
@@ -1,7 +1,7 @@
 import { For, Show, type JSX } from 'solid-js';
 import Modal from './Modal';
 import { t } from '../i18n';
-import { formatArgs, isoTime, relativeTime } from '../utils';
+import { absoluteTime, formatArgs, hoverTime, relativeTime } from '../utils';
 import type { ActionDef } from './JobSetActionBar';
 
 // Union of the fields the various list endpoints expose for a job/entry
@@ -87,10 +87,18 @@ export default function JobDetailModal(props: JobDetailModalProps) {
                 <Field label={t('job.retries')}>{entry().retry_count}</Field>
               </Show>
               <Show when={entry().enqueued_at != null}>
-                <Field label={t('job.enqueued')} mono>{isoTime(entry().enqueued_at!)} ({relativeTime(entry().enqueued_at!)})</Field>
+                <Field label={t('job.enqueued')} mono>
+                  <span title={hoverTime(entry().enqueued_at!)}>
+                    {absoluteTime(entry().enqueued_at!)} ({relativeTime(entry().enqueued_at!)})
+                  </span>
+                </Field>
               </Show>
               <Show when={entry().at != null}>
-                <Field label={props.atLabel ?? t('job.at')} mono>{isoTime(entry().at!)} ({relativeTime(entry().at!)})</Field>
+                <Field label={props.atLabel ?? t('job.at')} mono>
+                  <span title={hoverTime(entry().at!)}>
+                    {absoluteTime(entry().at!)} ({relativeTime(entry().at!)})
+                  </span>
+                </Field>
               </Show>
             </div>
 

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -4,6 +4,7 @@ import { t } from '../i18n';
 import { useMeta } from '../hooks/useMeta';
 import { useSSE } from '../hooks/useSSE';
 import LocalePicker from './LocalePicker';
+import TimezonePicker from './TimezonePicker';
 import logoUrl from '../assets/wurk-logo.png';
 
 interface NavProps {
@@ -244,8 +245,10 @@ export default function Nav(props: NavProps) {
         </button>
 
         {/* The rail footer is the dashboard's only non-route control area, so the
-            language menu lives here next to the collapse toggle. */}
+            display preferences — language, then the zone every timestamp is
+            rendered in — live here next to the collapse toggle. */}
         <LocalePicker />
+        <TimezonePicker />
 
         {/* Footer: link out to the source repo. Pinned to the bottom because the
             nav list above is flex:1. Muted by default; hover lifts like a nav item. */}

--- a/frontend/src/components/TimezonePicker.test.tsx
+++ b/frontend/src/components/TimezonePicker.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@solidjs/testing-library';
+import TimezonePicker from './TimezonePicker';
+import { t } from '../i18n';
+import { browserZone, setTimeZone, timeZone } from '../tz';
+
+// Only setTimeZone is stubbed: it persists and then reloads, and jsdom has no
+// navigation. Resolution stays real so the picker is exercised against the
+// zones Intl actually offers.
+vi.mock('../tz', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../tz')>()),
+  setTimeZone: vi.fn(),
+}));
+
+// jsdom has no <dialog> top-layer support. Unlike Modal.test.tsx's inert stubs,
+// these carry the `open` state: a closed <dialog> keeps its subtree out of the
+// accessibility tree, and every query below is a role query.
+HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+  this.open = true;
+});
+HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+  this.open = false;
+});
+
+const trigger = () => screen.getByRole('button', { name: t('nav.timezone_current', { name: timeZone }) });
+const options = () => screen.getAllByRole('option');
+const filter = () => screen.getByRole('searchbox', { name: t('timezone.filter') });
+
+function open() {
+  render(() => <TimezonePicker />);
+  fireEvent.click(trigger());
+}
+
+function type(query: string) {
+  const input = filter();
+  fireEvent.input(input, { target: { value: query } });
+  return input;
+}
+
+beforeEach(() => vi.mocked(setTimeZone).mockClear());
+afterEach(() => localStorage.clear());
+
+describe('TimezonePicker', () => {
+  it('labels the trigger with the resolved zone and opens nothing until asked', () => {
+    render(() => <TimezonePicker />);
+
+    expect(trigger()).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(trigger()).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger()).toHaveAttribute('title', t('timezone.shown_in', { name: timeZone }));
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('says which zone the times on screen are in', () => {
+    open();
+    expect(screen.getByText(t('timezone.shown_in', { name: timeZone }))).toBeInTheDocument();
+  });
+
+  it('leads with the automatic entry, then UTC, then the IANA zones', () => {
+    open();
+    const labels = options().map((el) => el.textContent);
+
+    expect(trigger()).toHaveAttribute('aria-expanded', 'true');
+    expect(labels[0]).toBe(t('timezone.automatic', { name: browserZone() }));
+    expect(labels[1]).toBe('UTC');
+    expect(labels).toContain('America/New_York');
+  });
+
+  it('marks the automatic entry while no zone is pinned', () => {
+    open();
+    const selected = options().filter((el) => el.getAttribute('aria-selected') === 'true');
+
+    expect(selected).toHaveLength(1);
+    expect(selected[0].textContent).toBe(t('timezone.automatic', { name: browserZone() }));
+  });
+
+  it('marks the pinned zone instead once one is stored', () => {
+    localStorage.setItem('wurk.tz', 'Asia/Tokyo');
+    open();
+    const selected = options().filter((el) => el.getAttribute('aria-selected') === 'true');
+
+    expect(selected).toHaveLength(1);
+    expect(selected[0].textContent).toBe('Asia/Tokyo');
+  });
+
+  it('narrows the list as the user types, ignoring separators and case', () => {
+    open();
+    type('new york');
+
+    expect(options().map((el) => el.textContent)).toEqual(['America/New_York']);
+  });
+
+  it('says so when nothing matches', () => {
+    open();
+    type('atlantis');
+
+    expect(screen.queryAllByRole('option')).toHaveLength(0);
+    expect(screen.getByText(t('timezone.empty', { query: 'atlantis' }))).toBeInTheDocument();
+  });
+
+  it('reports a pinned zone and closes', () => {
+    open();
+    type('tokyo');
+    fireEvent.click(screen.getByRole('option', { name: 'Asia/Tokyo' }));
+
+    expect(vi.mocked(setTimeZone)).toHaveBeenCalledWith('Asia/Tokyo');
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('reports null for the automatic entry, dropping the override', () => {
+    localStorage.setItem('wurk.tz', 'Asia/Tokyo');
+    open();
+    fireEvent.click(options()[0]);
+
+    expect(vi.mocked(setTimeZone)).toHaveBeenCalledWith(null);
+  });
+
+  it('takes the first match on Enter, so a filtered pick needs no mouse', () => {
+    open();
+    fireEvent.keyDown(type('lisbon'), { key: 'Enter' });
+
+    expect(vi.mocked(setTimeZone)).toHaveBeenCalledWith('Europe/Lisbon');
+  });
+
+  it('ignores Enter on an empty filter rather than pinning the automatic entry', () => {
+    open();
+    fireEvent.keyDown(filter(), { key: 'Enter' });
+
+    expect(vi.mocked(setTimeZone)).not.toHaveBeenCalled();
+  });
+
+  it('walks the list from the filter and back again', () => {
+    open();
+    type('europe/l');
+    const rows = options();
+    expect(rows.length).toBeGreaterThan(1);
+
+    fireEvent.keyDown(filter(), { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(rows[0]);
+
+    fireEvent.keyDown(document.activeElement!, { key: 'End' });
+    expect(document.activeElement).toBe(rows[rows.length - 1]);
+
+    fireEvent.keyDown(document.activeElement!, { key: 'Home' });
+    expect(document.activeElement).toBe(rows[0]);
+
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(rows[1]);
+
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowUp' });
+    expect(document.activeElement).toBe(rows[0]);
+
+    // Off the top of the list is the filter, not a trapped first row.
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowUp' });
+    expect(document.activeElement).toBe(filter());
+  });
+
+  it('drops the filter when closed, so the next open starts from the whole list', () => {
+    open();
+    type('tokyo');
+    fireEvent.click(screen.getByLabelText('Close'));
+    fireEvent.click(trigger());
+
+    expect(filter()).toHaveValue('');
+    expect(options().length).toBeGreaterThan(2);
+  });
+});

--- a/frontend/src/components/TimezonePicker.tsx
+++ b/frontend/src/components/TimezonePicker.tsx
@@ -1,0 +1,178 @@
+import { For, Show, createEffect, createMemo, createSignal } from 'solid-js';
+import { t } from '../i18n';
+import { browserZone, setTimeZone, storedZone, supportedZones, timeZone } from '../tz';
+import Modal from './Modal';
+
+interface Entry {
+  /** The zone to persist, or null for the entry that clears the override. */
+  zone: string | null;
+  label: string;
+  selected: boolean;
+}
+
+/** Folds a zone id and a query onto common ground: "America/New_York" -> "america new york". */
+function normalize(s: string): string {
+  return s.toLowerCase().replace(/[_/]/g, ' ');
+}
+
+/** "Europe/Berlin" -> "Berlin". The rail is far too narrow for the full id. */
+function shortLabel(zone: string): string {
+  return zone.slice(zone.lastIndexOf('/') + 1).replace(/_/g, ' ');
+}
+
+/**
+ * Timezone menu for the nav rail's footer, next to the language one. There are
+ * ~400 zones, so this opens a filterable dialog rather than the flat menu eight
+ * locales get. The resolved zone is baked in at module load (`tz.ts`), so
+ * picking one reloads the page — `setTimeZone()` owns that.
+ */
+export default function TimezonePicker() {
+  // Fixed for the page's life, for the same reason: nothing here can change
+  // without the reload.
+  const override = storedZone();
+  const automatic = browserZone();
+
+  const [isOpen, setIsOpen] = createSignal(false);
+  const [query, setQuery] = createSignal('');
+
+  let filter: HTMLInputElement | undefined;
+  let list: HTMLDivElement | undefined;
+  // Read from the DOM rather than collected into a ref array as the rows
+  // render: the list is filtered while the user types, and a stale ref array
+  // would move focus onto a row that is no longer on screen.
+  const options = () => Array.from(list?.querySelectorAll<HTMLButtonElement>('[role="option"]') ?? []);
+
+  const entries = createMemo<Entry[]>(() => {
+    const all: Entry[] = [
+      { zone: null, label: t('timezone.automatic', { name: automatic }), selected: override === undefined },
+      ...supportedZones().map((zone) => ({ zone, label: zone, selected: zone === override })),
+    ];
+    const q = normalize(query().trim());
+    return q ? all.filter((entry) => normalize(entry.label).includes(q)) : all;
+  });
+
+  const close = () => {
+    setIsOpen(false);
+    setQuery('');
+  };
+
+  const choose = (zone: string | null) => {
+    close();
+    // Re-picking the zone already showing is not a no-op: it's how the browser
+    // zone becomes a pinned choice that survives the OS zone changing.
+    setTimeZone(zone);
+  };
+
+  // The dialog opens onto its filter — this list is long enough that typing is
+  // the way in, not scrolling.
+  createEffect(() => {
+    if (isOpen()) filter?.focus();
+  });
+
+  const onFilterKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      options()[0]?.focus();
+    } else if (e.key === 'Enter' && query().trim()) {
+      // Only with a query: on the unfiltered list the first row is "automatic",
+      // which nobody means to pick by pressing Enter on an empty field.
+      const first = entries()[0];
+      if (!first) return;
+      choose(first.zone);
+    } else {
+      return;
+    }
+    e.preventDefault();
+  };
+
+  const onListKeyDown = (e: KeyboardEvent) => {
+    const rows = options();
+    const cur = rows.findIndex((el) => el === document.activeElement);
+    switch (e.key) {
+      case 'ArrowDown':
+        rows[Math.min(cur + 1, rows.length - 1)]?.focus();
+        break;
+      case 'ArrowUp':
+        // Off the top of the list is back to the filter, so a correction
+        // doesn't need a reach for the mouse.
+        if (cur <= 0) filter?.focus();
+        else rows[cur - 1].focus();
+        break;
+      case 'Home':
+        rows[0]?.focus();
+        break;
+      case 'End':
+        rows[rows.length - 1]?.focus();
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        class="wurk-navlink timezone-picker__trigger"
+        aria-haspopup="dialog"
+        aria-expanded={isOpen()}
+        aria-label={t('nav.timezone_current', { name: timeZone })}
+        title={t('timezone.shown_in', { name: timeZone })}
+        onClick={() => setIsOpen(true)}
+      >
+        <i class="fa-solid fa-globe wurk-navlink__icon" aria-hidden="true" />
+        <span class="nav-label">
+          <bdi>{shortLabel(timeZone)}</bdi>
+        </span>
+      </button>
+
+      <Modal open={isOpen()} onClose={close} title={t('timezone.title')} width={420}>
+        {/* Gated so ~400 rows are built when the dialog opens, not on every
+            page load — Nav, and this picker with it, is mounted for the app's
+            whole lifetime. */}
+        <Show when={isOpen()}>
+          <p class="timezone-picker__hint">{t('timezone.shown_in', { name: timeZone })}</p>
+          <input
+            ref={filter}
+            class="input timezone-picker__filter"
+            type="search"
+            value={query()}
+            placeholder={t('timezone.filter')}
+            aria-label={t('timezone.filter')}
+            aria-controls="timezone-picker-list"
+            onInput={(e) => setQuery(e.currentTarget.value)}
+            onKeyDown={onFilterKeyDown}
+          />
+          <div
+            ref={list}
+            id="timezone-picker-list"
+            role="listbox"
+            aria-label={t('timezone.title')}
+            class="timezone-picker__list"
+            onKeyDown={onListKeyDown}
+          >
+            <For each={entries()}>
+              {(entry) => (
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={entry.selected}
+                  class="timezone-picker__option"
+                  onClick={() => choose(entry.zone)}
+                >
+                  <bdi>{entry.label}</bdi>
+                  <Show when={entry.selected}>
+                    <i class="fa-solid fa-check" aria-hidden="true" />
+                  </Show>
+                </button>
+              )}
+            </For>
+          </div>
+          <Show when={entries().length === 0}>
+            <p class="timezone-picker__empty">{t('timezone.empty', { query: query().trim() })}</p>
+          </Show>
+        </Show>
+      </Modal>
+    </>
+  );
+}

--- a/frontend/src/components/charts/util.tsx
+++ b/frontend/src/components/charts/util.tsx
@@ -1,4 +1,5 @@
 import { createSignal, onCleanup, onMount, For, Show, type JSX } from 'solid-js';
+import { formatNumber } from '../../utils';
 
 // Shared primitives for the hand-rolled SVG charts that replace recharts. No
 // deps beyond Solid + SVG — the dark Obsidian palette is baked in here so every
@@ -117,7 +118,7 @@ export function yScale(maxVal: number, allowDecimals = true): { max: number; tic
 }
 
 export function fmtTick(v: number): string {
-  return Number.isInteger(v) ? v.toLocaleString() : v.toFixed(v < 10 ? 2 : 1);
+  return Number.isInteger(v) ? formatNumber(v) : v.toFixed(v < 10 ? 2 : 1);
 }
 
 // preserveStartEnd + minTickGap: keep both endpoints and thin the interior to
@@ -226,7 +227,7 @@ export interface TooltipRow {
 }
 
 function fmtVal(v: number): string {
-  return Number.isInteger(v) ? v.toLocaleString() : v.toFixed(2);
+  return Number.isInteger(v) ? formatNumber(v) : v.toFixed(2);
 }
 
 // HTML overlay tooltip (crisp text, unlike SVG <text>). Flips to the other side

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -17,6 +17,8 @@
     "expand": "توسيع",
     "language": "اللغة",
     "language_current": "اللغة: {name}",
+    "timezone": "المنطقة الزمنية",
+    "timezone_current": "المنطقة الزمنية: {name}",
     "status_active": "حالة النظام: نشط",
     "status_inactive": "حالة النظام: غير متصل"
   },
@@ -258,5 +260,12 @@
     "queue_latency_seconds": "زمن استجابة الطابور (ثوانٍ)",
     "historical_snapshots": "اللقطات التاريخية",
     "view_job_detail": "عرض تفاصيل فئة المهمة"
+  },
+  "timezone": {
+    "title": "المنطقة الزمنية",
+    "shown_in": "الأوقات معروضة بتوقيت {name}",
+    "automatic": "تلقائي ({name})",
+    "filter": "تصفية المناطق الزمنية…",
+    "empty": "لا توجد منطقة زمنية تطابق «{query}»"
   }
 }

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -17,6 +17,8 @@
     "expand": "Ausklappen",
     "language": "Sprache",
     "language_current": "Sprache: {name}",
+    "timezone": "Zeitzone",
+    "timezone_current": "Zeitzone: {name}",
     "status_active": "Systemstatus: Aktiv",
     "status_inactive": "Systemstatus: Getrennt"
   },
@@ -258,5 +260,12 @@
     "queue_latency_seconds": "Warteschlangen-Latenz (Sekunden)",
     "historical_snapshots": "Historische Snapshots",
     "view_job_detail": "Job-Klassendetail anzeigen"
+  },
+  "timezone": {
+    "title": "Zeitzone",
+    "shown_in": "Zeiten werden in {name} angezeigt",
+    "automatic": "Automatisch ({name})",
+    "filter": "Zeitzonen filtern…",
+    "empty": "Keine Zeitzone passt zu „{query}“"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -17,6 +17,8 @@
     "expand": "Expand",
     "language": "Language",
     "language_current": "Language: {name}",
+    "timezone": "Timezone",
+    "timezone_current": "Timezone: {name}",
     "status_active": "System Status: Active",
     "status_inactive": "System Status: Disconnected"
   },
@@ -258,5 +260,12 @@
     "queue_latency_seconds": "Queue Latency (seconds)",
     "historical_snapshots": "Historical Snapshots",
     "view_job_detail": "View job class detail"
+  },
+  "timezone": {
+    "title": "Timezone",
+    "shown_in": "Times shown in {name}",
+    "automatic": "Automatic ({name})",
+    "filter": "Filter timezones…",
+    "empty": "No timezone matches “{query}”"
   }
 }

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -17,6 +17,8 @@
     "expand": "Expandir",
     "language": "Idioma",
     "language_current": "Idioma: {name}",
+    "timezone": "Zona horaria",
+    "timezone_current": "Zona horaria: {name}",
     "status_active": "Estado del sistema: Activo",
     "status_inactive": "Estado del sistema: Desconectado"
   },
@@ -258,5 +260,12 @@
     "queue_latency_seconds": "Latencia de cola (segundos)",
     "historical_snapshots": "Instantáneas históricas",
     "view_job_detail": "Ver detalle de la clase de trabajo"
+  },
+  "timezone": {
+    "title": "Zona horaria",
+    "shown_in": "Horas mostradas en {name}",
+    "automatic": "Automática ({name})",
+    "filter": "Filtrar zonas horarias…",
+    "empty": "Ninguna zona horaria coincide con “{query}”"
   }
 }

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -17,6 +17,8 @@
     "expand": "Développer",
     "language": "Langue",
     "language_current": "Langue : {name}",
+    "timezone": "Fuseau horaire",
+    "timezone_current": "Fuseau horaire : {name}",
     "status_active": "État du système : Actif",
     "status_inactive": "État du système : Déconnecté"
   },
@@ -258,5 +260,12 @@
     "queue_latency_seconds": "Latence de file (secondes)",
     "historical_snapshots": "Instantanés historiques",
     "view_job_detail": "Voir le détail de la classe de tâche"
+  },
+  "timezone": {
+    "title": "Fuseau horaire",
+    "shown_in": "Heures affichées dans le fuseau {name}",
+    "automatic": "Automatique ({name})",
+    "filter": "Filtrer les fuseaux horaires…",
+    "empty": "Aucun fuseau horaire ne correspond à « {query} »"
   }
 }

--- a/frontend/src/i18n/ja.json
+++ b/frontend/src/i18n/ja.json
@@ -17,6 +17,8 @@
     "expand": "展開",
     "language": "言語",
     "language_current": "言語: {name}",
+    "timezone": "タイムゾーン",
+    "timezone_current": "タイムゾーン: {name}",
     "status_active": "システム状態: 稼働中",
     "status_inactive": "システム状態: 切断"
   },
@@ -258,5 +260,12 @@
     "queue_latency_seconds": "キューレイテンシ(秒)",
     "historical_snapshots": "過去のスナップショット",
     "view_job_detail": "ジョブクラスの詳細を表示"
+  },
+  "timezone": {
+    "title": "タイムゾーン",
+    "shown_in": "{name} の時刻で表示しています",
+    "automatic": "自動 ({name})",
+    "filter": "タイムゾーンを絞り込み…",
+    "empty": "“{query}”に一致するタイムゾーンはありません"
   }
 }

--- a/frontend/src/i18n/pt-BR.json
+++ b/frontend/src/i18n/pt-BR.json
@@ -17,6 +17,8 @@
     "expand": "Expandir",
     "language": "Idioma",
     "language_current": "Idioma: {name}",
+    "timezone": "Fuso horário",
+    "timezone_current": "Fuso horário: {name}",
     "status_active": "Status do sistema: Ativo",
     "status_inactive": "Status do sistema: Desconectado"
   },
@@ -258,5 +260,12 @@
     "queue_latency_seconds": "Latência da fila (segundos)",
     "historical_snapshots": "Snapshots históricos",
     "view_job_detail": "Ver detalhe da classe de job"
+  },
+  "timezone": {
+    "title": "Fuso horário",
+    "shown_in": "Horários exibidos em {name}",
+    "automatic": "Automático ({name})",
+    "filter": "Filtrar fusos horários…",
+    "empty": "Nenhum fuso horário corresponde a “{query}”"
   }
 }

--- a/frontend/src/i18n/zh-CN.json
+++ b/frontend/src/i18n/zh-CN.json
@@ -17,6 +17,8 @@
     "expand": "展开",
     "language": "语言",
     "language_current": "语言：{name}",
+    "timezone": "时区",
+    "timezone_current": "时区：{name}",
     "status_active": "系统状态：运行中",
     "status_inactive": "系统状态：已断开"
   },
@@ -258,5 +260,12 @@
     "queue_latency_seconds": "队列延迟（秒）",
     "historical_snapshots": "历史快照",
     "view_job_detail": "查看任务类详情"
+  },
+  "timezone": {
+    "title": "时区",
+    "shown_in": "时间以 {name} 显示",
+    "automatic": "自动（{name}）",
+    "filter": "筛选时区…",
+    "empty": "没有与“{query}”匹配的时区"
   }
 }

--- a/frontend/src/pages/BatchDetail.tsx
+++ b/frontend/src/pages/BatchDetail.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/solid-query';
 import { onMount, For, Show, Switch, Match, type JSX } from 'solid-js';
 import { A, useParams } from '@solidjs/router';
 import { t } from '../i18n';
-import { relativeTime } from '../utils';
+import { formatNumber, relativeTime } from '../utils';
 import { SkeletonCards } from '../components/Skeleton';
 import { basePath } from '../basePath';
 
@@ -122,10 +122,10 @@ export default function BatchDetail() {
                   'margin-top': '1rem',
                 }}
               >
-                <Field label={t('table.total')}>{data().total.toLocaleString()}</Field>
-                <Field label={t('table.pending')}>{data().pending.toLocaleString()}</Field>
-                <Field label={t('table.failures')}>{data().failures.toLocaleString()}</Field>
-                <Field label={t('batches.children')}>{data().child_count.toLocaleString()}</Field>
+                <Field label={t('table.total')}>{formatNumber(data().total)}</Field>
+                <Field label={t('table.pending')}>{formatNumber(data().pending)}</Field>
+                <Field label={t('table.failures')}>{formatNumber(data().failures)}</Field>
+                <Field label={t('batches.children')}>{formatNumber(data().child_count)}</Field>
                 <Field label={t('table.created')}>{data().created_at ? relativeTime(data().created_at!) : '—'}</Field>
                 <Field label={t('batches.completed')}>{data().complete_at ? relativeTime(data().complete_at!) : '—'}</Field>
                 <Show when={data().parent_bid}>

--- a/frontend/src/pages/Batches.tsx
+++ b/frontend/src/pages/Batches.tsx
@@ -8,7 +8,7 @@ import { usePageParam } from '../hooks/usePageParam';
 import { useResetPageOnEmpty } from '../hooks/useResetPageOnEmpty';
 import { t } from '../i18n';
 import { PageHeader } from '../components/PageHeader';
-import { relativeTime, truncate } from '../utils';
+import { formatNumber, relativeTime, truncate } from '../utils';
 import { SkeletonTable } from '../components/Skeleton';
 import { basePath } from '../basePath';
 import { getJSON } from '../http';
@@ -75,7 +75,7 @@ export default function Batches() {
         {(data) => (
           <div>
             <PageHeader icon="fa-table-cells-large" title={t('nav.batches')} summary={t('summaries.batches')}>
-              <span class="badge badge-accent">{data().total.toLocaleString()}</span>
+              <span class="badge badge-accent">{formatNumber(data().total)}</span>
             </PageHeader>
 
             <Show when={sorted().length > 0} fallback={<div class="empty-state">{t('common.empty')}</div>}>
@@ -105,12 +105,12 @@ export default function Batches() {
                               </A>
                             </td>
                             <td title={batch.description ?? ''}>{truncate(batch.description ?? '—', 40)}</td>
-                            <td>{batch.total.toLocaleString()}</td>
+                            <td>{formatNumber(batch.total)}</td>
                             <td style={{ color: batch.pending > 0 ? 'var(--warning)' : 'var(--success)' }}>
-                              {batch.pending.toLocaleString()}
+                              {formatNumber(batch.pending)}
                             </td>
                             <td style={{ color: batch.failures > 0 ? 'var(--danger)' : undefined }}>
-                              {batch.failures.toLocaleString()}
+                              {formatNumber(batch.failures)}
                             </td>
                             <td style={{ width: '100px' }}>
                               <div style={{ display: 'flex', 'align-items': 'center', gap: '0.5rem' }}>

--- a/frontend/src/pages/Busy.test.tsx
+++ b/frontend/src/pages/Busy.test.tsx
@@ -136,7 +136,7 @@ describe('Busy', () => {
 
   it('renders a live heartbeat from the API `beat` field', async () => {
     renderBusy();
-    const beats = await screen.findAllByText(/\ds ago/);
+    const beats = await screen.findAllByText(/\d seconds ago/);
     expect(beats.length).toBeGreaterThanOrEqual(3);
     expect(screen.queryAllByText('—')).toHaveLength(0);
   });

--- a/frontend/src/pages/Busy.tsx
+++ b/frontend/src/pages/Busy.tsx
@@ -4,7 +4,7 @@ import { t } from '../i18n';
 import { PageHeader } from '../components/PageHeader';
 import Modal from '../components/Modal';
 import { ArgsValue } from '../components/ArgsValue';
-import { relativeTime, isoTime, formatKb, formatDuration, formatArgs, truncate } from '../utils';
+import { relativeTime, hoverTime, formatKb, formatDuration, formatArgs, truncate } from '../utils';
 import { useMeta } from '../hooks/useMeta';
 import { SkeletonCards } from '../components/Skeleton';
 import { basePath } from '../basePath';
@@ -107,8 +107,8 @@ function ProcessDetail(props: { proc: Process }) {
     [t('busy.identity'), <code style={{ 'font-size': '12px' }}>{props.proc.identity}</code>],
     [t('busy.leader'), props.proc.leader ? <span class="badge badge-accent">{t('busy.leader')}</span> : '—'],
     ['PID', props.proc.pid],
-    [t('busy.started'), props.proc.started_at ? <span title={isoTime(props.proc.started_at)}>{relativeTime(props.proc.started_at)}</span> : '—'],
-    [t('busy.heartbeat'), <span title={isoTime(props.proc.beat)}>{relativeTime(props.proc.beat)}</span>],
+    [t('busy.started'), props.proc.started_at ? <span title={hoverTime(props.proc.started_at)}>{relativeTime(props.proc.started_at)}</span> : '—'],
+    [t('busy.heartbeat'), <span title={hoverTime(props.proc.beat)}>{relativeTime(props.proc.beat)}</span>],
     [`${t('table.busy')} / ${t('table.concurrency')}`, `${props.proc.busy} / ${props.proc.concurrency}`],
     [t('busy.rss'), formatKb(props.proc.rss ?? 0)],
     [t('busy.rtt'), props.proc.rtt_us ? `${(props.proc.rtt_us / 1000).toFixed(1)} ${t('common.ms')}` : '—'],
@@ -162,7 +162,7 @@ function ProcessDetail(props: { proc: Process }) {
                     <td style={{ 'font-weight': 500 }}>{w.klass}</td>
                     <td><span class="badge badge-muted">{w.queue}</span></td>
                     <td><ArgsValue str={formatArgs(w.args)} max={40} /></td>
-                    <td title={isoTime(w.run_at)}>{relativeTime(w.run_at)}</td>
+                    <td title={hoverTime(w.run_at)}>{relativeTime(w.run_at)}</td>
                   </tr>
                 )}
               </For>

--- a/frontend/src/pages/Busy.tsx
+++ b/frontend/src/pages/Busy.tsx
@@ -4,7 +4,7 @@ import { t } from '../i18n';
 import { PageHeader } from '../components/PageHeader';
 import Modal from '../components/Modal';
 import { ArgsValue } from '../components/ArgsValue';
-import { relativeTime, hoverTime, formatKb, formatDuration, formatArgs, truncate } from '../utils';
+import { relativeTime, hoverTime, formatKb, formatDuration, formatArgs, nowSeconds, truncate } from '../utils';
 import { useMeta } from '../hooks/useMeta';
 import { SkeletonCards } from '../components/Skeleton';
 import { basePath } from '../basePath';
@@ -305,7 +305,7 @@ export default function Busy() {
                       <For each={group.processes}>
                         {(proc) => {
                           const utilization = proc.concurrency > 0 ? (proc.busy / proc.concurrency) * 100 : 0;
-                          const isRecent = Date.now() / 1000 - proc.beat < 30;
+                          const isRecent = nowSeconds() - proc.beat < 30;
 
                           return (
                             <div
@@ -317,7 +317,7 @@ export default function Busy() {
                                   <div style={{ 'font-weight': 600, 'font-size': '15px' }}>PID {proc.pid}</div>
                                   <div style={{ color: 'var(--text-muted)', 'font-size': '12px' }}>
                                     {proc.tag || proc.hostname}
-                                    {proc.started_at ? ` · ${t('busy.up_for')} ${formatDuration(Date.now() / 1000 - proc.started_at)}` : ''}
+                                    {proc.started_at ? ` · ${t('busy.up_for')} ${formatDuration(nowSeconds() - proc.started_at)}` : ''}
                                   </div>
                                 </div>
                                 <div style={{ display: 'flex', gap: '0.375rem' }}>

--- a/frontend/src/pages/Cron.tsx
+++ b/frontend/src/pages/Cron.tsx
@@ -4,7 +4,7 @@ import { t } from '../i18n';
 import { PageHeader } from '../components/PageHeader';
 import { SkeletonTable } from '../components/Skeleton';
 import Modal from '../components/Modal';
-import { relativeTime, isoTime, truncate } from '../utils';
+import { relativeTime, hoverTime, truncate } from '../utils';
 import { useMeta } from '../hooks/useMeta';
 import { SortableTh } from '../components/SortableTh';
 import { useSort, type Accessors } from '../hooks/useSort';
@@ -196,7 +196,7 @@ export default function Cron() {
                           <For each={history()}>
                             {([firedAt, jid]) => (
                               <tr>
-                                <td style={{ color: 'var(--text-muted)' }} title={isoTime(firedAt)}>
+                                <td style={{ color: 'var(--text-muted)' }} title={hoverTime(firedAt)}>
                                   {relativeTime(firedAt)}
                                 </td>
                                 <td style={{ 'font-family': 'monospace', 'font-size': '12px' }}>{jid}</td>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -7,7 +7,8 @@ import { PageHeader } from '../components/PageHeader';
 import { Skeleton, SkeletonCards, SkeletonTable } from '../components/Skeleton';
 import { t } from '../i18n';
 import { useSSE } from '../hooks/useSSE';
-import { formatDuration } from '../utils';
+import { formatBucket, formatDuration } from '../utils';
+import { timeZone } from '../tz';
 import { basePath } from '../basePath';
 
 interface StatsData {
@@ -62,14 +63,6 @@ const RANGES = [
   { key: '30d', bucket: '1h', window: '30d', desc_key: 'dashboard.range_30d_desc' },
 ] as const;
 
-const fmtBucket = (at: number, bucket: string) => {
-  const d = new Date(at * 1000);
-  const hh = String(d.getHours()).padStart(2, '0');
-  return bucket === '1h'
-    ? `${d.getMonth() + 1}/${d.getDate()} ${hh}:00`
-    : `${hh}:${String(d.getMinutes()).padStart(2, '0')}`;
-};
-
 function DeltaSub(props: { pct: number | null; goodWhenUp: boolean }) {
   return (
     <Show when={props.pct !== null} fallback={<span class="obs-metric__sub">{t('dashboard.vs_last_hour')}</span>}>
@@ -119,7 +112,7 @@ export default function Dashboard() {
   // hourlyDeltaPct() and slice only for chart rendering. Slicing first would
   // drop the comparison window on the 1h tab and force the 100% fallback.
   const fullSeries = createMemo(() =>
-    (historyQuery.data?.series ?? []).map((p) => ({ ...p, label: fmtBucket(p.at, range().bucket) })),
+    (historyQuery.data?.series ?? []).map((p) => ({ ...p, label: formatBucket(p.at, range().bucket, timeZone) })),
   );
   const series = createMemo(() => {
     const r = range();

--- a/frontend/src/pages/Dead.tsx
+++ b/frontend/src/pages/Dead.tsx
@@ -7,7 +7,7 @@ import { useSort, type Accessors } from '../hooks/useSort';
 import { usePageParam } from '../hooks/usePageParam';
 import { t } from '../i18n';
 import { PageHeader } from '../components/PageHeader';
-import { relativeTime, truncate, formatArgs, hoverTime } from '../utils';
+import { formatArgs, formatNumber, hoverTime, relativeTime, truncate } from '../utils';
 import JobDetailModal, { type JobEntry } from '../components/JobDetailModal';
 import JobSetActionBar, { type ActionDef } from '../components/JobSetActionBar';
 import { useMeta } from '../hooks/useMeta';
@@ -105,7 +105,7 @@ export default function Dead() {
         {(data) => (
           <div>
             <PageHeader icon="fa-skull" title={t('nav.dead')} summary={t('summaries.dead')}>
-              <span class="badge badge-danger">{data().total.toLocaleString()}</span>
+              <span class="badge badge-danger">{formatNumber(data().total)}</span>
             </PageHeader>
 
             <FilterBox value={filter()} onChange={onFilterChange} placeholder={t('common.filter_placeholder')} />

--- a/frontend/src/pages/Dead.tsx
+++ b/frontend/src/pages/Dead.tsx
@@ -7,7 +7,7 @@ import { useSort, type Accessors } from '../hooks/useSort';
 import { usePageParam } from '../hooks/usePageParam';
 import { t } from '../i18n';
 import { PageHeader } from '../components/PageHeader';
-import { relativeTime, truncate, formatArgs, isoTime } from '../utils';
+import { relativeTime, truncate, formatArgs, hoverTime } from '../utils';
 import JobDetailModal, { type JobEntry } from '../components/JobDetailModal';
 import JobSetActionBar, { type ActionDef } from '../components/JobSetActionBar';
 import { useMeta } from '../hooks/useMeta';
@@ -164,7 +164,7 @@ export default function Dead() {
                                 {truncate(entry.error_class, 25)}
                               </td>
                               <td title={entry.error_message ?? ''}>{truncate(entry.error_message, 40)}</td>
-                              <td title={isoTime(entry.at)}>
+                              <td title={hoverTime(entry.at)}>
                                 {relativeTime(entry.at)}
                               </td>
                             </tr>

--- a/frontend/src/pages/Limiters.tsx
+++ b/frontend/src/pages/Limiters.tsx
@@ -8,6 +8,7 @@ import { useResetPageOnEmpty } from '../hooks/useResetPageOnEmpty';
 import { t } from '../i18n';
 import { PageHeader } from '../components/PageHeader';
 import { SkeletonTable } from '../components/Skeleton';
+import { formatNumber } from '../utils';
 import { useMeta } from '../hooks/useMeta';
 import { basePath } from '../basePath';
 import { getJSON, post } from '../http';
@@ -102,7 +103,7 @@ export default function Limiters() {
         {(data) => (
           <div>
             <PageHeader icon="fa-gauge" title={t('nav.limiters')} summary={t('summaries.limiters')}>
-              <span class="badge badge-muted">{data().total.toLocaleString()}</span>
+              <span class="badge badge-muted">{formatNumber(data().total)}</span>
             </PageHeader>
 
             <Show when={sorted().length > 0} fallback={<div class="empty-state">{t('common.empty')}</div>}>
@@ -140,10 +141,10 @@ export default function Limiters() {
                             <td style={{ 'font-weight': 500 }} title={limiter.name}>{limiter.name}</td>
                             <td><span class="badge badge-accent">{limiter.type}</span></td>
                             <td style={{ 'font-variant-numeric': 'tabular-nums' }} title={metricTitle}>
-                              {used.toLocaleString()}
+                              {formatNumber(used)}
                             </td>
                             <td style={{ 'font-variant-numeric': 'tabular-nums' }}>
-                              {limit == null ? '∞' : limit.toLocaleString()}
+                              {limit == null ? '∞' : formatNumber(limit)}
                             </td>
                             <td style={{ width: '160px' }}>
                               <Show

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -5,7 +5,8 @@ import { PageHeader } from '../components/PageHeader';
 import { Skeleton } from '../components/Skeleton';
 import Modal from '../components/Modal';
 import { t } from '../i18n';
-import { formatDuration, truncate } from '../utils';
+import { formatBucket, formatDuration, formatNumber, truncate } from '../utils';
+import { timeZone } from '../tz';
 import { basePath } from '../basePath';
 
 // Matches Wurk::Api::Serializers.metric_row — processed (successes), failed,
@@ -95,14 +96,6 @@ const RANGES = [
   { key: '7d', bucket: '5m', window: '7d', minutes: 7 * 24 * 60 },
   { key: '30d', bucket: '1h', window: '30d', minutes: 30 * 24 * 60 },
 ] as const;
-
-const fmtBucket = (at: number, bucket: string) => {
-  const d = new Date(at * 1000);
-  const hh = String(d.getHours()).padStart(2, '0');
-  return bucket === '1h'
-    ? `${d.getMonth() + 1}/${d.getDate()} ${hh}:00`
-    : `${hh}:${String(d.getMinutes()).padStart(2, '0')}`;
-};
 
 function deltaPct(series: HistoryPoint[], key: 'processed' | 'failed'): number | null {
   if (series.length < 2) return null;
@@ -198,7 +191,7 @@ export default function Metrics() {
   // Keep the full history for deltaPct() — slicing first would drop the
   // previous-hour comparison window and force the 100% fallback on the 1h tab.
   const fullSeries = createMemo(() =>
-    (historyQuery.data?.series ?? []).map((p) => ({ ...p, label: fmtBucket(p.at, range().bucket) })),
+    (historyQuery.data?.series ?? []).map((p) => ({ ...p, label: formatBucket(p.at, range().bucket, timeZone) })),
   );
   const series = createMemo(() => {
     const r = range();
@@ -214,7 +207,7 @@ export default function Metrics() {
   const depthRows = createMemo(() =>
     sample(
       ats().map((at, i) => ({
-        label: fmtBucket(at, range().bucket),
+        label: formatBucket(at, range().bucket, timeZone),
         depth: queues().reduce((s, q) => s + (q.points[i]?.size ?? 0), 0),
       })),
       16,
@@ -261,7 +254,7 @@ export default function Metrics() {
             <i class="fa-solid fa-circle-check obs-metric__icon" aria-hidden="true" />
           </div>
           <span class="obs-metric__value">
-            {(statsQuery.data?.processed ?? 0).toLocaleString()}
+            {formatNumber(statsQuery.data?.processed ?? 0)}
             <Delta pct={deltaPct(fullSeries(), 'processed')} goodWhenUp />
           </span>
           <span class="obs-metric__sub">{t('metrics.across_all_queues')}</span>
@@ -272,7 +265,7 @@ export default function Metrics() {
             <i class="fa-solid fa-triangle-exclamation obs-metric__icon" aria-hidden="true" />
           </div>
           <span class="obs-metric__value">
-            {(statsQuery.data?.failed ?? 0).toLocaleString()}
+            {formatNumber(statsQuery.data?.failed ?? 0)}
             <Delta pct={deltaPct(fullSeries(), 'failed')} goodWhenUp={false} />
           </span>
           <span class="obs-metric__sub">{t('metrics.total_failures')}</span>
@@ -290,7 +283,7 @@ export default function Metrics() {
             <span class="obs-mono">{t('metrics.active_workers')}</span>
             <i class="fa-solid fa-gears obs-metric__icon" aria-hidden="true" />
           </div>
-          <span class="obs-metric__value">{(statsQuery.data?.processes ?? 0).toLocaleString()}</span>
+          <span class="obs-metric__value">{formatNumber(statsQuery.data?.processes ?? 0)}</span>
           <span class="obs-metric__sub">{(statsQuery.data?.processes ?? 0) > 0 ? t('metrics.stable') : t('metrics.no_workers')}</span>
         </div>
       </div>
@@ -336,7 +329,7 @@ export default function Metrics() {
         <div class="obs-card obs-panel">
           <div class="obs-panel__head">
             <h2 class="obs-panel__title" style={{ 'font-size': '18px' }}>{t('metrics.queue_depth')}</h2>
-            <span class="obs-mono">{maxDepth() > 0 ? t('metrics.peak', { n: maxDepth().toLocaleString() }) : ''}</span>
+            <span class="obs-mono">{maxDepth() > 0 ? t('metrics.peak', { n: formatNumber(maxDepth()) }) : ''}</span>
           </div>
           <div class="obs-chartbox">
             <Show when={!queueQuery.isPending} fallback={<ChartLoader height={240} />}>
@@ -395,7 +388,7 @@ export default function Metrics() {
                               {truncate(j.klass.split('::').pop() ?? j.klass, 36)}
                             </button>
                           </td>
-                          <td style={{ 'text-align': 'end', 'font-variant-numeric': 'tabular-nums' }}>{j.count.toLocaleString()}</td>
+                          <td style={{ 'text-align': 'end', 'font-variant-numeric': 'tabular-nums' }}>{formatNumber(j.count)}</td>
                           <td class="obs-pct" style={{ 'text-align': 'end' }}>
                             {jobsTotal() > 0 ? Math.round((j.count / jobsTotal()) * 100) : 0}%
                           </td>
@@ -433,7 +426,7 @@ function JobMetricsModal(props: { klass: string | null; minutes: number; onClose
   }));
 
   const rows = createMemo(() =>
-    (data.data?.series ?? []).map((p) => ({ label: fmtBucket(p.at, '1m'), processed: p.p, failed: p.f, runtime_ms: p.ms })),
+    (data.data?.series ?? []).map((p) => ({ label: formatBucket(p.at, '1m', timeZone), processed: p.p, failed: p.f, runtime_ms: p.ms })),
   );
   const hasData = createMemo(() => rows().some((r) => r.processed > 0 || r.failed > 0));
   const totals = createMemo(() => rows().reduce((acc, r) => ({ processed: acc.processed + r.processed, failed: acc.failed + r.failed }), { processed: 0, failed: 0 }));
@@ -444,11 +437,11 @@ function JobMetricsModal(props: { klass: string | null; minutes: number; onClose
         <div style={{ display: 'flex', gap: '1.5rem', 'margin-bottom': '1rem' }}>
           <div>
             <div class="obs-mono">{t('dashboard.processed')}</div>
-            <div style={{ 'font-size': '18px', 'font-weight': 600 }}>{totals().processed.toLocaleString()}</div>
+            <div style={{ 'font-size': '18px', 'font-weight': 600 }}>{formatNumber(totals().processed)}</div>
           </div>
           <div>
             <div class="obs-mono">{t('dashboard.failed')}</div>
-            <div style={{ 'font-size': '18px', 'font-weight': 600, color: 'var(--danger)' }}>{totals().failed.toLocaleString()}</div>
+            <div style={{ 'font-size': '18px', 'font-weight': 600, color: 'var(--danger)' }}>{formatNumber(totals().failed)}</div>
           </div>
         </div>
         <Show when={!data.isPending} fallback={<ChartLoader height={240} />}>
@@ -501,7 +494,7 @@ function QueueLatencyHistory(props: { range: (typeof RANGES)[number] }) {
   const ats = createMemo(() => queues()[0]?.points.map((p) => p.at) ?? []);
   const rows = createMemo(() =>
     ats().map((at, i) => {
-      const row: Datum = { label: fmtBucket(at, props.range.bucket) };
+      const row: Datum = { label: formatBucket(at, props.range.bucket, timeZone) };
       queues().forEach((q, qi) => { row[queueKeys()[qi].key] = q.points[i]?.latency ?? 0; });
       return row;
     }),
@@ -554,8 +547,7 @@ function HistoricalSnapshots() {
   );
   const rows = createMemo(() =>
     snapshots().map((s) => {
-      const d = new Date(s.at * 1000);
-      const row: Datum = { label: `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}` };
+      const row: Datum = { label: formatBucket(s.at, '1m', timeZone) };
       for (const k of Object.keys(s)) row[k] = s[k];
       return row;
     }),

--- a/frontend/src/pages/Profiles.tsx
+++ b/frontend/src/pages/Profiles.tsx
@@ -2,6 +2,8 @@ import { useQuery } from '@tanstack/solid-query';
 import { onMount, For, Switch, Match, Show } from 'solid-js';
 import { SkeletonTable } from '../components/Skeleton';
 import { t } from '../i18n';
+import { absoluteTime, formatNumber, hoverTime } from '../utils';
+import { timeZone } from '../tz';
 import { basePath } from '../basePath';
 
 // One row from GET <mount>/api/profiles (Wurk::Api::Serializers.profile_record).
@@ -19,10 +21,6 @@ function fmtBytes(n: number): string {
   if (n < 1024) return `${n} B`;
   if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
   return `${(n / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-function fmtWhen(ts: number | null): string {
-  return ts ? new Date(ts * 1000).toLocaleString() : '—';
 }
 
 export default function Profiles() {
@@ -60,7 +58,7 @@ export default function Profiles() {
                 <h1>{t('nav.profiles')}</h1>
                 <p class="obs-panel__sub">{t('summaries.profiles')}</p>
               </div>
-              <span class="obs-chip obs-chip--active">{data().length.toLocaleString()}</span>
+              <span class="obs-chip obs-chip--active">{formatNumber(data().length)}</span>
             </div>
 
             <Show
@@ -86,8 +84,12 @@ export default function Profiles() {
                           <tr>
                             <td style={{ 'font-weight': 500, color: 'var(--obs-text)' }}>{p.type}</td>
                             <td><span class="obs-mono-cell">{p.jid}</span></td>
-                            <td>{fmtWhen(p.started_at)}</td>
-                            <td>{p.elapsed.toLocaleString()} {t('common.ms')}</td>
+                            <td>
+                              <Show when={p.started_at} fallback="—">
+                                {(startedAt) => <span title={hoverTime(startedAt(), timeZone)}>{absoluteTime(startedAt(), timeZone)}</span>}
+                              </Show>
+                            </td>
+                            <td>{formatNumber(p.elapsed)} {t('common.ms')}</td>
                             <td>{fmtBytes(p.size)}</td>
                             <td style={{ 'text-align': 'end' }}>
                               {/* Full reload (not client-route): the backend POSTs the blob

--- a/frontend/src/pages/Queues.tsx
+++ b/frontend/src/pages/Queues.tsx
@@ -8,7 +8,7 @@ import { usePageParam } from '../hooks/usePageParam';
 import { useResetPageOnEmpty } from '../hooks/useResetPageOnEmpty';
 import { t } from '../i18n';
 import { PageHeader } from '../components/PageHeader';
-import { relativeTime, truncate, formatArgs, formatDuration } from '../utils';
+import { formatArgs, formatDuration, formatNumber, relativeTime, truncate } from '../utils';
 import JobDetailModal, { type JobEntry } from '../components/JobDetailModal';
 import Modal from '../components/Modal';
 import { Tooltip } from '../components/Tooltip';
@@ -97,7 +97,7 @@ function QueueJobs(props: { name: string }) {
           <div class="qjobs">
             <div style={{ display: 'flex', 'align-items': 'center', gap: '0.75rem', 'margin-bottom': '1rem' }}>
               <span style={{ color: 'var(--text-muted)', 'font-size': '13px' }}>
-                {t('queues.job_count', { n: data().size.toLocaleString() })} ·{' '}
+                {t('queues.job_count', { n: formatNumber(data().size) })} ·{' '}
                 <span title={`${data().latency.toFixed(3)}s`}>{t('queues.latency_label')} {formatDuration(data().latency)}</span>
               </span>
               <Show when={data().paused}>
@@ -253,7 +253,7 @@ export default function Queues() {
                       {(q) => (
                         <tr class="row-clickable" onClick={() => setSelectedQueue(q.name)}>
                           <td style={{ 'font-weight': 500 }}>{q.name}</td>
-                          <td>{q.size.toLocaleString()}</td>
+                          <td>{formatNumber(q.size)}</td>
                           <td title={`${q.latency.toFixed(3)}s`}>{formatDuration(q.latency)}</td>
                           <td>
                             <Show when={q.paused} fallback={<span class="badge badge-success">{t('dashboard.active')}</span>}>

--- a/frontend/src/pages/Retries.tsx
+++ b/frontend/src/pages/Retries.tsx
@@ -4,7 +4,7 @@ import { Pagination } from '../components/Pagination';
 import { ArgsValue } from '../components/ArgsValue';
 import { t } from '../i18n';
 import { PageHeader } from '../components/PageHeader';
-import { relativeTime, truncate, formatArgs, hoverTime } from '../utils';
+import { formatArgs, formatNumber, hoverTime, relativeTime, truncate } from '../utils';
 import JobDetailModal, { type JobEntry } from '../components/JobDetailModal';
 import JobSetActionBar, { type ActionDef } from '../components/JobSetActionBar';
 import { SortableTh } from '../components/SortableTh';
@@ -115,7 +115,7 @@ export default function Retries() {
         {(data) => (
           <div>
             <PageHeader icon="fa-rotate-right" title={t('nav.retries')} summary={t('summaries.retries')}>
-              <span class="badge badge-warning">{data().total.toLocaleString()}</span>
+              <span class="badge badge-warning">{formatNumber(data().total)}</span>
             </PageHeader>
 
             <FilterBox value={filter()} onChange={onFilterChange} placeholder={t('common.filter_placeholder')} />

--- a/frontend/src/pages/Retries.tsx
+++ b/frontend/src/pages/Retries.tsx
@@ -4,7 +4,7 @@ import { Pagination } from '../components/Pagination';
 import { ArgsValue } from '../components/ArgsValue';
 import { t } from '../i18n';
 import { PageHeader } from '../components/PageHeader';
-import { relativeTime, truncate, formatArgs, isoTime } from '../utils';
+import { relativeTime, truncate, formatArgs, hoverTime } from '../utils';
 import JobDetailModal, { type JobEntry } from '../components/JobDetailModal';
 import JobSetActionBar, { type ActionDef } from '../components/JobSetActionBar';
 import { SortableTh } from '../components/SortableTh';
@@ -169,7 +169,7 @@ export default function Retries() {
                               </td>
                               <td title={entry.error_message ?? ''}>{truncate(entry.error_message, 50)}</td>
                               <td style={{ color: 'var(--warning)' }}>{entry.retry_count}</td>
-                              <td title={isoTime(entry.at)}>
+                              <td title={hoverTime(entry.at)}>
                                 {relativeTime(entry.at)}
                               </td>
                             </tr>

--- a/frontend/src/pages/Scheduled.tsx
+++ b/frontend/src/pages/Scheduled.tsx
@@ -7,7 +7,7 @@ import { useSort, type Accessors } from '../hooks/useSort';
 import { usePageParam } from '../hooks/usePageParam';
 import { t } from '../i18n';
 import { PageHeader } from '../components/PageHeader';
-import { relativeTime, truncate, formatArgs, hoverTime } from '../utils';
+import { formatArgs, formatNumber, hoverTime, relativeTime, truncate } from '../utils';
 import JobDetailModal, { type JobEntry } from '../components/JobDetailModal';
 import JobSetActionBar, { type ActionDef } from '../components/JobSetActionBar';
 import { useMeta } from '../hooks/useMeta';
@@ -99,7 +99,7 @@ export default function Scheduled() {
         {(data) => (
           <div>
             <PageHeader icon="fa-clock" title={t('nav.scheduled')} summary={t('summaries.scheduled')}>
-              <span class="badge badge-accent">{data().total.toLocaleString()}</span>
+              <span class="badge badge-accent">{formatNumber(data().total)}</span>
             </PageHeader>
 
             <FilterBox value={filter()} onChange={onFilterChange} placeholder={t('common.filter_placeholder')} />

--- a/frontend/src/pages/Scheduled.tsx
+++ b/frontend/src/pages/Scheduled.tsx
@@ -7,7 +7,7 @@ import { useSort, type Accessors } from '../hooks/useSort';
 import { usePageParam } from '../hooks/usePageParam';
 import { t } from '../i18n';
 import { PageHeader } from '../components/PageHeader';
-import { relativeTime, truncate, formatArgs, isoTime } from '../utils';
+import { relativeTime, truncate, formatArgs, hoverTime } from '../utils';
 import JobDetailModal, { type JobEntry } from '../components/JobDetailModal';
 import JobSetActionBar, { type ActionDef } from '../components/JobSetActionBar';
 import { useMeta } from '../hooks/useMeta';
@@ -152,7 +152,7 @@ export default function Scheduled() {
                               </td>
                               <td style={{ 'font-weight': 500 }}>{entry.klass}</td>
                               <td><ArgsValue str={argsStr} max={60} /></td>
-                              <td title={isoTime(entry.at)}>
+                              <td title={hoverTime(entry.at)}>
                                 {relativeTime(entry.at)}
                               </td>
                             </tr>

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -5,7 +5,7 @@ import { t } from '../i18n';
 import { PageHeader } from '../components/PageHeader';
 import { ArgsValue } from '../components/ArgsValue';
 import { SkeletonTable } from '../components/Skeleton';
-import { relativeTime, truncate, isoTime, formatArgs } from '../utils';
+import { relativeTime, truncate, hoverTime, formatArgs } from '../utils';
 import { basePath } from '../basePath';
 import { getJSON } from '../http';
 
@@ -141,7 +141,8 @@ export default function Search() {
     ).slice(0, 5);
 
   // Sorted-set hits carry `at`; queue hits fall back to enqueue time. NaN when
-  // neither is present — relativeTime/isoTime both render that as a safe dash.
+  // neither is present — relativeTime renders that as a dash, hoverTime as an
+  // empty title.
   const whenOf = (h: SearchHit) => (typeof h.at === 'number' ? h.at : (h.enqueued_at ?? NaN));
   const count = () => results.data?.hits.length ?? 0;
 
@@ -229,7 +230,7 @@ export default function Search() {
                                   <span title={hit.error_message ?? ''}>{truncate(hit.error_class, 28)}</span>
                                 </Show>
                               </td>
-                              <td title={isoTime(whenOf(hit))}>{relativeTime(whenOf(hit))}</td>
+                              <td title={hoverTime(whenOf(hit))}>{relativeTime(whenOf(hit))}</td>
                             </tr>
                           )}
                         </For>

--- a/frontend/src/styles/components/_timezone-picker.scss
+++ b/frontend/src/styles/components/_timezone-picker.scss
@@ -1,0 +1,77 @@
+// ── Timezone picker ──────────────────────────────────────────────────────────
+// The rail-footer zone control. Its panel is a <Modal>, so the dialog chrome
+// comes from `components/modal`; only the trigger's button reset and the zone
+// list inside the panel live here.
+
+@use '../abstracts' as *;
+
+// Chained with `.wurk-navlink` for the same reason the locale trigger is:
+// Nav.tsx declares that class in an inline <style> that ships after this
+// stylesheet, so a single-class rule here would lose the tie and inherit
+// nav-item (not footer-control) colouring.
+.wurk-navlink.timezone-picker__trigger {
+  width: calc(100% - #{to-rem(16)});
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: to-rem(13);
+  text-align: start;
+  cursor: pointer;
+}
+
+.timezone-picker__hint {
+  margin-bottom: to-rem(12);
+  color: var(--text-muted);
+  font-size: to-rem(13);
+}
+
+.timezone-picker__filter {
+  width: 100%;
+  margin-bottom: to-rem(8);
+}
+
+.timezone-picker__list {
+  // Capped so the dialog never outgrows a short viewport: ~400 zones scroll
+  // inside the list, not the page behind it.
+  max-height: to-rem(320);
+  overflow-y: auto;
+}
+
+.timezone-picker__option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: to-rem(12);
+  width: 100%;
+  padding: to-rem(7) to-rem(10);
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text);
+  font-family: inherit;
+  font-size: to-rem(13);
+  text-align: start;
+  cursor: pointer;
+  @include transition(background color);
+
+  &:hover {
+    background: var(--surface-hover);
+    color: var(--accent);
+  }
+
+  &:focus-visible {
+    @include focus-ring;
+  }
+
+  &[aria-selected='true'] {
+    color: var(--accent);
+    font-weight: 600;
+  }
+}
+
+.timezone-picker__empty {
+  padding: to-rem(12) to-rem(10);
+  color: var(--text-muted);
+  font-size: to-rem(13);
+}

--- a/frontend/src/styles/main.scss
+++ b/frontend/src/styles/main.scss
@@ -37,6 +37,7 @@
 @use 'components/skeleton';
 @use 'components/toast';
 @use 'components/locale-picker';
+@use 'components/timezone-picker';
 
 // — Layout —
 @use 'layout/shell';

--- a/frontend/src/tick.test.tsx
+++ b/frontend/src/tick.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@solidjs/testing-library';
+import { For } from 'solid-js';
+import { TICK_MS, useLiveTick, __resetTick } from './tick';
+import { relativeTime } from './utils';
+
+const NOW = new Date('2026-08-08T12:00:00Z');
+const EPOCH = NOW.getTime() / 1000;
+
+// A cell exactly as the tables render one: the relative label is the whole of
+// a JSX expression, so Solid wraps it in its own computation.
+function Cell(props: { at: number }) {
+  return <span data-testid="cell">{relativeTime(props.at)}</span>;
+}
+
+/** A page: owns the tick once, renders `rows` labels under it. */
+function Page(props: { rows: number }) {
+  useLiveTick();
+  return (
+    <For each={Array.from({ length: props.rows }, (_, i) => EPOCH - i)}>{(at) => <Cell at={at} />}</For>
+  );
+}
+
+describe('shared live tick', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    // Dispose the trees first: cleanup runs the onCleanup that releases the
+    // refcount, and it has to happen while the fake clock still owns the timer.
+    cleanup();
+    __resetTick();
+    vi.useRealTimers();
+  });
+
+  it('runs one interval for a whole table, not one per cell', () => {
+    render(() => <Page rows={200} />);
+
+    expect(screen.getAllByTestId('cell')).toHaveLength(200);
+    expect(vi.getTimerCount()).toBe(1);
+  });
+
+  it('shares that one interval across concurrently mounted pages', () => {
+    render(() => <Page rows={3} />);
+    render(() => <Page rows={3} />);
+
+    expect(vi.getTimerCount()).toBe(1);
+  });
+
+  it('ages every label on the tick, with no refetch and no prop change', () => {
+    render(() => <Cell at={EPOCH - 5} />);
+    expect(screen.getByTestId('cell')).toHaveTextContent('5 seconds ago');
+
+    render(() => <Page rows={0} />);
+    vi.advanceTimersByTime(60 * TICK_MS);
+
+    expect(screen.getByTestId('cell')).toHaveTextContent('1 minute ago');
+  });
+
+  it('keeps ticking while any consumer is still mounted', () => {
+    const first = render(() => <Page rows={1} />);
+    render(() => <Page rows={1} />);
+
+    first.unmount();
+
+    expect(vi.getTimerCount()).toBe(1);
+  });
+
+  it('clears the interval when the last consumer unmounts', () => {
+    const first = render(() => <Page rows={1} />);
+    const second = render(() => <Page rows={1} />);
+
+    first.unmount();
+    second.unmount();
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('restarts cleanly after the last consumer left', () => {
+    render(() => <Page rows={1} />).unmount();
+    render(() => <Page rows={1} />);
+
+    expect(vi.getTimerCount()).toBe(1);
+  });
+
+  // The tick announces that time moved; it is not itself the clock. A label
+  // rendered where nothing owns the timer — a standalone modal in a test, a
+  // page mounted outside the shell — must still read off Date.now().
+  it('formats against the wall clock even with no timer running', () => {
+    render(() => <Cell at={EPOCH - 5} />);
+
+    expect(vi.getTimerCount()).toBe(0);
+    expect(screen.getByTestId('cell')).toHaveTextContent('5 seconds ago');
+  });
+});

--- a/frontend/src/tick.ts
+++ b/frontend/src/tick.ts
@@ -1,0 +1,54 @@
+import { createSignal, onCleanup, onMount } from 'solid-js';
+
+// One interval for the whole app, driving every relative label on screen.
+// Relative times are read per cell and a single table can render hundreds of
+// them (VirtualList.tsx keeps the DOM short, not the data), so a timer per cell
+// would mean hundreds of timers to observe one second passing. The timer is
+// instead a module singleton ref-counted across consumers — the same shape as
+// the SSE stream in hooks/useSSE.ts: started on the first mount, cleared when
+// the last consumer unmounts, never two at once.
+
+// One second: below the smallest unit any label renders, so a "3 seconds ago"
+// cell is never visibly behind the clock, and the work per tick is one integer.
+export const TICK_MS = 1000;
+
+const [tick, setTick] = createSignal(0);
+let timer: ReturnType<typeof setInterval> | null = null;
+let refs = 0;
+
+/**
+ * Subscribes the calling computation to the shared tick. The returned count
+ * carries no meaning on its own — it only announces that time moved, so a
+ * label reading it recomputes against a fresh clock. Deliberately *not* the
+ * current time: a label rendered where nothing owns the timer still formats
+ * against `Date.now()` instead of freezing at whenever the bundle loaded.
+ */
+export function liveTick(): number {
+  return tick();
+}
+
+function stopTimer(): void {
+  if (timer !== null) clearInterval(timer);
+  timer = null;
+}
+
+/** Owns the shared timer for as long as the calling component stays mounted. */
+export function useLiveTick(): void {
+  onMount(() => {
+    if (refs === 0) timer = setInterval(() => setTick((n) => n + 1), TICK_MS);
+    refs += 1;
+    onCleanup(() => {
+      refs -= 1;
+      if (refs === 0) stopTimer();
+    });
+  });
+}
+
+// Test-only: the timer and refcount are module state that outlives a single
+// test case, so a test throwing before its onCleanup runs would leak a live
+// interval and a non-zero refcount into the next one. Mirrors `__resetSSE`.
+export function __resetTick(): void {
+  stopTimer();
+  refs = 0;
+  setTick(0);
+}

--- a/frontend/src/tz.test.ts
+++ b/frontend/src/tz.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { browserZone, detectTimeZone, setTimeZone, storedZone, supportedZones } from './tz';
+
+const KEY = 'wurk.tz';
+// Whatever zone the test runner boots in — asserted against rather than pinned,
+// so the suite reads the same on a laptop in Berlin and on a UTC CI runner.
+const RUNTIME_ZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+// jsdom's Location is unforgeable, so the reload `setTimeZone` ends on can't be
+// stubbed or observed here; these assert what it persists on the way there.
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe('browserZone', () => {
+  it('reports the zone the runtime resolves', () => {
+    expect(browserZone()).toBe(RUNTIME_ZONE);
+  });
+
+  it('falls back to UTC when the runtime names no zone', () => {
+    vi.spyOn(Intl, 'DateTimeFormat').mockReturnValue({
+      resolvedOptions: () => ({ timeZone: undefined }),
+    } as unknown as Intl.DateTimeFormat);
+
+    expect(browserZone()).toBe('UTC');
+  });
+});
+
+describe('storedZone', () => {
+  it('returns the persisted pick', () => {
+    localStorage.setItem(KEY, 'Asia/Tokyo');
+    expect(storedZone()).toBe('Asia/Tokyo');
+  });
+
+  it('returns the spelling Intl uses, so a stored alias still matches the list', () => {
+    localStorage.setItem(KEY, 'utc');
+    expect(storedZone()).toBe('UTC');
+  });
+
+  it('ignores a zone Intl cannot format in rather than throwing out of it', () => {
+    localStorage.setItem(KEY, 'Not/AZone');
+    expect(() => storedZone()).not.toThrow();
+    expect(storedZone()).toBeUndefined();
+  });
+
+  it('ignores storage that refuses to be read', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('denied', 'SecurityError');
+    });
+
+    expect(storedZone()).toBeUndefined();
+  });
+});
+
+describe('detectTimeZone', () => {
+  it('prefers the stored pick over the browser zone', () => {
+    localStorage.setItem(KEY, 'America/New_York');
+    expect(detectTimeZone()).toBe('America/New_York');
+  });
+
+  it('falls back to the browser zone when nothing is stored', () => {
+    expect(detectTimeZone()).toBe(RUNTIME_ZONE);
+  });
+
+  it('falls back to the browser zone when the stored one is unusable', () => {
+    localStorage.setItem(KEY, 'Mars/Olympus_Mons');
+    expect(detectTimeZone()).toBe(RUNTIME_ZONE);
+  });
+
+  it('resolves the module-scope zone from the stored pick', async () => {
+    localStorage.setItem(KEY, 'Asia/Tokyo');
+    vi.resetModules();
+
+    const mod = await import('./tz');
+    expect(mod.timeZone).toBe('Asia/Tokyo');
+  });
+});
+
+describe('setTimeZone', () => {
+  it('persists an explicit pick', () => {
+    setTimeZone('Europe/Berlin');
+    expect(localStorage.getItem(KEY)).toBe('Europe/Berlin');
+  });
+
+  it('drops the override when cleared, falling back to the browser zone', () => {
+    localStorage.setItem(KEY, 'Europe/Berlin');
+    setTimeZone(null);
+
+    expect(localStorage.getItem(KEY)).toBeNull();
+    expect(detectTimeZone()).toBe(RUNTIME_ZONE);
+  });
+
+  it('refuses a zone Intl cannot format in, leaving the current pick alone', () => {
+    localStorage.setItem(KEY, 'Europe/Berlin');
+    setTimeZone('Not/AZone');
+
+    expect(localStorage.getItem(KEY)).toBe('Europe/Berlin');
+  });
+
+  it('gives up quietly when storage refuses the write', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('quota', 'QuotaExceededError');
+    });
+
+    expect(() => setTimeZone('Europe/Berlin')).not.toThrow();
+  });
+});
+
+describe('supportedZones', () => {
+  it('offers UTC first — Intl does not list it, and ops read logs in it', () => {
+    expect(supportedZones()[0]).toBe('UTC');
+    expect(supportedZones().filter((zone) => zone === 'UTC')).toHaveLength(1);
+  });
+
+  it('offers the IANA zones Intl knows', () => {
+    expect(supportedZones()).toContain('America/New_York');
+    expect(supportedZones()).toContain('Asia/Tokyo');
+  });
+
+  it('builds the list once', () => {
+    expect(supportedZones()).toBe(supportedZones());
+  });
+
+  it('degrades to the zones that always resolve where Intl cannot enumerate', async () => {
+    const supported = Intl.supportedValuesOf;
+    // @ts-expect-error modelling a runtime older than ES2022 (Safari < 15.4).
+    delete Intl.supportedValuesOf;
+    vi.resetModules();
+
+    try {
+      const mod = await import('./tz');
+      expect(mod.supportedZones()).toEqual(['UTC', RUNTIME_ZONE].filter((z, i, a) => a.indexOf(z) === i));
+    } finally {
+      Intl.supportedValuesOf = supported;
+    }
+  });
+});

--- a/frontend/src/tz.ts
+++ b/frontend/src/tz.ts
@@ -1,0 +1,86 @@
+const STORAGE_KEY = 'wurk.tz';
+
+/**
+ * `zone` as Intl names it, or undefined when Intl can't format in it. Every
+ * zone reaching this module is untrusted — storage holds whatever a previous
+ * build, another tab, or a devtools session wrote — and `Intl` throws a
+ * RangeError on a name it doesn't know, out of every formatted cell on the
+ * page. Resolving through a formatter both validates the name and hands back
+ * the spelling Intl itself uses, so a stored `utc` still matches the `UTC`
+ * entry the picker lists.
+ */
+function usableZone(zone: string | null | undefined): string | undefined {
+  if (!zone) return undefined;
+  try {
+    return Intl.DateTimeFormat(undefined, { timeZone: zone }).resolvedOptions().timeZone;
+  } catch {
+    return undefined;
+  }
+}
+
+/** The zone the runtime reports, or UTC when it won't name a usable one. */
+export function browserZone(): string {
+  return usableZone(Intl.DateTimeFormat().resolvedOptions().timeZone) ?? 'UTC';
+}
+
+/** The user's explicit pick, or undefined when they've never made one. */
+export function storedZone(): string | undefined {
+  try {
+    return usableZone(localStorage.getItem(STORAGE_KEY));
+  } catch {
+    // localStorage throws SecurityError in private mode and sandboxed iframes —
+    // same guard the stored locale uses in `i18n/index.ts`.
+    return undefined;
+  }
+}
+
+/** Highest-precedence zone source that yields one Intl can format in. */
+export function detectTimeZone(): string {
+  return storedZone() ?? browserZone();
+}
+
+/**
+ * The zone every absolute timestamp renders in. Resolved once, like `locale`:
+ * a change arrives by reload, so no consumer of the formatters has to become
+ * reactive to it.
+ */
+export const timeZone = detectTimeZone();
+
+/**
+ * Record an explicit zone — or drop the override with `null`, falling back to
+ * the browser's — and reload into it.
+ */
+export function setTimeZone(zone: string | null): void {
+  const next = zone === null ? null : usableZone(zone);
+  if (next === undefined) return;
+
+  try {
+    if (next === null) localStorage.removeItem(STORAGE_KEY);
+    else localStorage.setItem(STORAGE_KEY, next);
+  } catch {
+    // Storage is disabled. Unlike a locale, a zone has no `?tz=` carrier to
+    // fall back on, so the pick can't survive a reload — don't run one and
+    // pretend it did.
+    return;
+  }
+  window.location.reload();
+}
+
+let zones: readonly string[] | undefined;
+
+/**
+ * Every zone the picker offers, `UTC` first. UTC is prepended rather than
+ * sorted in: `Intl.supportedValuesOf` lists canonical IANA zones only, which
+ * excludes it, and it's the zone ops staff reach for when reading these times
+ * against server logs.
+ */
+export function supportedZones(): readonly string[] {
+  if (!zones) {
+    // supportedValuesOf is ES2022. Where it's missing there's no way to
+    // enumerate zones at all, so the picker offers the two that always resolve.
+    const named =
+      typeof Intl.supportedValuesOf === 'function' ? Intl.supportedValuesOf('timeZone') : [browserZone()];
+    zones = Object.freeze(['UTC', ...named.filter((zone) => zone !== 'UTC')]);
+  }
+  return zones;
+}

--- a/frontend/src/utils.test.ts
+++ b/frontend/src/utils.test.ts
@@ -117,6 +117,122 @@ describe('locale-aware formatting', () => {
   });
 });
 
+// Full ladder walk, past and future, for every shipped locale that isn't
+// English — pins the exact CLDR strings (including the day/year "yesterday" /
+// "next year" idioms numeric:'auto' substitutes at count 1) so a future CLDR
+// update or a ladder-threshold regression fails loudly instead of silently
+// changing copy in one locale.
+describe('relativeTime across locales', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    document.getElementById('wurk-root')?.remove();
+    vi.resetModules();
+  });
+
+  const BOUNDARIES: { [locale: string]: { ago: [number, string][]; ahead: [number, string][] } } = {
+    en: {
+      ago: [
+        [0, 'now'],
+        [45, '45 seconds ago'],
+        [170, '3 minutes ago'],
+        [3 * 3600, '3 hours ago'],
+        [86400, 'yesterday'],
+        [2 * 86400, '2 days ago'],
+        [21 * 86400, '3 weeks ago'],
+        [100 * 86400, '3 months ago'],
+        [800 * 86400, '2 years ago'],
+      ],
+      ahead: [
+        [150, 'in 3 minutes'],
+        [86400, 'tomorrow'],
+        [3 * 86400, 'in 3 days'],
+      ],
+    },
+    de: {
+      ago: [
+        [0, 'jetzt'],
+        [45, 'vor 45 Sekunden'],
+        [170, 'vor 3 Minuten'],
+        [3 * 3600, 'vor 3 Stunden'],
+        [86400, 'gestern'],
+        [2 * 86400, 'vorgestern'],
+        [21 * 86400, 'vor 3 Wochen'],
+        [100 * 86400, 'vor 3 Monaten'],
+        [800 * 86400, 'vor 2 Jahren'],
+      ],
+      ahead: [
+        [150, 'in 3 Minuten'],
+        [86400, 'morgen'],
+        [3 * 86400, 'in 3 Tagen'],
+      ],
+    },
+    ja: {
+      ago: [
+        [0, '今'],
+        [45, '45 秒前'],
+        [170, '3 分前'],
+        [3 * 3600, '3 時間前'],
+        [86400, '昨日'],
+        [2 * 86400, '一昨日'],
+        [21 * 86400, '3 週間前'],
+        [100 * 86400, '3 か月前'],
+        [800 * 86400, '2 年前'],
+      ],
+      ahead: [
+        [150, '3 分後'],
+        [86400, '明日'],
+        [3 * 86400, '3 日後'],
+      ],
+    },
+    ar: {
+      ago: [
+        [0, 'الآن'],
+        [45, 'قبل 45 ثانية'],
+        [170, 'قبل 3 دقائق'],
+        [3 * 3600, 'قبل 3 ساعات'],
+        [86400, 'أمس'],
+        [2 * 86400, 'أول أمس'],
+        [21 * 86400, 'قبل 3 أسابيع'],
+        [100 * 86400, 'قبل 3 أشهر'],
+        [800 * 86400, 'قبل سنتين'],
+      ],
+      ahead: [
+        [150, 'خلال 3 دقائق'],
+        [86400, 'غدًا'],
+        [3 * 86400, 'خلال 3 أيام'],
+      ],
+    },
+  };
+
+  for (const [loc, { ago, ahead }] of Object.entries(BOUNDARIES)) {
+    it(`walks the past ladder in ${loc}`, async () => {
+      const mod = await utilsIn(loc);
+      for (const [seconds, expected] of ago) {
+        expect(mod.relativeTime(EPOCH - seconds)).toBe(expected);
+      }
+    });
+
+    it(`walks the future ladder in ${loc}`, async () => {
+      const mod = await utilsIn(loc);
+      for (const [seconds, expected] of ahead) {
+        expect(mod.relativeTime(EPOCH + seconds)).toBe(expected);
+      }
+    });
+  }
+
+  it('guards a timestamp that never arrived, in every locale', async () => {
+    for (const loc of Object.keys(BOUNDARIES)) {
+      const mod = await utilsIn(loc);
+      expect(mod.relativeTime(NaN)).toBe('—');
+      expect(mod.relativeTime(Infinity)).toBe('—');
+    }
+  });
+});
+
 describe('absoluteTime', () => {
   // 2026-02-02T02:40:00Z — the same instant is the previous evening in New York
   // and the same morning in Tokyo.

--- a/frontend/src/utils.test.ts
+++ b/frontend/src/utils.test.ts
@@ -1,5 +1,167 @@
-import { describe, it, expect } from 'vitest';
-import { formatDuration, formatKb, truncate } from './utils';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { relativeTime, absoluteTime, hoverTime, formatDuration, formatKb, truncate } from './utils';
+
+// Fixed instant so every ladder rung lands on a deterministic value; jsdom
+// resolves navigator.language to en-US, so unqualified expectations are English.
+const NOW = new Date('2026-08-08T12:00:00Z');
+const EPOCH = NOW.getTime() / 1000;
+
+describe('relativeTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => vi.useRealTimers());
+
+  const ago = (seconds: number) => relativeTime(EPOCH - seconds);
+  const ahead = (seconds: number) => relativeTime(EPOCH + seconds);
+
+  it('guards a timestamp that never arrived', () => {
+    expect(relativeTime(NaN)).toBe('—');
+    expect(relativeTime(Infinity)).toBe('—');
+  });
+
+  it('walks the ladder from seconds to years', () => {
+    expect(ago(0)).toBe('now');
+    expect(ago(45)).toBe('45 seconds ago');
+    expect(ago(170)).toBe('3 minutes ago');
+    expect(ago(3 * 3600)).toBe('3 hours ago');
+    expect(ago(2 * 86400)).toBe('2 days ago');
+    expect(ago(21 * 86400)).toBe('3 weeks ago');
+    expect(ago(100 * 86400)).toBe('3 months ago');
+    expect(ago(800 * 86400)).toBe('2 years ago');
+  });
+
+  // The whole point of the ladder: the old formatter stopped at days, so a dead
+  // job from last spring read "400d ago".
+  it('never reports a year-old job in days', () => {
+    expect(ago(400 * 86400)).toBe('last year');
+  });
+
+  it('reads the future forwards', () => {
+    expect(ahead(150)).toBe('in 3 minutes');
+    expect(ahead(86400)).toBe('tomorrow');
+    expect(ahead(3 * 86400)).toBe('in 3 days');
+  });
+
+  // Rounding happens before the unit is chosen, so the top of a rung rolls into
+  // the next one instead of rendering "60 seconds ago".
+  it('rolls a rounded value up to the next unit', () => {
+    expect(ago(59.4)).toBe('59 seconds ago');
+    expect(ago(59.6)).toBe('1 minute ago');
+    expect(ago(3599.6)).toBe('1 hour ago');
+  });
+});
+
+// The formatters resolve their locale once at module scope, the same way the
+// bundle does, so a locale-specific expectation needs a fresh module registry.
+async function utilsIn(loc: string) {
+  const root = document.createElement('div');
+  root.id = 'wurk-root';
+  root.dataset.locale = loc;
+  document.body.appendChild(root);
+  vi.resetModules();
+  return import('./utils');
+}
+
+describe('locale-aware formatting', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    document.getElementById('wurk-root')?.remove();
+    vi.resetModules();
+  });
+
+  it('translates relative time instead of appending English " ago"', async () => {
+    const de = await utilsIn('de');
+    expect(de.relativeTime(EPOCH - 3 * 3600)).toBe('vor 3 Stunden');
+    expect(de.relativeTime(EPOCH + 86400)).toBe('morgen');
+  });
+
+  it('renders a locale with different grammar entirely', async () => {
+    const ja = await utilsIn('ja');
+    expect(ja.relativeTime(EPOCH - 3 * 3600)).toBe('3 時間前');
+    expect(ja.relativeTime(EPOCH - 86400)).toBe('昨日');
+  });
+
+  // Digit shape is engine-dependent for Arabic (JavaScriptCore renders
+  // Arabic-Indic, V8 Latin), so this pins the words, not the numerals.
+  it('renders RTL copy for an RTL locale', async () => {
+    const ar = await utilsIn('ar');
+    expect(ar.relativeTime(EPOCH - 3 * 3600)).toContain('ساعات');
+    expect(ar.relativeTime(EPOCH - 86400)).toBe('أمس');
+  });
+
+  it('localizes duration and size units', async () => {
+    const de = await utilsIn('de');
+    expect(de.formatDuration(1309.324)).toBe('21 Min. 49 Sek.');
+    // German separates value from unit with a no-break space, hence the \s.
+    expect(de.formatKb(16777216)).toMatch(/^16,0\sGB$/);
+  });
+
+  it('formats dates in the locale, not just the zone', async () => {
+    const ja = await utilsIn('ja');
+    expect(ja.absoluteTime(Date.UTC(2026, 1, 2, 2, 40) / 1000, 'Asia/Tokyo')).toBe('2026/02/02 11:40:00');
+  });
+
+  // i18n only validates BCP-47 shape, and `?locale=` is untrusted: this tag is
+  // shape-valid but Intl rejects it (repeated variant subtag). Falling back
+  // beats throwing out of every formatted cell on the page.
+  it('falls back to English for a tag Intl refuses', async () => {
+    const bogus = await utilsIn('en-aaaaa-aaaaa');
+    expect(bogus.relativeTime(EPOCH - 3 * 3600)).toBe('3 hours ago');
+    expect(bogus.formatDuration(1309.324)).toBe('21m 49s');
+  });
+});
+
+describe('absoluteTime', () => {
+  // 2026-02-02T02:40:00Z — the same instant is the previous evening in New York
+  // and the same morning in Tokyo.
+  const AT = Date.UTC(2026, 1, 2, 2, 40) / 1000;
+
+  it('guards a timestamp that never arrived', () => {
+    expect(absoluteTime(NaN)).toBe('');
+    expect(absoluteTime(Infinity)).toBe('');
+  });
+
+  it('renders the requested zone', () => {
+    expect(absoluteTime(AT, 'UTC')).toMatch(/^Feb 2, 2026, 2:40:00\sAM$/);
+    expect(absoluteTime(AT, 'America/New_York')).toMatch(/^Feb 1, 2026, 9:40:00\sPM$/);
+    expect(absoluteTime(AT, 'Asia/Tokyo')).toMatch(/^Feb 2, 2026, 11:40:00\sAM$/);
+  });
+
+  it('defaults to the runtime zone', () => {
+    expect(absoluteTime(AT)).toBe(absoluteTime(AT, Intl.DateTimeFormat().resolvedOptions().timeZone));
+  });
+
+  // 05:30 UTC on 2026-11-01 is inside the hour New York repeats when DST ends.
+  it('formats an ambiguous DST hour without throwing', () => {
+    expect(absoluteTime(Date.UTC(2026, 10, 1, 5, 30) / 1000, 'America/New_York')).toMatch(
+      /^Nov 1, 2026, 1:30:00\sAM$/,
+    );
+  });
+});
+
+describe('hoverTime', () => {
+  const AT = Date.UTC(2026, 1, 2, 2, 40) / 1000;
+
+  // `new Date(NaN).toISOString()` throws a RangeError, which unmounted the
+  // whole table when a sorted-set entry arrived without a score.
+  it('guards a timestamp that never arrived', () => {
+    expect(hoverTime(NaN)).toBe('');
+    expect(hoverTime(Infinity)).toBe('');
+  });
+
+  // Ops read these titles against UTC server logs, so the ISO form has to
+  // survive alongside the localized one.
+  it('carries the local rendering and the UTC ISO string', () => {
+    const title = hoverTime(AT, 'America/New_York');
+    expect(title).toMatch(/^Feb 1, 2026, 9:40:00\sPM · 2026-02-02T02:40:00\.000Z$/);
+  });
+});
 
 describe('formatDuration', () => {
   it('guards non-finite input', () => {
@@ -43,8 +205,10 @@ describe('formatKb', () => {
     expect(formatKb(NaN)).toBe('—');
   });
 
+  // "kB" is CLDR's English kilobyte symbol — the unit comes from Intl now, not
+  // from a hand-written letter.
   it('scales KB → MB → GB', () => {
-    expect(formatKb(500)).toBe('500 KB');
+    expect(formatKb(500)).toBe('500 kB');
     expect(formatKb(524288)).toBe('512 MB');
     expect(formatKb(16777216)).toBe('16.0 GB');
   });

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,4 +1,5 @@
 import { locale } from './i18n';
+import { liveTick } from './tick';
 
 // Intl constructors throw a RangeError on a tag they cannot parse, and the
 // locale can arrive from an untrusted `?locale=` link — i18n only checks
@@ -35,8 +36,14 @@ export function relativeTime(epochSeconds: number): string {
   // value renders a dash instead of "NaNs ago".
   if (!Number.isFinite(epochSeconds)) return '—';
 
+  // Subscribes this cell to the app's shared tick (tick.ts), so "5 minutes ago"
+  // becomes "6 minutes ago" on its own rather than standing still until the
+  // query behind the table refetches. One interval drives every label on the
+  // page; nothing is attached per cell.
+  liveTick();
+
   // Intl's sign convention: the past is negative, the future positive.
-  let value = epochSeconds - Date.now() / 1000;
+  let value = epochSeconds - nowSeconds();
   for (const [unit, perNextUnit] of RELATIVE_LADDER) {
     // Round before comparing, not after: at 59.6s the rounded value is already
     // 60, and that has to read "1 minute ago", not "60 seconds ago".

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,57 +1,136 @@
+import { locale } from './i18n';
+
+// Intl constructors throw a RangeError on a tag they cannot parse, and the
+// locale can arrive from an untrusted `?locale=` link — i18n only checks
+// BCP-47 *shape*, which still admits tags Intl rejects (a repeated variant
+// subtag, for one). Resolving once here keeps a bad link from throwing out of
+// every formatted cell on the page.
+function usableLocale(tag: string): string {
+  try {
+    Intl.getCanonicalLocales(tag);
+    return tag;
+  } catch {
+    return 'en';
+  }
+}
+
+const LOCALE = usableLocale(locale);
+
+const relative = new Intl.RelativeTimeFormat(LOCALE, { numeric: 'auto' });
+
+// How many of each unit make the next one up. The week -> month rung is the
+// usual 365.2425 / 12 / 7 approximation; these numbers only pick which noun
+// Intl renders, no date math downstream depends on them.
+const RELATIVE_LADDER: readonly (readonly [Intl.RelativeTimeFormatUnit, number])[] = [
+  ['second', 60],
+  ['minute', 60],
+  ['hour', 24],
+  ['day', 7],
+  ['week', 4.34524],
+  ['month', 12],
+];
+
 export function relativeTime(epochSeconds: number): string {
   // Sorted-set entries can arrive without a usable timestamp; guard so a bad
   // value renders a dash instead of "NaNs ago".
   if (!Number.isFinite(epochSeconds)) return '—';
 
-  const now = Date.now() / 1000;
-  const diff = now - epochSeconds;
-  const absDiff = Math.abs(diff);
-  const future = diff < 0;
-
-  let value: string;
-  if (absDiff < 60) {
-    value = `${Math.round(absDiff)}s`;
-  } else if (absDiff < 3600) {
-    value = `${Math.round(absDiff / 60)}m`;
-  } else if (absDiff < 86400) {
-    value = `${Math.round(absDiff / 3600)}h`;
-  } else {
-    value = `${Math.round(absDiff / 86400)}d`;
+  // Intl's sign convention: the past is negative, the future positive.
+  let value = epochSeconds - Date.now() / 1000;
+  for (const [unit, perNextUnit] of RELATIVE_LADDER) {
+    // Round before comparing, not after: at 59.6s the rounded value is already
+    // 60, and that has to read "1 minute ago", not "60 seconds ago".
+    if (Math.round(Math.abs(value)) < perNextUnit) return relative.format(Math.round(value), unit);
+    value /= perNextUnit;
   }
-
-  return future ? `${value} from now` : `${value} ago`;
+  return relative.format(Math.round(value), 'year');
 }
 
-// ISO timestamp for hover titles. `new Date(NaN).toISOString()` throws a
-// RangeError that unmounts the whole table; returning '' keeps the cell safe
-// when the epoch is missing or non-numeric.
-export function isoTime(epochSeconds: number): string {
+const dateFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function dateFormat(timeZone: string | undefined): Intl.DateTimeFormat {
+  const key = timeZone ?? '';
+  let formatter = dateFormatters.get(key);
+  if (!formatter) {
+    // An omitted `timeZone` means the runtime's own zone, which is what a
+    // browser user reads clocks in.
+    formatter = new Intl.DateTimeFormat(LOCALE, { timeZone, dateStyle: 'medium', timeStyle: 'medium' });
+    dateFormatters.set(key, formatter);
+  }
+  return formatter;
+}
+
+// Both absolute renderings go through this. `new Date(NaN).toISOString()` and
+// `Intl.DateTimeFormat#format(NaN)` each throw a RangeError that unmounts the
+// whole table, so a missing or non-numeric epoch never reaches either.
+function millis(epochSeconds: number): number | undefined {
   const ms = epochSeconds * 1000;
-  if (!Number.isFinite(ms)) return '';
-  return new Date(ms).toISOString();
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
+/** Localized absolute timestamp, in `timeZone` or the runtime's zone. */
+export function absoluteTime(epochSeconds: number, timeZone?: string): string {
+  const ms = millis(epochSeconds);
+  return ms === undefined ? '' : dateFormat(timeZone).format(ms);
+}
+
+/**
+ * Hover-title timestamp: the localized rendering plus the UTC ISO one. Ops
+ * correlate these cells against server logs, which are UTC, so trading the ISO
+ * form for a localized one would be a regression — the title carries both.
+ */
+export function hoverTime(epochSeconds: number, timeZone?: string): string {
+  const ms = millis(epochSeconds);
+  return ms === undefined ? '' : `${dateFormat(timeZone).format(ms)} · ${new Date(ms).toISOString()}`;
+}
+
+const unitFormatters = new Map<string, Intl.NumberFormat>();
+
+function unit(name: string, value: number, unitDisplay: 'narrow' | 'short', digits = 0): string {
+  const key = `${name}|${unitDisplay}|${digits}`;
+  let formatter = unitFormatters.get(key);
+  if (!formatter) {
+    formatter = new Intl.NumberFormat(LOCALE, {
+      style: 'unit',
+      unit: name,
+      unitDisplay,
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits,
+    });
+    unitFormatters.set(key, formatter);
+  }
+  return formatter.format(value);
 }
 
 // Human-readable duration from float seconds: "850ms", "4.2s", "21m 49s",
 // "2h 5m", "3d 4h". Used for queue latency, which the API reports in seconds.
+// Narrow units keep the two-part forms short enough for a table cell; Intl has
+// no composite duration, so each part is formatted on its own and joined —
+// never spelled with raw letters, which would stay English in all 8 locales.
 export function formatDuration(seconds: number): string {
   if (!Number.isFinite(seconds)) return '—';
   const s = Math.abs(seconds);
-  if (s < 1) return `${Math.round(s * 1000)}ms`;
-  if (s < 10) return `${s.toFixed(1)}s`;
+  if (s < 1) return unit('millisecond', Math.round(s * 1000), 'narrow');
+  if (s < 10) return unit('second', s, 'narrow', 1);
   const total = Math.round(s);
-  if (total < 60) return `${total}s`;
-  if (total < 3600) return `${Math.floor(total / 60)}m ${total % 60}s`;
-  if (total < 86400) return `${Math.floor(total / 3600)}h ${Math.floor((total % 3600) / 60)}m`;
-  return `${Math.floor(total / 86400)}d ${Math.floor((total % 86400) / 3600)}h`;
+  if (total < 60) return unit('second', total, 'narrow');
+  if (total < 3600) {
+    return `${unit('minute', Math.floor(total / 60), 'narrow')} ${unit('second', total % 60, 'narrow')}`;
+  }
+  if (total < 86400) {
+    return `${unit('hour', Math.floor(total / 3600), 'narrow')} ${unit('minute', Math.floor((total % 3600) / 60), 'narrow')}`;
+  }
+  return `${unit('day', Math.floor(total / 86400), 'narrow')} ${unit('hour', Math.floor((total % 86400) / 3600), 'narrow')}`;
 }
 
-// RSS and total memory arrive from the heartbeat as kilobytes.
+// RSS and total memory arrive from the heartbeat as kilobytes. Short units
+// here, not narrow: a size reads as "512 MB", and narrow drops the space.
 export function formatKb(kb: number): string {
   if (!Number.isFinite(kb) || kb <= 0) return '—';
-  if (kb < 1024) return `${Math.round(kb)} KB`;
+  if (kb < 1024) return unit('kilobyte', Math.round(kb), 'short');
   const mb = kb / 1024;
-  if (mb < 1024) return `${Math.round(mb)} MB`;
-  return `${(mb / 1024).toFixed(1)} GB`;
+  if (mb < 1024) return unit('megabyte', Math.round(mb), 'short');
+  return unit('gigabyte', mb / 1024, 'short', 1);
 }
 
 export function truncate(s: string | null | undefined, max = 80): string {

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -84,6 +84,40 @@ export function hoverTime(epochSeconds: number, timeZone?: string): string {
   return ms === undefined ? '' : `${dateFormat(timeZone).format(ms)} · ${new Date(ms).toISOString()}`;
 }
 
+const bucketFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function bucketFormat(dated: boolean, timeZone: string | undefined): Intl.DateTimeFormat {
+  const key = `${dated}|${timeZone ?? ''}`;
+  let formatter = bucketFormatters.get(key);
+  if (!formatter) {
+    // `dated` buckets (hourly rollups) need the date to disambiguate across
+    // midnight; finer rollups fit a whole chart axis in HH:MM alone.
+    formatter = dated
+      ? new Intl.DateTimeFormat(LOCALE, { timeZone, month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false })
+      : new Intl.DateTimeFormat(LOCALE, { timeZone, hour: '2-digit', minute: '2-digit', hour12: false });
+    bucketFormatters.set(key, formatter);
+  }
+  return formatter;
+}
+
+/** Chart-axis / table bucket label, in `timeZone` or the runtime's zone. */
+export function formatBucket(epochSeconds: number, bucket: string, timeZone?: string): string {
+  const ms = millis(epochSeconds);
+  return ms === undefined ? '' : bucketFormat(bucket === '1h', timeZone).format(ms);
+}
+
+const numberFormatter = new Intl.NumberFormat(LOCALE);
+
+/** Locale-aware thousands grouping for a plain count. */
+export function formatNumber(n: number): string {
+  return numberFormatter.format(n);
+}
+
+/** Current time in epoch seconds — one call site for every `Date.now()/1000`. */
+export function nowSeconds(): number {
+  return Date.now() / 1000;
+}
+
 const unitFormatters = new Map<string, Intl.NumberFormat>();
 
 function unit(name: string, value: number, unitDisplay: 'narrow' | 'short', digits = 0): string {


### PR DESCRIPTION
## Summary
- Replace all four date/number formatters with `Intl` (`relativeTime`, `absoluteTime`/`hoverTime`, `formatBucket`, `formatNumber`/`formatDuration`/`formatKb`) — zero `Intl.` usage existed in the SPA before this.
- Add timezone resolution + picker (`tz.ts`, `TimezonePicker.tsx`): stored override → browser zone → UTC fallback, validated through `Intl` so a bad stored name never throws.
- Sweep every consumer that bypassed `utils.ts` onto the shared formatters (`formatBucket`/`formatNumber`/`nowSeconds`).
- One shared tick signal (`tick.ts`) drives every live relative label from a single ref-counted timer instead of one per cell.
- Test coverage: full past/future relative-time ladder walk pinned per locale (en/de/ja/ar) at every unit boundary including the count-1 CLDR idioms ("yesterday"/"next year"), plus NaN/Infinity guards in every locale. tz.ts and tick.ts already carried full coverage for fixed-epoch-per-zone, override-beats-browser, invalid-zone fallback, DST-ambiguous hours, and timer lifecycle from earlier commits on this branch.

## Test plan
- [x] `bun run test` — 246/246 passed
- [x] `tsc --noEmit` clean
- [x] `oxlint --deny-warnings` clean
- [x] Mutation check: widening the day→week ladder rung breaks the new ja/ar boundary assertions as expected; reverted clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788802525&installation_model_id=11168&pr_number=400&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F400&signature=d209f0a2286b4547f6dbd6b188a5126b6129ee8e6ea39626a515e875ab1947ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->