### PR TITLE
feat(telemetry): OpenTelemetry distributed tracing (opt-in)

### DIFF
--- a/docs/idea/parity-divergences.md
+++ b/docs/idea/parity-divergences.md
@@ -296,3 +296,56 @@ Chain order verified in `test/unit/metrics_agreement_test.rb:79-82`.
 `lib/wurk/metrics/statsd.rb:145-169,191-196`,
 `lib/wurk/middleware/interrupt_handler.rb:29-34,46`,
 `docs/plans/2026/08/07/101-beyond-sidekiq/00-semantics-signoff.md` §1.
+
+## OpenTelemetry adds `traceparent`/`tracestate` as top-level job-JSON keys, opt-in only
+
+**Wurk:** when a host opts into tracing (`config.telemetry = true`, gem
+present), `Wurk::Telemetry::ClientMiddleware` writes a W3C `traceparent`
+string — and `tracestate` only when the trace carries vendor state — as extra
+top-level keys on the job hash, on every plain push and every `push_bulk`
+item (`lib/wurk/telemetry/client_middleware.rb:26-56`). Nothing else about
+the payload changes: byte-compared against an untraced push, the only key
+diff is `traceparent` (`test/unit/telemetry_client_middleware_test.rb`,
+`test_opting_in_adds_the_trace_context_and_nothing_else`). A host that never
+opts in, or that has `telemetry = true` but no `opentelemetry-api` installed,
+gets byte-identical payloads to today — proven by the same suite and by
+`rake bench` with tracing off.
+
+**Spec:** `docs/target/sidekiq-free.md` has no `traceparent`/`tracestate`
+concept — Sidekiq itself ships no first-party tracing, so there is no spec
+position to diverge from. The relevant question is whether an unrecognized
+top-level key is safe cargo on the wire, which is a `Sidekiq::Processor`
+question, not a spec one.
+
+**Why:** `Sidekiq::Processor#dispatch` and `Sidekiq::JobLogger#prepare`,
+pinned at `test/parity/.sidekiq_sha`
+(`e1f808a08645f9b8a194852a171b5667f5f877bd`, fetched verbatim, not from
+memory) read the job hash exclusively by known key name —
+`job_hash["class"]`, `job_hash["jid"]`, `job_hash["wrapped"] ||
+job_hash["class"]`, `job_hash[attr] if job_hash.has_key?(attr)` for
+`logged_job_attributes` — off a plain `Sidekiq.load_json` (`JSON.parse`).
+Nothing enumerates or validates the full key set, so `traceparent` is inert
+cargo to a real stock-Sidekiq dispatch, not a protocol violation. This
+reproduces that exact fragment against a real traced Wurk payload
+(`test/unit/telemetry_client_middleware_test.rb`,
+`test_a_traced_job_dispatches_unmodified_through_stock_sidekiqs_processor`
+and neighbors) rather than merely asserting the payload shape in isolation.
+The reverse direction — a stock-Sidekiq-shaped job with no `traceparent` at
+all, hand-built and `LPUSH`ed the way `Sidekiq::Client` actually writes it —
+still runs cleanly under a Wurk swarm with tracing on, as a root span with no
+parent or link (`test/integration/telemetry_fork_test.rb`,
+`test_a_stock_sidekiq_shaped_job_with_no_traceparent_is_consumed_here`).
+`traceparent` is metadata, not an argument: `lib/wurk/encryption.rb`'s
+encrypted-args envelope only ever touches `args.last`, so it neither
+encrypts the trace context nor is perturbed by its presence
+(`test/unit/encryption_test.rb`, the "telemetry interaction" section).
+Retries reuse the original `traceparent` (`JobRetry#schedule_retry` re-ZADDs
+the same hash, so the client chain never runs again), and a producer context
+older than 60s becomes a span **link** instead of a parent edge — both
+documented in `lib/wurk/telemetry/server_middleware.rb:28-53`. Full terms in
+`docs/plans/2026/08/07/101-beyond-sidekiq/00-semantics-signoff.md` §2.
+
+**Anchor:** `lib/wurk/telemetry/client_middleware.rb`,
+`lib/wurk/telemetry/server_middleware.rb`,
+`docs/plans/2026/08/07/101-beyond-sidekiq/00-semantics-signoff.md` §2,
+`test/parity/.sidekiq_sha`.

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -127,6 +127,7 @@ module Wurk
       @web_redis_pool = nil
       @logger = nil
       @thread_priority = DEFAULT_THREAD_PRIORITY
+      @telemetry_installed = false
       @frozen = false
     end
 
@@ -420,10 +421,17 @@ module Wurk
     def telemetry=(enabled)
       guard_frozen!
       @options[:telemetry] = enabled ? true : false
-      return unless @options[:telemetry]
+      # Turning tracing back off still has to unregister, but must not *load*
+      # the module to do it — that require is the whole cost this flag gates,
+      # and a config that never opted in has nothing registered to undo. Tracked
+      # per instance rather than off `defined?(Wurk::Telemetry)`: whether some
+      # *other* config loaded the module says nothing about this one's chain.
+      return if !@options[:telemetry] && !@telemetry_installed
 
       require_relative 'telemetry'
-      return if Wurk::Telemetry.available?
+      @telemetry_installed = true
+      Wurk::Telemetry.install!(self)
+      return if !@options[:telemetry] || Wurk::Telemetry.available?
 
       logger.warn { 'config.telemetry = true but opentelemetry-api is not installed; tracing stays off' }
     end

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -58,7 +58,13 @@ module Wurk
       # keep succeeded jobs around longer than they ran, or to 0 for Sidekiq's
       # own behavior, where a job that succeeds leaves nothing behind.
       status_ttl: Keys::STATUS_TTL,
-      status_retention: nil
+      status_retention: nil,
+      # Distributed tracing (Wurk::Telemetry). Seeded here, not written on
+      # demand, so the read side answers on a config that `freeze!` has already
+      # closed — and so a gem inspecting @options sees the same key set whether
+      # or not the host traces. Flipping it is only half the gate; the
+      # opentelemetry-api gem has to be present too (Wurk::Telemetry.enabled?).
+      telemetry: false
     }.freeze
 
     # :fork fires only inside swarm children, after fork + internal AR/Redis
@@ -393,6 +399,34 @@ module Wurk
     def history_enabled? = @options.key?(:history_interval)
     def history_interval = @options.fetch(:history_interval, HISTORY_DEFAULT_INTERVAL)
     def history_collector = @options[:history_collector]
+
+    # --- Distributed tracing (OpenTelemetry) ------------------------------
+
+    # @return [Boolean] whether the host asked for tracing. Half the gate;
+    #   {Wurk::Telemetry.enabled?} is the whole one.
+    def telemetry? = @options[:telemetry] == true
+
+    # Opt into Wurk::Telemetry — a producer span carrying W3C trace context on
+    # the job hash at enqueue, a linked consumer span on execute:
+    #
+    #   Wurk.configure_server { |config| config.telemetry = true }
+    #
+    # Loading `wurk/telemetry` is deferred to this call, which is the only
+    # reason `require "wurk"` can leave `opentelemetry-api` untouched in an app
+    # that doesn't trace.
+    #
+    # Warns when the host opted in but the gem is missing: tracing then stays
+    # off, and a silent no-op is indistinguishable from a broken exporter.
+    def telemetry=(enabled)
+      guard_frozen!
+      @options[:telemetry] = enabled ? true : false
+      return unless @options[:telemetry]
+
+      require_relative 'telemetry'
+      return if Wurk::Telemetry.available?
+
+      logger.warn { 'config.telemetry = true but opentelemetry-api is not installed; tracing stays off' }
+    end
 
     # --- Web dashboard ----------------------------------------------------
 

--- a/lib/wurk/telemetry.rb
+++ b/lib/wurk/telemetry.rb
@@ -41,6 +41,9 @@ module Wurk
   # constant, so aliasing would invent a Sidekiq surface rather than mirror one
   # — same call as `Wurk::Status` (see lib/wurk/compat.rb).
   module Telemetry
+    # Instrumentation scope stamped on every span this gem emits.
+    INSTRUMENTATION_NAME = 'wurk'
+
     # The API the client/server middlewares call. A defined `::OpenTelemetry` is
     # not proof the gem is there — a host can own that constant itself, and an
     # `opentelemetry-api` old enough to predate these entry points would answer
@@ -71,6 +74,41 @@ module Wurk
       def enabled?(config = Wurk.configuration)
         config.telemetry? && available?
       end
+
+      # Bring the middleware registrations in line with {enabled?}. Called by
+      # {Wurk::Configuration#telemetry=}, so the chain follows the flag in both
+      # directions: a host that turns tracing back off (a test, a capsule built
+      # for a client-only process) must stop stamping payloads, not just stop
+      # exporting.
+      #
+      # Idempotent — Chain#add removes any prior entry for the same class first.
+      #
+      # @param config [Wurk::Configuration]
+      def install!(config = Wurk.configuration)
+        return config.client_middleware.remove(ClientMiddleware) unless enabled?(config)
+
+        config.client_middleware.add(ClientMiddleware)
+      end
+
+      # Memoized against the provider that produced it rather than once for the
+      # process: `OpenTelemetry::SDK.configure` is routinely called *after* the
+      # code that will emit spans is loaded, and `OpenTelemetry.tracer_provider=`
+      # swaps the object — a tracer cached before that would silently export
+      # nothing for the life of the process. The check costs one `equal?` per
+      # enqueue and re-resolves whenever the provider actually changes.
+      #
+      # The pair is published in a single store so a concurrent reader sees
+      # either the old provider with its own tracer or the new one with its own,
+      # never a tracer attributed to the wrong provider.
+      def tracer
+        memo     = @tracer
+        provider = ::OpenTelemetry.tracer_provider
+        return memo[1] if memo && memo[0].equal?(provider)
+
+        (@tracer = [provider, provider.tracer(INSTRUMENTATION_NAME, Wurk::VERSION)].freeze)[1]
+      end
     end
   end
 end
+
+require_relative 'telemetry/client_middleware'

--- a/lib/wurk/telemetry.rb
+++ b/lib/wurk/telemetry.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require_relative '../wurk'
+
+# `opentelemetry-api` is deliberately NOT a gemspec dependency (see wurk.gemspec):
+# a host that doesn't trace must not carry the gem, and one that does already has
+# it — every OTel SDK, exporter and instrumentation gem depends on the API.
+#
+# The require sits at load rather than at a call site so the answer is settled
+# once. It is wrapped because "not installed" is the normal case, not an error.
+begin
+  require 'opentelemetry-api'
+rescue LoadError
+  # No OTel in this app. Wurk::Telemetry.available? reports false and nothing
+  # downstream registers; see the module doc below.
+  nil
+end
+
+module Wurk
+  # Distributed tracing over the Redis hop: a producer span on enqueue whose
+  # W3C trace context rides the job hash, and a linked consumer span when a
+  # worker picks the job up.
+  #
+  # This file is not loaded by `require "wurk"`. {Wurk::Configuration#telemetry=}
+  # pulls it in, so an app that never opts in never requires `opentelemetry-api`
+  # either — Wurk does not decide on a host's behalf when a third-party gem gets
+  # loaded, and an app with the gem installed but tracing off keeps the exact
+  # object graph, payload bytes and hot path it has today.
+  #
+  # Opt in from the server config:
+  #
+  #   Wurk.configure_server do |config|
+  #     config.telemetry = true
+  #   end
+  #
+  # Both halves must hold before anything registers: the gem has to be there
+  # ({available?}) *and* the host has to have asked ({Wurk::Configuration#telemetry?}).
+  # {enabled?} is that gate.
+  #
+  # There is no `Sidekiq::Telemetry` alias: upstream Sidekiq has no such
+  # constant, so aliasing would invent a Sidekiq surface rather than mirror one
+  # — same call as `Wurk::Status` (see lib/wurk/compat.rb).
+  module Telemetry
+    # The API the client/server middlewares call. A defined `::OpenTelemetry` is
+    # not proof the gem is there — a host can own that constant itself, and an
+    # `opentelemetry-api` old enough to predate these entry points would answer
+    # the constant check too. Asking for the surface at install time turns
+    # either case into "tracing stays off" rather than a NoMethodError on the
+    # first job of a deploy.
+    REQUIRED_API = %i[propagation tracer_provider].freeze
+
+    class << self
+      # @return [Boolean] whether opentelemetry-api is loaded and exposes
+      #   {REQUIRED_API}.
+      #
+      # Not memoized. A host is free to require `opentelemetry` after this file
+      # (an initializer ordering Wurk before its tracing setup), and a `false`
+      # cached at load would disable tracing for the life of the process with
+      # nothing to point at.
+      def available?
+        return false unless defined?(::OpenTelemetry)
+
+        REQUIRED_API.all? { |method| ::OpenTelemetry.respond_to?(method) }
+      end
+
+      # The registration gate — the host flag first, deliberately: an app that
+      # never opted in must not so much as resolve the OTel constant.
+      #
+      # @param config [Wurk::Configuration]
+      # @return [Boolean]
+      def enabled?(config = Wurk.configuration)
+        config.telemetry? && available?
+      end
+    end
+  end
+end

