### PR TITLE
feat: per-job timeout & deadline (slice 08)

### DIFF
--- a/docs/plans/2026/08/07/101-beyond-sidekiq/00-semantics-signoff.md
+++ b/docs/plans/2026/08/07/101-beyond-sidekiq/00-semantics-signoff.md
@@ -253,7 +253,7 @@ reputation.
 |---|---|---|
 | 05 OpenTelemetry | `traceparent`, optionally `tracestate` | only when tracing is opted in (`Telemetry.available?` **and** host opt-in) |
 | 06 Status | one opt-in marker key (exact name settled in 06 against the `sidekiq-status` ecosystem suite's existing key names — must not collide) | only for a worker class with `wurk_options track: true` |
-| 08 Timeout/deadline | `timeout`, `deadline` | only when set in `wurk_options` |
+| 08 Timeout/deadline | `timeout`, `deadline`, plus `deadline_at` — the absolute epoch-float `deadline` resolves to at push, exactly as Pro's `expires_in` resolves to `expiry` (`job_util.rb`) | only when set in `wurk_options` |
 
 **Required to hold, for every key any of the three slices add:**
 

--- a/docs/plans/2026/08/07/101-beyond-sidekiq/08-watchdog-measurement.md
+++ b/docs/plans/2026/08/07/101-beyond-sidekiq/08-watchdog-measurement.md
@@ -1,0 +1,75 @@
+# Measurement: one watchdog vs N timer threads (Slice 08)
+
+**Decision:** one `Wurk::Watchdog` per Capsule (so one per Manager), spawned by
+the first bounded job. Not stdlib `Timeout`, not a timer thread per job.
+**Date:** 2026-08-08 — settles step 1 of [`08-timeout-deadline.md`](08-timeout-deadline.md).
+
+## Correcting the premise
+
+The plan says stdlib `Timeout` "spawns a thread per call". That was true up to
+timeout 0.1.x (Ruby ≤ 3.0). Since timeout 0.2 / Ruby 3.1 it runs **one** shared
+monitor thread and pushes each call onto its request queue — measured here on
+Ruby 3.2.3 with the bundled timeout 0.6.1, one `Timeout stdlib thread` for any
+number of concurrent calls. So thread count is *not* what separates the options.
+
+What does:
+
+- **Containment.** `Timeout::Request#interrupt` calls `Thread#raise` under a
+  `@done` mutex and nothing else. A bound that wins the race against the block
+  returning is therefore delivered at whatever checkpoint the target thread
+  reaches next — in a Processor that is the ACK, or the next job's `perform`.
+  The gem's own documentation instructs every caller to wrap each call in a
+  `Thread.handle_interrupt(klass => :never)` / `:immediate` sandwich to avoid it.
+  `Watchdog#watch` writes that sandwich once, so every bounded job gets it, and
+  a fired raise is delivered while `#watch` is still on the stack.
+- **A bound that already passed.** `Timeout.timeout` raises `ArgumentError` on a
+  negative `sec`. An absolute `deadline` read off an old payload yields exactly
+  that, so every call site would need its own guard.
+
+## Numbers
+
+`bundle exec ruby` on Ruby 3.2.3 (timeout 0.6.1), trivial guarded block, warm.
+Per-call cost of arming and retracting a bound that never fires — the cost every
+bounded job pays:
+
+| Shape | N=200k | per call | vs watchdog | allocations/call |
+|---|---|---|---|---|
+| unbounded (baseline) | 0.016 s | 0.08 µs | — | 0 |
+| `Watchdog#watch` | 0.60 s | 3.0 µs | 1.0x | 7 |
+| `Timeout.timeout(sec, klass)` | 0.89 s | 4.5 µs | 1.5x | 7 |
+| `Timeout.timeout(sec)` (default class) | 1.13 s | 5.7 µs | 1.9x | 7 |
+
+The shape the plan asked to price against — one timer thread per bounded job,
+killed and joined on completion — at N=20k:
+
+| Shape | per call | vs watchdog |
+|---|---|---|
+| `Watchdog#watch` | 2.8 µs | 1.0x |
+| `Timeout.timeout(sec, klass)` | 4.0 µs | 1.4x |
+| `Thread.new { sleep sec; target.raise }` per job | 27.4 µs | 9.6x |
+
+Idle cost of the scanner with nothing armed, `SCAN_INTERVAL = 0.5`:
+**0.0011 s CPU over 3 s wall = 0.036%** of one core. That is the price of the
+coarse-scan design, and it buys back the signal-per-arm a
+wake-at-nearest-deadline loop would need. Overshoot is bounded by the interval:
+a bound fires in `[deadline, deadline + 0.5s)`.
+
+And unconfigured — no job declaring `timeout:`/`deadline:` — the cost is zero by
+construction, not by measurement: `Capsule#prepare!` allocates the object, the
+first `#watch` spawns the thread, and nothing calls `#watch`. Pinned by
+`WatchdogTest#test_construction_spawns_no_thread`.
+
+## Harness
+
+Not committed as a bench script: it prices an alternative we are not shipping,
+and `rake bench` gates wurk against its own past self. Reproduce with
+
+```ruby
+# bundle exec ruby -Ilib
+wd = Wurk::Watchdog.new(Wurk::Capsule.new('m', Wurk::Configuration.new))
+Benchmark.bm { |b| b.report('watch') { N.times { wd.watch(60, Bound) { nil } } } }
+```
+
+plus the same loop over `Timeout.timeout(60, Bound)` and over a per-call
+`Thread.new { sleep 60; target.raise(Bound) }` that is killed and joined in an
+`ensure`.

--- a/lib/wurk.rb
+++ b/lib/wurk.rb
@@ -291,6 +291,14 @@ require_relative 'wurk/middleware/interrupt_handler'
 # Spec: docs/target/sidekiq-ent.md §1.4.
 Wurk.configuration.server_middleware.add(Wurk::Limiter::ServerMiddleware)
 
+# Per-attempt wall-clock bound — `sidekiq_options timeout: 30`, a Wurk extra
+# with no Sidekiq counterpart. Sits here for both of its neighbours: INSIDE
+# Limiter, so the watchdog's raise can never land between Limiter's reschedule
+# and the `Rescheduled` it raises after it (a job both rescheduled *and*
+# retried), and OUTSIDE the three middleware below, so a timeout unwinds
+# through Statsd, History and Status and is booked as the failure it is.
+require_relative 'wurk/middleware/timeout'
+
 # Statsd metrics middleware: per-job count / success / failure / perform_dist
 # emissions. No-op when `config.dogstatsd` is unset (Statsd.client returns
 # nil and the middleware yields straight through), so auto-registering here

--- a/lib/wurk/capsule.rb
+++ b/lib/wurk/capsule.rb
@@ -4,6 +4,7 @@ require_relative 'redis_pool'
 require_relative 'pool_checkout'
 require_relative 'middleware/chain'
 require_relative 'fetcher/reliable'
+require_relative 'watchdog'
 
 module Wurk
   # One processing unit: a set of threads + queues sharing a fetcher and a
@@ -14,7 +15,7 @@ module Wurk
   class Capsule
     MODES = %i[strict weighted random].freeze
 
-    attr_reader :name, :queues, :mode, :weights, :config
+    attr_reader :name, :queues, :mode, :weights, :config, :watchdog
     attr_accessor :concurrency, :fetcher
 
     # Capsule-hosted components (Manager, Processor, Fetcher) hand their capsule
@@ -41,6 +42,7 @@ module Wurk
       @pools = {}
       @client_chain = nil
       @server_chain = nil
+      @watchdog = nil
     end
 
     def to_h
@@ -78,6 +80,11 @@ module Wurk
     def prepare!
       prepare_shared!
       @fetcher ||= build_fetcher
+      # Here rather than in the constructor so a client-only process — a web
+      # dyno building the same Configuration — allocates nothing, and so the
+      # scanner thread a bounded job spawns belongs to the child that runs it.
+      # The object itself holds no thread until something is bounded.
+      @watchdog ||= Watchdog.new(self)
       redis_pool
       fetch_redis_pool
       self

--- a/lib/wurk/job.rb
+++ b/lib/wurk/job.rb
@@ -32,6 +32,14 @@ module Wurk
     # breaking every `Timeout.timeout(...)` written inside a `perform`.
     class TimedOut < RuntimeError; end
 
+    # Raised into the thread running `perform` by {Wurk::Watchdog} once the job
+    # outlives `sidekiq_options deadline:` — the cutoff measured from enqueue,
+    # not from this attempt. Unlike {TimedOut} it is not a failure to retry:
+    # {Wurk::Middleware::Expiry} catches it and books the job `expired`, the
+    # same terminal state as one whose deadline had already passed before it
+    # started. A job may still rescue it to clean up after itself.
+    class DeadlineExceeded < RuntimeError; end
+
     # Per-call option carrier returned by `set(...)`. Sidekiq 7+ documents it
     # under the modern mixin name `Sidekiq::Job::Setter`; since
     # `Sidekiq::Job = Wurk::Job`, this rebind is what makes that constant

--- a/lib/wurk/job.rb
+++ b/lib/wurk/job.rb
@@ -21,6 +21,17 @@ module Wurk
     # Spec: docs/target/sidekiq-free.md §6.4.
     class Interrupted < RuntimeError; end
 
+    # Raised into the thread running `perform` by {Wurk::Watchdog} once the
+    # attempt outlives `sidekiq_options timeout:`. An ordinary error on purpose:
+    # the job may rescue it to clean up, and the retry layer books it exactly
+    # like any other failure. See {Wurk::Middleware::Timeout}.
+    #
+    # `TimedOut`, not `Timeout`, and the name is load-bearing: `include
+    # Sidekiq::Job` puts this module into the worker's ancestry, and a constant
+    # named `Timeout` here would resolve ahead of the top-level one — silently
+    # breaking every `Timeout.timeout(...)` written inside a `perform`.
+    class TimedOut < RuntimeError; end
+
     # Per-call option carrier returned by `set(...)`. Sidekiq 7+ documents it
     # under the modern mixin name `Sidekiq::Job::Setter`; since
     # `Sidekiq::Job = Wurk::Job`, this rebind is what makes that constant

--- a/lib/wurk/job/options.rb
+++ b/lib/wurk/job/options.rb
@@ -26,6 +26,7 @@ module Wurk
         def sidekiq_options(opts = {})
           stringified = opts.transform_keys(&:to_s)
           Wurk::JobUtil.validate_track!(stringified['track'], stringified) if stringified.key?('track')
+          Wurk::JobUtil.validate_bounds!(stringified)
           @sidekiq_options_hash = get_sidekiq_options.merge(stringified)
         end
 

--- a/lib/wurk/job_util.rb
+++ b/lib/wurk/job_util.rb
@@ -40,6 +40,39 @@ module Wurk
       raise(ArgumentError, "Job 'track' must be true or false: `#{subject}`")
     end
 
+    # The two wall-clock bounds, both in seconds: `timeout` bounds one attempt,
+    # `deadline` bounds the job from enqueue onward. Checked here rather than
+    # where they are read, for the same reason `track` is — the reader is
+    # {Wurk::Middleware::Timeout}, on a server one deploy away from whoever
+    # wrote `deadline: '5 minutes'`, and its answer to a bound it cannot use is
+    # to run the job unbounded, because the payload may predate the option or
+    # come from stock Sidekiq. Silence is right there and useless here, so both
+    # doors a Wurk-written bound comes through — a class-level `sidekiq_options`
+    # (worker or ActiveJob) and a payload push — call this instead.
+    BOUND_OPTIONS = %w[timeout deadline].freeze
+
+    # @raise [ArgumentError] unless every bound present is a positive, finite
+    #   number of seconds.
+    def self.validate_bounds!(item)
+      BOUND_OPTIONS.each do |name|
+        value = item[name]
+        next if value.nil? || positive_seconds?(value)
+
+        raise(ArgumentError, "Job '#{name}' must be a positive number of seconds: `#{item}`")
+      end
+    end
+
+    # The one definition of a bound Wurk can act on, shared by the check above
+    # and by the middleware that arms it, so "valid where it was declared" and
+    # "usable where it is read" cannot drift apart. ActiveSupport durations
+    # pass: `5.minutes.is_a?(Numeric)` is true by that class's own design.
+    def self.positive_seconds?(value)
+      return false unless value.is_a?(::Numeric)
+
+      seconds = value.to_f
+      seconds.finite? && seconds.positive?
+    end
+
     # @raise [ArgumentError] if the payload is structurally invalid.
     def validate(item)
       raise(ArgumentError, "Job must be a Hash with 'class' and 'args' keys: `#{item}`") unless valid_shape?(item)
@@ -85,6 +118,7 @@ module Wurk
       raise(ArgumentError, "Job tags must be an Array: `#{item}`") unless valid_tags?(item)
 
       JobUtil.validate_track!(item['track'], item)
+      JobUtil.validate_bounds!(item)
       return if valid_retry_for?(item)
 
       raise(ArgumentError, "Job retry_for over #{RETRY_FOR_MAX} is unreasonable: `#{item}`")
@@ -140,22 +174,47 @@ module Wurk
       normalized['retry_for'] = numeric_retry_for(normalized['retry_for']) if normalized.key?('retry_for')
       normalized['created_at'] ||= now_in_millis
       stamp_expiry(normalized)
+      stamp_deadline(normalized)
       normalized
     end
 
     # Pro `expires_in:` → absolute epoch-float `expiry` resolved once at push,
     # so the server middleware doesn't redo the math. Spec: sidekiq-pro.md §7.
-    # For scheduled jobs the clock origin is `at` (epoch seconds), not
-    # `created_at` (epoch millis) — otherwise any delay > expires_in makes the
-    # job born-expired: perform_in(2h) + expires_in: 1h must expire at 3h.
     # nil.respond_to?(:to_f) is true on modern Ruby (returns 0.0), so we must
     # gate on a non-nil duration before coercing.
     def stamp_expiry(item)
       d = item['expires_in']
       return if d.nil? || !d.respond_to?(:to_f)
 
-      origin = item['at'] ? item['at'].to_f : (item['created_at'].to_f / 1000.0)
-      item['expiry'] ||= origin + d.to_f
+      item['expiry'] ||= clock_origin(item) + d.to_f
+    end
+
+    # `deadline:` → absolute epoch-float `deadline_at`, the same conversion
+    # #stamp_expiry does and, here, the thing that makes the option mean what it
+    # says. A deadline is absolute: retries can't outlive it, and neither can an
+    # IterableJob resuming after a cooperative interrupt. Both re-push this hash
+    # and the stamp rides along on it, so every later attempt measures against
+    # the first push's cutoff instead of restarting the clock — which is exactly
+    # what a per-attempt `timeout` does instead, and why they are two options.
+    # `||=` protects the same property against a caller that re-normalizes.
+    #
+    # An unusable value is left unstamped rather than raised on: both doors that
+    # can write one already refused it (.validate_bounds!), so what reaches here
+    # is a class default set some other way, and Middleware::Timeout's answer to
+    # a bound it can't use — run the job unbounded — is the one to agree with.
+    def stamp_deadline(item)
+      d = item['deadline']
+      return unless JobUtil.positive_seconds?(d)
+
+      item['deadline_at'] ||= clock_origin(item) + d.to_f
+    end
+
+    # For scheduled jobs the clock origin is `at` (epoch seconds), not
+    # `created_at` (epoch millis) — otherwise any delay longer than the duration
+    # makes the job born-expired: perform_in(2h) + expires_in: 1h must expire at
+    # 3h, and the same holds for a deadline.
+    def clock_origin(item)
+      item['at'] ? item['at'].to_f : (item['created_at'].to_f / 1000.0)
     end
 
     def report_unsafe(item, offender, mode)

--- a/lib/wurk/manager.rb
+++ b/lib/wurk/manager.rb
@@ -84,6 +84,11 @@ module Wurk
 
       hard_shutdown
     ensure
+      # After the drain, not in #quiet: a quieted capsule still has in-flight
+      # jobs, and a bound shorter than the drain budget has to fire before
+      # shutdown wins. Ahead of capsule.stop so no scan can raise into a thread
+      # once the capsule has released what that thread was holding.
+      capsule.watchdog&.terminate
       capsule.stop
     end
 

--- a/lib/wurk/metrics/history.rb
+++ b/lib/wurk/metrics/history.rb
@@ -71,17 +71,25 @@ module Wurk
           result = yield
           success = true
           result
-        rescue Wurk::Job::Interrupted
-          # A cooperative interruption is not a failure. InterruptHandler
-          # self-prepends, so it sits *outside* this middleware: Interrupted
-          # passes through here before it becomes a JobRetry::Skip, and
-          # without this arm one interrupted IterableJob books a spurious
-          # `<klass>|f` (#394). Upstream's ExecutionTracker#track books `p`
-          # + `ms` for that Skip and reserves `f` for a real exception; `p`
-          # is the bucket for "reached perform and didn't error", so the
-          # resumed run booking a second `p` is the oracle's behavior, not a
-          # rounding error. Signed off in
+        rescue Wurk::Job::Interrupted, Wurk::Job::DeadlineExceeded
+          # Neither is the job failing. A cooperative interruption is not a
+          # failure: InterruptHandler self-prepends, so it sits *outside* this
+          # middleware, Interrupted passes through here before it becomes a
+          # JobRetry::Skip, and without this arm one interrupted IterableJob
+          # books a spurious `<klass>|f` (#394). Upstream's
+          # ExecutionTracker#track books `p` + `ms` for that Skip and reserves
+          # `f` for a real exception; `p` is the bucket for "reached perform and
+          # didn't error", so the resumed run booking a second `p` is the
+          # oracle's behavior, not a rounding error. Signed off in
           # docs/plans/2026/08/07/101-beyond-sidekiq/00-semantics-signoff.md §1.
+          #
+          # A job cut by its absolute deadline lands in the same bucket for a
+          # plainer reason: Middleware::Expiry, also outside this one, catches
+          # that raise and books the job `expired`. Booking `f` here too would
+          # put one abandoned job in two of the three counts an operator
+          # subtracts (executed = processed - failed - expired), and would make
+          # it the only expired job that also reads as failed — the ones dropped
+          # before `perform` never reach this middleware at all.
           success = true
           raise
         ensure

--- a/lib/wurk/metrics/statsd.rb
+++ b/lib/wurk/metrics/statsd.rb
@@ -158,10 +158,12 @@ module Wurk
         begin
           yield
           success = true
-        rescue Wurk::Job::Interrupted
-          # Same arm, same reason as Metrics::History#call (#394): InterruptHandler
-          # self-prepends, so a cooperative interruption passes through here before
-          # it becomes a JobRetry::Skip, and without this it emits `jobs.failure`.
+        rescue Wurk::Job::Interrupted, Wurk::Job::DeadlineExceeded
+          # Same arm, same reasons as Metrics::History#call (#394): a cooperative
+          # interruption passes through here before InterruptHandler turns it
+          # into a JobRetry::Skip, and a job cut by its deadline passes through
+          # before Middleware::Expiry books it `expired` — both sit outside this
+          # middleware, and without this arm either one emits `jobs.failure`.
           # Pro's statsd emitter is closed source, so the oracle is the free
           # ExecutionTracker plus the rule that the two Wurk emitters must never
           # classify one event differently. Signed off in

--- a/lib/wurk/middleware/expiry.rb
+++ b/lib/wurk/middleware/expiry.rb
@@ -43,27 +43,58 @@ module Wurk
     class Expiry
       include Wurk::Middleware::ServerMiddleware
 
+      # The rescue is scoped to the guarded call rather than the method body:
+      # only a job that carries a cutoff can be cut by one, and a job that
+      # raises `DeadlineExceeded` from its own code without carrying one has to
+      # unwind to JobRetry like any other failure instead of being acked.
       def call(_job_instance, job, _queue)
         expiry = job['expiry']
         deadline = job['deadline_at']
         return yield unless expiry || deadline
 
-        return drop(job) if ::Time.now.to_f > cutoff(expiry, deadline)
+        at = cutoff(expiry, deadline)
+        return yield unless at
 
-        yield
-      rescue ::Wurk::Job::DeadlineExceeded
-        drop(job)
+        return drop(job) if ::Time.now.to_f > at
+
+        begin
+          yield
+        rescue ::Wurk::Job::DeadlineExceeded
+          drop(job)
+        end
       end
 
       private
 
-      # Whichever window closes first. Coerced rather than type-checked, so a
-      # payload that round-tripped a timestamp as a String still expires.
+      # Whichever window closes first, or nil when neither field carries a
+      # cutoff this can read.
+      #
+      # Coerced rather than type-checked — a payload that round-tripped a
+      # timestamp as a String still expires — but only where the coercion means
+      # something. `to_f` alone answered `'soon'` with 1970 and silently
+      # discarded the job, and answered `true` with NoMethodError out of the
+      # middleware chain. Neither is an answer: an unreadable cutoff leaves the
+      # job alone, which is what {Timeout} already does with a bound it cannot
+      # arm, and the two must not disagree about the same `deadline_at`.
+      #
+      # Deliberately not JobUtil.positive_seconds?: that validates a *duration*
+      # option where it is declared, and refuses `'300'` so a typo in
+      # `sidekiq_options deadline:` is reported to its author. These are
+      # absolute instants off the wire, where a numeric String is a value rather
+      # than a typo — and one at or before epoch is simply long past, the same
+      # reading Sidekiq Pro's bare `Time.now.to_f > job['expiry']` gives it.
+      #
+      # Reached only by a job that declared a window: the presence check in
+      # #call is what keeps the default job allocation-free through this frame.
       def cutoff(expiry, deadline)
-        return deadline.to_f unless expiry
-        return expiry.to_f unless deadline
+        [instant(expiry), instant(deadline)].compact.min
+      end
 
-        [expiry.to_f, deadline.to_f].min
+      # Finite or nothing: Infinity is a window that never closes and NaN
+      # compares false against everything, so both already meant "no cutoff".
+      def instant(value)
+        seconds = Float(value, exception: false)
+        seconds if seconds&.finite?
       end
 
       # nil, never a raise — the skip path above, and the reason nothing

--- a/lib/wurk/middleware/expiry.rb
+++ b/lib/wurk/middleware/expiry.rb
@@ -1,15 +1,27 @@
 # frozen_string_literal: true
 
+require_relative '../job'
 require_relative '../middleware'
 require_relative '../metrics/statsd'
 require_relative '../processor'
 
 module Wurk
   module Middleware
-    # Server middleware. Drops jobs whose `expiry` timestamp (stamped at push
-    # by the client from `sidekiq_options expires_in:`) has passed before
-    # `perform` gets a chance to start. Once `perform` is invoked, expiry no
-    # longer preempts — long-running jobs that started in time finish.
+    # Server middleware. Drops a job whose window has closed before `perform`
+    # gets a chance to start. Two options open such a window, both stamped onto
+    # the payload as an absolute epoch-float at push (JobUtil#finalize), and the
+    # earlier of the two is the one that counts:
+    #
+    #   * `expiry`, from Pro's `sidekiq_options expires_in:`. Once `perform` is
+    #     invoked it no longer preempts — a long-running job that started in
+    #     time finishes.
+    #   * `deadline_at`, from `sidekiq_options deadline:`. This one does preempt:
+    #     {Timeout} arms the watchdog with whatever is left of it, and the
+    #     {Wurk::Job::DeadlineExceeded} that lands in a job still running past
+    #     its cutoff unwinds to here, where it takes the same skip path. So a
+    #     deadline reaches the same terminal state whether it passed while the
+    #     job queued or while it ran — one state to reason about, one counter to
+    #     watch, and no retry either way.
     #
     # The skip path:
     #   * bumps Wurk::Processor::EXPIRED so the heartbeat flushes
@@ -33,15 +45,33 @@ module Wurk
 
       def call(_job_instance, job, _queue)
         expiry = job['expiry']
-        return yield unless expiry
+        deadline = job['deadline_at']
+        return yield unless expiry || deadline
 
-        if ::Time.now.to_f > expiry.to_f
-          Wurk::Processor::EXPIRED.incr
-          Wurk::Metrics::Statsd.increment('jobs.expired', tags: ["class:#{job['class']}"])
-          return
-        end
+        return drop(job) if ::Time.now.to_f > cutoff(expiry, deadline)
 
         yield
+      rescue ::Wurk::Job::DeadlineExceeded
+        drop(job)
+      end
+
+      private
+
+      # Whichever window closes first. Coerced rather than type-checked, so a
+      # payload that round-tripped a timestamp as a String still expires.
+      def cutoff(expiry, deadline)
+        return deadline.to_f unless expiry
+        return expiry.to_f unless deadline
+
+        [expiry.to_f, deadline.to_f].min
+      end
+
+      # nil, never a raise — the skip path above, and the reason nothing
+      # schedules another attempt at a job whose window has already closed.
+      def drop(job)
+        Wurk::Processor::EXPIRED.incr
+        Wurk::Metrics::Statsd.increment('jobs.expired', tags: ["class:#{job['class']}"])
+        nil
       end
     end
   end

--- a/lib/wurk/middleware/status.rb
+++ b/lib/wurk/middleware/status.rb
@@ -47,7 +47,13 @@ module Wurk
       # job in the process, tracked or not.
       #
       # Rescue taxonomy mirrors Batch::ServerMiddleware — a handled skip and a
-      # cooperative interruption are not failures. Caveat inherited from the
+      # cooperative interruption are not failures. A job cut by its absolute
+      # `deadline` deliberately is one here, where the two metric emitters count
+      # it as processed-and-expired instead: those feed an aggregate an operator
+      # subtracts (executed = processed - failed - expired), while this row
+      # answers "what happened to this job" — it did not finish, and
+      # `error_class`/`error_message` say why. `interrupted` would promise a
+      # resume that never comes. Caveat inherited from the
       # chain position it shares with Metrics::History: a `Limiter::OverLimit`
       # raised inside the job body unwinds through here *before* Limiter (outer)
       # converts it into a reschedule, so a rate-limited job books `failed` for

--- a/lib/wurk/middleware/timeout.rb
+++ b/lib/wurk/middleware/timeout.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require_relative '../middleware'
+require_relative '../job'
+
+module Wurk
+  module Middleware
+    # Puts `sidekiq_options timeout: <seconds>` of wall clock on one attempt.
+    # Past it the capsule's {Wurk::Watchdog} raises {Wurk::Job::TimedOut} into
+    # the thread running `perform`, and the job takes the ordinary failure path
+    # from there: booked as a failure, retried on the class's own policy, dead
+    # set once the retries run out. A class without `timeout:` — the default —
+    # costs one Hash lookup and a `yield`.
+    #
+    # Per attempt, not per job: every attempt re-arms its own bound, so a retry
+    # of a job that timed out gets the full budget again.
+    #
+    # Soft only. `Thread#kill` would cut the job between any two instructions,
+    # stranding whatever it was holding — a checked-out connection, a half
+    # written file, a lock nobody is left to release. That is the class of bug
+    # docs/plans/2026/07/31/101-leak-logic-perf-fixes/ closed, and the reason a
+    # hard kill belongs to the process supervisor rather than to a thread. What
+    # soft costs is that a `perform` which swallows StandardError swallows this
+    # too: the same bargain Celery's soft time limit and stdlib `Timeout` make.
+    #
+    # Chain position (lib/wurk.rb), both halves load-bearing:
+    #   * OUTSIDE Statsd / History / Status, so the raise unwinds *through* all
+    #     three and the timeout is measured and booked as the failure it is.
+    #   * INSIDE Batch, Expiry and Limiter. Limiter is the sharp one: its rescue
+    #     re-enqueues an over-limit job and only then raises `Rescheduled`, so a
+    #     bound reaching around it could fire between those two steps and leave
+    #     the job both rescheduled and retried. Ending the bound before that
+    #     frame puts the bookkeeping out of the watchdog's reach.
+    #
+    # Against `shutdown_timeout`: both bounds run and the shorter one wins. A
+    # `timeout` under the drain budget fires first and the job retries; over it,
+    # shutdown unwinds the job with `Wurk::Shutdown` instead and the payload is
+    # reclaimed from the private list on the next boot.
+    class Timeout
+      include Wurk::Middleware::ServerMiddleware
+
+      # The block is passed on rather than taken as `&block`: reifying it would
+      # allocate a Proc for every job in the process, bounded or not.
+      def call(_worker, job, _queue)
+        seconds = bound_for(job)
+        timer = seconds && watchdog
+        return yield unless timer
+
+        timer.watch(seconds, ::Wurk::Job::TimedOut, message_for(job, seconds)) { yield } # rubocop:disable Style/ExplicitBlockArgument
+      end
+
+      private
+
+      # A `timeout` written through Wurk is type-checked at declaration, where
+      # the author can be told about it. This is the other door: a payload from
+      # stock Sidekiq, a raw LPUSH, or a release older than the option never
+      # passed that check, and a bound we can't use on one of those has to leave
+      # the job unbounded rather than break it.
+      def bound_for(job)
+        seconds = job['timeout']
+        return unless seconds.is_a?(::Numeric) && seconds.positive? && seconds.finite?
+
+        seconds
+      end
+
+      # The watchdog belongs to the Capsule, which builds it in `prepare!`.
+      # Nothing else that invokes a server chain has one — a Configuration-bound
+      # chain, `Wurk::Testing.inline!`, a chain driven straight from a test — and
+      # those run the job unbounded: the bound is a safety net, and a harness
+      # that never built a capsule is not the place to fail a job over it.
+      def watchdog
+        config.watchdog if config.respond_to?(:watchdog)
+      end
+
+      # What an operator reads in the retry set, the dead set, and their error
+      # tracker, so it names both the class and the bound it broke.
+      def message_for(job, seconds)
+        "#{job['class']} timed out after #{seconds}s"
+      end
+    end
+  end
+end
+
+Wurk.configuration.server_middleware.add(Wurk::Middleware::Timeout)

--- a/lib/wurk/middleware/timeout.rb
+++ b/lib/wurk/middleware/timeout.rb
@@ -2,18 +2,31 @@
 
 require_relative '../middleware'
 require_relative '../job'
+require_relative '../job_util'
 
 module Wurk
   module Middleware
-    # Puts `sidekiq_options timeout: <seconds>` of wall clock on one attempt.
-    # Past it the capsule's {Wurk::Watchdog} raises {Wurk::Job::TimedOut} into
-    # the thread running `perform`, and the job takes the ordinary failure path
-    # from there: booked as a failure, retried on the class's own policy, dead
-    # set once the retries run out. A class without `timeout:` — the default —
-    # costs one Hash lookup and a `yield`.
+    # Arms the capsule's {Wurk::Watchdog} with whichever wall-clock bounds a job
+    # declared. A class that declares neither — the default — costs two Hash
+    # lookups and a `yield`.
     #
-    # Per attempt, not per job: every attempt re-arms its own bound, so a retry
-    # of a job that timed out gets the full budget again.
+    # `sidekiq_options timeout: <seconds>` bounds one attempt. Past it the
+    # watchdog raises {Wurk::Job::TimedOut} into the thread running `perform`,
+    # and the job takes the ordinary failure path from there: booked as a
+    # failure, retried on the class's own policy, dead set once the retries run
+    # out. Per attempt, not per job — every attempt re-arms its own bound, so a
+    # retry of a job that timed out gets the full budget again.
+    #
+    # `sidekiq_options deadline: <seconds>` bounds the job from enqueue onward.
+    # The client resolves it to an absolute `deadline_at` once, at push
+    # (JobUtil#stamp_deadline), and what this middleware arms is whatever is
+    # left of it — so retries and IterableJob resumes eat into one budget rather
+    # than each getting a fresh one. Past it the watchdog raises
+    # {Wurk::Job::DeadlineExceeded}, which is not a failure to retry:
+    # {Expiry} catches it one frame out and books the job `expired`, the same
+    # terminal state as one whose deadline had already passed before it started.
+    # That check, immediately before `perform`, is the other half of the bound —
+    # a job whose window closed while it queued never starts at all.
     #
     # Soft only. `Thread#kill` would cut the job between any two instructions,
     # stranding whatever it was holding — a checked-out connection, a half
@@ -25,12 +38,16 @@ module Wurk
     #
     # Chain position (lib/wurk.rb), both halves load-bearing:
     #   * OUTSIDE Statsd / History / Status, so the raise unwinds *through* all
-    #     three and the timeout is measured and booked as the failure it is.
+    #     three and the timeout is measured and booked as the failure it is. A
+    #     `DeadlineExceeded` crosses the same three, which is why the two metric
+    #     emitters name it: it is booked `expired`, and booking it failed as
+    #     well would count one abandoned job twice.
     #   * INSIDE Batch, Expiry and Limiter. Limiter is the sharp one: its rescue
     #     re-enqueues an over-limit job and only then raises `Rescheduled`, so a
     #     bound reaching around it could fire between those two steps and leave
     #     the job both rescheduled and retried. Ending the bound before that
-    #     frame puts the bookkeeping out of the watchdog's reach.
+    #     frame puts the bookkeeping out of the watchdog's reach. Expiry has to
+    #     be outside for a second reason: it is what catches the deadline raise.
     #
     # Against `shutdown_timeout`: both bounds run and the shorter one wins. A
     # `timeout` under the drain budget fires first and the job retries; over it,
@@ -42,25 +59,56 @@ module Wurk
       # The block is passed on rather than taken as `&block`: reifying it would
       # allocate a Proc for every job in the process, bounded or not.
       def call(_worker, job, _queue)
-        seconds = bound_for(job)
-        timer = seconds && watchdog
+        attempt = bound_for(job)
+        remaining = deadline_for(job)
+        timer = (attempt || remaining) && watchdog
         return yield unless timer
 
-        timer.watch(seconds, ::Wurk::Job::TimedOut, message_for(job, seconds)) { yield } # rubocop:disable Style/ExplicitBlockArgument
+        within_deadline(timer, job, remaining) do
+          within_attempt(timer, job, attempt) { yield } # rubocop:disable Style/ExplicitBlockArgument
+        end
       end
 
       private
 
-      # A `timeout` written through Wurk is type-checked at declaration, where
-      # the author can be told about it. This is the other door: a payload from
+      # Both bounds are armed, not just whichever lands first — a job that
+      # rescues its own `TimedOut` and carries on is still cut when the deadline
+      # comes, which is the whole promise of an absolute bound. Which of the two
+      # `watch` frames encloses the other is not load-bearing (each masks only
+      # its own exception class, so both stay deliverable inside the job either
+      # way); the absolute one is written outside to match the scopes they name.
+      def within_deadline(timer, job, remaining)
+        return yield unless remaining
+
+        timer.watch(remaining, ::Wurk::Job::DeadlineExceeded, deadline_message(job)) { yield } # rubocop:disable Style/ExplicitBlockArgument
+      end
+
+      def within_attempt(timer, job, seconds)
+        return yield unless seconds
+
+        timer.watch(seconds, ::Wurk::Job::TimedOut, timeout_message(job, seconds)) { yield } # rubocop:disable Style/ExplicitBlockArgument
+      end
+
+      # A bound written through Wurk is type-checked at declaration, where the
+      # author can be told about it. This is the other door: a payload from
       # stock Sidekiq, a raw LPUSH, or a release older than the option never
       # passed that check, and a bound we can't use on one of those has to leave
       # the job unbounded rather than break it.
       def bound_for(job)
         seconds = job['timeout']
-        return unless seconds.is_a?(::Numeric) && seconds.positive? && seconds.finite?
+        seconds if ::Wurk::JobUtil.positive_seconds?(seconds)
+      end
 
-        seconds
+      # What is left of the absolute cutoff, in seconds. Negative is not an
+      # error and is armed as it comes: {Expiry} turns away everything already
+      # past the cutoff one frame further out, so a bound that reaches here in
+      # the past is the sliver between that check and this one — and the
+      # Watchdog, unlike `Timeout.timeout`, accepts a bound that has passed.
+      def deadline_for(job)
+        at = job['deadline_at']
+        return unless ::Wurk::JobUtil.positive_seconds?(at)
+
+        at.to_f - ::Time.now.to_f
       end
 
       # The watchdog belongs to the Capsule, which builds it in `prepare!`.
@@ -72,10 +120,15 @@ module Wurk
         config.watchdog if config.respond_to?(:watchdog)
       end
 
-      # What an operator reads in the retry set, the dead set, and their error
-      # tracker, so it names both the class and the bound it broke.
-      def message_for(job, seconds)
+      # What an operator reads in the retry set, the dead set, a tracked job's
+      # status row, and their error tracker — so each names the class and the
+      # bound it broke.
+      def timeout_message(job, seconds)
         "#{job['class']} timed out after #{seconds}s"
+      end
+
+      def deadline_message(job)
+        "#{job['class']} exceeded its deadline"
       end
     end
   end

--- a/lib/wurk/watchdog.rb
+++ b/lib/wurk/watchdog.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require_relative 'component'
+require_relative 'timer_loop'
+
+module Wurk
+  # One timer thread per Capsule — so one per Manager — that cuts jobs which
+  # outlive a bound. `#watch` arms a bound around a block; once it passes, this
+  # thread raises the caller's exception into the thread that armed it. Soft by
+  # construction: an exception the job can rescue and the retry layer can book,
+  # never `Thread#kill`.
+  #
+  # Not stdlib `Timeout`, which since Ruby 3.1 also runs one shared monitor
+  # thread — that half of the folklore is out of date. What it still doesn't do
+  # is contain its own raise: `Timeout::Request#interrupt` calls `Thread#raise`
+  # with no interrupt mask, so a bound that wins the race against the block
+  # returning lands at whatever checkpoint the thread reaches next — inside a
+  # Processor, the ACK or the next job. Its own docs tell every caller to
+  # hand-roll the `handle_interrupt` sandwich that avoids this; `#watch` writes
+  # it once, for every bounded job. It is also ~1.5x cheaper per call
+  # (08-watchdog-measurement.md in the slice plan) and accepts a bound that has
+  # already passed, which `Timeout.timeout` rejects outright — an absolute
+  # deadline read off an old payload is exactly that.
+  #
+  # Nothing bounded, nothing running: the thread is spawned by the first
+  # `#watch`, so a process whose jobs declare no bound never has one. The
+  # Capsule holds this like it holds the fetcher; the Manager drives its
+  # lifecycle (Manager#stop, not #quiet — a quieted process still has in-flight
+  # jobs, and a bound shorter than the drain budget must still fire).
+  class Watchdog
+    include Component
+
+    # Scan cadence, and therefore the overshoot: a bound fires somewhere in
+    # [deadline, deadline + SCAN_INTERVAL). Job bounds are wall-clock seconds,
+    # so 500ms of slack is invisible; waking at the nearest deadline instead
+    # would buy precision nobody asked for and cost a signal on every arm.
+    SCAN_INTERVAL = 0.5
+
+    THREAD_NAME = 'watchdog'
+
+    Entry = Struct.new(:thread, :at_ms, :exception, :message)
+    private_constant :Entry
+
+    def initialize(capsule, interval: SCAN_INTERVAL)
+      @config = @capsule = capsule
+      @timer = TimerLoop.new(interval)
+      @lock = ::Mutex.new
+      # Keyed by a counter, not by Thread or by the Entry itself: one job can
+      # hold two bounds at once (a per-attempt `timeout` inside an absolute
+      # `deadline`), and Struct identity is value equality, so twin entries
+      # would collide.
+      @armed = {}
+      @seq = 0
+      @thread = nil
+    end
+
+    # Runs the block with `seconds` of wall-clock on it. Still on this thread's
+    # stack when that runs out → `exception` (a class, with an optional message)
+    # is raised into it. A bound that already passed is not special-cased; it
+    # fires on the next scan.
+    #
+    # The interrupt pair is the containment guarantee, and the whole reason this
+    # exists instead of `Timeout.timeout`. `:never` on the outer scope means a
+    # raise that wins the race against #disarm is delivered when that scope pops
+    # — inside this method — instead of at whatever checkpoint the thread
+    # reaches next, which by then can be the ACK, or the next job. `:immediate`
+    # on the inner scope is what lets a wedged job be interrupted at all;
+    # without it the outer mask would hold the raise until the block it is meant
+    # to cut short returned on its own.
+    def watch(seconds, exception, message = nil)
+      bound_id = arm(seconds, exception, message)
+      Thread.handle_interrupt(exception => :never) do
+        Thread.handle_interrupt(exception => :immediate) { yield } # rubocop:disable Style/ExplicitBlockArgument
+      ensure
+        disarm(bound_id)
+      end
+    end
+
+    # Idempotent, and a no-op when nothing was ever armed. Bounded join like
+    # every other periodic component: a scan blocked on a raise must not hold
+    # the process's shutdown open. The thread reference is deliberately kept on
+    # a join timeout — a wedged scan stays tracked, so a later #watch returns it
+    # rather than spawning a second one alongside it.
+    def terminate
+      @timer.terminate
+      @lock.synchronize { @thread }&.join(TimerLoop::JOIN_TIMEOUT)
+    end
+
+    # The two assertable halves of "zero cost when unconfigured, nothing leaked
+    # when used": no bound was ever armed → no thread; every armed bound is
+    # retracted on every exit path → nothing accumulates.
+    def running?
+      thread = @lock.synchronize { @thread }
+      !thread.nil? && thread.alive?
+    end
+
+    def size
+      @lock.synchronize { @armed.size }
+    end
+
+    # Capsule doesn't define handle_exception (it's a Configuration method);
+    # override Component's delegation so error handlers fire.
+    def handle_exception(ex, ctx = {})
+      @capsule.config.handle_exception(ex, ctx)
+    end
+
+    private
+
+    def arm(seconds, exception, message)
+      entry = Entry.new(Thread.current, mono_ms + (seconds * 1000).round, exception, message)
+      @lock.synchronize do
+        bound_id = (@seq += 1)
+        @armed[bound_id] = entry
+        spawn_scanner
+        bound_id
+      end
+    end
+
+    def disarm(bound_id)
+      @lock.synchronize { @armed.delete(bound_id) }
+    end
+
+    # Under @lock so two jobs arming at once can't spawn two scanners, and so a
+    # thread that died of an unhandled error (safe_thread reports and re-raises)
+    # is replaced by the next #watch instead of leaving the capsule unguarded.
+    # TimerLoop#reset clears a previous #terminate: an embedded host that boots
+    # again reuses this object, and the fresh thread would otherwise see the
+    # stale done flag and exit at once.
+    def spawn_scanner
+      return if @thread&.alive?
+
+      @timer.reset
+      @thread = safe_thread(THREAD_NAME) { @timer.run { tick } }
+    end
+
+    def tick
+      due.each { |entry| interrupt(entry) }
+    end
+
+    # Entries are removed here, before the raise: a fired bound can't fire
+    # twice, and #disarm has nothing left to do if the exception lands on it.
+    # That removal is also what retracts a stranded bound — one armed by a
+    # thread that then died, so no #disarm will ever reach it. No liveness check
+    # guards the raise itself: `Thread#raise` into a dead thread is a documented
+    # no-op, and it doesn't even build the exception first.
+    def due
+      now = mono_ms
+      @lock.synchronize do
+        expired = @armed.select { |_, entry| entry.at_ms <= now }
+        expired.each_key { |bound_id| @armed.delete(bound_id) }
+        expired.values
+      end
+    end
+
+    # Per entry, not per scan: one exception class that can't be instantiated
+    # must not swallow the bounds of every other job in the same pass, and must
+    # not take the scanner down with it — its bound was already retracted, so
+    # nothing would ever re-arm it.
+    def interrupt(entry)
+      entry.thread.raise(entry.exception, entry.message)
+    rescue StandardError => e
+      handle_exception(e, { context: THREAD_NAME })
+    end
+  end
+end

--- a/lib/wurk/watchdog.rb
+++ b/lib/wurk/watchdog.rb
@@ -67,12 +67,22 @@ module Wurk
     # on the inner scope is what lets a wedged job be interrupted at all;
     # without it the outer mask would hold the raise until the block it is meant
     # to cut short returned on its own.
+    #
+    # The mask only contains a raise that is issued while this frame is on the
+    # stack; #tick is what guarantees that, by taking the same @lock #disarm
+    # takes and holding it across the raise.
     def watch(seconds, exception, message = nil)
       bound_id = arm(seconds, exception, message)
       Thread.handle_interrupt(exception => :never) do
         Thread.handle_interrupt(exception => :immediate) { yield } # rubocop:disable Style/ExplicitBlockArgument
       ensure
-        disarm(bound_id)
+        # Masked against everything, not just `exception`: a job holding two
+        # bounds runs this inside the other one's `:immediate` scope, and a raise
+        # landing mid-retraction would strand this entry — still armed, no longer
+        # retractable, free to fire into whatever the thread picks up next.
+        # `:never` defers rather than discards, so the other bound is still
+        # delivered, one frame later.
+        Thread.handle_interrupt(::Object => :never) { disarm(bound_id) }
       end
     end
 
@@ -133,22 +143,35 @@ module Wurk
       @thread = safe_thread(THREAD_NAME) { @timer.run { tick } }
     end
 
+    # Selection and raise are one critical section, under the lock #disarm also
+    # takes. Splitting them leaves a window the mask cannot close: the scan
+    # picks an entry, loses the GVL before the raise, and the thread it aimed at
+    # finishes, retracts, and leaves #watch in the meantime — so the exception
+    # lands on the ACK or on the next job, which is the stdlib `Timeout` failure
+    # this class exists to avoid. Holding the lock means a thread racing us is
+    # parked in #disarm, still inside its mask, when the raise goes out.
+    #
+    # Errors are reported after the lock, not under it: an error handler is host
+    # code, and running it here would let a handler that arms a bound of its own
+    # deadlock the scanner against itself.
     def tick
-      due.each { |entry| interrupt(entry) }
+      failures = []
+      @lock.synchronize { fire_due(mono_ms, failures) }
+      failures.each { |ex| handle_exception(ex, { context: THREAD_NAME }) }
     end
 
-    # Entries are removed here, before the raise: a fired bound can't fire
-    # twice, and #disarm has nothing left to do if the exception lands on it.
-    # That removal is also what retracts a stranded bound — one armed by a
-    # thread that then died, so no #disarm will ever reach it. No liveness check
-    # guards the raise itself: `Thread#raise` into a dead thread is a documented
-    # no-op, and it doesn't even build the exception first.
-    def due
-      now = mono_ms
-      @lock.synchronize do
-        expired = @armed.select { |_, entry| entry.at_ms <= now }
-        expired.each_key { |bound_id| @armed.delete(bound_id) }
-        expired.values
+    # Entries are removed as they fire: a fired bound can't fire twice, and
+    # #disarm has nothing left to do if the exception lands on it. That removal
+    # is also what retracts a stranded bound — one armed by a thread that then
+    # died, so no #disarm will ever reach it. No liveness check guards the raise
+    # itself: `Thread#raise` into a dead thread is a documented no-op, and it
+    # doesn't even build the exception first.
+    def fire_due(now, failures)
+      @armed.delete_if do |_, entry|
+        next false unless entry.at_ms <= now
+
+        interrupt(entry, failures)
+        true
       end
     end
 
@@ -156,10 +179,10 @@ module Wurk
     # must not swallow the bounds of every other job in the same pass, and must
     # not take the scanner down with it — its bound was already retracted, so
     # nothing would ever re-arm it.
-    def interrupt(entry)
+    def interrupt(entry, failures)
       entry.thread.raise(entry.exception, entry.message)
     rescue StandardError => e
-      handle_exception(e, { context: THREAD_NAME })
+      failures << e
     end
   end
 end

--- a/lib/wurk/worker.rb
+++ b/lib/wurk/worker.rb
@@ -111,13 +111,17 @@ module Wurk
       #   sidekiq_options queue: "mailers", retry: 3, unique_for: 10.minutes
       # @example Opt into Wurk::Status tracking
       #   sidekiq_options track: true
+      # @example Bound one attempt, and the job as a whole
+      #   sidekiq_options timeout: 30, deadline: 5.minutes
       # @param opts [Hash] any of `queue:`, `retry:`, `dead:`, `backtrace:`,
-      #   `expires_in:`, `tags:`, `pool:`, `unique_for:`, `track:`, … (see the
-      #   migration guide's sidekiq_options table for the full set)
+      #   `expires_in:`, `tags:`, `pool:`, `unique_for:`, `track:`, `timeout:`,
+      #   `deadline:`, … (see the migration guide's sidekiq_options table for
+      #   the full set)
       # @return [Hash] the merged, string-keyed options hash
       def sidekiq_options(opts = {})
         stringified = opts.transform_keys(&:to_s)
         Wurk::JobUtil.validate_track!(stringified['track'], stringified) if stringified.key?('track')
+        Wurk::JobUtil.validate_bounds!(stringified)
         @sidekiq_options_hash = get_sidekiq_options.merge(stringified)
       end
 

--- a/test/integration/timeout_hang_test.rb
+++ b/test/integration/timeout_hang_test.rb
@@ -1,0 +1,268 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'securerandom'
+
+# Top-level for the same fork/Marshal reason as SwarmBootSentinelWorker /
+# GracefulShutdownSentinelWorker: Object.const_get(name) has to resolve the
+# same way inside the forked child, which inherits the constant table but no
+# Minitest lexical scope. Genuinely sleeps — nothing here cooperates with the
+# cut, so only Wurk::Watchdog raising into the thread stops it early.
+class TimeoutHangWorker
+  include Wurk::Job
+
+  sidekiq_options timeout: 0.3, retry: 1
+
+  def perform(redis_url, started_key, done_key, sleep_seconds)
+    client = RedisClient.config(url: redis_url).new_client
+    client.call('SET', started_key, ::Process.pid.to_s)
+    client.call('EXPIRE', started_key, 60)
+    sleep sleep_seconds
+    client.call('SET', done_key, '1')
+    client.call('EXPIRE', done_key, 60)
+  ensure
+    client&.close
+  end
+end
+
+class DeadlineHangWorker
+  include Wurk::Job
+
+  sidekiq_options deadline: 0.5, retry: 3
+
+  def perform(redis_url, started_key, done_key, sleep_seconds)
+    client = RedisClient.config(url: redis_url).new_client
+    client.call('SET', started_key, ::Process.pid.to_s)
+    client.call('EXPIRE', started_key, 60)
+    sleep sleep_seconds
+    client.call('SET', done_key, '1')
+    client.call('EXPIRE', done_key, 60)
+  ensure
+    client&.close
+  end
+end
+
+# A bound long enough that Watchdog's 0.5s production scan interval never
+# gets near it within this test's window — proves shutdown's own drain budget
+# is what cuts the job, not the declared timeout:.
+class LongTimeoutWorker
+  include Wurk::Job
+
+  sidekiq_options timeout: 30, retry: 1
+
+  def perform(redis_url, started_key, done_key, sleep_seconds)
+    client = RedisClient.config(url: redis_url).new_client
+    client.call('SET', started_key, ::Process.pid.to_s)
+    client.call('EXPIRE', started_key, 60)
+    sleep sleep_seconds
+    client.call('SET', done_key, '1')
+    client.call('EXPIRE', done_key, 60)
+  ensure
+    client&.close
+  end
+end
+
+# 08-timeout-deadline.md done-when: "wurk_options timeout: 30, deadline:
+# 5.minutes bounds a hanging job." The unit suite (timeout_middleware_test.rb,
+# deadline_test.rb, watchdog_test.rb) pins the middleware/Watchdog contract
+# against a hand-built chain and a fast test-only scan interval; this is the
+# one test proving the whole stack — a real fork, a real Redis round trip, a
+# job that genuinely never yields — actually cuts a job that would otherwise
+# sleep for HANG_SLEEP_SECONDS, in well under that, at production's own
+# Watchdog::SCAN_INTERVAL (no test-only speedup here).
+#
+# Also covers the shutdown_timeout interaction lib/wurk/middleware/timeout.rb
+# documents (swarm.rb's shutdown/hard_shutdown path, cli.rb's `config[:timeout]`
+# → Swarm#shutdown_timeout wiring): the shorter of the two bounds wins. A
+# `timeout:` under the drain budget fires first (first test below); one far
+# longer than it never gets the chance, and shutdown's own hard_shutdown wins
+# instead (last test below).
+class TimeoutHangTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  POLL_TIMEOUT = 20.0
+  POLL_INTERVAL = 0.1
+  HANG_SLEEP_SECONDS = 5
+  FAST_DRAIN_TIMEOUT = 2
+
+  def setup
+    super
+    @ns = "tohang-#{::Process.pid}-#{object_id}"
+    @queue_name = "#{@ns}-q"
+    @started_key = "#{@ns}-started"
+    @done_key = "#{@ns}-done"
+    @observer = RedisClient.config(url: Wurk::Test.redis_url).new_client
+    @expired_before = @observer.call('GET', 'stat:expired').to_i
+  end
+
+  def teardown
+    @observer&.call('UNLINK', @started_key, @done_key, public_queue_key)
+    @observer&.call('SREM', 'queues', @queue_name)
+    remove_retry_entries
+    @observer&.close
+  ensure
+    super
+  end
+
+  def test_a_genuinely_sleeping_job_is_cut_at_its_timeout_bound_and_booked_for_retry
+    jid = push(TimeoutHangWorker)
+
+    run_swarm(shutdown_timeout: 10) do
+      assert wait_for_key(@started_key), 'job never started within the poll window'
+      start = monotonic_now
+
+      entry = wait_for_retry_entry(jid)
+
+      assert entry, "job never landed on the retry set — the bound never fired (#{elapsed(start)}s elapsed)"
+      assert_operator elapsed(start), :<, HANG_SLEEP_SECONDS,
+                      'the job must be cut well before its own sleep would have returned on its own'
+      assert_equal 'Wurk::Job::TimedOut', entry['error_class']
+      assert_match(/timed out after 0\.3s/, entry['error_message'])
+      refute @observer.call('GET', @done_key), 'a cut attempt must not reach its own completion write'
+    end
+  end
+
+  # stat:expired is process-local (Processor::EXPIRED) until the next
+  # heartbeat or shutdown flushes it — waiting out a real BEAT_PAUSE would
+  # make this test as slow as the cadence it's not actually testing, so the
+  # swarm is shut down as soon as the abandonment itself is confirmed
+  # (private list empty — nothing left in flight), which flushes it deterministically.
+  def test_a_genuinely_sleeping_job_past_its_deadline_is_abandoned_and_booked_expired
+    jid = push(DeadlineHangWorker)
+
+    run_swarm(shutdown_timeout: 10) do |swarm|
+      assert wait_for_key(@started_key), 'job never started within the poll window'
+      start = monotonic_now
+
+      assert wait_for { private_list_keys.empty? }, 'the abandoned job never cleared the in-flight private list'
+      abandoned_within = elapsed(start)
+      swarm.shutdown(timeout: 10)
+
+      assert_operator abandoned_within, :<, HANG_SLEEP_SECONDS,
+                      'the job must be abandoned well before its own sleep would have returned on its own'
+      assert_operator stat_expired_delta, :>, 0, 'stat:expired must be booked once the shutdown flush runs'
+      refute @observer.call('GET', @done_key), 'an abandoned job must not reach its own completion write'
+      refute wait_for_retry_entry(jid, timeout: 1), 'a deadline cut is booked expired, never retried'
+    end
+  end
+
+  # The bound (30s) never gets near firing inside this test; a short
+  # shutdown_timeout has to win the race on its own, exactly as
+  # lib/wurk/middleware/timeout.rb's class comment claims.
+  def test_a_timeout_far_longer_than_the_drain_budget_loses_to_shutdown
+    push(LongTimeoutWorker)
+
+    run_swarm(shutdown_timeout: FAST_DRAIN_TIMEOUT) do |swarm|
+      assert wait_for_key(@started_key), 'job never started within the poll window'
+
+      swarm.shutdown(timeout: FAST_DRAIN_TIMEOUT)
+
+      refute @observer.call('GET', @done_key), 'job must not have completed'
+      assert_equal 1, @observer.call('LLEN', public_queue_key),
+                   'hard_shutdown must requeue — the drain budget lost the race, not the 30s bound'
+      assert_empty private_list_keys, 'bulk_requeue must leave no residual private-list entries'
+    end
+  end
+
+  private
+
+  # The actual class, not its name: JobUtil only merges class-level
+  # sidekiq_options (the timeout:/deadline: this whole file bounds jobs with)
+  # when it can call get_sidekiq_options on what 'class' points at.
+  def push(klass)
+    Wurk::Client.new.push(
+      'class' => klass, 'args' => [Wurk::Test.redis_url, @started_key, @done_key, HANG_SLEEP_SECONDS],
+      'queue' => @queue_name
+    )
+  end
+
+  def run_swarm(shutdown_timeout:)
+    config = Wurk::Configuration.new
+    config.logger = ::Logger.new(IO::NULL)
+    config[:timeout] = shutdown_timeout
+    seed_default_middleware!(config)
+    topology = Wurk::Topology.flat(count: 1, queues: [@queue_name], concurrency: 1)
+    swarm = Wurk::Swarm.new(topology: topology, config: config, shutdown_timeout: shutdown_timeout)
+    supervisor = nil
+    begin
+      swarm.boot(install_signals: false)
+      supervisor = Thread.new { swarm.supervise }
+      yield swarm
+    ensure
+      begin
+        swarm.shutdown(timeout: shutdown_timeout)
+      rescue StandardError
+        nil
+      end
+      stop_supervisor_thread(supervisor, shutdown_timeout + 10)
+      config.reset_redis_pools!
+    end
+  end
+
+  # Wurk::Middleware::Timeout/Expiry (and every other built-in) register
+  # themselves once, at file-require time, onto the ONE `Wurk.configuration`
+  # the gem lazily creates on first access (lib/wurk.rb's trailing
+  # `Wurk.configuration.server_middleware.add(...)` calls) — a *later*
+  # `Wurk::Configuration.new` starts with an empty chain of its own and never
+  # sees them. Every other real-fork integration test in this suite gets away
+  # with that because it only exercises swarm/launcher lifecycle, not job
+  # middleware; this file specifically needs Timeout and Expiry to be the ones
+  # doing the cutting, so the fresh, test-private config this harness needs
+  # for queue isolation has to replay the same registrations by hand. None of
+  # the built-ins take constructor args, so klass-only entries round-trip.
+  def seed_default_middleware!(config)
+    Wurk.configuration.client_middleware.entries.each { |e| config.client_middleware.add(e.klass) }
+    Wurk.configuration.server_middleware.entries.each { |e| config.server_middleware.add(e.klass) }
+  end
+
+  def public_queue_key = "#{Wurk::Keys::QUEUE_PREFIX}#{@queue_name}"
+
+  def private_list_keys
+    keys = []
+    cursor = '0'
+    loop do
+      cursor, batch = @observer.call('SCAN', cursor, 'MATCH', "#{public_queue_key}|*", 'COUNT', 100)
+      keys.concat(batch)
+      break if cursor == '0'
+    end
+    keys
+  end
+
+  def wait_for_key(key)
+    wait_for { @observer.call('GET', key) }
+  end
+
+  def wait_for_retry_entry(jid, timeout: POLL_TIMEOUT)
+    wait_for(timeout: timeout) { find_retry_entry(jid) }
+  end
+
+  def find_retry_entry(jid)
+    @observer.call('ZRANGE', 'retry', 0, -1)
+             .map { |raw| ::JSON.parse(raw) }
+             .find { |msg| msg['jid'] == jid }
+  end
+
+  def stat_expired_delta
+    @observer.call('GET', 'stat:expired').to_i - @expired_before
+  end
+
+  def remove_retry_entries
+    @observer&.call('ZRANGE', 'retry', 0, -1)&.each do |raw|
+      @observer.call('ZREM', 'retry', raw) if ::JSON.parse(raw)['queue'] == @queue_name
+    end
+  end
+
+  def wait_for(timeout: POLL_TIMEOUT)
+    deadline = monotonic_now + timeout
+    while monotonic_now < deadline
+      value = yield
+      return value if value
+
+      sleep POLL_INTERVAL
+    end
+    false
+  end
+
+  def monotonic_now = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+  def elapsed(start) = monotonic_now - start
+end

--- a/test/unit/capsule_test.rb
+++ b/test/unit/capsule_test.rb
@@ -146,6 +146,29 @@ class CapsuleTest < Wurk::Test::UnitCase
     refute_nil @capsule.instance_variable_get(:@pools)[:fetch]
   end
 
+  # --- watchdog (per-job bounds) -----------------------------------------
+
+  # One per capsule, so one per Manager. Materialized here rather than in the
+  # constructor so a client-only process allocates none — and holding no thread
+  # until a job is actually bounded is the zero-cost claim.
+  def test_prepare_materializes_a_thread_free_watchdog
+    assert_nil @capsule.watchdog
+
+    @capsule.prepare!
+
+    assert_instance_of Wurk::Watchdog, @capsule.watchdog
+    refute_predicate @capsule.watchdog, :running?
+  end
+
+  def test_prepare_keeps_the_same_watchdog_across_calls
+    @capsule.prepare!
+    first = @capsule.watchdog
+
+    @capsule.prepare!
+
+    assert_same first, @capsule.watchdog
+  end
+
   # --- prepare_shared! (the half a swarm parent runs pre-fork) ----------
 
   def test_prepare_shared_materializes_the_middleware_chains

--- a/test/unit/deadline_test.rb
+++ b/test/unit/deadline_test.rb
@@ -27,6 +27,12 @@ class DeadlineTest < Wurk::Test::UnitCase
   # positive, finite number of seconds.
   UNUSABLE = ['300', 0, -1, Float::INFINITY, Float::NAN, true, :soon].freeze
 
+  # The subset of UNUSABLE that is not a readable instant either. `'300'`, `0`
+  # and `-1` are unusable as durations and perfectly readable as cutoffs — all
+  # three are long past, and Middleware::Expiry drops on them, which is what
+  # Sidekiq Pro's bare `Time.now.to_f > job['expiry']` does too.
+  UNREADABLE = ['soon', true, :soon, Float::INFINITY, Float::NAN].freeze
+
   CREATED_AT_MS = 1_700_000_000_000
   CREATED_AT_S = CREATED_AT_MS / 1000.0
 
@@ -189,6 +195,48 @@ class DeadlineTest < Wurk::Test::UnitCase
     assert yielded_through_expiry?('expiry' => now + 60, 'deadline_at' => now + 60)
   end
 
+  # The mirror of test_an_unusable_cutoff_leaves_the_job_unbounded, on the same
+  # field. Expiry is the outer frame, so a cutoff it reads differently is the
+  # one that lands: a `deadline_at` it cannot read has to run the job, not
+  # discard it, or Timeout's policy never gets a say.
+  def test_a_cutoff_neither_middleware_can_read_leaves_the_job_alone
+    live = ::Time.now.to_f + 60
+    with_expired_counter do
+      UNREADABLE.each do |value|
+        assert yielded_through_expiry?('deadline_at' => value), "deadline_at #{value.inspect} dropped the job"
+        assert yielded_through_expiry?('expiry' => value), "expiry #{value.inspect} dropped the job"
+        # And it is dropped, not carried into the comparison: NaN and Infinity
+        # both poison a `min` against the window that *was* readable.
+        assert yielded_through_expiry?('expiry' => live, 'deadline_at' => value),
+               "deadline_at #{value.inspect} broke the readable window beside it"
+      end
+
+      assert_equal 0, Wurk::Processor::EXPIRED.reset
+    end
+  end
+
+  # The tolerance that guard must not cost: a cutoff that round-tripped as a
+  # String is a value, not a typo, and still closes its window.
+  def test_a_cutoff_that_round_tripped_as_a_string_still_expires
+    with_expired_counter do
+      refute yielded_through_expiry?('deadline_at' => (::Time.now.to_f - 1).to_s)
+      assert_equal 1, Wurk::Processor::EXPIRED.reset
+    end
+  end
+
+  # Only a job carrying a cutoff can be cut by one. Without a cutoff the same
+  # exception is the job's own, and it unwinds to JobRetry rather than being
+  # swallowed into a clean ack.
+  def test_a_deadline_error_from_a_job_that_declared_none_is_not_swallowed
+    with_expired_counter do
+      assert_raises(Wurk::Job::DeadlineExceeded) do
+        expiry.call(nil, job, 'q') { raise Wurk::Job::DeadlineExceeded }
+      end
+
+      assert_equal 0, Wurk::Processor::EXPIRED.reset
+    end
+  end
+
   def test_the_drop_emits_the_same_statsd_counter_as_expires_in
     with_statsd_recorder do |calls|
       expiry.call(nil, job('class' => 'MyJob', 'deadline_at' => ::Time.now.to_f - 1), 'q') { flunk 'must not yield' }
@@ -252,10 +300,14 @@ class DeadlineTest < Wurk::Test::UnitCase
   end
 
   # The absolute bound is armed outside the per-attempt one, so a job that
-  # swallows its `TimedOut` and carries on is still cut by its deadline.
+  # swallows its `TimedOut` and carries on is still cut by its deadline. The
+  # deadline is a whole second rather than the milliseconds the other timing
+  # tests use: those race `sleep 5` and have unbounded margin, this one has a
+  # real ceiling, and a loaded parallel CI run can eat a tenth of a second in
+  # scheduling alone.
   def test_the_deadline_outlives_a_swallowed_timeout
     attach_watchdog
-    job = running_job(0.15).merge('timeout' => 0.02)
+    job = running_job(1.0).merge('timeout' => 0.02)
 
     assert_raises(Wurk::Job::DeadlineExceeded) do
       timeout.call(nil, job, 'q') do

--- a/test/unit/deadline_test.rb
+++ b/test/unit/deadline_test.rb
@@ -1,0 +1,351 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# `sidekiq_options deadline: <seconds>` end to end: rejected where it is
+# written, resolved to an absolute cutoff once at push, and enforced twice —
+# before `perform` by Wurk::Middleware::Expiry, and during it by the watchdog
+# Wurk::Middleware::Timeout arms with whatever is left.
+#
+# The property that separates it from `timeout:` is that it is absolute. A
+# `timeout` is renewed by every attempt; a deadline is stamped once and every
+# later attempt measures against that same instant, so retries and IterableJob
+# resumes cannot outlive it.
+class DeadlineTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  # Enough of ActiveSupport::Duration to pin the case that matters: it is not a
+  # Numeric subclass, it answers `is_a?(Numeric)` by delegating to its value,
+  # and `deadline: 5.minutes` is how the option will actually be written.
+  class DurationLike
+    def initialize(value) = @value = value
+    def is_a?(klass) = klass == DurationLike || @value.is_a?(klass)
+    def to_f = @value.to_f
+  end
+
+  # Every shape JSON (or a typo) can leave in a bound field that is not a
+  # positive, finite number of seconds.
+  UNUSABLE = ['300', 0, -1, Float::INFINITY, Float::NAN, true, :soon].freeze
+
+  CREATED_AT_MS = 1_700_000_000_000
+  CREATED_AT_S = CREATED_AT_MS / 1000.0
+
+  def setup
+    super
+    @config = Wurk::Configuration.new
+    @config.logger = ::Logger.new(IO::NULL)
+    @capsule = Wurk::Capsule.new("deadline-#{Process.pid}-#{object_id}", @config)
+    @watchdogs = []
+  end
+
+  def teardown
+    @watchdogs.each(&:terminate)
+  ensure
+    super
+  end
+
+  # --- validation, at the door it was written --------------------------
+
+  def test_the_worker_dsl_accepts_a_positive_number_of_seconds
+    klass = Class.new { include Wurk::Worker }
+
+    assert_equal 300, klass.sidekiq_options(deadline: 300)['deadline']
+    assert_in_delta 1.5, klass.sidekiq_options(timeout: 1.5)['timeout']
+  end
+
+  def test_the_worker_dsl_accepts_an_activesupport_duration
+    klass = Class.new { include Wurk::Worker }
+    duration = DurationLike.new(300)
+
+    assert_same duration, klass.sidekiq_options(deadline: duration)['deadline']
+  end
+
+  def test_the_worker_dsl_rejects_an_unusable_bound
+    klass = Class.new { include Wurk::Worker }
+
+    UNUSABLE.each do |value|
+      error = assert_raises(ArgumentError, "#{value.inspect} was accepted") { klass.sidekiq_options(deadline: value) }
+      assert_match(/'deadline' must be a positive number of seconds/, error.message)
+    end
+    refute klass.get_sidekiq_options.key?('deadline'), 'a rejected option must not be half-applied'
+  end
+
+  # Both bounds go through the same check, so neither can be tightened without
+  # the other.
+  def test_the_worker_dsl_rejects_an_unusable_timeout
+    klass = Class.new { include Wurk::Worker }
+
+    error = assert_raises(ArgumentError) { klass.sidekiq_options(timeout: -5) }
+    assert_match(/'timeout' must be a positive number of seconds/, error.message)
+  end
+
+  # The ActiveJob options DSL is a second copy of the same surface; a bad value
+  # has to fail identically there or the two drift.
+  def test_the_activejob_options_dsl_rejects_an_unusable_bound
+    klass = Class.new { include Wurk::Job::Options }
+
+    assert_raises(ArgumentError) { klass.sidekiq_options(deadline: '300') }
+    assert_equal 300, klass.sidekiq_options(deadline: 300)['deadline']
+  end
+
+  def test_a_string_keyed_bound_is_validated_too
+    klass = Class.new { include Wurk::Worker }
+
+    assert_raises(ArgumentError) { klass.sidekiq_options('deadline' => 0) }
+  end
+
+  # The other door: a payload handed straight to the client, never through a
+  # class-level option.
+  def test_an_unusable_bound_is_rejected_at_push
+    error = assert_raises(ArgumentError) { normalize(job('deadline' => Float::NAN)) }
+
+    assert_match(/'deadline' must be a positive number of seconds/, error.message)
+  end
+
+  def test_an_absent_bound_is_not_an_error
+    payload = normalize(job)
+
+    refute payload.key?('deadline')
+    refute payload.key?('deadline_at')
+  end
+
+  # --- absolute carry ---------------------------------------------------
+
+  def test_push_resolves_the_relative_option_to_an_absolute_cutoff
+    payload = normalize(job('deadline' => 300, 'created_at' => CREATED_AT_MS))
+
+    assert_in_delta CREATED_AT_S + 300, payload['deadline_at'], 0.001
+    assert_equal 300, payload['deadline'], 'the declaration stays on the payload'
+  end
+
+  # Same rule `expires_in` follows: for a scheduled job the clock starts when
+  # the job is due, or perform_in(2h) + deadline: 5.minutes would be born past
+  # its cutoff and could never run.
+  def test_a_scheduled_job_measures_from_its_run_time
+    at = CREATED_AT_S + 7200
+    payload = normalize(job('deadline' => 300, 'created_at' => CREATED_AT_MS, 'at' => at))
+
+    assert_in_delta at + 300, payload['deadline_at'], 0.001
+    assert_operator payload['deadline_at'], :>, at, 'a scheduled job must not be born past its deadline'
+  end
+
+  def test_a_class_level_deadline_reaches_the_payload
+    klass = Class.new { include Wurk::Worker }
+    klass.sidekiq_options(deadline: 300, queue: 'default')
+    payload = normalize({ 'class' => klass, 'args' => [], 'created_at' => CREATED_AT_MS })
+
+    assert_in_delta CREATED_AT_S + 300, payload['deadline_at'], 0.001
+  end
+
+  # The whole point of the option. A retry re-ZADDs this hash and an
+  # interrupted IterableJob re-pushes it verbatim, so the cutoff rides along
+  # unchanged — and a path that re-normalizes must not restart the clock.
+  def test_the_cutoff_survives_re_enqueue
+    payload = normalize(job('deadline' => 300, 'created_at' => CREATED_AT_MS))
+    original = payload['deadline_at']
+
+    resumed = Wurk.load_json(Wurk.dump_json(payload))
+    resumed['created_at'] = CREATED_AT_MS + 600_000
+    renormalized = normalize(resumed)
+
+    assert_in_delta original, renormalized['deadline_at'], 0.001
+  end
+
+  # A `deadline` no door validated — a class option set some other way, a
+  # default_job_options entry — is left unstamped rather than raised on, which
+  # is the same answer Middleware::Timeout gives a bound it cannot arm.
+  def test_an_unusable_class_default_is_left_unstamped
+    stamper = Class.new { include Wurk::JobUtil }.new
+    item = { 'class' => 'X', 'args' => [], 'created_at' => CREATED_AT_MS, 'deadline' => '300' }
+
+    stamper.send(:stamp_deadline, item)
+
+    refute item.key?('deadline_at')
+  end
+
+  # --- before perform ---------------------------------------------------
+
+  def test_a_job_past_its_cutoff_never_starts
+    with_expired_counter do
+      refute yielded_through_expiry?('deadline_at' => ::Time.now.to_f - 1)
+      assert_equal 1, Wurk::Processor::EXPIRED.reset
+    end
+  end
+
+  def test_a_job_inside_its_cutoff_runs
+    with_expired_counter do
+      assert yielded_through_expiry?('deadline_at' => ::Time.now.to_f + 60)
+      assert_equal 0, Wurk::Processor::EXPIRED.reset
+    end
+  end
+
+  # Two windows, and the one that closes first is the one that counts —
+  # whichever option opened it.
+  def test_the_earlier_of_the_two_windows_wins
+    now = ::Time.now.to_f
+
+    refute yielded_through_expiry?('expiry' => now - 1, 'deadline_at' => now + 60)
+    refute yielded_through_expiry?('expiry' => now + 60, 'deadline_at' => now - 1)
+    assert yielded_through_expiry?('expiry' => now + 60, 'deadline_at' => now + 60)
+  end
+
+  def test_the_drop_emits_the_same_statsd_counter_as_expires_in
+    with_statsd_recorder do |calls|
+      expiry.call(nil, job('class' => 'MyJob', 'deadline_at' => ::Time.now.to_f - 1), 'q') { flunk 'must not yield' }
+
+      assert_equal [['jobs.expired', ['class:MyJob']]], calls
+    end
+  end
+
+  # --- during perform ---------------------------------------------------
+
+  def test_a_running_job_is_cut_when_the_cutoff_passes
+    attach_watchdog
+    started = false
+
+    error = assert_raises(Wurk::Job::DeadlineExceeded) do
+      timeout.call(nil, running_job(0.02), 'q') do
+        started = true
+        sleep 5
+      end
+    end
+
+    assert started, 'the job must start — the cutoff had not passed yet'
+    assert_equal 'SlowJob exceeded its deadline', error.message
+  end
+
+  def test_the_cut_is_booked_expired_and_not_retried
+    attach_watchdog
+    with_expired_counter do
+      result = expiry.call(nil, running_job(0.02), 'q') do
+        timeout.call(nil, running_job(0.02), 'q') { sleep 5 }
+      end
+
+      assert_nil result, 'a swallowed cut is a clean exit: JobRetry never sees it, the processor acks'
+      assert_equal 1, Wurk::Processor::EXPIRED.reset
+    end
+  end
+
+  # A job may rescue the cut to clean up behind itself — soft by contract, the
+  # same bargain `timeout:` makes.
+  def test_the_cut_is_an_error_the_job_can_rescue
+    attach_watchdog
+
+    result = timeout.call(nil, running_job(0.02), 'q') do
+      sleep 5
+    rescue Wurk::Job::DeadlineExceeded
+      :cleaned_up
+    end
+
+    assert_equal :cleaned_up, result
+  end
+
+  def test_both_bounds_are_armed_independently
+    watchdog = attach_watchdog
+    armed = nil
+    job = running_job(5).merge('timeout' => 5)
+
+    timeout.call(nil, job, 'q') { armed = watchdog.size }
+
+    assert_equal 2, armed, 'a job declaring both must hold both bounds at once'
+    assert_equal 0, watchdog.size, 'and retract both on the way out'
+  end
+
+  # The absolute bound is armed outside the per-attempt one, so a job that
+  # swallows its `TimedOut` and carries on is still cut by its deadline.
+  def test_the_deadline_outlives_a_swallowed_timeout
+    attach_watchdog
+    job = running_job(0.15).merge('timeout' => 0.02)
+
+    assert_raises(Wurk::Job::DeadlineExceeded) do
+      timeout.call(nil, job, 'q') do
+        sleep 5
+      rescue Wurk::Job::TimedOut
+        sleep 5
+      end
+    end
+  end
+
+  def test_a_job_without_a_cutoff_arms_nothing
+    watchdog = attach_watchdog
+
+    assert_equal :ok, timeout.call(nil, job, 'q') { :ok }
+    refute_predicate watchdog, :running?
+  end
+
+  # Declaration-time validation never saw a payload from stock Sidekiq or a raw
+  # LPUSH; an unusable cutoff on one of those leaves the job unbounded rather
+  # than failing it.
+  def test_an_unusable_cutoff_leaves_the_job_unbounded
+    watchdog = attach_watchdog
+
+    UNUSABLE.each do |value|
+      assert_equal :ok, timeout.call(nil, job('deadline_at' => value), 'q') { :ok }, "#{value.inspect} armed a bound"
+    end
+    refute_predicate watchdog, :running?
+  end
+
+  private
+
+  def job(extra = {})
+    { 'class' => 'DeadlineJob', 'args' => [] }.merge(extra)
+  end
+
+  def running_job(seconds_left)
+    job('class' => 'SlowJob', 'deadline_at' => ::Time.now.to_f + seconds_left)
+  end
+
+  def normalize(item)
+    Class.new { include Wurk::JobUtil }.new.normalize_item(item)
+  end
+
+  def expiry
+    Wurk::Middleware::Expiry.new.tap { |middleware| middleware.config = @config }
+  end
+
+  def timeout
+    Wurk::Middleware::Timeout.new.tap { |middleware| middleware.config = @capsule }
+  end
+
+  # What Capsule#prepare! assigns in production, minus the Redis pools and the
+  # fetcher it opens on the way. The fast scan keeps a blown bound in the
+  # milliseconds instead of SCAN_INTERVAL.
+  def attach_watchdog(interval: 0.01)
+    Wurk::Watchdog.new(@capsule, interval: interval).tap do |watchdog|
+      @watchdogs << watchdog
+      @capsule.instance_variable_set(:@watchdog, watchdog)
+    end
+  end
+
+  def yielded_through_expiry?(fields)
+    yielded = false
+    expiry.call(nil, job(fields), 'q') { yielded = true }
+    yielded
+  end
+
+  # The EXPIRED counter is a process-global singleton — serialize against every
+  # other test class that reads or resets it.
+  def with_expired_counter
+    Wurk::Test::PROCESSOR_COUNTER_MUTEX.synchronize do
+      Wurk::Processor::EXPIRED.reset
+      yield
+    end
+  end
+
+  # `Wurk::Metrics::Statsd.increment` is a process-global singleton method.
+  def with_statsd_recorder
+    Wurk::Test::STATSD_MUTEX.synchronize do
+      calls = []
+      real = Wurk::Metrics::Statsd.method(:increment)
+      Wurk::Metrics::Statsd.singleton_class.send(:define_method, :increment) do |metric, tags: nil|
+        calls << [metric, tags]
+        nil
+      end
+      begin
+        yield calls
+      ensure
+        Wurk::Metrics::Statsd.singleton_class.send(:define_method, :increment, real)
+      end
+    end
+  end
+end

--- a/test/unit/iterable_job_test.rb
+++ b/test/unit/iterable_job_test.rb
@@ -350,6 +350,30 @@ class IterableJobTest < Wurk::Test::UnitCase
     redis.with { |c| c.call('EXISTS', "it-#{jid}") } == 1
   end
 
+  def interrupt_handler
+    Wurk::Middleware::InterruptHandler.new.tap { |m| m.config = Wurk.configuration }
+  end
+
+  def pop_repush(queue)
+    raw = redis.with { |c| c.call('LPOP', "queue:#{queue}") }
+
+    refute_nil raw, 'InterruptHandler must have repushed the job'
+    ::JSON.parse(raw)
+  end
+
+  def build_timeout_capsule
+    config = Wurk::Configuration.new
+    config.logger = ::Logger.new(IO::NULL)
+    capsule = Wurk::Capsule.new("it-timeout-#{::Process.pid}-#{object_id}", config)
+    watchdog = Wurk::Watchdog.new(capsule, interval: 0.01)
+    capsule.instance_variable_set(:@watchdog, watchdog)
+    [capsule, watchdog]
+  end
+
+  def timeout_middleware(capsule)
+    Wurk::Middleware::Timeout.new.tap { |m| m.config = capsule }
+  end
+
   def test_cancel_persists_to_iteration_hash_when_jid_set
     jid = random_jid
     worker = SimpleIterable.new
@@ -756,6 +780,113 @@ class IterableJobTest < Wurk::Test::UnitCase
 
       assert_equal %i[cancel stop complete], worker.events
     ensure
+      cleanup_iteration_key(jid)
+    end
+  end
+
+  # --- interaction with sidekiq_options timeout:/deadline: (08-timeout-deadline) --
+
+  # A cooperative interrupt persists cursor state to `it-<jid>` (iteration_key,
+  # flush_state) — a HASH keyed off the jid, entirely separate from the job
+  # envelope InterruptHandler re-pushes. `deadline_at` lives on that envelope,
+  # so proving it survives is proving InterruptHandler's repush is verbatim,
+  # not that IterableJob does anything with it — it never sees the field.
+  class DeadlineAwareIterable
+    include Wurk::IterableJob
+
+    attr_writer :seen
+
+    def seen = @seen ||= []
+
+    def build_enumerator(*, cursor:)
+      start = cursor || 0
+      Enumerator.new { |y| start.upto(2) { |i| y << [i, i + 1] } }
+    end
+
+    def each_iteration(item, *)
+      seen << item
+    end
+  end
+
+  def test_deadline_survives_interrupt_and_resume
+    jid = random_jid
+    queue = "iq-#{::Process.pid}-#{object_id}"
+    deadline_at = ::Time.now.to_f + 300
+    job = { 'class' => DeadlineAwareIterable.name, 'args' => [], 'jid' => jid, 'deadline_at' => deadline_at }
+
+    begin
+      worker = DeadlineAwareIterable.new
+      worker.jid = jid
+      worker._context = StoppingContext.new(stop_after: 1)
+
+      assert_raises(Wurk::JobRetry::Skip) do
+        interrupt_handler.call(worker, job, queue) { worker.perform }
+      end
+
+      repushed = pop_repush(queue)
+
+      assert_in_delta deadline_at, repushed['deadline_at'], 0.001,
+                      'the absolute cutoff must ride the repush unchanged, not be re-derived'
+
+      resumed = DeadlineAwareIterable.new
+      resumed.jid = jid
+      resumed.perform
+
+      assert_equal [1, 2], resumed.seen, 'resumed iteration continues from the persisted cursor either way'
+    ensure
+      cleanup_iteration_key(jid)
+      redis.with { |c| c.call('DEL', "queue:#{queue}") }
+    end
+  end
+
+  # `timeout:` is per-attempt: Middleware::Timeout reads job['timeout'] fresh
+  # on every call, so a resumed IterableJob attempt gets the whole bound again
+  # rather than whatever was left when the first attempt was interrupted.
+  class TimeoutResumableJob
+    include Wurk::IterableJob
+
+    attr_writer :seen, :sleep_before_next
+
+    def seen = @seen ||= []
+    def sleep_before_next = @sleep_before_next ||= 0
+
+    def build_enumerator(*, cursor:)
+      start = cursor || 0
+      Enumerator.new { |y| start.upto(2) { |i| y << [i, i + 1] } }
+    end
+
+    def each_iteration(item, *)
+      sleep sleep_before_next if sleep_before_next.positive?
+      seen << item
+    end
+  end
+
+  def test_timeout_resets_per_attempt_across_iterable_resume
+    jid = random_jid
+    capsule, watchdog = build_timeout_capsule
+    job = { 'class' => TimeoutResumableJob.name, 'timeout' => 0.05 }
+
+    begin
+      interrupted = TimeoutResumableJob.new
+      interrupted.jid = jid
+      interrupted._context = StoppingContext.new(stop_after: 1)
+
+      assert_raises(Wurk::IterableJob::Interrupted) do
+        timeout_middleware(capsule).call(nil, job, 'q') { interrupted.perform }
+      end
+      assert_equal 0, watchdog.size, 'a cooperative interrupt retracts the bound cleanly — it never gets to fire'
+
+      resumed = TimeoutResumableJob.new
+      resumed.jid = jid
+      resumed.sleep_before_next = 0.2
+
+      err = assert_raises(Wurk::Job::TimedOut) do
+        timeout_middleware(capsule).call(nil, job, 'q') { resumed.perform }
+      end
+      assert_match(/timed out after 0\.05s/, err.message,
+                   'the resumed attempt must get the full bound again, not whatever was left of the first')
+    ensure
+      watchdog.terminate
       cleanup_iteration_key(jid)
     end
   end

--- a/test/unit/manager_test.rb
+++ b/test/unit/manager_test.rb
@@ -372,6 +372,47 @@ class ManagerTest < Wurk::Test::UnitCase
     refute called
   end
 
+  # --- watchdog lifecycle ----------------------------------------------
+
+  # The capsule's per-job watchdog is released by #stop, not #quiet: a quieted
+  # capsule still has in-flight jobs, and a bound shorter than the drain budget
+  # has to fire before shutdown wins.
+  def test_quiet_leaves_the_capsule_watchdog_running
+    mgr = Wurk::Manager.new(@capsule)
+    silence_processors(mgr)
+    terminated = watchdog_terminations
+
+    mgr.quiet
+
+    assert_equal 0, terminated.size
+  end
+
+  def test_stop_terminates_the_capsule_watchdog
+    mgr = Wurk::Manager.new(@capsule)
+    silence_processors(mgr)
+    mgr.workers.clear
+    terminated = watchdog_terminations
+    @capsule.define_singleton_method(:stop) { nil }
+
+    mgr.stop(::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + 1)
+
+    assert_equal 1, terminated.size
+  end
+
+  # Stop can land on a capsule that never reached prepare! (a launcher that
+  # raised mid-boot), so the terminate has to tolerate no watchdog at all.
+  def test_stop_tolerates_a_capsule_without_a_watchdog
+    mgr = Wurk::Manager.new(@capsule)
+    silence_processors(mgr)
+    mgr.workers.clear
+
+    assert_nil @capsule.watchdog
+
+    mgr.stop(::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + 1)
+
+    assert_predicate mgr, :stopped?
+  end
+
   # --- compat ---------------------------------------------------------
 
   def test_pause_time_constant_defined
@@ -413,6 +454,15 @@ class ManagerTest < Wurk::Test::UnitCase
   # kill real (un-started) threads.
   def silence_processors(mgr)
     mgr.workers.each { |w| w.define_singleton_method(:terminate) { nil } }
+  end
+
+  # Materializes the capsule's watchdog (prepare! is what a real boot runs) and
+  # records each #terminate; returns the recorder.
+  def watchdog_terminations
+    @capsule.prepare!
+    [].tap do |seen|
+      @capsule.watchdog.define_singleton_method(:terminate) { seen << :terminated }
+    end
   end
 
   # #stop only waits on processors that hold a live thread — a never-started

--- a/test/unit/metrics_emitter_agreement_test.rb
+++ b/test/unit/metrics_emitter_agreement_test.rb
@@ -39,10 +39,14 @@ class MetricsEmitterAgreementTest < Wurk::Test::UnitCase
   end
 
   # Job outcome → the classification both emitters owe it. The interrupted row
-  # is #394: a cooperative interruption is not a failure.
+  # is #394: a cooperative interruption is not a failure. Neither is a job cut
+  # by its absolute deadline — Middleware::Expiry books that one `expired`, and
+  # counting it failed here as well would put one abandoned job in two of the
+  # three counts an operator subtracts.
   PATHS = [
     ['clean return', :processed, -> { :ok }],
     ['cooperative interruption', :processed, -> { raise Wurk::Job::Interrupted }],
+    ['deadline cut', :processed, -> { raise Wurk::Job::DeadlineExceeded }],
     ['real exception', :failed, -> { raise 'boom' }]
   ].freeze
 

--- a/test/unit/timeout_middleware_test.rb
+++ b/test/unit/timeout_middleware_test.rb
@@ -1,0 +1,243 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'securerandom'
+
+# Pins Wurk::Middleware::Timeout, the per-attempt wall-clock bound behind
+# `sidekiq_options timeout:`. Three properties carry it: a class that declares
+# no bound arms nothing and starts no timer, a class that declares one has its
+# attempt cut by an error it can still rescue, and the cut is booked as the
+# failure it is — which is a fact about where the middleware sits in the chain,
+# not about the middleware itself, so the last one runs through the real chain.
+class TimeoutMiddlewareTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  # Registration order in lib/wurk.rb. Chain walks entries outside-in on the way
+  # in and unwinds inside-out on the way out, so the LOWER index is the OUTER
+  # middleware: everything that acks or reschedules a job the bound may have cut
+  # belongs outside it, everything that books the attempt belongs inside.
+  OUTER_OF_TIMEOUT = [
+    Wurk::Batch::ServerMiddleware,
+    Wurk::Middleware::Expiry,
+    Wurk::Limiter::ServerMiddleware
+  ].freeze
+  INNER_OF_TIMEOUT = [
+    Wurk::Metrics::Statsd,
+    Wurk::Metrics::History,
+    Wurk::Middleware::Status
+  ].freeze
+
+  def setup
+    super
+    @config = Wurk::Configuration.new
+    @config.logger = ::Logger.new(IO::NULL)
+    @capsule = Wurk::Capsule.new("timeout-#{Process.pid}-#{object_id}", @config)
+    @watchdogs = []
+    @booked = []
+  end
+
+  def teardown
+    @watchdogs.each(&:terminate)
+    drop_bucket_fields
+  ensure
+    super
+  end
+
+  # ---- nothing declared, nothing paid --------------------------------------
+
+  def test_a_job_without_a_bound_yields_and_arms_nothing
+    watchdog = attach_watchdog
+
+    assert_equal :ok, invoke({ 'class' => 'PlainJob' }) { :ok }
+    assert_equal 0, watchdog.size
+    refute_predicate watchdog, :running?, 'a class with no timeout: must not start the scanner'
+  end
+
+  # Every shape JSON can leave in the field that isn't a usable number of
+  # seconds. Declaration-time validation rejects these where they are written;
+  # a payload from stock Sidekiq, a raw LPUSH, or a release older than the
+  # option never met that check, and must still run.
+  def test_an_unusable_bound_leaves_the_job_unbounded
+    watchdog = attach_watchdog
+
+    ['30', 0, -1, Float::INFINITY, Float::NAN, nil, true].each do |value|
+      assert_equal :ok, invoke({ 'class' => 'PlainJob', 'timeout' => value }) { :ok }, "#{value.inspect} armed a bound"
+    end
+
+    refute_predicate watchdog, :running?
+  end
+
+  # A Configuration owns no watchdog — only a Capsule does — and a chain bound
+  # to one is what `Wurk::Testing.inline!` and a hand-driven chain invoke.
+  def test_a_config_that_owns_no_watchdog_runs_the_job_unbounded
+    result = build(@config).call(nil, bounded_job(0.01), 'default') do
+      sleep 0.05
+      :ok
+    end
+
+    assert_equal :ok, result
+  end
+
+  # Capsule#prepare! is what builds the watchdog, so a capsule the launcher
+  # never got that far with has none. The bound is a safety net; a missing timer
+  # is not a reason to fail the job.
+  def test_an_unprepared_capsule_runs_the_job_unbounded
+    assert_nil @capsule.watchdog
+
+    result = build(@capsule).call(nil, bounded_job(0.01), 'default') do
+      sleep 0.05
+      :ok
+    end
+
+    assert_equal :ok, result
+  end
+
+  # ---- bound met -----------------------------------------------------------
+
+  def test_a_job_inside_its_bound_returns_its_value_and_retracts
+    watchdog = attach_watchdog
+
+    assert_equal :ok, invoke(bounded_job(5)) { :ok }
+    assert_equal 0, watchdog.size
+  end
+
+  # Nothing may outlive the attempt: a pending raise here would land on the ACK
+  # or on the next job, the stdlib `Timeout` failure mode Watchdog exists to
+  # avoid, now proven through its caller.
+  def test_a_completed_attempt_leaves_no_pending_interrupt
+    attach_watchdog
+
+    invoke(bounded_job(5)) { sleep 0.05 }
+
+    refute_predicate Thread, :pending_interrupt?
+  end
+
+  # ---- bound exceeded ------------------------------------------------------
+
+  def test_a_job_over_its_bound_is_cut_with_a_named_error
+    watchdog = attach_watchdog
+
+    err = assert_raises(Wurk::Job::TimedOut) { invoke(bounded_job(0.02, 'SlowJob')) { sleep 5 } }
+
+    assert_equal 'SlowJob timed out after 0.02s', err.message
+    assert_equal 0, watchdog.size
+  end
+
+  # Soft, by contract. The job sees an ordinary error and gets to clean up
+  # behind itself — `Thread#kill` would strand whatever `perform` was holding.
+  def test_the_cut_is_an_error_the_job_can_rescue
+    attach_watchdog
+    cleaned = false
+
+    result = invoke(bounded_job(0.02)) do
+      sleep 5
+    rescue Wurk::Job::TimedOut
+      cleaned = true
+      :cleaned_up
+    end
+
+    assert_equal :cleaned_up, result
+    assert cleaned
+  end
+
+  # Per attempt, not per job: the retry of a job that timed out is handed the
+  # whole budget again rather than inheriting an exhausted one.
+  def test_each_attempt_gets_its_own_bound
+    attach_watchdog
+    job = bounded_job(0.05)
+
+    assert_raises(Wurk::Job::TimedOut) { invoke(job) { sleep 5 } }
+    assert_equal :ok, invoke(job) { :ok }
+  end
+
+  # ---- chain position ------------------------------------------------------
+
+  def test_registered_between_the_reschedulers_and_the_bookkeepers
+    klasses = Wurk.configuration.server_middleware.map(&:klass)
+    index = klasses.index(Wurk::Middleware::Timeout)
+
+    refute_nil index, 'Middleware::Timeout must be auto-registered on the server chain'
+    OUTER_OF_TIMEOUT.each do |klass|
+      assert_operator klasses.index(klass), :<, index, "#{klass} must be registered OUTER of Timeout"
+    end
+    INNER_OF_TIMEOUT.each do |klass|
+      assert_operator klasses.index(klass), :>, index, "#{klass} must be registered INNER of Timeout"
+    end
+  end
+
+  # Isolation proves the middleware arms a bound; only the real chain proves the
+  # position pays for itself. A `TimedOut` raised from the job body has to unwind
+  # through Metrics::History and be booked `f` — register Timeout inside History
+  # instead and the cut never reaches it, so a job that hung is a job that, as
+  # far as every metric in the dashboard is concerned, never happened.
+  def test_a_timeout_through_the_real_chain_books_a_failure
+    klass = book("TimeoutJob-#{SecureRandom.hex(8)}")
+    job = { 'class' => klass, 'args' => [], 'jid' => SecureRandom.hex(12), 'queue' => 'default' }
+    before = ::Time.now.utc
+
+    assert_raises(Wurk::Job::TimedOut) do
+      real_chain.invoke(nil, job, 'default') { raise Wurk::Job::TimedOut, 'cut' }
+    end
+    Wurk::Metrics::History.flush
+
+    assert_includes recorded_fields(klass, before), 'f'
+  end
+
+  private
+
+  def build(config)
+    Wurk::Middleware::Timeout.new.tap { |middleware| middleware.config = config }
+  end
+
+  def invoke(job, &)
+    build(@capsule).call(nil, job, 'default', &)
+  end
+
+  def bounded_job(seconds, klass = 'BoundedJob')
+    { 'class' => klass, 'timeout' => seconds }
+  end
+
+  # What Capsule#prepare! assigns in production, minus the Redis pools and the
+  # fetcher it opens on the way. The fast scan keeps a blown bound in the
+  # milliseconds instead of SCAN_INTERVAL.
+  def attach_watchdog(interval: 0.01)
+    Wurk::Watchdog.new(@capsule, interval: interval).tap do |watchdog|
+      @watchdogs << watchdog
+      @capsule.instance_variable_set(:@watchdog, watchdog)
+    end
+  end
+
+  def real_chain = Wurk.configuration.default_capsule.server_middleware
+
+  def book(klass)
+    @booked << klass
+    klass
+  end
+
+  # The middleware records at its own Time.now, which may cross a minute
+  # boundary, so both candidate buckets are merged.
+  def recorded_fields(klass, started_at)
+    minute_keys(started_at).flat_map do |key|
+      raw = Wurk.redis { |conn| conn.call('HGETALL', key) }
+      fields = raw.is_a?(::Hash) ? raw.keys : raw.each_slice(2).map(&:first)
+      fields.select { |field| field.start_with?("#{klass}|") }.map { |field| field.split('|', 2).last }
+    end
+  end
+
+  def minute_keys(started_at)
+    [started_at, ::Time.now.utc].map { |t| Wurk::Metrics::History.minute_key(t) }.uniq
+  end
+
+  # Per-class fields live in shared minute buckets no FLUSHDB-per-test reaches
+  # before a parallel sibling reads them, so drop exactly the ones booked here.
+  def drop_bucket_fields
+    return if @booked.empty?
+
+    Wurk.redis do |conn|
+      minute_keys(::Time.now.utc - 60).each do |key|
+        mine = conn.call('HKEYS', key).select { |field| @booked.any? { |klass| field.start_with?("#{klass}|") } }
+        conn.call('HDEL', key, *mine) unless mine.empty?
+      end
+    end
+  end
+end

--- a/test/unit/timeout_middleware_test.rb
+++ b/test/unit/timeout_middleware_test.rb
@@ -183,6 +183,46 @@ class TimeoutMiddlewareTest < Wurk::Test::UnitCase
     assert_includes recorded_fields(klass, before), 'f'
   end
 
+  # ---- zero cost, at process scope ------------------------------------------
+
+  # The other tests in this file pin "zero cost" through the Watchdog's own
+  # bookkeeping (#size, #running?); this one pins the claim the plan doc asks
+  # for literally — the OS thread count of the process a class with no bound
+  # runs in must not move, not just the Watchdog's private view of itself.
+  def test_no_bound_configured_leaves_the_process_thread_count_unchanged
+    attach_watchdog
+    before = Thread.list.size
+
+    100.times { assert_equal :ok, invoke({ 'class' => 'PlainJob' }) { :ok } }
+
+    assert_equal before, Thread.list.size
+  end
+
+  # ---- leak check ------------------------------------------------------------
+
+  # 1000 attempts, every one cut, through the real registered chain (Batch,
+  # Expiry, Limiter, Timeout, Statsd, History, Status) — the same RAII
+  # discipline docs/plans/2026/07/31/101-leak-logic-perf-fixes/ closed applies
+  # here: an interrupt landing mid-bookkeeping must never strand a Redis
+  # checkout or an OS thread. One class, so the minute-bucket field this
+  # leaves behind is one HINCRBY target, not a thousand.
+  def test_a_thousand_cut_attempts_leak_no_thread_or_connection
+    klass = book("TimeoutLeakJob-#{SecureRandom.hex(8)}")
+    job = { 'class' => klass, 'args' => [], 'jid' => SecureRandom.hex(12), 'queue' => 'default' }
+    pool = Wurk.configuration.default_capsule.redis_pool
+    threads_before = Thread.list.size
+    available_before = pool.available
+
+    1000.times do
+      assert_raises(Wurk::Job::TimedOut) do
+        real_chain.invoke(nil, job, 'default') { raise Wurk::Job::TimedOut, 'cut' }
+      end
+    end
+
+    assert_equal threads_before, Thread.list.size, 'no thread may accumulate across 1000 cut attempts'
+    assert_equal available_before, pool.available, 'every Redis checkout the chain took must have been returned'
+  end
+
   private
 
   def build(config)

--- a/test/unit/watchdog_test.rb
+++ b/test/unit/watchdog_test.rb
@@ -12,6 +12,10 @@ class WatchdogTest < Wurk::Test::UnitCase
 
   class Bound < StandardError; end
 
+  # A second class, because the two masks in #watch are per-exception: only a
+  # bound of a *different* class can be delivered inside another one's scope.
+  class Other < StandardError; end
+
   # Models a host handing us an exception class that can't be built. Thread#raise
   # instantiates in the *calling* thread, so this blows up in the scanner.
   Unbuildable = Class.new(StandardError) do
@@ -116,6 +120,57 @@ class WatchdogTest < Wurk::Test::UnitCase
     assert retracted, 'the raise must not land inside the masked retraction'
     refute_predicate Thread, :pending_interrupt?, 'no interrupt may outlive #watch'
     assert_equal 0, wd.size
+  end
+
+  # The other half of the same race, and the one the mask alone cannot close:
+  # the scan has already selected the entry and is about to raise when the
+  # thread it aimed at finishes. Selection and raise are one critical section
+  # under @lock, and #disarm takes that lock, so the thread is parked inside its
+  # mask — not past it — when the exception goes out.
+  def test_a_raise_already_selected_cannot_overtake_the_retraction
+    wd = build(interval: 60)
+    poised, release = poise_the_scan(wd)
+    finish = Queue.new
+    left_block = Queue.new
+    outcome = Queue.new
+    worker = bounded_worker(wd, finish, left_block, outcome)
+    wait_until { wd.size == 1 }
+    scan = Thread.new { wd.send(:tick) }
+
+    poised.pop(timeout: 5)      # entry selected, raise not issued yet
+    finish << :go               # the guarded block returns at exactly that moment
+    left_block.pop(timeout: 5)
+    wait_until { worker.status == 'sleep' || !worker.status }
+    release << :go              # and only now does the raise go out
+
+    assert_equal :contained, outcome.pop(timeout: 5), 'the raise landed outside #watch'
+    assert_equal :clean, outcome.pop(timeout: 5), 'no interrupt may outlive #watch'
+  ensure
+    release&.<<(:go)
+    scan&.join(2)
+    worker&.join(2)
+  end
+
+  # Two bounds on one thread: the inner retraction runs inside the outer bound's
+  # `:immediate` scope, so an outer raise landing mid-retraction would strand the
+  # inner entry — still armed, no thread left to retract it, free to fire into
+  # whatever that thread picks up next. Widening #disarm makes the race
+  # deterministic: the outer bound passes while the inner one is retracting.
+  def test_an_outer_bound_firing_mid_retraction_strands_nothing
+    wd = build(interval: 0.01)
+    inner_id = nil
+    wd.define_singleton_method(:disarm) do |id|
+      sleep 0.3 if id == inner_id
+      super(id)
+    end
+
+    assert_raises(Other) do
+      wd.watch(0.02, Other, 'outer') do
+        wd.watch(5, Bound, 'inner') { inner_id = wd.instance_variable_get(:@seq) }
+      end
+    end
+
+    assert_equal 0, wd.size, 'the inner bound must be retracted, not stranded'
   end
 
   def test_nested_bounds_fire_independently
@@ -252,6 +307,39 @@ class WatchdogTest < Wurk::Test::UnitCase
   end
 
   private
+
+  # Parks the scan between selecting a due entry and raising into it — the exact
+  # interleaving the lock exists to forbid. Returns the two gates: one that fires
+  # when the scan is poised, one that lets it through.
+  def poise_the_scan(watchdog)
+    poised = Queue.new
+    release = Queue.new
+    watchdog.define_singleton_method(:interrupt) do |entry, failures|
+      poised << :selected
+      release.pop
+      super(entry, failures)
+    end
+    [poised, release]
+  end
+
+  # A thread holding a bound that has already passed, blocked inside the guarded
+  # block until `finish`. Reports where the raise landed — inside #watch or after
+  # it — and whether anything was still pending once #watch returned.
+  def bounded_worker(watchdog, finish, left_block, outcome)
+    Thread.new do
+      landed = begin
+        watchdog.watch(0, Bound) do
+          finish.pop
+          left_block << :returning
+        end
+        :escaped
+      rescue Bound
+        :contained
+      end
+      outcome << landed
+      outcome << (Thread.pending_interrupt? ? :pending : :clean)
+    end
+  end
 
   def build(interval: Wurk::Watchdog::SCAN_INTERVAL)
     Wurk::Watchdog.new(@capsule, interval: interval).tap { |wd| @watchdogs << wd }

--- a/test/unit/watchdog_test.rb
+++ b/test/unit/watchdog_test.rb
@@ -1,0 +1,274 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Pins Wurk::Watchdog, the single monotonic timer thread that cuts jobs which
+# outlive a bound. Three properties carry the design: no bound armed → no
+# thread; one thread serves every bounded job in the capsule; and a fired raise
+# is delivered inside the block it guards, never after it — the stdlib `Timeout`
+# failure mode this class exists to avoid.
+class WatchdogTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  class Bound < StandardError; end
+
+  # Models a host handing us an exception class that can't be built. Thread#raise
+  # instantiates in the *calling* thread, so this blows up in the scanner.
+  Unbuildable = Class.new(StandardError) do
+    def self.exception(*)
+      raise 'cannot build'
+    end
+  end
+
+  def setup
+    super
+    @config = Wurk::Configuration.new
+    @config.logger = ::Logger.new(IO::NULL)
+    @capsule = Wurk::Capsule.new("wd-#{Process.pid}-#{object_id}", @config)
+    @watchdogs = []
+  end
+
+  def teardown
+    @watchdogs.each(&:terminate)
+  ensure
+    super
+  end
+
+  # --- zero cost when nothing is bounded --------------------------------
+
+  def test_construction_spawns_no_thread
+    wd = build
+
+    refute_predicate wd, :running?
+    assert_equal 0, wd.size
+    assert_empty scanners, 'an unconfigured capsule must carry no scanner thread'
+  end
+
+  def test_terminate_without_a_bound_is_a_noop
+    wd = build
+
+    wd.terminate
+
+    refute_predicate wd, :running?
+  end
+
+  # --- bound met --------------------------------------------------------
+
+  def test_returns_the_block_value_and_retracts_the_bound
+    wd = build
+
+    assert_equal :ok, wd.watch(5, Bound) { :ok }
+    assert_equal 0, wd.size
+  end
+
+  def test_a_block_that_raises_its_own_error_still_retracts_the_bound
+    wd = build
+
+    assert_raises(ArgumentError) { wd.watch(5, Bound) { raise ArgumentError } }
+    assert_equal 0, wd.size
+  end
+
+  def test_completion_inside_the_bound_leaves_no_pending_interrupt
+    wd = build(interval: 0.01)
+
+    wd.watch(5, Bound) { sleep 0.05 }
+
+    refute_predicate Thread, :pending_interrupt?
+  end
+
+  # --- bound exceeded ---------------------------------------------------
+
+  def test_bound_exceeded_raises_the_callers_exception_and_message
+    wd = build(interval: 0.01)
+
+    err = assert_raises(Bound) { wd.watch(0.02, Bound, 'execution expired') { sleep 5 } }
+
+    assert_equal 'execution expired', err.message
+    assert_equal 0, wd.size
+  end
+
+  def test_bound_exceeded_without_a_message_carries_the_class_name
+    wd = build(interval: 0.01)
+
+    err = assert_raises(Bound) { wd.watch(0, Bound) { sleep 5 } }
+
+    assert_equal Bound.name, err.message
+  end
+
+  # --- containment (the stdlib Timeout failure mode) --------------------
+
+  # A raise that wins the race against retraction must be delivered where #watch
+  # is still on the stack — not at whatever checkpoint the thread reaches next,
+  # which inside a Processor is the ACK, or the next job. Widening #disarm makes
+  # that race deterministic: the bound passes while the thread sits in the
+  # masked retraction.
+  def test_a_raise_racing_the_retraction_lands_inside_watch
+    wd = build(interval: 0.01)
+    retracted = false
+    wd.define_singleton_method(:disarm) do |id|
+      sleep 0.1
+      super(id)
+      retracted = true
+    end
+
+    assert_raises(Bound) { wd.watch(0.02, Bound) { :done } }
+
+    assert retracted, 'the raise must not land inside the masked retraction'
+    refute_predicate Thread, :pending_interrupt?, 'no interrupt may outlive #watch'
+    assert_equal 0, wd.size
+  end
+
+  def test_nested_bounds_fire_independently
+    wd = build(interval: 0.01)
+    inner = nil
+
+    wd.watch(5, Bound, 'outer') do
+      wd.watch(0.02, Bound, 'inner') { sleep 5 }
+    rescue Bound => e
+      inner = e.message
+    end
+
+    assert_equal 'inner', inner
+    assert_equal 0, wd.size
+  end
+
+  # --- one thread, many bounds ------------------------------------------
+
+  def test_one_scanner_serves_every_bounded_thread
+    wd = build
+    gate = Queue.new
+    threads = Array.new(4) { Thread.new { wd.watch(5, Bound) { gate.pop } } }
+    wait_until { wd.size == 4 }
+
+    assert_equal 1, scanners.size
+  ensure
+    4.times { gate << :go }
+    threads&.each { |t| t.join(2) }
+  end
+
+  # safe_thread names the thread from inside it, so the name appears a beat
+  # after #watch returns — wait for it rather than racing it.
+  def test_the_scanner_is_named_for_the_logs
+    wd = build
+    wd.watch(5, Bound) { :ok }
+
+    assert_predicate wd, :running?
+    wait_until { scanners.size == 1 }
+
+    assert_same wd.instance_variable_get(:@thread), scanners.first
+  end
+
+  def test_repeated_bounds_leak_neither_entries_nor_threads
+    wd = build
+
+    200.times { wd.watch(5, Bound) { nil } }
+    wait_until { scanners.size == 1 }
+
+    assert_equal 0, wd.size
+    assert_equal [wd.instance_variable_get(:@thread)], scanners
+  end
+
+  # --- stranded entries -------------------------------------------------
+
+  # A bound armed by a thread that then died (killed mid-drain) is retracted by
+  # the scan, and the raise into the corpse costs nothing — an Unbuildable that
+  # was never built proves Thread#raise short-circuits on a dead target, which is
+  # why no liveness check guards it.
+  def test_a_bound_whose_thread_died_is_dropped_without_raising
+    wd = build(interval: 60)
+    reported = capture_errors
+    dead = Thread.new { wd.send(:arm, 0, Unbuildable, nil) }
+    dead.join
+
+    assert_equal 1, wd.size
+    wd.send(:tick)
+
+    assert_equal 0, wd.size
+    assert_empty reported
+  end
+
+  def test_an_exception_class_that_cannot_be_built_is_reported_not_fatal
+    wd = build(interval: 60)
+    reported = capture_errors
+    wd.send(:arm, 0, Unbuildable, nil)
+
+    wd.send(:tick)
+
+    assert_equal 0, wd.size
+    assert_equal 1, reported.size
+    ex, ctx = reported.first
+
+    assert_equal 'cannot build', ex.message
+    assert_equal Wurk::Watchdog::THREAD_NAME, ctx[:context]
+    assert_predicate wd, :running?
+  end
+
+  # --- lifecycle --------------------------------------------------------
+
+  def test_terminate_stops_the_scanner
+    wd = build(interval: 0.01)
+    wd.watch(5, Bound) { :ok }
+
+    assert_predicate wd, :running?
+
+    wd.terminate
+
+    refute_predicate wd, :running?
+  end
+
+  def test_terminate_is_idempotent
+    wd = build(interval: 0.01)
+    wd.watch(5, Bound) { :ok }
+
+    wd.terminate
+    wd.terminate
+
+    refute_predicate wd, :running?
+  end
+
+  # An embedded host that boots again reuses the capsule, and therefore this
+  # object: the next bound must get a scanner that ticks, not one that sees the
+  # stale done flag and exits at once.
+  def test_a_bound_armed_after_terminate_still_fires
+    wd = build(interval: 0.01)
+    wd.watch(5, Bound) { :ok }
+    wd.terminate
+
+    assert_raises(Bound) { wd.watch(0.02, Bound) { sleep 5 } }
+    assert_predicate wd, :running?
+  end
+
+  # safe_thread reports and re-raises, so an unhandled error inside a scan kills
+  # the thread. The capsule must not stay unguarded for the life of the process.
+  def test_a_dead_scanner_is_replaced_by_the_next_bound
+    wd = build(interval: 0.01)
+    wd.watch(5, Bound) { :ok }
+    scanner = wd.instance_variable_get(:@thread)
+    scanner.kill
+    scanner.join(2)
+
+    assert_raises(Bound) { wd.watch(0.02, Bound) { sleep 5 } }
+    refute_same scanner, wd.instance_variable_get(:@thread)
+  end
+
+  private
+
+  def build(interval: Wurk::Watchdog::SCAN_INTERVAL)
+    Wurk::Watchdog.new(@capsule, interval: interval).tap { |wd| @watchdogs << wd }
+  end
+
+  def scanners
+    Thread.list.select { |t| t.name == Wurk::Watchdog::THREAD_NAME }
+  end
+
+  def capture_errors
+    [].tap { |seen| @config.error_handlers << ->(ex, ctx, _cfg) { seen << [ex, ctx] } }
+  end
+
+  def wait_until(timeout: 3)
+    deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + timeout
+    sleep 0.005 until yield || ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) > deadline
+
+    assert yield, 'condition never became true'
+  end
+end