--- a/lib/wurk/telemetry.rb
+++ b/lib/wurk/telemetry.rb
@@ -81,13 +81,18 @@ module Wurk
       # for a client-only process) must stop stamping payloads, not just stop
       # exporting.
       #
-      # Idempotent — Chain#add removes any prior entry for the same class first.
+      # Idempotent — Chain#add and the insert helpers all drop any prior entry
+      # for the same class first.
       #
       # @param config [Wurk::Configuration]
       def install!(config = Wurk.configuration)
-        return config.client_middleware.remove(ClientMiddleware) unless enabled?(config)
+        unless enabled?(config)
+          config.client_middleware.remove(ClientMiddleware)
+          return config.server_middleware.remove(ServerMiddleware)
+        end
 
         config.client_middleware.add(ClientMiddleware)
+        install_server(config.server_middleware)
       end
 
       # Memoized against the provider that produced it rather than once for the
@@ -107,8 +112,26 @@ module Wurk
 
         (@tracer = [provider, provider.tracer(INSTRUMENTATION_NAME, Wurk::VERSION)].freeze)[1]
       end
+
+      private
+
+      # As far out in the server chain as the consumer span can go while still
+      # sitting *inside* `InterruptHandler` — see ServerMiddleware's note on why
+      # that one middleware stays outside. `InterruptHandler` prepends itself
+      # when `wurk.rb` loads, so on the process config it is always entry 0 and
+      # this lands at 1; a bare `Wurk::Configuration` (a client-only capsule, a
+      # test) has no chain to anchor against and takes the head instead.
+      # `insert_after`'s own miss behaviour is the tail, which would be the
+      # innermost position — the opposite of what this wants.
+      def install_server(chain)
+        anchor = Wurk::Middleware::InterruptHandler
+        return chain.insert_after(anchor, ServerMiddleware) if chain.exists?(anchor)
+
+        chain.prepend(ServerMiddleware)
+      end
     end
   end
 end
 
 require_relative 'telemetry/client_middleware'
+require_relative 'telemetry/server_middleware'

--- a/lib/wurk/telemetry/client_middleware.rb
+++ b/lib/wurk/telemetry/client_middleware.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative '../middleware'
+
+module Wurk
+  module Telemetry
+    # Producer half of the pair: a `<queue> publish` span around the rest of the
+    # enqueue, with that span's W3C trace context written onto the job hash so
+    # the worker that eventually runs the job can tie its own span back to
+    # whoever pushed it. Injection happens once per payload, which means every
+    # `push_bulk` item gets its own context — the chain runs per item there
+    # (Client#build_bulk_payloads), not once for the slice.
+    #
+    # Registered only by {Wurk::Telemetry.install!}, i.e. only once the host
+    # opted in *and* opentelemetry-api is loaded. An app that did neither has no
+    # entry in the chain at all — no span, and not one extra byte on the wire.
+    #
+    # Tail position (`add`) is deliberate on both counts: a middleware that
+    # halts the push — a uniqueness gem dropping a duplicate — runs *outside*
+    # this one, so no publish span is opened for a job that was never published;
+    # and nothing downstream of the injection can strip the key back off.
+    class ClientMiddleware
+      include Wurk::Middleware::ClientMiddleware
+
+      def call(_worker, job, queue, _redis_pool)
+        Telemetry.tracer.in_span("#{queue} publish", attributes: attributes(job, queue), kind: :producer) do
+          # Inside the span so the context written is the producer span's own,
+          # which is what the consumer end links back to.
+          #
+          # The propagator writes `traceparent`, plus `tracestate` only when the
+          # trace actually carries vendor state — top-level String values, so
+          # this adds nothing to the args tree `verify_json` walks one frame in
+          # (bulk verifies inside this very block; see
+          # Client#invoke_chain_verified). The single-walk-per-push property
+          # holds unchanged: this middleware never verifies.
+          ::OpenTelemetry.propagation.inject(job)
+          yield
+        end
+      end
+
+      private
+
+      # `messaging.*` names are the OTel messaging semantic conventions. The job
+      # class has no conventional name, so it takes the `messaging.<system>.*`
+      # extension slot those conventions reserve — where
+      # opentelemetry-instrumentation-sidekiq puts it too. `wrapped` is the real
+      # class behind an ActiveJob wrapper; without it every AJ span would read
+      # as the one adapter class.
+      def attributes(job, queue)
+        {
+          'messaging.system' => 'wurk',
+          'messaging.destination.name' => queue,
+          'messaging.message.id' => job['jid'],
+          'messaging.wurk.job_class' => job['wrapped'] || job['class']
+        }
+      end
+    end
+  end
+end

--- a/lib/wurk/telemetry/server_middleware.rb
+++ b/lib/wurk/telemetry/server_middleware.rb
@@ -43,6 +43,16 @@ module Wurk
       # that would otherwise have already ruled on the producer's trace.
       PARENT_WINDOW_SECONDS = 60
 
+      # `created_at` is epoch millis today — `JobUtil#now_in_millis`, and
+      # upstream's own since Sidekiq 8.x — but Sidekiq <= 7.x stamped a Float of
+      # epoch *seconds*, and those payloads outlive the upgrade in the retry,
+      # scheduled and dead sets. Read shape-agnostically on the same threshold
+      # `JobRecord#parse_time` and `Stats` use: no epoch-second stamp reaches
+      # ten digits until 2286, and no epoch-milli one has been under it since
+      # April 1970. Assuming millis would date every seconds-shaped job to 1970
+      # and demote a perfectly fresh one from parent to link.
+      SECONDS_SHAPED_BELOW = 10_000_000_000
+
       # Retries carry the *original* `traceparent`: `JobRetry#schedule_retry`
       # re-ZADDs the same hash, so the client chain — and with it injection —
       # never runs again. That is deliberate and it is the answer to "one trace
@@ -110,14 +120,18 @@ module Wurk
         [::OpenTelemetry::Trace::Link.new(producer)] if producer.valid?
       end
 
-      # Age of the *trace context*, not of the enqueue: `created_at` (epoch
-      # millis, JobUtil#now_in_millis) is stamped at push, which is when the
-      # producer span ended. `enqueued_at` would be wrong here — the scheduler
-      # re-stamps it when it moves a job onto the queue, so every scheduled job
-      # would look fresh no matter how long it waited.
+      # Age of the *trace context*, not of the enqueue: `created_at` is stamped
+      # at push, which is when the producer span ended. `enqueued_at` would be
+      # wrong here — the scheduler re-stamps it when it moves a job onto the
+      # queue, so every scheduled job would look fresh no matter how long it
+      # waited.
       def age_of(job)
         created = job['created_at']
-        created && (::Process.clock_gettime(::Process::CLOCK_REALTIME) - (created.to_f / 1000.0))
+        return nil if created.nil?
+
+        created = created.to_f
+        seconds = created < SECONDS_SHAPED_BELOW ? created : created / 1000.0
+        ::Process.clock_gettime(::Process::CLOCK_REALTIME) - seconds
       end
 
       # Same `messaging.*` vocabulary as the producer half, so one query spans

--- a/lib/wurk/telemetry/server_middleware.rb
+++ b/lib/wurk/telemetry/server_middleware.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require_relative '../middleware'
+require_relative '../job'
+require_relative '../job_retry'
+
+module Wurk
+  module Telemetry
+    # Consumer half of the pair: a `<klass> process` span around the rest of the
+    # server chain and `perform`, tied back to the producer span whose W3C trace
+    # context {ClientMiddleware} wrote onto the job hash.
+    #
+    # Registered only by {Wurk::Telemetry.install!} — gem present *and* host
+    # opted in — one position inside `Middleware::InterruptHandler`, so the span
+    # covers every other middleware (limiter, batch, metrics, status) and the
+    # job body, and its duration is the job's real wall clock rather than
+    # `perform`'s alone. Inside rather than outside the interrupt handler
+    # because that handler's rescue is what turns a cooperative stop into a
+    # re-push plus `JobRetry::Skip`: from outside, the span would also be
+    # wrapping a Redis RPUSH that is not part of running the job.
+    #
+    # A job with no `traceparent` — pushed by stock Sidekiq, by a Wurk process
+    # with tracing off, or straight into Redis by hand — still gets a span. It
+    # is simply a root, with nothing to point at.
+    class ServerMiddleware
+      include Wurk::Middleware::ServerMiddleware
+
+      # How stale a producer context may be and still be used as the span's
+      # *parent* rather than as a link.
+      #
+      # Under this, enqueue and execute are one causal step and the pair belongs
+      # in one trace: the parent edge is what OTel's messaging conventions ask
+      # for, and it is what makes "show me this request" include the work it
+      # queued. Past it, the job is a scheduled one, a cron tick, or a retry
+      # backoff — the producer's trace was exported, sampled and closed minutes
+      # to hours ago, and hanging a new span off it yields a trace the backend
+      # will split, drop, or hold open for a day. So past the window the
+      # relationship is recorded as a span **link**: same information, no
+      # unbounded trace.
+      #
+      # 60s is chosen to sit above normal enqueue→execute latency on a healthy
+      # queue (sub-second) and below the decision window of the tail samplers
+      # that would otherwise have already ruled on the producer's trace.
+      PARENT_WINDOW_SECONDS = 60
+
+      # Retries carry the *original* `traceparent`: `JobRetry#schedule_retry`
+      # re-ZADDs the same hash, so the client chain — and with it injection —
+      # never runs again. That is deliberate and it is the answer to "one trace
+      # per logical job vs. a fresh root per attempt": every attempt is
+      # reachable from the enqueue that caused it. Attempt 1 usually lands
+      # inside the window and is a child; later attempts, pushed out by
+      # exponential backoff, land outside it and are roots carrying a link back.
+      # Neither is ever an unrelated root.
+      def call(_worker, job, queue)
+        span = start(job, queue)
+        # `yield` rather than taking the chain's block as `&block`: capturing it
+        # allocates a Proc for every job in the process, and this frame runs on
+        # every one of them.
+        ::OpenTelemetry::Trace.with_span(span) { yield } # rubocop:disable Style/ExplicitBlockArgument
+      rescue Wurk::JobRetry::Handled, Wurk::Job::Interrupted
+        # The canonical not-an-error list (see Batch::ServerMiddleware): a
+        # cooperative interruption, and every `Handled` — which is where
+        # `JobRetry::Skip` and, under it, `Limiter::Rescheduled` live. None of
+        # them is a job that went wrong; each is one that was put back and will
+        # run again. Marking the span an error would paint a rate-limited or
+        # gracefully-paused deploy as an outage.
+        raise
+      rescue Exception => e # rubocop:disable Lint/RescueException
+        # Everything else that unwinds through here, `Wurk::Shutdown` included:
+        # a job killed by a hard shutdown did not complete, and that is exactly
+        # the signal an operator tuning `shutdown_timeout` is looking for.
+        span&.record_exception(e)
+        span&.status = ::OpenTelemetry::Trace::Status.error("Unhandled exception of type: #{e.class}")
+        raise
+      ensure
+        span&.finish
+      end
+
+      private
+
+      # Hand-rolled rather than `tracer.in_span`: that helper rescues
+      # `Exception` and unconditionally stamps an error status, which would cost
+      # us the taxonomy above — its `record_exception:` kwarg suppresses the
+      # event but not the status.
+      def start(job, queue)
+        context  = ::OpenTelemetry.propagation.extract(job)
+        producer = ::OpenTelemetry::Trace.current_span(context).context
+        name     = "#{job_class(job)} process"
+        common   = { attributes: attributes(job, queue), kind: :consumer }
+
+        return Telemetry.tracer.start_span(name, with_parent: context, **common) if parent?(producer, job)
+
+        Telemetry.tracer.start_root_span(name, links: link_to(producer), **common)
+      end
+
+      # Unknown age resolves to a link, not a parent. The two mistakes are not
+      # symmetric: a link where a parent belonged costs one hop in the UI, while
+      # a parent where a link belonged can stretch a trace across hours and lose
+      # it entirely.
+      def parent?(producer, job)
+        return false unless producer.valid?
+
+        age = age_of(job)
+        !age.nil? && age < PARENT_WINDOW_SECONDS
+      end
+
+      # nil, not [], when there is nothing to point at — `links: nil` is the
+      # API's own "no links" and keeps a span from carrying an empty array.
+      def link_to(producer)
+        [::OpenTelemetry::Trace::Link.new(producer)] if producer.valid?
+      end
+
+      # Age of the *trace context*, not of the enqueue: `created_at` (epoch
+      # millis, JobUtil#now_in_millis) is stamped at push, which is when the
+      # producer span ended. `enqueued_at` would be wrong here — the scheduler
+      # re-stamps it when it moves a job onto the queue, so every scheduled job
+      # would look fresh no matter how long it waited.
+      def age_of(job)
+        created = job['created_at']
+        created && (::Process.clock_gettime(::Process::CLOCK_REALTIME) - (created.to_f / 1000.0))
+      end
+
+      # Same `messaging.*` vocabulary as the producer half, so one query spans
+      # both ends of the hop. `queue` is the argument rather than `job['queue']`
+      # because it is the queue this job was actually consumed from.
+      def attributes(job, queue)
+        {
+          'messaging.system' => 'wurk',
+          'messaging.destination.name' => queue,
+          'messaging.message.id' => job['jid'],
+          'messaging.wurk.job_class' => job_class(job)
+        }
+      end
+
+      def job_class(job) = job['wrapped'] || job['class']
+    end
+  end
+end

--- a/test/integration/telemetry_fork_test.rb
+++ b/test/integration/telemetry_fork_test.rb
@@ -302,10 +302,15 @@ class TelemetryForkTest < Wurk::Test::UnitCase
                  'both ends of the hop must agree on the jid — the messaging conventions survive the fork too'
   end
 
-  # `created_at`/`enqueued_at` (epoch seconds, Sidekiq's own format — Wurk
-  # matches it) plus the handful of keys `Sidekiq::Client` actually writes.
-  # Deliberately built by hand rather than via Wurk::Client so no Wurk-only
-  # field (`traceparent` chief among them) can leak in.
+  # Only the keys `Sidekiq::Client` actually writes, built by hand rather than
+  # pushed through Wurk::Client so no Wurk-only field (`traceparent` chief among
+  # them) can leak in. `created_at`/`enqueued_at` are Float epoch *seconds* —
+  # what Sidekiq <= 7.x stamped, not the millis Wurk and Sidekiq 8.x write —
+  # because the old shape is the one a drop-in still has to read. That shape is
+  # incidental to what this case proves, though: with no `traceparent` there is
+  # no producer context to age, so the span is a root either way and
+  # `ServerMiddleware#age_of` never runs. The shape itself is pinned in the unit
+  # suite instead.
   def push_stock_sidekiq_job
     jid = SecureRandom.hex(12)
     now = Time.now.to_f

--- a/test/integration/telemetry_fork_test.rb
+++ b/test/integration/telemetry_fork_test.rb
@@ -1,0 +1,359 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'wurk/telemetry'
+require 'securerandom'
+require 'json'
+
+# A Redis-backed stand-in for opentelemetry-api that survives a real fork.
+#
+# opentelemetry-api is deliberately not a dependency (see wurk.gemspec) and
+# still isn't installable in this sandbox (no network) — see TelemetryTest /
+# TelemetryClientMiddlewareTest / TelemetryServerMiddlewareTest, which fake it
+# per-process. This one has to fake it *across* a `Process.fork`: the producer
+# span opens in the test process, the consumer span opens in a forked child,
+# and nothing in that child can see this process's in-memory span list. So
+# instead of collecting spans in an array, every span writes itself to a Redis
+# LIST on finish — the one channel both sides of the fork actually share.
+#
+# Assigned onto the top-level `OpenTelemetry` constant before `swarm.boot`
+# forks, so the child inherits it via the fork's copy-on-write memory exactly
+# like it inherits every other loaded class — no marshaling, no IPC beyond the
+# Redis writes themselves.
+module TelemetryForkFakeOtel
+  SpanContext = Struct.new(:trace_id, :span_id) do
+    def valid? = !(trace_id.nil? || span_id.nil?)
+  end
+
+  RemoteSpan = Struct.new(:context)
+  Context = Struct.new(:span)
+  Link = Struct.new(:span_context)
+
+  module Status
+    Error = Struct.new(:description)
+
+    def self.error(description) = Error.new(description)
+  end
+
+  # One instance per producer or consumer span. `role` is stamped by whichever
+  # Tracer method built it, so the Redis record self-identifies without the
+  # test needing to infer it from shape. `attributes` rides along too — proof
+  # that the messaging.* conventions survive the fork, not just the trace ids.
+  class Span
+    attr_reader :trace_id, :span_id
+    attr_accessor :status
+
+    def initialize(role:, name:, kind:, trace_id:, span_id:, attributes: nil, parent_span_id: nil, link: nil)
+      @role = role
+      @name = name
+      @kind = kind
+      @trace_id = trace_id
+      @span_id = span_id
+      @attributes = attributes
+      @parent_span_id = parent_span_id
+      @link = link
+      @exception = nil
+      @finished = false
+    end
+
+    def record_exception(exception) = @exception = exception.class.name
+
+    # Idempotent: ClientMiddleware relies on `in_span` to finish the producer
+    # span implicitly, ServerMiddleware finishes the consumer span explicitly
+    # in its `ensure` — neither may double-write.
+    def finish
+      return if @finished
+
+      @finished = true
+      TelemetryForkFakeOtel.record(
+        role: @role, name: @name, kind: @kind.to_s, trace_id: @trace_id, span_id: @span_id,
+        attributes: @attributes, parent_span_id: @parent_span_id,
+        link_trace_id: @link&.trace_id, link_span_id: @link&.span_id,
+        error: !(@status.nil? && @exception.nil?), exception: @exception
+      )
+    end
+  end
+
+  class Tracer
+    # Producer half — ClientMiddleware's `in_span`. Always a fresh trace: a
+    # push has nothing upstream to inherit a context from.
+    def in_span(name, attributes: nil, kind: nil)
+      span = Span.new(role: 'producer', name: name, kind: kind, attributes: attributes,
+                      trace_id: SecureRandom.hex(16), span_id: SecureRandom.hex(8))
+      previous = Thread.current[:telemetry_fork_current_span]
+      Thread.current[:telemetry_fork_current_span] = span
+      begin
+        yield span
+      ensure
+        span.finish
+        Thread.current[:telemetry_fork_current_span] = previous
+      end
+    end
+
+    # Consumer half, in-window case — ServerMiddleware's `start_span` when the
+    # producer context is fresh enough to parent to.
+    def start_span(name, with_parent:, attributes: nil, kind: nil)
+      parent = with_parent.span.context
+      Span.new(role: 'consumer', name: name, kind: kind, attributes: attributes, trace_id: parent.trace_id,
+               span_id: SecureRandom.hex(8), parent_span_id: parent.span_id)
+    end
+
+    # Consumer half, no-parent / stale case — a fresh trace carrying a link
+    # back to the producer instead of a parent edge.
+    def start_root_span(name, attributes: nil, links: nil, kind: nil)
+      Span.new(role: 'consumer', name: name, kind: kind, attributes: attributes, trace_id: SecureRandom.hex(16),
+               span_id: SecureRandom.hex(8), link: links&.first&.span_context)
+    end
+  end
+
+  class TracerProvider
+    def tracer(_name, _version) = Tracer.new
+  end
+
+  class Propagation
+    # ClientMiddleware calls this from inside `in_span`'s block, so "the
+    # current span" is always whatever `in_span` just pushed.
+    def inject(carrier)
+      span = Thread.current[:telemetry_fork_current_span]
+      return unless span
+
+      carrier['traceparent'] = "00-#{span.trace_id}-#{span.span_id}-01"
+    end
+
+    def extract(carrier)
+      match = /\A00-(?<trace_id>\h{32})-(?<span_id>\h{16})-\h{2}\z/.match(carrier['traceparent'].to_s)
+      return Context.new(nil) unless match
+
+      Context.new(RemoteSpan.new(SpanContext.new(match[:trace_id], match[:span_id])))
+    end
+  end
+
+  module Trace
+    class << self
+      def current_span(context = nil)
+        (context.respond_to?(:span) && context.span) || RemoteSpan.new(SpanContext.new(nil, nil))
+      end
+
+      def with_span(span)
+        previous = Thread.current[:telemetry_fork_current_span]
+        Thread.current[:telemetry_fork_current_span] = span
+        yield span
+      ensure
+        Thread.current[:telemetry_fork_current_span] = previous
+      end
+    end
+
+    Status = TelemetryForkFakeOtel::Status
+    Link = TelemetryForkFakeOtel::Link
+  end
+
+  class << self
+    attr_accessor :redis_url, :redis_key
+
+    def configure(url, key)
+      self.redis_url = url
+      self.redis_key = key
+    end
+
+    def tracer_provider = @tracer_provider ||= TracerProvider.new
+    def propagation = @propagation ||= Propagation.new
+
+    # Opens its own connection every call rather than memoizing one: this runs
+    # from both the test process (producer) and a forked child (consumer), and
+    # a Redis socket does not survive a fork shared between two processes.
+    def record(payload)
+      client = RedisClient.config(url: redis_url).new_client
+      client.call('RPUSH', redis_key, JSON.generate(payload))
+    ensure
+      client&.close
+    end
+  end
+end
+
+# Top-level so Object.const_get(name) resolves inside the forked child (which
+# inherits the constant table but has no Minitest test-class lexical scope) —
+# same reasoning as SwarmBootSentinelWorker / StatusCrossProcessWorker.
+class TelemetryForkWorker
+  include Wurk::Job
+
+  def perform(*)
+    :ok
+  end
+end
+
+# #05 done-when: "Enqueue and execute spans link across the Redis hop, in-
+# process and across forks." The unit-level middleware tests already pin the
+# parent/link decision and the error taxonomy against a same-process fake;
+# this is the one test that proves the W3C context and the taxonomy actually
+# survive a real `Process.fork` with a real Redis round trip in between —
+# nothing here may mock Redis.
+class TelemetryForkTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  # `OpenTelemetry` is a process-wide constant, same as every other telemetry
+  # test — serialize against them via the same mutex.
+  def run(*)
+    Wurk::Test::GLOBAL_STATE_MUTEX.synchronize { super }
+  end
+
+  def setup
+    super
+    @ns = "telfork-#{Process.pid}-#{object_id}"
+    @queue_name = "#{@ns}-q"
+    @span_key = "#{@ns}-spans"
+    @observer = RedisClient.config(url: Wurk::Test.redis_url).new_client
+    Object.const_set(:OpenTelemetry, TelemetryForkFakeOtel)
+    TelemetryForkFakeOtel.configure(Wurk::Test.redis_url, @span_key)
+    @config = build_config
+  end
+
+  def teardown
+    @observer&.call('UNLINK', @span_key, "queue:#{@queue_name}", private_queue_key(@queue_name))
+    @observer&.call('SREM', 'queues', @queue_name)
+    @observer&.close
+    @config&.reset_redis_pools!
+    Object.send(:remove_const, :OpenTelemetry) if Object.const_defined?(:OpenTelemetry)
+  ensure
+    super
+  end
+
+  def test_traced_enqueue_links_to_traced_execute_across_a_real_fork
+    jid = push_traced_job
+
+    swarm = Wurk::Swarm.new(topology: topology_n(1), config: @config, shutdown_timeout: 5)
+    supervisor = nil
+
+    begin
+      swarm.boot(install_signals: false)
+      supervisor = Thread.new { swarm.supervise }
+
+      spans = wait_for_spans(2)
+
+      refute_nil spans, "expected a producer and a consumer span for #{jid}, got #{read_spans.inspect}"
+    ensure
+      begin
+        swarm.shutdown(timeout: 5)
+      rescue StandardError
+        nil
+      end
+      stop_supervisor_thread(supervisor, 10)
+    end
+
+    assert_producer_linked_to_consumer(spans)
+  end
+
+  # The other drop-in direction: a job that a stock Sidekiq client actually
+  # enqueued — no `traceparent`, no field Wurk itself would add — must still
+  # run cleanly here with tracing on. Hand-built and LPUSHed directly (the
+  # exact two commands Client#push_plain_group issues: SADD queues + LPUSH),
+  # never through Wurk::Client, so nothing Wurk-specific rides along by
+  # accident.
+  def test_a_stock_sidekiq_shaped_job_with_no_traceparent_is_consumed_here
+    jid = push_stock_sidekiq_job
+
+    swarm = Wurk::Swarm.new(topology: topology_n(1), config: @config, shutdown_timeout: 5)
+    supervisor = nil
+
+    begin
+      swarm.boot(install_signals: false)
+      supervisor = Thread.new { swarm.supervise }
+
+      spans = wait_for_spans(1)
+
+      refute_nil spans, "expected the job to run and a consumer span to be recorded for #{jid}"
+    ensure
+      begin
+        swarm.shutdown(timeout: 5)
+      rescue StandardError
+        nil
+      end
+      stop_supervisor_thread(supervisor, 10)
+    end
+
+    consumer = spans.find { |s| s['role'] == 'consumer' }
+
+    refute_nil consumer, 'a stock-Sidekiq-shaped job must still be picked up and run'
+    assert_equal 'TelemetryForkWorker process', consumer['name']
+    refute consumer['error'], 'a clean run must not be recorded as a span error'
+    assert_nil consumer['parent_span_id'], 'nothing to parent to — there was no traceparent on the wire'
+    assert_nil consumer['link_trace_id'], 'nothing to link to either — a root span with no relation at all'
+  end
+
+  private
+
+  def assert_producer_linked_to_consumer(spans)
+    producer = spans.find { |s| s['role'] == 'producer' }
+    consumer = spans.find { |s| s['role'] == 'consumer' }
+
+    refute_nil producer, 'no producer span was recorded'
+    refute_nil consumer, 'no consumer span was recorded — the fork never ran ServerMiddleware'
+
+    assert_equal "#{@queue_name} publish", producer['name']
+    assert_equal 'TelemetryForkWorker process', consumer['name']
+    assert_equal producer['trace_id'], consumer['trace_id'],
+                 'the consumer span must belong to the same trace as the producer — the link across the fork'
+    assert_equal producer['span_id'], consumer['parent_span_id'],
+                 'a job run within the parent window must be a CHILD of the producer span, not merely linked'
+    assert_nil consumer['link_trace_id'], 'an in-window job is parented, not linked — no link should be recorded'
+    refute consumer['error'], 'a clean run must not be recorded as a span error'
+    assert_equal @queue_name, consumer['attributes']['messaging.destination.name'],
+                 'the consumer span must report the queue the fork actually consumed from'
+    assert_equal producer['attributes']['messaging.message.id'], consumer['attributes']['messaging.message.id'],
+                 'both ends of the hop must agree on the jid — the messaging conventions survive the fork too'
+  end
+
+  # `created_at`/`enqueued_at` (epoch seconds, Sidekiq's own format — Wurk
+  # matches it) plus the handful of keys `Sidekiq::Client` actually writes.
+  # Deliberately built by hand rather than via Wurk::Client so no Wurk-only
+  # field (`traceparent` chief among them) can leak in.
+  def push_stock_sidekiq_job
+    jid = SecureRandom.hex(12)
+    now = Time.now.to_f
+    payload = JSON.generate(
+      'class' => TelemetryForkWorker.name, 'args' => [], 'queue' => @queue_name,
+      'jid' => jid, 'retry' => true, 'created_at' => now, 'enqueued_at' => now
+    )
+    @observer.call('SADD', 'queues', @queue_name)
+    @observer.call('LPUSH', "queue:#{@queue_name}", payload)
+    jid
+  end
+
+  def push_traced_job
+    Wurk::Client.new(config: @config).push(
+      'class' => TelemetryForkWorker.name, 'args' => [], 'queue' => @queue_name
+    )
+  end
+
+  def topology_n(count)
+    Wurk::Topology.flat(count: count, queues: [@queue_name], concurrency: 1)
+  end
+
+  def build_config
+    config = Wurk::Configuration.new
+    config.logger = ::Logger.new(IO::NULL)
+    config[:timeout] = 5
+    config.telemetry = true
+    config
+  end
+
+  def read_spans
+    @observer.call('LRANGE', @span_key, 0, -1).map { |raw| JSON.parse(raw) }
+  end
+
+  def wait_for_spans(count, timeout: 20.0, interval: 0.1)
+    deadline = monotonic_now + timeout
+    while monotonic_now < deadline
+      spans = read_spans
+      return spans if spans.size >= count
+
+      sleep interval
+    end
+    nil
+  end
+
+  def monotonic_now = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+
+  def private_queue_key(queue_name)
+    Wurk::Fetcher::Reliable.private_queue_name("queue:#{queue_name}")
+  end
+end

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -915,7 +915,71 @@ class ConfigurationTest < Wurk::Test::UnitCase
     assert_raises(FrozenError) { @config.topology = Wurk::Topology.new }
   end
 