### PR DESCRIPTION
## Summary
- One monotonic `Wurk::Watchdog` per Manager, zero-cost when nothing is bounded (measured: 3.0µs/bounded job vs stdlib `Timeout`'s 4.5µs).
- `sidekiq_options timeout:` (per-attempt, soft, retried like any other failure) and `deadline:` (absolute from enqueue, survives retries/IterableJob resumes, booked `expired`, never retried).
- Chain position: outside Statsd/History/Status (so a cut is measured and booked), inside Batch/Expiry/Limiter (so Limiter's reschedule+raise pair and Expiry's deadline catch can't be split by a mid-frame bound).
- Full test pass: thread-count/leak proofs, IterableJob interrupt+resume interaction (deadline survives, timeout resets per attempt), and a real-fork/real-Redis integration test proving a genuinely hanging job is actually cut — including the `shutdown_timeout` interaction (shorter bound fires first; a much longer one loses to shutdown's own drain).

## Test plan
- [x] `bin/rake test` (3550 runs, 0 failures)
- [x] `bin/rake test:parity` (23 runs, 0 failures)
- [x] `bundle exec rubocop` (419 files, 0 offenses)
- [x] Mutation check: disabling the watchdog arm makes the new integration tests fail as expected, confirmed clean revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788824204&installation_model_id=11168&pr_number=404&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F404&signature=188d0619d91777b5f2d49a824bc32ba918a015bb5950b82f2a0e252248326af0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable per-attempt timeouts and end-to-end job deadlines.
  * Jobs exceeding a deadline are automatically expired and removed from processing.
  * Timeout and deadline settings are validated and preserved across scheduling, retries, and re-enqueueing.
  * Added automatic enforcement during job execution, including support for concurrent bounded jobs.
* **Bug Fixes**
  * Improved shutdown handling and metric classification for timed-out and deadline-expired jobs.
* **Tests**
  * Added comprehensive coverage for timeout, deadline, retry, expiry, shutdown, and resource-cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->