+  # --- telemetry (Wurk::Telemetry opt-in) --------------------------------
+
+  def test_defaults_telemetry_is_off
+    assert_same false, @config[:telemetry]
+    refute_predicate @config, :telemetry?
+  end
+
+  # Seeded in DEFAULTS rather than written on first use, so the read side keeps
+  # answering on a config `freeze!` has already closed.
+  def test_telemetry_reads_on_a_frozen_config
+    @config.freeze!
+
+    refute_predicate @config, :telemetry?
+    assert_same false, @config[:telemetry]
+  end
+
+  def test_telemetry_opt_in
+    opt_into_telemetry(true)
+
+    assert_predicate @config, :telemetry?
+    assert_same true, @config[:telemetry]
+  end
+
+  def test_telemetry_opt_out
+    opt_into_telemetry(true)
+    @config.telemetry = false
+
+    refute_predicate @config, :telemetry?
+    assert_same false, @config[:telemetry]
+  end
+
+  # Stored as a real Boolean, not the argument: `config[:telemetry]` is on the
+  # options Hash third-party gems read.
+  def test_telemetry_coerces_to_a_boolean
+    opt_into_telemetry('yes')
+
+    assert_same true, @config[:telemetry]
+  end
+
+  # Message asserted, not just the class: the frozen options Hash would raise
+  # FrozenError on its own, so only the text proves the writer went through
+  # guard_frozen! and reports like every other closed setter here.
+  def test_telemetry_setter_raises_once_frozen
+    @config.freeze!
+
+    err = assert_raises(FrozenError) { @config.telemetry = true }
+
+    assert_equal 'Wurk::Configuration is frozen', err.message
+  end
+
+  def test_telemetry_opt_in_loads_the_telemetry_module
+    opt_into_telemetry(true)
+
+    assert Wurk.const_defined?(:Telemetry, false), 'config.telemetry = true must require wurk/telemetry'
+  end
+
   private
+
+  # Opting in warns whenever opentelemetry-api is absent, which it is in this
+  # suite. Keep that off the runner's stdout — TelemetryTest asserts the warning
+  # itself, in a subprocess where the gem's presence is pinned by a fixture.
+  def opt_into_telemetry(value)
+    @config.logger = ::Logger.new(IO::NULL)
+    @config.telemetry = value
+  end
 
   def build_exception(message)
     raise StandardError, message

--- a/test/unit/encryption_test.rb
+++ b/test/unit/encryption_test.rb
@@ -524,6 +524,71 @@ class EncryptionTest < Wurk::Test::UnitCase
     end
   end
 
+  # ---- telemetry interaction: traceparent is metadata, not an argument (slice 05) ----
+  #
+  # `Wurk::Telemetry::ClientMiddleware` writes `traceparent` (and optionally
+  # `tracestate`) as top-level String keys on the job hash — see
+  # lib/wurk/telemetry/client_middleware.rb:36. Encryption only ever reads and
+  # rewrites `job['args'].last` (`#encrypt` above, `#decrypt_last_arg!` below);
+  # this pins that contract when both features are opted into the same job, in
+  # either order, without depending on opentelemetry-api being installed — the
+  # two middleware pairs never interact through anything but the job hash they
+  # share, and a real `traceparent` string is enough to prove it.
+
+  TRACEPARENT = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
+  TRACESTATE = 'rojo=00f067aa0ba902b7'
+
+  def test_traceparent_and_tracestate_survive_the_client_middleware_untouched
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      job = { 'class' => 'X', 'args' => [1, { 'ssn' => '123-45-6789' }], 'encrypt' => true,
+              'traceparent' => TRACEPARENT, 'tracestate' => TRACESTATE }
+      invoke_client(job)
+
+      assert_equal TRACEPARENT, job['traceparent'], 'trace context is metadata, not an argument to encrypt'
+      assert_equal TRACESTATE, job['tracestate']
+      assert Wurk::Encryption.envelope?(job['args'].last), 'args.last must still be enveloped'
+    end
+  end
+
+  def test_traceparent_is_not_folded_into_the_envelope
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      job = { 'class' => 'X', 'args' => ['plaintext arg'], 'encrypt' => true, 'traceparent' => TRACEPARENT }
+      invoke_client(job)
+      envelope = job['args'].last
+
+      refute_includes envelope.values.join, TRACEPARENT, 'the trace context must never end up inside the ciphertext'
+    end
+  end
+
+  # The headline assertion: a traceparent riding alongside `encrypt: true`
+  # must not perturb encryption.rb:131-137's envelope shape or its round trip
+  # back to plaintext, and the server-side decrypt must leave the trace
+  # context exactly as it found it — nothing here is Telemetry-aware, on
+  # purpose; if it needed to be, the "metadata, not an argument" contract
+  # would already be broken.
+  def test_the_args_round_trip_is_unaffected_by_a_traceparent_key
+    ENABLE_MUTEX.synchronize do
+      Wurk::Encryption.enable(active_version: 1) { |_v| KEY_V1 }
+      secret = { 'card' => '4111', 'cvv' => '999' }
+      job = { 'class' => 'X', 'jid' => jid, 'args' => [42, secret], 'encrypt' => true,
+              'traceparent' => TRACEPARENT, 'tracestate' => TRACESTATE }
+      before_metadata = job.except('args').dup
+
+      invoke_client(job)
+
+      assert Wurk::Encryption.envelope?(job['args'].last), 'the enqueued payload must be ciphertext'
+
+      invoke_server(job) { :ok }
+
+      assert_equal [42, secret], job['args'],
+                   'a traceparent alongside encrypt: true must not break the envelope round-trip'
+      assert_equal before_metadata, job.except('args'),
+                   'traceparent/tracestate must be byte-identical before and after the whole round trip'
+    end
+  end
+
   # ---- Web UI redaction (§4.7) -----------------------------------------
 
   def test_redact_args_passthrough_when_not_encrypted

--- a/test/unit/telemetry_client_middleware_test.rb
+++ b/test/unit/telemetry_client_middleware_test.rb
@@ -1,0 +1,466 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'wurk/telemetry'
+require 'json'
+require 'logger'
+
+# Wurk::Telemetry::ClientMiddleware — the producer half of the Redis hop.
+#
+# opentelemetry-api is deliberately not a dependency (see wurk.gemspec), so the
+# slice of it this middleware touches is stood up below as a *behavioral* fake:
+# `in_span` returns the block's value and lets exceptions through like the real
+# Tracer, and `inject` writes only while a span is open, and only the keys the
+# W3C propagator writes (`tracestate` solely when the trace carries vendor
+# state). A fake more permissive than the gem would make every assertion here
+# worthless.
+#
+# Takes GLOBAL_STATE_MUTEX for the whole class: `::OpenTelemetry` is a process
+# constant, and TelemetryTest installs and removes it too.
+class TelemetryClientMiddlewareTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  TRACE_ID = 'd4cda95b652f4a1592b449d5929fda1b'
+  JID      = 'aaaabbbbccccddddeeeeffff'
+  CREATED  = 1_700_000_000_000
+
+  def run(*)
+    Wurk::Test::GLOBAL_STATE_MUTEX.synchronize { super }
+  end
+
+  def setup
+    super
+    @pool       = Wurk.configuration.redis_pool
+    @queue      = "tc-q-#{Process.pid}-#{object_id}"
+    @class_name = "TelemetryJob@#{Process.pid}-#{object_id}"
+    @bid        = "TC-#{Process.pid}-#{object_id}"
+  end
+
+  def teardown
+    @pool.with do |conn|
+      conn.call('DEL', "queue:#{@queue}", "b-#{@bid}", "b-#{@bid}-jids")
+      conn.call('SREM', 'queues', @queue)
+    end
+  ensure
+    super
+  end
+
+  # --- injection -----------------------------------------------------------
+
+  def test_push_injects_the_producer_spans_trace_context
+    with_otel do |provider|
+      client = recording_client
+      client.push(item)
+
+      assert_equal "00-#{TRACE_ID}-#{span(provider).span_id}-01", client.pushed.first['traceparent']
+    end
+  end
+
+  def test_push_omits_tracestate_when_the_trace_carries_none
+    with_otel do
+      client = recording_client
+      client.push(item)
+
+      refute client.pushed.first.key?('tracestate'), 'an empty tracestate must not reach the wire'
+    end
+  end
+
+  def test_push_injects_tracestate_when_the_trace_carries_vendor_state
+    with_otel(tracestate: 'rojo=00f067aa0ba902b7') do
+      client = recording_client
+      client.push(item)
+
+      assert_equal 'rojo=00f067aa0ba902b7', client.pushed.first['tracestate']
+    end
+  end
+
+  # The chain runs per item in the bulk path (Client#build_bulk_payloads), so
+  # each job carries the context of its own producer span — not one context
+  # smeared across the slice.
+  def test_push_bulk_injects_a_distinct_context_into_every_item
+    with_otel do |provider|
+      client = recording_client
+      client.push_bulk('class' => @class_name, 'queue' => @queue, 'args' => [[1], [2], [3]])
+
+      traceparents = client.pushed.map { |p| p['traceparent'] }
+
+      assert_equal 3, traceparents.compact.uniq.size
+      assert_equal 3, spans(provider).size
+    end
+  end
+
+  # --- the byte-compare proof ---------------------------------------------
+  #
+  # Every case below drives the real registration gate (Configuration#telemetry=
+  # → Telemetry.install!) rather than hand-building a chain, because "keys only
+  # when tracing is enabled" is a claim about that gate, not about the middleware.
+
+  def test_payload_bytes_are_unchanged_when_the_host_never_opted_in
+    with_otel do
+      assert_equal baseline_json, pushed_json(silent_config)
+    end
+  end
+
+  # An explicit `= false` on a config that never traced must stay a no-op — it
+  # has nothing to unregister, and must not pay the require to find that out.
+  def test_opting_out_without_ever_opting_in_registers_nothing
+    config = silent_config
+    config.telemetry = false
+
+    assert_empty config.client_middleware.entries
+    assert_equal baseline_json, pushed_json(config)
+  end
+
+  def test_payload_bytes_are_unchanged_when_the_gem_is_missing
+    config = silent_config
+    config.telemetry = true
+
+    assert_equal baseline_json, pushed_json(config)
+  end
+
+  def test_opting_in_adds_the_trace_context_and_nothing_else
+    with_otel do
+      config = silent_config
+      config.telemetry = true
+      traced = JSON.parse(pushed_json(config))
+
+      assert_equal ['traceparent'], traced.keys - JSON.parse(baseline_json).keys
+      assert_equal baseline_json, Wurk.dump_json(traced.except('traceparent'))
+    end
+  end
+
+  # Tail, so a middleware that halts the push runs outside the span and nothing
+  # downstream can strip the injected key back off.
+  def test_opting_in_registers_at_the_tail_of_the_chain
+    with_otel do
+      config = silent_config
+      config.client_middleware.add(HaltingMiddleware)
+      config.telemetry = true
+
+      assert_equal [HaltingMiddleware, Wurk::Telemetry::ClientMiddleware],
+                   config.client_middleware.entries.map(&:klass)
+    end
+  end
+
+  def test_opting_back_out_restores_the_untraced_bytes
+    with_otel do
+      config = silent_config
+      config.telemetry = true
+      config.telemetry = false
+
+      assert_equal baseline_json, pushed_json(config)
+    end
+  end
+
+  # --- span shape ----------------------------------------------------------
+
+  def test_producer_span_is_named_for_the_destination
+    with_otel do |provider|
+      recording_client.push(item)
+
+      assert_equal "#{@queue} publish", span(provider).name
+    end
+  end
+
+  def test_producer_span_kind_is_producer
+    with_otel do |provider|
+      recording_client.push(item)
+
+      assert_equal :producer, span(provider).kind
+    end
+  end
+
+  def test_producer_span_carries_the_messaging_conventions
+    with_otel do |provider|
+      recording_client.push(item)
+
+      assert_equal({ 'messaging.system' => 'wurk',
+                     'messaging.destination.name' => @queue,
+                     'messaging.message.id' => JID,
+                     'messaging.wurk.job_class' => @class_name },
+                   span(provider).attributes)
+    end
+  end
+
+  # An ActiveJob payload's `class` is the adapter's wrapper; without `wrapped`
+  # every AJ span in the system would read as that one class.
+  def test_producer_span_reports_the_wrapped_class_for_activejob
+    with_otel do |provider|
+      recording_client.push(item('wrapped' => 'SomeMailerJob'))
+
+      assert_equal 'SomeMailerJob', span(provider).attributes['messaging.wurk.job_class']
+    end
+  end
+
+  def test_the_tracer_is_scoped_to_this_gem
+    with_otel do |provider|
+      recording_client.push(item)
+
+      assert_equal ['wurk', Wurk::VERSION], [tracer(provider).name, tracer(provider).version]
+    end
+  end
+
+  # --- the chain contract --------------------------------------------------
+
+  def test_the_chains_return_value_survives_the_span
+    with_otel do
+      assert_equal JID, recording_client.push(item)
+    end
+  end
+
+  # Tail registration is what buys this: a middleware that drops the job runs
+  # outside the span, so nothing reports a publish that never happened.
+  def test_a_job_dropped_upstream_opens_no_producer_span
+    with_otel do |provider|
+      client = recording_client(outer: HaltingMiddleware)
+
+      assert_nil client.push(item)
+      assert_empty spans(provider)
+      assert_empty client.pushed
+    end
+  end
+
+  # --- the single args walk (plan 04/S6) -----------------------------------
+  #
+  # `verify_json` recurses the whole args tree and runs exactly once per job:
+  # after the chain in #push, inside it in #push_bulk. Injection adds top-level
+  # String keys and never verifies, so the count must not move — and the walk
+  # must already be looking at an injected payload, which is what pins the
+  # ordering rather than merely the arithmetic.
+
+  def test_push_still_walks_the_args_exactly_once
+    with_otel do
+      client = recording_client
+      client.push(item)
+
+      assert_equal 1, client.verified.size
+    end
+  end
+
+  def test_push_bulk_still_walks_the_args_exactly_once_per_job
+    with_otel do
+      client = recording_client
+      client.push_bulk('class' => @class_name, 'queue' => @queue, 'args' => [[1], [2], [3]])
+
+      assert_equal 3, client.verified.size
+    end
+  end
+
+  def test_the_walk_sees_the_injected_payload
+    with_otel do
+      client = recording_client
+      client.push_bulk('class' => @class_name, 'queue' => @queue, 'args' => [[1]])
+
+      assert client.verified.first.key?('traceparent'), 'injection must precede the bulk walk, not follow it'
+    end
+  end
+
+  # The bulk walk runs inside the span, so a rejected payload surfaces through
+  # `in_span` — which must re-raise, not swallow.
+  def test_a_rejected_payload_raises_through_the_span
+    with_otel do |provider|
+      client = recording_client
+
+      assert_raises(ArgumentError) do
+        client.push_bulk('class' => @class_name, 'queue' => @queue, 'args' => [[:not_json]])
+      end
+      assert_equal 1, spans(provider).size
+      assert_empty client.pushed
+    end
+  end
+
+  # --- survival to Redis ---------------------------------------------------
+
+  def test_the_context_survives_a_plain_push_to_redis
+    with_otel do
+      traced_client.push(item)
+
+      assert_match(/\A00-#{TRACE_ID}-/, stored.first['traceparent'])
+    end
+  end
+
+  # The batched path serializes inside Lua (BATCH_PUSH), not in Ruby — the
+  # injected key has to ride that too.
+  def test_the_context_survives_the_lua_batch_path
+    @pool.with { |conn| Wurk::Lua::Loader.script_load_all(conn) }
+    with_otel do
+      traced_client.push(item('bid' => @bid))
+
+      assert_match(/\A00-#{TRACE_ID}-/, stored.first['traceparent'])
+    end
+  end
+
+  # --- tracer resolution ---------------------------------------------------
+
+  def test_the_tracer_is_resolved_once_per_provider
+    with_otel do |provider|
+      3.times { recording_client.push(item) }
+
+      assert_equal 1, provider.tracer_calls
+    end
+  end
+
+  # An SDK installed after the opt-in replaces the provider object; a tracer
+  # cached across that swap would export nothing for the rest of the process.
+  def test_the_tracer_is_re_resolved_when_the_provider_is_replaced
+    with_otel do
+      recording_client.push(item)
+      swapped = FakeOtel.tracer_provider = FakeTracerProvider.new
+      recording_client.push(item)
+
+      assert_equal 1, spans(swapped).size
+    end
+  end
+
+  private
+
+  # --- fixtures ------------------------------------------------------------
+
+  def item(overrides = {})
+    { 'class' => @class_name, 'args' => [1, 'two'], 'queue' => @queue,
+      'jid' => JID, 'created_at' => CREATED }.merge(overrides)
+  end
+
+  def silent_config
+    Wurk::Configuration.new.tap { |c| c.logger = ::Logger.new(IO::NULL) }
+  end
+
+  def recording_client(outer: nil)
+    chain = Wurk::Middleware::Chain.new(Wurk.configuration)
+    chain.add(outer) if outer
+    chain.add(Wurk::Telemetry::ClientMiddleware)
+    RecordingClient.new(pool: @pool, chain: chain)
+  end
+
+  def traced_client
+    chain = Wurk::Middleware::Chain.new(Wurk.configuration)
+    chain.add(Wurk::Telemetry::ClientMiddleware)
+    Wurk::Client.new(pool: @pool, chain: chain)
+  end
+
+  # The exact bytes an untraced enqueue writes. Same item, same jid, same
+  # created_at, so any difference is the middleware's doing.
+  def baseline_json
+    @baseline_json ||= Wurk.dump_json(
+      RecordingClient.new(pool: @pool, chain: Wurk::Middleware::Chain.new).tap { |c| c.push(item) }.pushed.first
+    )
+  end
+
+  def pushed_json(config)
+    client = RecordingClient.new(pool: @pool, chain: config.client_middleware)
+    client.push(item)
+    Wurk.dump_json(client.pushed.first)
+  end
+
+  def stored
+    @pool.with { |conn| conn.call('LRANGE', "queue:#{@queue}", 0, -1) }.map { |raw| JSON.parse(raw) }
+  end
+
+  # --- the opentelemetry-api stand-in --------------------------------------
+
+  def with_otel(tracestate: nil)
+    FakeOtel.tracer_provider = FakeTracerProvider.new
+    FakeOtel.propagation     = FakePropagator.new(tracestate)
+    FakeOtel.current_span    = nil
+    Object.const_set(:OpenTelemetry, FakeOtel)
+    yield FakeOtel.tracer_provider
+  ensure
+    Object.send(:remove_const, :OpenTelemetry)
+  end
+
+  def tracer(provider) = provider.tracer('wurk', Wurk::VERSION)
+  def spans(provider)  = tracer(provider).spans
+  def span(provider)   = spans(provider).first
+
+  class FakeTracer
+    Span = Struct.new(:name, :attributes, :kind, :span_id)
+
+    attr_reader :name, :version, :spans
+
+    def initialize(name, version)
+      @name    = name
+      @version = version
+      @spans   = []
+    end
+
+    # OpenTelemetry::Trace::Tracer#in_span: the block's value is the return
+    # value (Client#push threads the payload back through it), and an exception
+    # propagates after the span is finished.
+    def in_span(name, attributes: nil, kind: nil)
+      span = Span.new(name, attributes, kind, format('%016x', @spans.size + 1))
+      @spans << span
+      previous = FakeOtel.current_span
+      FakeOtel.current_span = span
+      begin
+        yield span
+      ensure
+        FakeOtel.current_span = previous
+      end
+    end
+  end
+
+  # Memoizes per (name, version) like OpenTelemetry::SDK::Trace::TracerProvider,
+  # and counts the lookups so the caller-side memo is observable.
+  class FakeTracerProvider
+    attr_reader :tracer_calls
+
+    def initialize
+      @tracer_calls = 0
+      @tracers      = {}
+    end
+
+    def tracer(name, version)
+      @tracer_calls += 1
+      @tracers[[name, version]] ||= FakeTracer.new(name, version)
+    end
+  end
+
+  # TraceContext::TextMapPropagator#inject: nothing without a valid current
+  # span context, `traceparent` always, `tracestate` only when non-empty.
+  class FakePropagator
+    def initialize(tracestate) = @tracestate = tracestate
+
+    def inject(carrier)
+      span = FakeOtel.current_span
+      return if span.nil?
+
+      carrier['traceparent'] = "00-#{TRACE_ID}-#{span.span_id}-01"
+      carrier['tracestate']  = @tracestate if @tracestate && !@tracestate.empty?
+      nil
+    end
+  end
+
+  module FakeOtel
+    class << self
+      attr_accessor :current_span, :tracer_provider, :propagation
+    end
+  end
+
+  # Stands in for a uniqueness/throttling gem dropping the job.
+  class HaltingMiddleware
+    def call(_worker, _job, _queue, _redis) = nil
+  end
+
+  class RecordingClient < Wurk::Client
+    attr_reader :pushed, :verified
+
+    def initialize(**)
+      super
+      @pushed   = []
+      @verified = []
+    end
+
+    # Snapshots rather than the live Hash: #push_plain_group stamps
+    # `enqueued_at` onto the payload it was handed, and a byte-compare against a
+    # mutated object would be measuring the clock.
+    def verify_json(item)
+      @verified << item.dup
+      super
+    end
+
+    def raw_push(payloads)
+      @pushed.concat(payloads.map(&:dup))
+      nil
+    end
+  end
+end

--- a/test/unit/telemetry_client_middleware_test.rb
+++ b/test/unit/telemetry_client_middleware_test.rb
@@ -17,6 +17,15 @@ require 'logger'
 #
 # Takes GLOBAL_STATE_MUTEX for the whole class: `::OpenTelemetry` is a process
 # constant, and TelemetryTest installs and removes it too.
+
+# A real, resolvable constant for the drop-in tests below — `Object.const_get`
+# needs an actual class on the lookup path, not the per-test synthetic string
+# names (`TelemetryJob@<pid>-<oid>`) used everywhere else in this file, and
+# stock Sidekiq's dispatch really does call `.new` and `.jid=` on it.
+class TelemetryDropInWorker
+  attr_accessor :jid
+end
+
 class TelemetryClientMiddlewareTest < Wurk::Test::UnitCase
   parallelize_me!
 
@@ -290,6 +299,77 @@ class TelemetryClientMiddlewareTest < Wurk::Test::UnitCase
     end
   end
 
+  # --- drop-in: dispatched the way stock Sidekiq actually does it ----------
+  #
+  # `Sidekiq::Processor#dispatch` and `Sidekiq::JobLogger#prepare`, pinned at
+  # test/parity/.sidekiq_sha (e1f808a08645f9b8a194852a171b5667f5f877bd),
+  # fetched verbatim rather than assumed:
+  #
+  #   # lib/sidekiq/processor.rb:137,148-150
+  #   @job_logger.prepare(job_hash) do
+  #     ...
+  #     klass = Object.const_get(job_hash["class"])
+  #     instance = klass.new
+  #     instance.jid = job_hash["jid"]
+  #
+  #   # lib/sidekiq/job_logger.rb:26-33
+  #   def prepare(job_hash, &block)
+  #     h = { jid: job_hash["jid"], class: job_hash["wrapped"] || job_hash["class"] }
+  #     @config[:logged_job_attributes].each do |attr|
+  #       h[attr.to_sym] = job_hash[attr] if job_hash.has_key?(attr)
+  #     end
+  #
+  # `Sidekiq.load_json` is a bare `JSON.parse` (lib/sidekiq.rb:62) and every
+  # access above is `Hash#[]`/`#has_key?` by known key name — nothing
+  # enumerates or validates the full key set. `stock_sidekiq_dispatch` below
+  # reproduces that exact fragment; running it against a real traced Wurk
+  # payload is what actually proves "Sidekiq's own Processor ignores unknown
+  # keys" rather than merely asserting the payload shape in isolation.
+  def stock_sidekiq_dispatch(jobstr, logged_job_attributes: %w[bid])
+    job_hash = JSON.parse(jobstr)
+    prepared = { jid: job_hash['jid'], class: job_hash['wrapped'] || job_hash['class'] }
+    logged_job_attributes.each { |attr| prepared[attr.to_sym] = job_hash[attr] if job_hash.key?(attr) }
+    klass = Object.const_get(job_hash['class'])
+    instance = klass.new
+    instance.jid = job_hash['jid']
+    { instance: instance, args: job_hash['args'], prepared: prepared }
+  end
+
+  def test_a_traced_job_dispatches_unmodified_through_stock_sidekiqs_processor
+    with_otel do
+      traced_client.push(item('class' => TelemetryDropInWorker.name))
+      dispatched = stock_sidekiq_dispatch(stored_raw.first)
+
+      assert_instance_of TelemetryDropInWorker, dispatched[:instance]
+      assert_equal JID, dispatched[:instance].jid
+      assert_equal [1, 'two'], dispatched[:args]
+      assert_equal({ jid: JID, class: TelemetryDropInWorker.name }, dispatched[:prepared])
+    end
+  end
+
+  # The wrapped-class label (ActiveJob) is read the same way whether or not
+  # the payload carries a trace context.
+  def test_a_traced_activejob_wrapper_reports_the_wrapped_class_to_the_logger
+    with_otel do
+      traced_client.push(item('class' => TelemetryDropInWorker.name, 'wrapped' => 'SomeMailerJob'))
+      dispatched = stock_sidekiq_dispatch(stored_raw.first)
+
+      assert_equal 'SomeMailerJob', dispatched[:prepared][:class]
+    end
+  end
+
+  # `logged_job_attributes` reads whatever the host configured — `bid` here —
+  # off the same hash `traceparent` landed on; the extra key must not shadow
+  # or shift access to any other one.
+  def test_traced_payload_does_not_disturb_logged_job_attribute_lookup
+    with_otel do
+      traced_client.push(item('class' => TelemetryDropInWorker.name, 'bid' => @bid))
+      dispatched = stock_sidekiq_dispatch(stored_raw.first)
+
+      assert_equal @bid, dispatched[:prepared][:bid]
+    end
+  end
+
   # --- tracer resolution ---------------------------------------------------
 
   def test_the_tracer_is_resolved_once_per_provider
@@ -353,7 +433,13 @@ class TelemetryClientMiddlewareTest < Wurk::Test::UnitCase
   end
 
   def stored
-    @pool.with { |conn| conn.call('LRANGE', "queue:#{@queue}", 0, -1) }.map { |raw| JSON.parse(raw) }
+    stored_raw.map { |raw| JSON.parse(raw) }
+  end
+
+  # Unparsed — the drop-in oracle above does its own `JSON.parse`, exactly
+  # like `Sidekiq.load_json`, rather than being handed an already-parsed Hash.
+  def stored_raw
+    @pool.with { |conn| conn.call('LRANGE', "queue:#{@queue}", 0, -1) }
   end
 
   # --- the opentelemetry-api stand-in --------------------------------------

--- a/test/unit/telemetry_server_middleware_test.rb
+++ b/test/unit/telemetry_server_middleware_test.rb
@@ -114,6 +114,23 @@ class TelemetryServerMiddlewareTest < Wurk::Test::UnitCase
     assert_equal [FakeOtel::Trace::Context, :root], [inside.class, outside]
   end
 
+  # The other `created_at` shape a drop-in has to read: Sidekiq <= 7.x wrote a
+  # Float of epoch seconds, and those payloads survive the upgrade in the retry
+  # and scheduled sets. Divided by 1000 they date to 1970, so a millis-only read
+  # links every one of them — including the ones enqueued a second ago.
+  def test_the_window_decides_on_a_seconds_shaped_created_at_too
+    inside  = with_otel { perform(traced_job('created_at' => seconds_ago(1))) } && span.parent
+    outside = with_otel { perform(traced_job('created_at' => seconds_ago(3600))) } && span.parent
+
+    assert_equal [FakeOtel::Trace::Context, :root], [inside.class, outside]
+  end
+
+  def test_a_seconds_shaped_child_points_at_the_producer
+    with_otel { perform(traced_job('created_at' => seconds_ago(1))) }
+
+    assert_equal [TRACE_ID, SPAN_ID], [parent_context.trace_id, parent_context.span_id]
+  end
+
   # Conservative on an unknown age: a link where a parent belonged costs one hop
   # in the UI; a parent where a link belonged can lose the trace outright.
   def test_a_job_with_no_created_at_links_instead_of_parenting
@@ -328,6 +345,10 @@ class TelemetryServerMiddlewareTest < Wurk::Test::UnitCase
   def millis_ago(seconds)
     ((Process.clock_gettime(Process::CLOCK_REALTIME) - seconds) * 1000).to_i
   end
+
+  # Float epoch seconds — what Sidekiq <= 7.x stamped, and still the shape of
+  # anything it left behind in a sorted set.
+  def seconds_ago(seconds) = Process.clock_gettime(Process::CLOCK_REALTIME) - seconds
 
   # Through a real Chain so entry construction and config binding are exercised
   # the way the Processor exercises them.

--- a/test/unit/telemetry_server_middleware_test.rb
+++ b/test/unit/telemetry_server_middleware_test.rb
@@ -1,0 +1,503 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'wurk/telemetry'
+require 'logger'
+
+# Wurk::Telemetry::ServerMiddleware — the consumer half of the Redis hop.
+#
+# opentelemetry-api is deliberately not a dependency (see wurk.gemspec), so the
+# slice of it this middleware touches is stood up below as a *behavioral* fake
+# modelled on opentelemetry-api 1.8: `with_span` returns the block's value and
+# restores the previously-active span, `current_span` falls back to an invalid
+# span when the context holds none, `start_span` parents to whatever context it
+# is handed while `start_root_span` detaches, and a SpanContext is `valid?` only
+# with both ids set. A fake more permissive than the gem would make every
+# assertion here worthless.
+#
+# Takes GLOBAL_STATE_MUTEX for the whole class: `::OpenTelemetry` is a process
+# constant, and TelemetryTest / TelemetryClientMiddlewareTest install and remove
+# it too.
+class TelemetryServerMiddlewareTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  TRACE_ID = 'd4cda95b652f4a1592b449d5929fda1b'
+  SPAN_ID  = '00f067aa0ba902b7'
+  JID      = 'aaaabbbbccccddddeeeeffff'
+
+  def run(*)
+    Wurk::Test::GLOBAL_STATE_MUTEX.synchronize { super }
+  end
+
+  def setup
+    super
+    @queue      = "ts-q-#{Process.pid}-#{object_id}"
+    @class_name = "TelemetryJob@#{Process.pid}-#{object_id}"
+  end
+
+  # --- span shape ----------------------------------------------------------
+
+  def test_consumer_span_is_named_for_the_job_class
+    with_otel { perform(job) }
+
+    assert_equal "#{@class_name} process", span.name
+  end
+
+  # An ActiveJob payload's `class` is the adapter's wrapper; without `wrapped`
+  # every AJ span in the system would read as that one class.
+  def test_consumer_span_is_named_for_the_wrapped_class_under_activejob
+    with_otel { perform(job('wrapped' => 'SomeMailerJob')) }
+
+    assert_equal 'SomeMailerJob process', span.name
+  end
+
+  def test_consumer_span_kind_is_consumer
+    with_otel { perform(job) }
+
+    assert_equal :consumer, span.kind
+  end
+
+  def test_consumer_span_carries_the_messaging_conventions
+    with_otel { perform(job) }
+
+    assert_equal({ 'messaging.system' => 'wurk',
+                   'messaging.destination.name' => @queue,
+                   'messaging.message.id' => JID,
+                   'messaging.wurk.job_class' => @class_name },
+                 span.attributes)
+  end
+
+  # The queue the job was consumed from, not the one the payload claims — a
+  # re-pushed or re-routed job is reported where it actually ran.
+  def test_the_destination_is_the_queue_the_job_was_fetched_from
+    with_otel { perform(job('queue' => 'stale-name')) }
+
+    assert_equal @queue, span.attributes['messaging.destination.name']
+  end
+
+  def test_the_tracer_is_scoped_to_this_gem
+    with_otel { perform(job) }
+
+    assert_equal ['wurk', Wurk::VERSION], [tracer.name, tracer.version]
+  end
+
+  # --- the producer relationship -------------------------------------------
+
+  def test_a_fresh_job_is_a_child_of_the_producer_span
+    with_otel { perform(traced_job) }
+
+    assert_equal [TRACE_ID, SPAN_ID], [parent_context.trace_id, parent_context.span_id]
+  end
+
+  # Redundant with the parent edge, and an empty array is not the API's "none".
+  def test_a_child_span_carries_no_link
+    with_otel { perform(traced_job) }
+
+    assert_nil span.links
+  end
+
+  # A job scheduled hours out has a long-dead producer span: parenting to it
+  # would stretch one trace across the delay.
+  def test_a_job_older_than_the_parent_window_links_instead_of_parenting
+    with_otel { perform(traced_job('created_at' => millis_ago(3600))) }
+
+    assert_equal :root, span.parent
+    assert_equal [TRACE_ID, SPAN_ID], link_target(span)
+  end
+
+  # The window is the whole of the decision: same context, same job, one second
+  # either side of PARENT_WINDOW_SECONDS.
+  def test_the_window_is_what_decides_parent_versus_link
+    inside  = with_otel { perform(traced_job('created_at' => millis_ago(59))) } && span.parent
+    outside = with_otel { perform(traced_job('created_at' => millis_ago(61))) } && span.parent
+
+    assert_equal [FakeOtel::Trace::Context, :root], [inside.class, outside]
+  end
+
+  # Conservative on an unknown age: a link where a parent belonged costs one hop
+  # in the UI; a parent where a link belonged can lose the trace outright.
+  def test_a_job_with_no_created_at_links_instead_of_parenting
+    with_otel { perform(traced_job.tap { |j| j.delete('created_at') }) }
+
+    assert_equal :root, span.parent
+    assert_equal [TRACE_ID, SPAN_ID], link_target(span)
+  end
+
+  # The drop-in direction: a job enqueued by stock Sidekiq, or by a Wurk process
+  # with tracing off, still gets a span — it simply has nothing to point at.
+  def test_a_job_with_no_trace_context_is_a_root_span_with_no_link
+    with_otel { perform(job) }
+
+    assert_equal :root, span.parent
+    assert_nil span.links
+  end
+
+  def test_a_malformed_trace_context_is_treated_as_absent
+    with_otel { perform(job('traceparent' => 'not-a-traceparent')) }
+
+    assert_equal :root, span.parent
+    assert_nil span.links
+  end
+
+  # JobRetry#schedule_retry re-ZADDs the same hash, so a retry still carries the
+  # *original* producer context — every attempt stays reachable from the enqueue
+  # that caused it rather than becoming an unrelated root.
+  def test_a_retried_job_still_points_at_the_original_trace
+    with_otel { perform(traced_job('retry_count' => 4, 'created_at' => millis_ago(900))) }
+
+    assert_equal [TRACE_ID, SPAN_ID], link_target(span)
+  end
+
+  # --- the chain contract --------------------------------------------------
+
+  def test_the_chains_return_value_survives_the_span
+    with_otel { assert_equal :the_result, perform(job) { :the_result } }
+  end
+
+  def test_the_job_body_runs_inside_the_consumer_span
+    active = nil
+    with_otel { perform(job) { active = FakeOtel::Trace.current } }
+
+    assert_same span, active
+  end
+
+  def test_the_previously_active_span_is_restored
+    with_otel { perform(job) }
+
+    assert_nil FakeOtel::Trace.current
+  end
+
+  def test_a_successful_job_finishes_its_span_exactly_once
+    with_otel { perform(job) }
+
+    assert_equal 1, span.finishes
+  end
+
+  def test_a_successful_job_leaves_the_span_status_unset
+    with_otel { perform(job) }
+
+    assert_nil span.status
+  end
+
+  # Tracing that fails while opening the span surfaces loudly rather than
+  # silently turning itself off — and neither the rescue nor the ensure may trip
+  # over the span they never got.
+  def test_a_failure_opening_the_span_propagates_without_a_second_error
+    with_otel do
+      FakeOtel.propagation = ExplodingPropagator.new
+
+      assert_raises(ExplodingPropagator::Boom) { perform(job) }
+      assert_empty tracer.spans
+    end
+  end
+
+  # --- the error taxonomy --------------------------------------------------
+  #
+  # The canonical not-an-error list (Batch::ServerMiddleware): each of these is
+  # a job that was put back and will run again, not one that went wrong.
+
+  NOT_ERRORS = {
+    cooperative_interruption: Wurk::Job::Interrupted,
+    interrupt_handler_skip: Wurk::JobRetry::Skip,
+    limiter_reschedule: Wurk::Limiter::Rescheduled,
+    handled_retry: Wurk::JobRetry::Handled
+  }.freeze
+
+  NOT_ERRORS.each do |label, error|
+    define_method(:"test_a_#{label}_is_not_a_span_error") do
+      with_otel { assert_raises(error) { perform(job) { raise error } } }
+
+      assert_nil span.status, "#{label} must not set an error status"
+      assert_empty span.exceptions, "#{label} must not be recorded as an exception"
+    end
+
+    define_method(:"test_a_#{label}_still_finishes_the_span") do
+      with_otel { assert_raises(error) { perform(job) { raise error } } }
+
+      assert_equal 1, span.finishes
+    end
+  end
+
+  def test_a_failing_job_records_the_exception_and_an_error_status
+    boom = ArgumentError.new('boom')
+
+    with_otel { assert_raises(ArgumentError) { perform(job) { raise boom } } }
+
+    assert_equal [boom], span.exceptions
+    assert_equal 'Unhandled exception of type: ArgumentError', span.status.description
+  end
+
+  def test_a_failing_job_finishes_its_span
+    with_otel { assert_raises(ArgumentError) { perform(job) { raise ArgumentError } } }
+
+    assert_equal 1, span.finishes
+  end
+
+  def test_a_failing_job_re_raises_untouched
+    with_otel do
+      raised = assert_raises(ArgumentError) { perform(job) { raise ArgumentError, 'boom' } }
+
+      assert_equal 'boom', raised.message
+    end
+  end
+
+  # `Wurk::Shutdown` is an Interrupt, not a StandardError: a job killed by a
+  # hard shutdown did not complete, and that is the signal an operator tuning
+  # `shutdown_timeout` is looking for.
+  def test_a_hard_shutdown_is_recorded_as_an_error
+    with_otel { assert_raises(Wurk::Shutdown) { perform(job) { raise Wurk::Shutdown } } }
+
+    assert_equal 'Unhandled exception of type: Wurk::Shutdown', span.status.description
+    assert_equal 1, span.finishes
+  end
+
+  # --- registration --------------------------------------------------------
+
+  def test_opting_in_registers_one_position_inside_the_interrupt_handler
+    with_otel do
+      config = booted_config
+      config.telemetry = true
+
+      assert_equal [Wurk::Middleware::InterruptHandler, Wurk::Telemetry::ServerMiddleware, Wurk::Metrics::History],
+                   config.server_middleware.entries.map(&:klass)
+    end
+  end
+
+  # A chain with no interrupt handler to stay inside of — a client-only capsule,
+  # a hand-built chain — takes the head. `insert_after`'s own miss behaviour is
+  # the tail, which is the innermost position and the opposite of the intent.
+  def test_opting_in_takes_the_head_when_there_is_no_interrupt_handler
+    with_otel do
+      config = silent_config
+      config.server_middleware.add(Wurk::Metrics::History)
+      config.telemetry = true
+
+      assert_equal [Wurk::Telemetry::ServerMiddleware, Wurk::Metrics::History],
+                   config.server_middleware.entries.map(&:klass)
+    end
+  end
+
+  def test_opting_back_out_unregisters_the_server_middleware
+    with_otel do
+      config = booted_config
+      config.telemetry = true
+      config.telemetry = false
+
+      refute config.server_middleware.exists?(Wurk::Telemetry::ServerMiddleware)
+    end
+  end
+
+  def test_nothing_registers_without_the_gem
+    config = booted_config
+    config.telemetry = true
+
+    refute config.server_middleware.exists?(Wurk::Telemetry::ServerMiddleware)
+  end
+
+  def test_nothing_registers_without_the_opt_in
+    with_otel do
+      config = booted_config
+      Wurk::Telemetry.install!(config)
+
+      refute config.server_middleware.exists?(Wurk::Telemetry::ServerMiddleware)
+    end
+  end
+
+  def test_opting_in_twice_registers_one_entry
+    with_otel do
+      config = booted_config
+      2.times { config.telemetry = true }
+
+      assert_equal 1, config.server_middleware.entries.map(&:klass).count(Wurk::Telemetry::ServerMiddleware)
+    end
+  end
+
+  private
+
+  # --- fixtures ------------------------------------------------------------
+
+  def job(overrides = {})
+    { 'class' => @class_name, 'args' => [1, 'two'], 'queue' => @queue,
+      'jid' => JID, 'created_at' => millis_ago(0) }.merge(overrides)
+  end
+
+  def traced_job(overrides = {})
+    job({ 'traceparent' => "00-#{TRACE_ID}-#{SPAN_ID}-01" }.merge(overrides))
+  end
+
+  def millis_ago(seconds)
+    ((Process.clock_gettime(Process::CLOCK_REALTIME) - seconds) * 1000).to_i
+  end
+
+  # Through a real Chain so entry construction and config binding are exercised
+  # the way the Processor exercises them.
+  def perform(job, &block)
+    block ||= -> { :ok }
+    chain = Wurk::Middleware::Chain.new(Wurk.configuration)
+    chain.add(Wurk::Telemetry::ServerMiddleware)
+    chain.invoke(nil, job, @queue, &block)
+  end
+
+  def silent_config
+    Wurk::Configuration.new.tap { |c| c.logger = ::Logger.new(IO::NULL) }
+  end
+
+  # A config shaped like a booted process: InterruptHandler at the head (it
+  # prepends itself when wurk.rb loads) with a built-in behind it.
+  def booted_config
+    silent_config.tap do |c|
+      c.server_middleware.prepend(Wurk::Middleware::InterruptHandler)
+      c.server_middleware.add(Wurk::Metrics::History)
+    end
+  end
+
+  # --- span accessors ------------------------------------------------------
+
+  def tracer = FakeOtel.tracer_provider.tracer('wurk', Wurk::VERSION)
+  def span   = tracer.spans.fetch(0)
+
+  def parent_context = FakeOtel::Trace.current_span(span.parent).context
+
+  def link_target(span)
+    context = span.links.fetch(0).span_context
+    [context.trace_id, context.span_id]
+  end
+
+  # --- the opentelemetry-api stand-in --------------------------------------
+
+  def with_otel
+    FakeOtel.tracer_provider = FakeTracerProvider.new
+    FakeOtel.propagation     = FakePropagator.new
+    FakeOtel::Trace.current  = nil
+    Object.const_set(:OpenTelemetry, FakeOtel)
+    yield
+  ensure
+    Object.send(:remove_const, :OpenTelemetry)
+  end
+
+  module FakeOtel
+    class << self
+      attr_accessor :tracer_provider, :propagation
+    end
+
+    module Trace
+      SpanContext = Struct.new(:trace_id, :span_id) do
+        def valid? = !(trace_id.nil? || span_id.nil?)
+      end
+
+      INVALID_CONTEXT = SpanContext.new(nil, nil).freeze
+
+      Link = Struct.new(:span_context)
+
+      module Status
+        Error = Struct.new(:description)
+
+        def self.error(description) = Error.new(description)
+      end
+
+      class Span
+        attr_reader :name, :attributes, :kind, :links, :parent, :context, :exceptions, :finishes
+        attr_accessor :status
+
+        def initialize(name: nil, attributes: nil, kind: nil, links: nil, parent: nil, context: INVALID_CONTEXT)
+          @name = name
+          @attributes = attributes
+          @kind = kind
+          @links = links
+          @parent = parent
+          @context = context
+          @status = nil
+          @exceptions = []
+          @finishes = 0
+        end
+
+        def record_exception(exception) = @exceptions << exception
+        def finish = @finishes += 1
+      end
+
+      INVALID = Span.new.freeze
+
+      # A Context is opaque to the middleware; all it ever does is hand one back
+      # to `current_span`. Modelling it as "the span the propagator extracted"
+      # is the whole of the surface under test.
+      Context = Struct.new(:span)
+
+      class << self
+        attr_accessor :current
+
+        def current_span(context = nil)
+          context.respond_to?(:span) && context.span ? context.span : INVALID
+        end
+
+        # Returns the block's value and restores the previously-active span,
+        # like Context.with_value's attach/detach pair.
+        def with_span(span)
+          previous = @current
+          @current = span
+          yield span
+        ensure
+          @current = previous
+        end
+      end
+    end
+  end
+
+  # TraceContext::TextMapPropagator#extract: a context holding the remote span
+  # when the header parses, and one holding nothing when it does not — which is
+  # what makes an absent or malformed `traceparent` resolve to Span::INVALID.
+  class FakePropagator
+    FORMAT = /\A00-(?<trace_id>\h{32})-(?<span_id>\h{16})-\h{2}\z/
+
+    def extract(carrier)
+      match = FORMAT.match(carrier['traceparent'].to_s)
+      return FakeOtel::Trace::Context.new(nil) unless match
+
+      context = FakeOtel::Trace::SpanContext.new(match[:trace_id], match[:span_id])
+      FakeOtel::Trace::Context.new(FakeOtel::Trace::Span.new(context: context))
+    end
+  end
+
+  class ExplodingPropagator
+    class Boom < StandardError; end
+
+    def extract(_carrier) = raise(Boom)
+  end
+
+  class FakeTracer
+    attr_reader :name, :version, :spans
+
+    def initialize(name, version)
+      @name    = name
+      @version = version
+      @spans   = []
+    end
+
+    def start_span(name, with_parent: nil, attributes: nil, links: nil, kind: nil)
+      record(name, attributes, links, kind, with_parent)
+    end
+
+    # The SDK's start_root_span is start_span with an empty parent context —
+    # `:root` here so a test can tell "detached" from "parented" at a glance.
+    def start_root_span(name, attributes: nil, links: nil, kind: nil)
+      record(name, attributes, links, kind, :root)
+    end
+
+    private
+
+    def record(name, attributes, links, kind, parent)
+      span = FakeOtel::Trace::Span.new(
+        name: name, attributes: attributes, links: links, kind: kind, parent: parent,
+        context: FakeOtel::Trace::SpanContext.new('0' * 32, format('%016x', @spans.size + 1))
+      )
+      @spans << span
+      span
+    end
+  end
+
+  # Memoizes per (name, version) like OpenTelemetry::SDK::Trace::TracerProvider.
+  class FakeTracerProvider
+    def initialize = @tracers = {}
+
+    def tracer(name, version) = @tracers[[name, version]] ||= FakeTracer.new(name, version)
+  end
+end

--- a/test/unit/telemetry_test.rb
+++ b/test/unit/telemetry_test.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'wurk/telemetry'
+require 'tmpdir'
+
+# The optional-dependency guard around opentelemetry-api.
+#
+# Every availability case runs in a subprocess against a fixture `opentelemetry-api.rb`
+# on the load path, never against whatever the ambient bundle happens to hold:
+# the require is a one-way, process-global side effect, and pinning both answers
+# to fixtures keeps the suite honest whether or not a later slice adds the real
+# gem to the Gemfile. The "absent" fixture *raises* LoadError rather than being
+# missing, so it shadows a real gem too.
+class TelemetryTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  LIB = File.expand_path('../../lib', __dir__)
+
+  FIXTURES = {
+    # Nothing installed: exactly what `require` does when the gem is absent.
+    absent: "raise LoadError, 'cannot load such file -- opentelemetry-api'",
+    # The whole surface Wurk::Telemetry::REQUIRED_API asks for.
+    present: 'module OpenTelemetry; def self.propagation; end; def self.tracer_provider; end; end',
+    # A constant that is not the OTel API — a host-owned OpenTelemetry, or a
+    # pre-0.17 release of the gem.
+    partial: 'module OpenTelemetry; def self.propagation; end; end'
+  }.freeze
+
+  # @param fixture [Symbol] key of FIXTURES to shadow `opentelemetry-api` with
+  # @param code [String] runs after `entry` is required; print assertions
+  # @param entry [String] what the subprocess requires
+  def ruby(fixture, code, entry: 'wurk/telemetry')
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, 'opentelemetry-api.rb'), FIXTURES.fetch(fixture))
+      # unshift here rather than via -I: bundler/setup lands from the inherited
+      # RUBYOPT and rewrites $LOAD_PATH, so ordering is only guaranteed for a
+      # path pushed from the script body.
+      script = "$LOAD_PATH.unshift(#{dir.inspect}); require '#{entry}'; #{code}"
+      IO.popen([RbConfig.ruby, '-I', LIB, '-e', script], err: %i[child out], &:read)
+    end
+  end
+
+  # Code that makes the subprocess print `key=<expr>`. The `#{}` is escaped so
+  # it interpolates over there, against the fixture, rather than here.
+  def probe(key, expr)
+    "print \"#{key}=\#{#{expr}}\""
+  end
+
+  def available(fixture)
+    ruby(fixture, probe('AVAILABLE', 'Wurk::Telemetry.available?'))
+  end
+
+  def enabled(fixture, opt_in)
+    ruby(fixture, "Wurk.configuration.telemetry = #{opt_in}; #{probe('ENABLED', 'Wurk::Telemetry.enabled?')}")
+  end
+
+  def otel_loaded
+    probe('LOADED', '$LOADED_FEATURES.grep(/opentelemetry-api/).any?')
+  end
+
+  # --- available? --------------------------------------------------------
+
+  def test_missing_gem_does_not_raise_on_require
+    assert_includes available(:absent), 'AVAILABLE=', 'require "wurk/telemetry" blew up without opentelemetry-api'
+  end
+
+  def test_not_available_without_the_gem
+    assert_includes available(:absent), 'AVAILABLE=false'
+  end
+
+  def test_available_with_the_gem
+    assert_includes available(:present), 'AVAILABLE=true'
+  end
+
+  def test_not_available_when_the_constant_lacks_the_required_api
+    assert_includes available(:partial), 'AVAILABLE=false'
+  end
+
+  # --- enabled? — both halves of the gate --------------------------------
+
+  def test_not_enabled_without_the_gem_even_when_opted_in
+    assert_includes enabled(:absent, true), 'ENABLED=false'
+  end
+
+  def test_not_enabled_with_the_gem_when_not_opted_in
+    assert_includes enabled(:present, false), 'ENABLED=false'
+  end
+
+  def test_enabled_with_the_gem_and_the_opt_in
+    assert_includes enabled(:present, true), 'ENABLED=true'
+  end
+
+  def test_opting_in_without_the_gem_warns_instead_of_silently_no_opping
+    out = enabled(:absent, true)
+
+    assert_includes out, 'opentelemetry-api is not installed'
+  end
+
+  def test_opting_in_with_the_gem_does_not_warn
+    refute_includes enabled(:present, true), 'opentelemetry-api is not installed'
+  end
+
+  # --- the additive invariant -------------------------------------------
+
+  # `require "wurk"` must not drag opentelemetry-api into an app that never
+  # asked for tracing — not even one that has the gem installed.
+  def test_requiring_wurk_does_not_load_the_otel_api
+    assert_includes ruby(:present, otel_loaded), 'LOADED=true',
+                    'fixture is unreachable; the assertion below would pass vacuously'
+    assert_includes ruby(:present, otel_loaded, entry: 'wurk'), 'LOADED=false'
+  end
+
+  # The opt-in is what pulls the API in — so an app that traces still gets it
+  # without requiring wurk/telemetry by hand.
+  def test_opting_in_loads_the_otel_api
+    out = ruby(:present, "Wurk.configuration.telemetry = true; #{otel_loaded}", entry: 'wurk')
+
+    assert_includes out, 'LOADED=true'
+  end
+
+  def test_no_sidekiq_telemetry_alias
+    refute Sidekiq.const_defined?(:Telemetry, false),
+           'upstream Sidekiq has no Telemetry constant; aliasing invents a surface instead of mirroring one'
+  end
+
+  # --- the same predicate, in this process -------------------------------
+  #
+  # The subprocess cases above are the real proof: only they exercise the
+  # load-time require. These re-run the predicate here so its branches are
+  # attributable to lib/wurk/telemetry.rb in the coverage report, which cannot
+  # follow an exec'd child.
+
+  # Safe despite `parallelize_me!`: that is a stub in test/test_helper.rb —
+  # minitest-parallel_fork splits by process, and tests inside a worker run
+  # sequentially — so no other class can observe the constant mid-flight.
+  def with_otel(*methods)
+    api = Module.new
+    methods.each { |m| api.define_singleton_method(m) { nil } }
+    Object.const_set(:OpenTelemetry, api)
+    yield
+  ensure
+    Object.send(:remove_const, :OpenTelemetry)
+  end
+
+  def silent_config
+    Wurk::Configuration.new.tap { |c| c.logger = ::Logger.new(IO::NULL) }
+  end
+
+  def test_available_in_process_with_the_full_api
+    with_otel(*Wurk::Telemetry::REQUIRED_API) { assert_predicate Wurk::Telemetry, :available? }
+  end
+
+  def test_not_available_in_process_with_a_partial_api
+    with_otel(:propagation) { refute_predicate Wurk::Telemetry, :available? }
+  end
+
+  def test_enabled_in_process_needs_both_halves
+    config = silent_config
+
+    with_otel(*Wurk::Telemetry::REQUIRED_API) do
+      refute Wurk::Telemetry.enabled?(config), 'gem present, host silent'
+      config.telemetry = true
+
+      assert Wurk::Telemetry.enabled?(config)
+    end
+  end
+
+  def test_not_enabled_in_process_without_the_api
+    config = silent_config
+    config.telemetry = true
+
+    refute Wurk::Telemetry.enabled?(config)
+  end
+
+  def test_enabled_defaults_to_the_process_configuration
+    with_otel(*Wurk::Telemetry::REQUIRED_API) do
+      refute_predicate Wurk::Telemetry, :enabled?, 'Wurk.configuration does not opt in by default'
+    end
+  end
+end

--- a/test/unit/telemetry_test.rb
+++ b/test/unit/telemetry_test.rb
@@ -140,16 +140,20 @@ class TelemetryTest < Wurk::Test::UnitCase
   # attributable to lib/wurk/telemetry.rb in the coverage report, which cannot
   # follow an exec'd child.
 
-  # Safe despite `parallelize_me!`: that is a stub in test/test_helper.rb —
-  # minitest-parallel_fork splits by process, and tests inside a worker run
-  # sequentially — so no other class can observe the constant mid-flight.
+  # `::OpenTelemetry` is process-global and the three sibling telemetry classes
+  # define it too, so hold the mutex they hold. Scoped to this method rather
+  # than the whole class the way they do it: the subprocess cases above touch no
+  # shared state, and guarding `run` would serialize a dozen `IO.popen`s behind
+  # TelemetryForkTest's real swarms for nothing.
   def with_otel(*methods)
-    api = Module.new
-    methods.each { |m| api.define_singleton_method(m) { nil } }
-    Object.const_set(:OpenTelemetry, api)
-    yield
-  ensure
-    Object.send(:remove_const, :OpenTelemetry)
+    Wurk::Test::GLOBAL_STATE_MUTEX.synchronize do
+      api = Module.new
+      methods.each { |m| api.define_singleton_method(m) { nil } }
+      Object.const_set(:OpenTelemetry, api)
+      yield
+    ensure
+      Object.send(:remove_const, :OpenTelemetry)
+    end
   end
 
   def silent_config

--- a/test/unit/telemetry_test.rb
+++ b/test/unit/telemetry_test.rb
@@ -111,6 +111,15 @@ class TelemetryTest < Wurk::Test::UnitCase
     assert_includes ruby(:present, otel_loaded, entry: 'wurk'), 'LOADED=false'
   end
 
+  # Explicitly turning tracing *off* still has to unregister the middlewares,
+  # but a host that never turned it on has nothing to undo — so the setter must
+  # reach install! without paying for the require it exists to avoid.
+  def test_opting_out_does_not_load_the_otel_api
+    out = ruby(:present, "Wurk.configuration.telemetry = false; #{otel_loaded}", entry: 'wurk')
+
+    assert_includes out, 'LOADED=false'
+  end
+
   # The opt-in is what pulls the API in — so an app that traces still gets it
   # without requiring wurk/telemetry by hand.
   def test_opting_in_loads_the_otel_api

--- a/wurk.gemspec
+++ b/wurk.gemspec
@@ -64,4 +64,10 @@ Gem::Specification.new do |spec|
   # orphan-guard test errors on LoadError). Declaring it keeps the kernel-level
   # path working there, exactly as base64/logger keep `require "wurk"` working.
   spec.add_dependency 'fiddle', '>= 1.0', '< 2'
+  # NOT declared, deliberately: opentelemetry-api. lib/wurk/telemetry.rb requires
+  # it inside a LoadError rescue and Wurk::Telemetry.available? reports the
+  # result, so tracing is inert without it and nothing here needs it to boot.
+  # Declaring it would install and load an observability API in every app that
+  # never traces, and buy nothing for the apps that do — those already resolve
+  # it transitively through their OTel SDK / exporter / instrumentation gems.
 end


### PR DESCRIPTION
## Summary
- Optional-dependency guard (`Wurk::Telemetry`): loads `opentelemetry-api` only when a host opts in (`config.telemetry = true`) and the gem is present — byte-identical payload/hot-path otherwise.
- Client middleware: injects a W3C `traceparent` (+ `tracestate` when present) as a producer span on push and every `push_bulk` item.
- Server middleware: linked consumer span on execute, correct error taxonomy (`Wurk::Job::Interrupted`/`JobRetry::Skip`/`Limiter::Rescheduled` are never span errors), parent-vs-link decided by a 60s producer-context-age window, retries reuse the original trace.
- Drop-in proof both directions: a traced Wurk job dispatches unmodified through a pinned, verbatim-fetched fragment of `Sidekiq::Processor#dispatch`/`JobLogger#prepare`; a stock-Sidekiq-shaped job with no `traceparent` runs cleanly here. Real-fork/real-Redis integration test proves the trace link survives the process boundary.
- Encryption interaction: `traceparent`/`tracestate` are metadata, never touched by the `args.last` encryption envelope.
- `docs/idea/parity-divergences.md` records the additive `traceparent`/`tracestate` top-level job-JSON keys per the PR 0 §2 sign-off.

## Test plan
- [x] `bin/rake test` — 3483 runs, 0 failures
- [x] `bin/rake test:parity` — 23 runs, 0 failures
- [x] `bin/rake test:ecosystem` — 182 runs, 0 failures
- [x] `bundle exec rubocop` — 413 files, no offenses
- [x] `COVERAGE=1 bin/rake test` — 97.15% line / 91.35% branch (≥90/90 gate)
- [x] `rake bench` (tracing off, the default) — enqueue 4.33k i/s, fetch+execute 3.63k i/s, bulk enqueue 78.7 i/s, swarm boot 105.8 i/s — no regression, nothing registers unless opted in
- [x] Mutation-tested the new proofs against production code (temporarily broke encryption's args-only scope and the server middleware's parent/link decision — both new tests failed as expected, then reverted)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788817239&installation_model_id=11168&pr_number=403&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F403&signature=7a661ce1b512889973146e5a036ccc324e1adb3bfcfc294676954f4ba2824a13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional OpenTelemetry tracing for job publishing and processing.
  * Propagates W3C trace context through individual and bulk jobs.
  * Records messaging details and links related enqueue and execution spans.
  * Handles retries, interruptions, errors, stale context, and missing trace data safely.
* **Compatibility**
  * Tracing-disabled configurations preserve existing job payloads.
  * Remains compatible with standard Sidekiq jobs and encrypted payloads.
* **Documentation**
  * Documented tracing behavior and compatibility considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->