### PR TITLE
feat(api): HTTP producer API — skeleton, auth, enqueue, validation, drop-in tests

### DIFF
--- a/lib/wurk.rb
+++ b/lib/wurk.rb
@@ -341,6 +341,12 @@ require_relative 'wurk/middleware/status'
 # Spec: docs/target/sidekiq-pro.md §11.
 require_relative 'wurk/api/fast'
 
+# The machine-facing HTTP API's mount point (`mount Wurk::API`, `run
+# Wurk::API`). Only the entry point loads here; the router, Rack::Request and
+# the rest arrive on the first request, so a swarm that never serves HTTP pays
+# nothing for the constant existing.
+require_relative 'wurk/api'
+
 # Sidekiq aliases load last — every Wurk::* constant they reference must be
 # fully defined first. compat.rb only redefines names, it does not gate
 # behavior, so trailing the load order is safe.

--- a/lib/wurk/api.rb
+++ b/lib/wurk/api.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Wurk
+  # Namespace for two unrelated things that both answer to "the API": the Pro
+  # data-API Lua extensions (API::Fast, required by lib/wurk.rb at its
+  # load-order-sensitive point) and the machine-facing HTTP API (API::App).
+  module API
+    class << self
+      # Class-level Rack entry, the same shape as Wurk::Web.call, so
+      # `mount Wurk::API => '/wurk-api'` and `run Wurk::API` both work.
+      #
+      # App and its dependencies (Rack::Request among them) load on the first
+      # request rather than at `require "wurk"`. The HTTP API is off unless a
+      # host mounts it, and eager-loading it cost every swarm child ~1.2 MB of
+      # pre-fork heap and measurably slower boot for a surface it never serves.
+      def call(env)
+        app.call(env)
+      end
+
+      private
+
+      # App is stateless, so every mount — engine-nested, separately mounted,
+      # standalone — can share one instance.
+      def app
+        @app ||= begin
+          require_relative 'api/app'
+          App.new
+        end
+      end
+    end
+  end
+end

--- a/lib/wurk/api/app.rb
+++ b/lib/wurk/api/app.rb
@@ -36,6 +36,9 @@ module Wurk
 
       def call(env)
         request = Request.new(env)
+        # Stamped once, before anything reads it, so every handler sees the
+        # same config the auth gate did — including a test's injected one.
+        request.config = config
         response = handle(request)
         # HEAD is routed as GET, so the handler built a body it must not send.
         request.head? ? [response[0], response[1], []] : response
@@ -58,6 +61,7 @@ module Wurk
       # unauthenticated prober can't enumerate which paths or versions exist
       # from the difference between a 404 and a 405.
       def handle(request)
+        config = request.config
         return not_found(request) unless Auth.configured?(config)
 
         principal = Auth.authenticate(request, config)

--- a/lib/wurk/api/app.rb
+++ b/lib/wurk/api/app.rb
@@ -3,6 +3,7 @@
 require 'json'
 require 'rack'
 require_relative '../version'
+require_relative 'auth'
 require_relative 'problem'
 require_relative 'request'
 require_relative 'router'
@@ -24,7 +25,12 @@ module Wurk
 
       JSON_HEADERS = { 'content-type' => 'application/json', 'x-content-type-options' => 'nosniff' }.freeze
 
-      def initialize
+      # `config` is read on every request rather than captured, so a token
+      # registered after the first request still takes effect. Injectable
+      # because a test must be able to hand this app its own token table
+      # instead of mutating the process-wide one.
+      def initialize(config: nil)
+        @config = config
         @router = Router.new
         draw(@router)
       end
@@ -38,23 +44,41 @@ module Wurk
 
       private
 
-      # Later slices hang their own tables off this: jobs, queues, swarm.
-      def draw(router)
-        router.get('/') { |request| root(request) }
+      def config
+        @config || ::Wurk.configuration
       end
 
+      # Later slices hang their own tables off this: jobs, queues, swarm.
+      def draw(router)
+        router.get('/', scope: Auth::ANY) { |request| root(request) }
+      end
+
+      # Authentication runs before the version gate and before routing, so an
+      # unauthenticated prober can't enumerate which paths or versions exist
+      # from the difference between a 404 and a 405.
       def handle(request)
+        return not_found(request) unless Auth.configured?(config)
+
+        principal = Auth.authenticate(request, config)
+        return Auth.unauthorized(request) unless principal
+
+        request.principal = principal
+        route(request)
+      rescue StandardError => e
+        internal_error(request, e)
+      end
+
+      def route(request)
         path = request.path_info.to_s
         return unsupported_version(request) unless versioned?(path)
 
         dispatch(request, path.delete_prefix(VERSION_PREFIX))
-      rescue StandardError => e
-        internal_error(request, e)
       end
 
       def dispatch(request, path)
         match = @router.match(request.request_method, path)
         return route_miss(request, match) unless match.handler
+        return Auth.forbidden(request, match.scope) unless request.principal.permits?(match.scope)
 
         request.path_params = match.params
         match.handler.call(request)

--- a/lib/wurk/api/app.rb
+++ b/lib/wurk/api/app.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
-require 'json'
 require 'rack'
 require_relative '../version'
 require_relative 'auth'
+require_relative 'jobs'
 require_relative 'problem'
 require_relative 'request'
+require_relative 'response'
 require_relative 'router'
 
 module Wurk
@@ -22,8 +23,6 @@ module Wurk
       API_VERSION = 'v1'
       VERSION_PREFIX = "/#{API_VERSION}".freeze
       SUPPORTED_VERSIONS = [API_VERSION].freeze
-
-      JSON_HEADERS = { 'content-type' => 'application/json', 'x-content-type-options' => 'nosniff' }.freeze
 
       # `config` is read on every request rather than captured, so a token
       # registered after the first request still takes effect. Injectable
@@ -48,9 +47,11 @@ module Wurk
         @config || ::Wurk.configuration
       end
 
-      # Later slices hang their own tables off this: jobs, queues, swarm.
+      # One table per plane, each owning its own routes and handlers. Queues and
+      # swarm join Jobs here.
       def draw(router)
         router.get('/', scope: Auth::ANY) { |request| root(request) }
+        Jobs.draw(router)
       end
 
       # Authentication runs before the version gate and before routing, so an
@@ -87,7 +88,9 @@ module Wurk
       # The document a client hits to confirm which mount and which contract it
       # is talking to before it starts guessing paths.
       def root(request)
-        json(200, api_version: API_VERSION, wurk_version: ::Wurk::VERSION, url: request.url_for(VERSION_PREFIX))
+        Response.json(
+          200, api_version: API_VERSION, wurk_version: ::Wurk::VERSION, url: request.url_for(VERSION_PREFIX)
+        )
       end
 
       def versioned?(path)
@@ -145,10 +148,6 @@ module Wurk
           detail: 'The request could not be completed.',
           instance: request.path
         )
-      end
-
-      def json(status, payload)
-        [status, JSON_HEADERS.dup, [::JSON.generate(payload)]]
       end
     end
   end

--- a/lib/wurk/api/app.rb
+++ b/lib/wurk/api/app.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'rack'
+require_relative '../version'
+require_relative 'problem'
+require_relative 'request'
+require_relative 'router'
+
+module Wurk
+  module API
+    # The machine-facing HTTP API. Plain Rack under lib/, with no reference to
+    # Rails or the engine, so one implementation serves all three mounts:
+    # engine-nested (`<mount>/api/v1`), separately mounted
+    # (`mount Wurk::API => '/wurk-api'`), and standalone (`run Wurk::API`).
+    #
+    # Nothing here hardcodes '/wurk'. Every URL the API emits is built from
+    # SCRIPT_NAME (Request#url_for) — the same mount-agnostic rule the SPA shell
+    # follows in dashboard_controller.rb.
+    class App
+      API_VERSION = 'v1'
+      VERSION_PREFIX = "/#{API_VERSION}".freeze
+      SUPPORTED_VERSIONS = [API_VERSION].freeze
+
+      JSON_HEADERS = { 'content-type' => 'application/json', 'x-content-type-options' => 'nosniff' }.freeze
+
+      def initialize
+        @router = Router.new
+        draw(@router)
+      end
+
+      def call(env)
+        request = Request.new(env)
+        response = handle(request)
+        # HEAD is routed as GET, so the handler built a body it must not send.
+        request.head? ? [response[0], response[1], []] : response
+      end
+
+      private
+
+      # Later slices hang their own tables off this: jobs, queues, swarm.
+      def draw(router)
+        router.get('/') { |request| root(request) }
+      end
+
+      def handle(request)
+        path = request.path_info.to_s
+        return unsupported_version(request) unless versioned?(path)
+
+        dispatch(request, path.delete_prefix(VERSION_PREFIX))
+      rescue StandardError => e
+        internal_error(request, e)
+      end
+
+      def dispatch(request, path)
+        match = @router.match(request.request_method, path)
+        return route_miss(request, match) unless match.handler
+
+        request.path_params = match.params
+        match.handler.call(request)
+      end
+
+      # The document a client hits to confirm which mount and which contract it
+      # is talking to before it starts guessing paths.
+      def root(request)
+        json(200, api_version: API_VERSION, wurk_version: ::Wurk::VERSION, url: request.url_for(VERSION_PREFIX))
+      end
+
+      def versioned?(path)
+        path == VERSION_PREFIX || path.start_with?("#{VERSION_PREFIX}/")
+      end
+
+      def route_miss(request, match)
+        return not_found(request) if match.allowed.empty?
+
+        Problem.render(
+          Problem::METHOD_NOT_ALLOWED,
+          status: 405,
+          detail: "#{request.request_method} is not allowed on #{request.path_info}.",
+          instance: request.path,
+          headers: { 'allow' => allow_header(match.allowed) }
+        )
+      end
+
+      # A path that answers GET answers HEAD too, so advertise both.
+      def allow_header(verbs)
+        verbs = verbs.dup
+        verbs << 'HEAD' if verbs.include?('GET')
+        verbs.join(', ')
+      end
+
+      def not_found(request)
+        Problem.render(
+          Problem::NOT_FOUND,
+          status: 404,
+          detail: "No route matches #{request.request_method} #{request.path_info}.",
+          instance: request.path
+        )
+      end
+
+      # 404 rather than 400: an unknown version is an address that does not
+      # exist, and the client's own request was well-formed.
+      def unsupported_version(request)
+        Problem.render(
+          Problem::UNSUPPORTED_API_VERSION,
+          status: 404,
+          detail: "The Wurk HTTP API is served under #{VERSION_PREFIX}.",
+          instance: request.path,
+          supported_versions: SUPPORTED_VERSIONS
+        )
+      end
+
+      # The exception details stay in the log. A machine client gets a stable
+      # slug it can retry on, never a backtrace naming host internals.
+      def internal_error(request, error)
+        ::Wurk.logger.error { "Wurk::API #{request.request_method} #{request.path}: #{error.class}: #{error.message}" }
+        ::Wurk.logger.debug { Array(error.backtrace).join("\n") }
+        Problem.render(
+          Problem::INTERNAL_ERROR,
+          status: 500,
+          detail: 'The request could not be completed.',
+          instance: request.path
+        )
+      end
+
+      def json(status, payload)
+        [status, JSON_HEADERS.dup, [::JSON.generate(payload)]]
+      end
+    end
+  end
+end

--- a/lib/wurk/api/auth.rb
+++ b/lib/wurk/api/auth.rb
@@ -45,9 +45,22 @@ module Wurk
 
       REALM = 'Bearer realm="wurk"'
 
-      # What the request proved about itself: the scopes it was granted, and
-      # nothing that could identify the secret it presented.
-      Principal = Struct.new(:scopes) do
+      # Domain-separated so the label below is not a digest of the raw token —
+      # a value that leaked into a log would otherwise be a free head start on
+      # confirming a guessed token offline.
+      FINGERPRINT_DOMAIN = 'wurk.api.token.'
+
+      # 128 bits of the digest. Long enough that two credentials never share a
+      # label, short enough to read in a log line.
+      FINGERPRINT_LENGTH = 32
+
+      # What the request proved about itself: the scopes it was granted, and a
+      # stable label for the credential that granted them. `id` is a truncated
+      # domain-separated digest, never the token — enough to namespace
+      # per-credential state (an Idempotency-Key record belongs to the producer
+      # that chose it, not to whoever guesses the same string), and nothing a
+      # holder could work backwards from.
+      Principal = Struct.new(:id, :scopes) do
         def permits?(scope)
           scope == ANY || scopes.include?(scope) || scopes.include?(:admin)
         end
@@ -94,8 +107,8 @@ module Wurk
         presented = bearer(request.get_header('HTTP_AUTHORIZATION'))
         return nil unless presented
 
-        scopes = lookup(presented, config.api_tokens)
-        scopes && Principal.new(scopes)
+        token, scopes = lookup(presented, config.api_tokens)
+        scopes && Principal.new(fingerprint(token), scopes)
       end
 
       def bearer(header)
@@ -113,9 +126,13 @@ module Wurk
         digest = ::Digest::SHA256.digest(presented)
         found = nil
         tokens.each do |token, scopes|
-          found = scopes if OpenSSL.fixed_length_secure_compare(digest, ::Digest::SHA256.digest(token))
+          found = [token, scopes] if OpenSSL.fixed_length_secure_compare(digest, ::Digest::SHA256.digest(token))
         end
         found
+      end
+
+      def fingerprint(token)
+        ::Digest::SHA256.hexdigest("#{FINGERPRINT_DOMAIN}#{token}")[0, FINGERPRINT_LENGTH]
       end
 
       # RFC 6750 §3. The challenge names `invalid_token` only when the client

--- a/lib/wurk/api/auth.rb
+++ b/lib/wurk/api/auth.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require 'digest'
+require 'openssl'
+require_relative 'problem'
+
+module Wurk
+  module API
+    # Bearer-token authentication and scope checks for the machine-facing HTTP
+    # API. Nothing behind /v1 answers without passing through here.
+    #
+    # Deliberately a separate plane from the dashboard's. That one is cookie-
+    # authenticated and CSRF-guarded by Wurk::SameOriginGuard, which denies any
+    # request that doesn't carry `Sec-Fetch-Site: same-origin` — a header the
+    # browser sets and a Python or Go producer never sends. Reusing it would
+    # mean either 403ing every legitimate machine client or relaxing the one
+    # check that stops a cross-site page from driving a logged-in operator's
+    # dashboard.
+    module Auth
+      # `admin` grants the other two. An operator token allowed to stop a
+      # process but refused a queue listing would be a surprise, not a
+      # safeguard.
+      SCOPES = %i[enqueue read admin].freeze
+
+      # Required scope for a route every authenticated client needs whatever it
+      # was granted — the discovery document, which an enqueue-only producer
+      # has to read to confirm the contract it is about to post to.
+      ANY = :any
+
+      ROUTE_SCOPES = (SCOPES + [ANY]).freeze
+
+      # Under 20 characters the host almost certainly typed the token instead of
+      # generating one (`SecureRandom.urlsafe_base64(16)` is 22). A guessable
+      # token on this API is remote code selection, not just a data leak.
+      MIN_TOKEN_LENGTH = 20
+
+      # Printable ASCII, no spaces — what an Authorization header carries
+      # intact. A token that loses a byte in transit fails as "wrong token",
+      # the least debuggable 401 there is, so reject the shape up front.
+      TOKEN_FORMAT = /\A[\x21-\x7e]+\z/
+
+      # RFC 6750 §2.1. The scheme is case-insensitive (RFC 9110 §11.1); the
+      # credential is not.
+      BEARER = /\ABearer[ \t]+([\x21-\x7e]+)[ \t]*\z/i
+
+      REALM = 'Bearer realm="wurk"'
+
+      # What the request proved about itself: the scopes it was granted, and
+      # nothing that could identify the secret it presented.
+      Principal = Struct.new(:scopes) do
+        def permits?(scope)
+          scope == ANY || scopes.include?(scope) || scopes.include?(:admin)
+        end
+      end
+
+      module_function
+
+      # The gate the whole API hangs off. No token registered → the engine
+      # never mounts the app, and an app mounted directly answers 404 rather
+      # than advertising a surface with nothing behind it.
+      def configured?(config)
+        !config.api_tokens.empty?
+      end
+
+      # Validates a credential where it is declared, so a typo raises in the
+      # initializer that wrote it instead of surfacing as a 401 in production.
+      #
+      # @return [Array(String, Array<Symbol>)] token value and granted scopes
+      def credential!(token, scopes)
+        value = token.to_s
+        unless value.length >= MIN_TOKEN_LENGTH
+          raise ArgumentError, "api_token must be at least #{MIN_TOKEN_LENGTH} characters"
+        end
+        raise ArgumentError, 'api_token must be printable ASCII with no spaces' unless TOKEN_FORMAT.match?(value)
+
+        [value, granted!(scopes)]
+      end
+
+      def granted!(scopes)
+        granted = Array(scopes).map { |scope| scope.to_s.to_sym }.uniq
+        raise ArgumentError, 'api_token requires at least one scope' if granted.empty?
+
+        unknown = granted - SCOPES
+        unless unknown.empty?
+          raise ArgumentError, "unknown api_token scope #{unknown.inspect}; valid scopes are #{SCOPES.inspect}"
+        end
+
+        granted.freeze
+      end
+
+      # @return [Principal, nil] nil when no credential was presented, or the
+      #   one presented matches nothing registered.
+      def authenticate(request, config)
+        presented = bearer(request.get_header('HTTP_AUTHORIZATION'))
+        return nil unless presented
+
+        scopes = lookup(presented, config.api_tokens)
+        scopes && Principal.new(scopes)
+      end
+
+      def bearer(header)
+        match = BEARER.match(header.to_s)
+        match && match[1]
+      end
+
+      # Walks every registered token with no early return on a hit, so the
+      # clock can't tell a client where in the table its guess landed — or
+      # whether it landed at all. Both sides are digested first: OpenSSL's
+      # compare demands equal lengths, and the bytesize pre-check the obvious
+      # implementation reaches for (Rack::Utils.secure_compare does exactly
+      # that) answers "how long is the real token" to anyone who can time this.
+      def lookup(presented, tokens)
+        digest = ::Digest::SHA256.digest(presented)
+        found = nil
+        tokens.each do |token, scopes|
+          found = scopes if OpenSSL.fixed_length_secure_compare(digest, ::Digest::SHA256.digest(token))
+        end
+        found
+      end
+
+      # RFC 6750 §3. The challenge names `invalid_token` only when the client
+      # actually presented one — telling a client that sent no credential that
+      # its credential was rejected sends it hunting for the wrong bug.
+      def unauthorized(request)
+        presented = request.get_header('HTTP_AUTHORIZATION')
+        Problem.render(
+          Problem::UNAUTHORIZED,
+          status: 401,
+          detail: presented ? 'The bearer token presented is not valid.' : 'A bearer token is required.',
+          instance: request.path,
+          headers: { 'www-authenticate' => presented ? %(#{REALM}, error="invalid_token") : REALM }
+        )
+      end
+
+      # 403, not a 404 hiding the route: the client already authenticated, so
+      # concealing the address buys nothing and costs it the one fact it needs
+      # — which scope to ask its operator for.
+      def forbidden(request, scope)
+        Problem.render(
+          Problem::INSUFFICIENT_SCOPE,
+          status: 403,
+          detail: "This token is not granted the #{scope} scope.",
+          instance: request.path,
+          headers: { 'www-authenticate' => %(#{REALM}, error="insufficient_scope", scope="#{scope}") },
+          required_scope: scope
+        )
+      end
+    end
+  end
+end

--- a/lib/wurk/api/idempotency.rb
+++ b/lib/wurk/api/idempotency.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require 'digest'
+require_relative '../keys'
+require_relative 'problem'
+require_relative 'response'
+require_relative 'validation'
+
+module Wurk
+  module API
+    # `Idempotency-Key` replay protection for the produce plane.
+    #
+    # A producer whose connection drops mid-`POST /jobs` cannot tell a lost
+    # request from a lost response, so its only safe move is to send it again —
+    # and without this, the retry is a second job. The header turns that retry
+    # into a replay: the first request's response comes back verbatim and
+    # nothing is enqueued twice.
+    #
+    # Entirely client-driven. No header means no key, no record and no round
+    # trip, so a producer that does not need this pays nothing for it.
+    module Idempotency
+      HEADER = 'HTTP_IDEMPOTENCY_KEY'
+
+      # The same shape a bearer token has to survive: printable ASCII, no
+      # spaces. A key that loses a byte in transit would silently address a
+      # different record, which is the one failure this module exists to
+      # prevent.
+      KEY_FORMAT = /\A[\x21-\x7e]{1,255}\z/
+
+      # Marks a replayed response, so a client can tell "your job was enqueued"
+      # from "your job was enqueued, earlier".
+      REPLAY_HEADER = 'idempotency-replayed'
+
+      # A record is `<status>\n<body digest>\n<body>`, and status `0` means a
+      # claim still in flight. Line-oriented rather than JSON because it is
+      # read back under contention: a truncated or hand-poisoned value has to
+      # degrade to "still in progress", not to a parser exception on the
+      # request path.
+      PENDING = 0
+
+      module_function
+
+      # Wraps a state-changing handler. Without the header this is a bare call
+      # through; with it, exactly one of the requests sharing a key runs the
+      # handler and the rest replay its answer.
+      #
+      # @param raw_body [String] the bytes the response is pinned to, so the
+      #   same key sent with a different body is a client bug, not a replay.
+      def around(request, raw_body, config, &handler)
+        key = presented(request)
+        return handler.call unless key
+
+        slot = slot_for(request, key)
+        fingerprint = ::Digest::SHA256.hexdigest(raw_body)
+        stored = claim(slot, fingerprint, config.api_idempotency_ttl)
+        return replay(request, stored, fingerprint) if stored
+
+        settle(slot, fingerprint, &handler)
+      end
+
+      def presented(request)
+        key = request.get_header(HEADER)
+        return nil if key.nil?
+        return key if KEY_FORMAT.match?(key)
+
+        raise Validation::Invalid, 'Idempotency-Key must be 1-255 printable ASCII characters with no spaces.'
+      end
+
+      # Scoped to the credential and to the route. The key is a string the
+      # client chose: two producers that both sent `1` must not see each
+      # other's jids, and the same key on `/jobs` and `/jobs/bulk` addresses two
+      # different requests. Hashed rather than concatenated so the client's own
+      # string never reaches Redis in the clear and every slot is one length.
+      def slot_for(request, key)
+        ::Wurk::Keys.idempotency(
+          ::Digest::SHA256.hexdigest("#{request.principal.id}\n#{request.path_info}\n#{key}")
+        )
+      end
+
+      # One round trip: reserve the key if it is free, and read what is there
+      # either way. Deliberately not a MULTI — the SET already picked the
+      # winner, and the GET only has to explain the loss.
+      #
+      # @return [String, nil] nil when this request owns the key; otherwise the
+      #   record the owner left, or is still to leave. An empty string when the
+      #   owner's record expired in between, which reads as "in flight" and is
+      #   the safe answer: it never enqueues a second job.
+      def claim(slot, fingerprint, ttl)
+        reserved, existing = ::Wurk.redis do |conn|
+          conn.pipelined do |pipe|
+            pipe.call('SET', slot, encode(PENDING, fingerprint, ''), 'NX', 'EX', ttl)
+            pipe.call('GET', slot)
+          end
+        end
+        reserved ? nil : existing.to_s
+      end
+
+      # Only a success is worth replaying. A rejected body is a request the
+      # client should be able to correct and send again under the same key, and
+      # a raise is a request whose outcome nobody knows — both release the key
+      # rather than pinning an answer to it.
+      def settle(slot, fingerprint)
+        response = yield
+        response[0] < 300 ? record(slot, fingerprint, response) : release(slot)
+        response
+      rescue StandardError
+        release(slot)
+        raise
+      end
+
+      # KEEPTTL so the window is the first request's, not this write's, and XX
+      # so a claim whose TTL lapsed mid-flight is not resurrected as a record
+      # with no expiry at all.
+      def record(slot, fingerprint, response)
+        status, _headers, body = response
+        ::Wurk.redis { |conn| conn.call('SET', slot, encode(status, fingerprint, body.join), 'XX', 'KEEPTTL') }
+      end
+
+      def release(slot)
+        ::Wurk.redis { |conn| conn.call('DEL', slot) }
+      end
+
+      def replay(request, stored, fingerprint)
+        record = decode(stored)
+        return in_progress(request) unless record
+
+        status, digest, body = record
+        return reused(request) unless digest == fingerprint
+        return in_progress(request) if status == PENDING
+
+        [status, Response::HEADERS.merge(REPLAY_HEADER => 'true'), [body]]
+      end
+
+      def encode(status, digest, body) = "#{status}\n#{digest}\n#{body}"
+
+      # @return [Array(Integer, String, String), nil] nil for a record that is
+      #   gone or unreadable — the caller treats both as still in flight.
+      def decode(stored)
+        status, digest, body = stored.split("\n", 3)
+        return nil if digest.nil? || digest.empty?
+
+        [status.to_i, digest, body.to_s]
+      end
+
+      # 409 rather than 400: the request is well-formed, and what it collides
+      # with is a fact about the server's state that the client can resolve by
+      # rotating the key.
+      def reused(request)
+        Problem.render(
+          Problem::IDEMPOTENCY_KEY_REUSED,
+          status: 409,
+          detail: 'This Idempotency-Key was already used for a different request body.',
+          instance: request.path
+        )
+      end
+
+      def in_progress(request)
+        Problem.render(
+          Problem::REQUEST_IN_PROGRESS,
+          status: 409,
+          detail: 'A request with this Idempotency-Key is still in flight.',
+          instance: request.path,
+          headers: { 'retry-after' => '1' }
+        )
+      end
+    end
+  end
+end

--- a/lib/wurk/api/jobs.rb
+++ b/lib/wurk/api/jobs.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
-require 'json'
+require_relative 'idempotency'
 require_relative 'problem'
 require_relative 'response'
+require_relative 'validation'
 
 module Wurk
   module API
@@ -23,18 +24,11 @@ module Wurk
     # chain and pool at call time — exactly what a Ruby producer in this process
     # gets — and the canonical inspectors this plane shares Redis with
     # (ScheduledSet, RetrySet) read `Wurk.redis` unconditionally.
+    #
+    # What a stranger may send is {Validation}'s job, and whether a retry of it
+    # counts twice is {Idempotency}'s. This module owns only the three routes
+    # and the order those two run in.
     module Jobs
-      # Raised for a body this module rejects before Client ever sees it.
-      # Client's own ArgumentError covers everything past that point.
-      class Invalid < StandardError; end
-
-      # A jid reaches Redis as a ZSCAN glob (JobSet#find_job wraps it in `*`),
-      # so an unbounded or metacharacter-carrying jid off the network is a scan
-      # this API runs on the client's behalf. Sidekiq's own jids are
-      # `SecureRandom.hex(12)`; admit any URL-safe token of a sane length and
-      # refuse the rest at the door.
-      JID_FORMAT = /\A[A-Za-z0-9_-]{1,255}\z/
-
       module_function
 
       def draw(router)
@@ -51,19 +45,54 @@ module Wurk
       # the push — a `collapse:`/`unique_for:` drop is the producer's own policy
       # doing its job, not a failure to report as one.
       def create(request)
-        jid = ::Wurk::Client.new.push(object_body(request))
-        Response.json(jid ? 201 : 200, jid: jid)
-      rescue Invalid, ::ArgumentError => e
-        invalid_request(request, e.message)
+        produce(request) do |payload, config|
+          Validation.job!(payload, principal: request.principal, config: config)
+          jid = ::Wurk::Client.new.push(payload)
+          Response.json(jid ? 201 : 200, jid: jid)
+        end
       end
 
       # The `push_bulk` shape verbatim: one `class`, an array of arg arrays, and
       # optionally `at`/`spread_interval`/`batch_size`. Nil entries in `jids`
       # mark the jobs middleware halted, positionally.
       def create_bulk(request)
-        jids = ::Wurk::Client.new.push_bulk(object_body(request))
-        Response.json(jids.any? { |jid| !jid.nil? } ? 201 : 200, jids: jids)
-      rescue Invalid, ::ArgumentError => e
+        produce(request) do |payload, config|
+          Validation.bulk!(payload, principal: request.principal, config: config)
+          jids = ::Wurk::Client.new.push_bulk(payload)
+          Response.json(jids.any? { |jid| !jid.nil? } ? 201 : 200, jids: jids)
+        end
+      end
+
+      # The shape both produce routes share.
+      #
+      # The body cap runs first, because it is the only check that can be made
+      # without holding the request. The `Idempotency-Key` claim wraps
+      # everything after it — parsing, validation and the push alike. That
+      # looks like it burns a client's key on a malformed body and does not:
+      # the claim releases on any answer that isn't a success, so the
+      # correction can be sent under the same key. What it buys is that the key
+      # is claimed *before* the push, the only ordering in which two concurrent
+      # retries of a dropped connection can't both enqueue.
+      def produce(request)
+        config = request.config
+        raw = Validation.body!(request, config.api_max_body_bytes)
+        Idempotency.around(request, raw, config) { rejectable(request) { yield(Validation.object!(raw), config) } }
+      rescue Validation::Invalid => e
+        # Only the two checks above the claim reach here — the body cap, and
+        # the shape of the Idempotency-Key itself. Everything below is answered
+        # inside the claim, where the status it decides on is visible.
+        problem(request, e)
+      end
+
+      # Renders a refusal *inside* the claim, so what the claim weighs is a
+      # response with a status on it rather than an exception it could only
+      # release on. Client owns what a valid job hash is past the boundary; the
+      # route surfaces its verdict instead of duplicating it.
+      def rejectable(request)
+        yield
+      rescue Validation::Invalid => e
+        problem(request, e)
+      rescue ::ArgumentError => e
         invalid_request(request, e.message)
       end
 
@@ -72,13 +101,13 @@ module Wurk
       # has already died stays in `dead`, where deleting it is an operator
       # action against a different set.
       def destroy(request)
-        jid = request.path_params[:jid].to_s
-        return invalid_request(request, 'A jid is a URL-safe token of up to 255 characters.') unless valid_jid?(jid)
-
+        jid = Validation.jid!(request.path_params[:jid].to_s)
         set = cancellable_sets.find { |candidate| remove(candidate, jid) }
         return job_not_found(request, jid) unless set
 
         Response.json(200, jid: jid, set: set.name)
+      rescue Validation::Invalid => e
+        problem(request, e)
       end
 
       # `schedule` first: a job merely waiting for its time is the one a
@@ -97,21 +126,10 @@ module Wurk
         entry ? entry.delete : false
       end
 
-      def valid_jid?(jid) = JID_FORMAT.match?(jid)
-
-      # The body is the job hash with no envelope around it. Client owns what a
-      # valid one is; this only insists it is a JSON object at all, because
-      # everything downstream indexes it by key.
-      def object_body(request)
-        parsed = ::JSON.parse(request.body&.read.to_s)
-        raise Invalid, 'The request body must be a JSON object.' unless parsed.is_a?(::Hash)
-
-        parsed
-      rescue ::JSON::ParserError
-        # Deliberately not the parser's own message: it quotes the unparsed
-        # remainder of the document, so a large malformed body would come back
-        # as a large error.
-        raise Invalid, 'The request body is not valid JSON.'
+      # Validation decided which problem this is; rendering it is all that is
+      # left, so a new rejection never needs a new arm here.
+      def problem(request, error)
+        Problem.render(error.type, status: error.status, detail: error.message, instance: request.path, **error.extra)
       end
 
       def invalid_request(request, detail)

--- a/lib/wurk/api/jobs.rb
+++ b/lib/wurk/api/jobs.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'json'
+require_relative 'problem'
+require_relative 'response'
+
+module Wurk
+  module API
+    # The produce plane: enqueue one job, enqueue many, take a not-yet-run job
+    # back out.
+    #
+    # The request body *is* the Sidekiq job hash — `{"class", "args", "queue",
+    # "at", "retry"}` — and every write below hands it to {Wurk::Client}, the
+    # same object `perform_async` reaches. Nothing here builds, renames, or
+    # re-keys a payload. That is the drop-in guarantee written as code: an
+    # HTTP-enqueued job is the same bytes in the same Redis structures as a
+    # Ruby-enqueued one, so stock Sidekiq runs it. A payload assembled here
+    # would pass its own tests forever and be wrong the first time Client
+    # changed.
+    #
+    # Client is instantiated per request rather than memoized, and without a
+    # config, for the same reason: it must resolve the process's own middleware
+    # chain and pool at call time — exactly what a Ruby producer in this process
+    # gets — and the canonical inspectors this plane shares Redis with
+    # (ScheduledSet, RetrySet) read `Wurk.redis` unconditionally.
+    module Jobs
+      # Raised for a body this module rejects before Client ever sees it.
+      # Client's own ArgumentError covers everything past that point.
+      class Invalid < StandardError; end
+
+      # A jid reaches Redis as a ZSCAN glob (JobSet#find_job wraps it in `*`),
+      # so an unbounded or metacharacter-carrying jid off the network is a scan
+      # this API runs on the client's behalf. Sidekiq's own jids are
+      # `SecureRandom.hex(12)`; admit any URL-safe token of a sane length and
+      # refuse the rest at the door.
+      JID_FORMAT = /\A[A-Za-z0-9_-]{1,255}\z/
+
+      module_function
+
+      def draw(router)
+        router.post('/jobs', scope: :enqueue) { |request| create(request) }
+        router.post('/jobs/bulk', scope: :enqueue) { |request| create_bulk(request) }
+        # :admin, not :enqueue. A jid is not bound to the token that produced
+        # it, so an enqueue-scoped producer holding this route could walk the
+        # retry set one jid at a time. Widening a scope later is additive to
+        # every client; narrowing one breaks them.
+        router.delete('/jobs/:jid', scope: :admin) { |request| destroy(request) }
+      end
+
+      # 201 with the jid, or 200 with a null one when client middleware halted
+      # the push — a `collapse:`/`unique_for:` drop is the producer's own policy
+      # doing its job, not a failure to report as one.
+      def create(request)
+        jid = ::Wurk::Client.new.push(object_body(request))
+        Response.json(jid ? 201 : 200, jid: jid)
+      rescue Invalid, ::ArgumentError => e
+        invalid_request(request, e.message)
+      end
+
+      # The `push_bulk` shape verbatim: one `class`, an array of arg arrays, and
+      # optionally `at`/`spread_interval`/`batch_size`. Nil entries in `jids`
+      # mark the jobs middleware halted, positionally.
+      def create_bulk(request)
+        jids = ::Wurk::Client.new.push_bulk(object_body(request))
+        Response.json(jids.any? { |jid| !jid.nil? } ? 201 : 200, jids: jids)
+      rescue Invalid, ::ArgumentError => e
+        invalid_request(request, e.message)
+      end
+
+      # Removes a job that has not run yet from `schedule` or `retry`. Not a
+      # cancel: a job already handed to a processor keeps running, and one that
+      # has already died stays in `dead`, where deleting it is an operator
+      # action against a different set.
+      def destroy(request)
+        jid = request.path_params[:jid].to_s
+        return invalid_request(request, 'A jid is a URL-safe token of up to 255 characters.') unless valid_jid?(jid)
+
+        set = cancellable_sets.find { |candidate| remove(candidate, jid) }
+        return job_not_found(request, jid) unless set
+
+        Response.json(200, jid: jid, set: set.name)
+      end
+
+      # `schedule` first: a job merely waiting for its time is the one a
+      # producer usually means to call off, and a jid in both sets at once
+      # would mean something else is already broken.
+      def cancellable_sets = [::Wurk::ScheduledSet.new, ::Wurk::RetrySet.new]
+
+      # Find-then-delete through the canonical inspectors rather than a second
+      # deletion path over the same ZSETs — the dashboard and every third-party
+      # tool use these objects, and two ways to remove a member is a place for
+      # them to disagree. A job promoted out of the set between the two steps
+      # removes nothing and reads as "already gone", the honest answer to a
+      # cancel that lost the race.
+      def remove(set, jid)
+        entry = set.find_job(jid)
+        entry ? entry.delete : false
+      end
+
+      def valid_jid?(jid) = JID_FORMAT.match?(jid)
+
+      # The body is the job hash with no envelope around it. Client owns what a
+      # valid one is; this only insists it is a JSON object at all, because
+      # everything downstream indexes it by key.
+      def object_body(request)
+        parsed = ::JSON.parse(request.body&.read.to_s)
+        raise Invalid, 'The request body must be a JSON object.' unless parsed.is_a?(::Hash)
+
+        parsed
+      rescue ::JSON::ParserError
+        # Deliberately not the parser's own message: it quotes the unparsed
+        # remainder of the document, so a large malformed body would come back
+        # as a large error.
+        raise Invalid, 'The request body is not valid JSON.'
+      end
+
+      def invalid_request(request, detail)
+        Problem.render(Problem::INVALID_REQUEST, status: 400, detail: detail, instance: request.path)
+      end
+
+      def job_not_found(request, jid)
+        Problem.render(
+          Problem::JOB_NOT_FOUND,
+          status: 404,
+          detail: "No scheduled or retrying job has jid #{jid}.",
+          instance: request.path,
+          jid: jid
+        )
+      end
+    end
+  end
+end

--- a/lib/wurk/api/problem.rb
+++ b/lib/wurk/api/problem.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Wurk
+  module API
+    # Error bodies for the HTTP API, shaped like RFC 9457 problem documents.
+    #
+    # One deliberate divergence from the RFC: `type` is a bare stable slug
+    # ('not_found'), not a URI. A URI would either hardcode a docs host that can
+    # move or emit a mount-relative path the client can't dereference, and the
+    # slug is the part a client actually branches on. `/v1` makes these slugs a
+    # contract: adding one is fine, renaming one is a breaking change.
+    module Problem
+      CONTENT_TYPE = 'application/problem+json'
+
+      NOT_FOUND = 'not_found'
+      METHOD_NOT_ALLOWED = 'method_not_allowed'
+      UNSUPPORTED_API_VERSION = 'unsupported_api_version'
+      INTERNAL_ERROR = 'internal_error'
+
+      # Every slug needs a human title; `fetch` below turns a missing one into a
+      # loud failure in the test suite rather than a half-formed error body.
+      TITLES = {
+        NOT_FOUND => 'Not Found',
+        METHOD_NOT_ALLOWED => 'Method Not Allowed',
+        UNSUPPORTED_API_VERSION => 'Unsupported API Version',
+        INTERNAL_ERROR => 'Internal Server Error'
+      }.freeze
+
+      module_function
+
+      # `extra` keywords become extension members (RFC 9457 §3.2), e.g.
+      # `supported_versions:`. Returns a Rack response triple.
+      def render(type, status:, detail:, instance:, headers: nil, **extra)
+        body = {
+          type: type, title: TITLES.fetch(type), status: status, detail: detail, instance: instance
+        }
+        body.merge!(extra)
+        [status, response_headers(headers), [::JSON.generate(body)]]
+      end
+
+      # nosniff so a browser pointed at an error can never be talked into
+      # rendering the reflected request path as anything but data.
+      def response_headers(extra)
+        headers = { 'content-type' => CONTENT_TYPE, 'x-content-type-options' => 'nosniff' }
+        extra ? headers.merge(extra) : headers
+      end
+    end
+  end
+end

--- a/lib/wurk/api/problem.rb
+++ b/lib/wurk/api/problem.rb
@@ -27,6 +27,20 @@ module Wurk
       # Named for RFC 6750 §3.1 so the slug and the `error=` the 403 carries in
       # WWW-Authenticate are the same word.
       INSUFFICIENT_SCOPE = 'insufficient_scope'
+      # Separate from `invalid_request` because the client's fix is different:
+      # nothing about the request's shape is wrong, it is only too big, and the
+      # `max_bytes` extension member says by how much.
+      PAYLOAD_TOO_LARGE = 'payload_too_large'
+      # An authorization verdict, like `insufficient_scope` — the credential is
+      # valid and the body is well-formed, but this class is not one the HTTP
+      # API may enqueue.
+      CLASS_NOT_ALLOWED = 'class_not_allowed'
+      # The two ways an `Idempotency-Key` collides. Reused means the same key
+      # arrived with different bytes, which is a client bug it must fix by
+      # rotating the key; in-progress means the first request holding it has
+      # not answered yet, which it fixes by waiting.
+      IDEMPOTENCY_KEY_REUSED = 'idempotency_key_reused'
+      REQUEST_IN_PROGRESS = 'request_in_progress'
 
       # Every slug needs a human title; `fetch` below turns a missing one into a
       # loud failure in the test suite rather than a half-formed error body.
@@ -38,7 +52,11 @@ module Wurk
         UNAUTHORIZED => 'Unauthorized',
         INSUFFICIENT_SCOPE => 'Insufficient Scope',
         INVALID_REQUEST => 'Invalid Request',
-        JOB_NOT_FOUND => 'Job Not Found'
+        JOB_NOT_FOUND => 'Job Not Found',
+        PAYLOAD_TOO_LARGE => 'Payload Too Large',
+        CLASS_NOT_ALLOWED => 'Class Not Allowed',
+        IDEMPOTENCY_KEY_REUSED => 'Idempotency Key Reused',
+        REQUEST_IN_PROGRESS => 'Request In Progress'
       }.freeze
 
       module_function

--- a/lib/wurk/api/problem.rb
+++ b/lib/wurk/api/problem.rb
@@ -19,6 +19,11 @@ module Wurk
       UNSUPPORTED_API_VERSION = 'unsupported_api_version'
       INTERNAL_ERROR = 'internal_error'
       UNAUTHORIZED = 'unauthorized'
+      INVALID_REQUEST = 'invalid_request'
+      # Distinct from `not_found`, which means the API has no such route. A
+      # client that asked to cancel a job needs to tell "you addressed nothing"
+      # apart from "that job already ran".
+      JOB_NOT_FOUND = 'job_not_found'
       # Named for RFC 6750 §3.1 so the slug and the `error=` the 403 carries in
       # WWW-Authenticate are the same word.
       INSUFFICIENT_SCOPE = 'insufficient_scope'
@@ -31,7 +36,9 @@ module Wurk
         UNSUPPORTED_API_VERSION => 'Unsupported API Version',
         INTERNAL_ERROR => 'Internal Server Error',
         UNAUTHORIZED => 'Unauthorized',
-        INSUFFICIENT_SCOPE => 'Insufficient Scope'
+        INSUFFICIENT_SCOPE => 'Insufficient Scope',
+        INVALID_REQUEST => 'Invalid Request',
+        JOB_NOT_FOUND => 'Job Not Found'
       }.freeze
 
       module_function

--- a/lib/wurk/api/problem.rb
+++ b/lib/wurk/api/problem.rb
@@ -18,6 +18,10 @@ module Wurk
       METHOD_NOT_ALLOWED = 'method_not_allowed'
       UNSUPPORTED_API_VERSION = 'unsupported_api_version'
       INTERNAL_ERROR = 'internal_error'
+      UNAUTHORIZED = 'unauthorized'
+      # Named for RFC 6750 §3.1 so the slug and the `error=` the 403 carries in
+      # WWW-Authenticate are the same word.
+      INSUFFICIENT_SCOPE = 'insufficient_scope'
 
       # Every slug needs a human title; `fetch` below turns a missing one into a
       # loud failure in the test suite rather than a half-formed error body.
@@ -25,7 +29,9 @@ module Wurk
         NOT_FOUND => 'Not Found',
         METHOD_NOT_ALLOWED => 'Method Not Allowed',
         UNSUPPORTED_API_VERSION => 'Unsupported API Version',
-        INTERNAL_ERROR => 'Internal Server Error'
+        INTERNAL_ERROR => 'Internal Server Error',
+        UNAUTHORIZED => 'Unauthorized',
+        INSUFFICIENT_SCOPE => 'Insufficient Scope'
       }.freeze
 
       module_function

--- a/lib/wurk/api/request.rb
+++ b/lib/wurk/api/request.rb
@@ -13,6 +13,12 @@ module Wurk
       # the time a handler runs — an unauthenticated request never reaches one.
       attr_accessor :principal
 
+      # The configuration this app is answering from, stamped by App before
+      # anything reads it. Injectable there for tests, so a handler that wants
+      # a boundary cap or a token's grants must ask the request rather than
+      # reaching for the process-wide singleton behind the app's back.
+      attr_accessor :config
+
       attr_writer :path_params
 
       def path_params
@@ -26,6 +32,14 @@ module Wurk
       # links to an origin they never asked for.
       def url_for(path)
         "#{script_name.to_s.chomp('/')}#{path}"
+      end
+
+      # At most `limit` bytes off the request body, so a caller can refuse an
+      # oversized one without ever holding it. Rack 3.1 made `rack.input`
+      # optional and a stream already at EOF answers nil, so both come back as
+      # an empty string: a bodyless request is a request, not a crash.
+      def read_body(limit)
+        body&.read(limit).to_s
       end
     end
   end

--- a/lib/wurk/api/request.rb
+++ b/lib/wurk/api/request.rb
@@ -4,10 +4,15 @@ require 'rack'
 
 module Wurk
   module API
-    # Rack::Request plus the two things every API handler needs: the segment
-    # captures the router bound ('/jobs/:jid' → `path_params[:jid]`) and
-    # mount-agnostic URL building.
+    # Rack::Request plus the three things every API handler needs: the segment
+    # captures the router bound ('/jobs/:jid' → `path_params[:jid]`), the
+    # authenticated principal, and mount-agnostic URL building.
     class Request < ::Rack::Request
+      # Set by App once Auth has accepted the credential, so a handler can ask
+      # what the caller was granted without re-reading the header. Never nil by
+      # the time a handler runs — an unauthenticated request never reaches one.
+      attr_accessor :principal
+
       attr_writer :path_params
 
       def path_params

--- a/lib/wurk/api/request.rb
+++ b/lib/wurk/api/request.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rack'
+
+module Wurk
+  module API
+    # Rack::Request plus the two things every API handler needs: the segment
+    # captures the router bound ('/jobs/:jid' → `path_params[:jid]`) and
+    # mount-agnostic URL building.
+    class Request < ::Rack::Request
+      attr_writer :path_params
+
+      def path_params
+        @path_params ||= {}
+      end
+
+      # Root-relative on purpose. The API answers under three different
+      # prefixes (engine-nested, separately mounted, standalone) and usually
+      # sits behind a proxy, so SCRIPT_NAME is the only prefix it can trust —
+      # rebuilding an absolute URL out of Host/X-Forwarded-* would hand clients
+      # links to an origin they never asked for.
+      def url_for(path)
+        "#{script_name.to_s.chomp('/')}#{path}"
+      end
+    end
+  end
+end

--- a/lib/wurk/api/response.rb
+++ b/lib/wurk/api/response.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Wurk
+  module API
+    # Success bodies for the HTTP API; Problem is the error half. One owner per
+    # content type the API emits, so a route table never spells out a header for
+    # itself and the two halves can't drift on the ones they share.
+    module Response
+      CONTENT_TYPE = 'application/json'
+
+      # nosniff for Problem's reason: a body that echoes what the client sent
+      # must never be talked into rendering as anything but data.
+      HEADERS = { 'content-type' => CONTENT_TYPE, 'x-content-type-options' => 'nosniff' }.freeze
+
+      module_function
+
+      # Dups the headers because a Rack middleware downstream is entitled to
+      # add to them, and the frozen literal is shared by every response.
+      #
+      # @return [Array(Integer, Hash, Array<String>)] Rack response triple.
+      def json(status, payload)
+        [status, HEADERS.dup, [::JSON.generate(payload)]]
+      end
+    end
+  end
+end

--- a/lib/wurk/api/router.rb
+++ b/lib/wurk/api/router.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rack'
+require_relative 'auth'
 
 module Wurk
   module API
@@ -12,12 +13,17 @@ module Wurk
     # A capture never spans '/', so a queue named "a/b" has to arrive
     # percent-encoded — the same constraint `config/routes.rb` puts on the
     # dashboard's `:name`.
+    #
+    # Every route names the Auth scope its caller must hold. The router only
+    # records it — App#dispatch enforces it — but the keyword is required, so
+    # adding an endpoint without deciding who may call it is impossible rather
+    # than merely discouraged. A new route can never default open.
     class Router
-      Route = Struct.new(:verb, :segments, :handler, keyword_init: true)
+      Route = Struct.new(:verb, :segments, :scope, :handler, keyword_init: true)
       # `handler` nil means nothing matched the path; `allowed` then carries the
       # verbs registered for a path that *did* match, so the caller can answer
       # 405 with an Allow header instead of a misleading 404.
-      Match = Struct.new(:handler, :params, :allowed, keyword_init: true)
+      Match = Struct.new(:handler, :params, :scope, :allowed, keyword_init: true)
 
       NO_PARAMS = {}.freeze
 
@@ -25,9 +31,9 @@ module Wurk
         @routes = []
       end
 
-      def get(pattern, &handler) = add('GET', pattern, handler)
-      def post(pattern, &handler) = add('POST', pattern, handler)
-      def delete(pattern, &handler) = add('DELETE', pattern, handler)
+      def get(pattern, scope:, &handler) = add('GET', pattern, scope, handler)
+      def post(pattern, scope:, &handler) = add('POST', pattern, scope, handler)
+      def delete(pattern, scope:, &handler) = add('DELETE', pattern, scope, handler)
 
       # HEAD is served by the GET route (RFC 9110 §9.3.2); the caller drops the
       # body.
@@ -38,17 +44,25 @@ module Wurk
         @routes.each do |route|
           params = bind(route.segments, segments)
           next unless params
-          return Match.new(handler: route.handler, params: params, allowed: nil) if route.verb == verb
+          if route.verb == verb
+            return Match.new(handler: route.handler, params: params, scope: route.scope, allowed: nil)
+          end
 
           allowed << route.verb
         end
-        Match.new(handler: nil, params: NO_PARAMS, allowed: allowed.uniq)
+        Match.new(handler: nil, params: NO_PARAMS, scope: nil, allowed: allowed.uniq)
       end
 
       private
 
-      def add(verb, pattern, handler)
-        @routes << Route.new(verb: verb, segments: split(pattern), handler: handler)
+      # A misspelled scope would 403 the route forever; reject it at draw time,
+      # which is boot, rather than letting it surface as a runtime denial.
+      def add(verb, pattern, scope, handler)
+        unless Auth::ROUTE_SCOPES.include?(scope)
+          raise ArgumentError, "unknown route scope #{scope.inspect}; valid scopes are #{Auth::ROUTE_SCOPES.inspect}"
+        end
+
+        @routes << Route.new(verb: verb, segments: split(pattern), scope: scope, handler: handler)
         self
       end
 

--- a/lib/wurk/api/router.rb
+++ b/lib/wurk/api/router.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rack'
+
+module Wurk
+  module API
+    # Path table for the HTTP API. Deliberately not ActionDispatch: the API has
+    # to route in standalone mode, where Rails is never loaded (CLAUDE.md —
+    # "standalone mode must run without loading the engine").
+    #
+    # Patterns are literal segments plus `:name` captures ('/jobs/:jid').
+    # A capture never spans '/', so a queue named "a/b" has to arrive
+    # percent-encoded — the same constraint `config/routes.rb` puts on the
+    # dashboard's `:name`.
+    class Router
+      Route = Struct.new(:verb, :segments, :handler, keyword_init: true)
+      # `handler` nil means nothing matched the path; `allowed` then carries the
+      # verbs registered for a path that *did* match, so the caller can answer
+      # 405 with an Allow header instead of a misleading 404.
+      Match = Struct.new(:handler, :params, :allowed, keyword_init: true)
+
+      NO_PARAMS = {}.freeze
+
+      def initialize
+        @routes = []
+      end
+
+      def get(pattern, &handler) = add('GET', pattern, handler)
+      def post(pattern, &handler) = add('POST', pattern, handler)
+      def delete(pattern, &handler) = add('DELETE', pattern, handler)
+
+      # HEAD is served by the GET route (RFC 9110 §9.3.2); the caller drops the
+      # body.
+      def match(verb, path)
+        verb = 'GET' if verb == 'HEAD'
+        segments = split(path).map { |seg| ::Rack::Utils.unescape_path(seg) }
+        allowed = []
+        @routes.each do |route|
+          params = bind(route.segments, segments)
+          next unless params
+          return Match.new(handler: route.handler, params: params, allowed: nil) if route.verb == verb
+
+          allowed << route.verb
+        end
+        Match.new(handler: nil, params: NO_PARAMS, allowed: allowed.uniq)
+      end
+
+      private
+
+      def add(verb, pattern, handler)
+        @routes << Route.new(verb: verb, segments: split(pattern), handler: handler)
+        self
+      end
+
+      def split(path) = path.to_s.split('/').reject(&:empty?)
+
+      # nil (no match) is a different answer from {} (matched, no captures) —
+      # the caller branches on it, so don't collapse them.
+      def bind(pattern, segments)
+        return nil unless pattern.size == segments.size
+
+        params = {}
+        pattern.each_with_index do |seg, index|
+          if seg.start_with?(':')
+            params[seg[1..].to_sym] = segments[index]
+          elsif seg != segments[index]
+            return nil
+          end
+        end
+        params
+      end
+    end
+  end
+end

--- a/lib/wurk/api/validation.rb
+++ b/lib/wurk/api/validation.rb
@@ -1,0 +1,259 @@
+# frozen_string_literal: true
+
+require 'json'
+require_relative 'problem'
+
+module Wurk
+  module API
+    # Everything the produce plane refuses before {Wurk::Client} sees it.
+    #
+    # Client validates a job hash written by Ruby running in this process. This
+    # validates one typed by a stranger, and the two are different jobs.
+    # `JobUtil::TRANSIENT_ATTRIBUTES` (job_util.rb) is a *strip*-list: it names
+    # the two keys that must never reach the wire and passes everything else
+    # through, which is the right default for a producer that already runs your
+    # code and the wrong one for a producer that doesn't. So the allow-list
+    # JobUtil has no reason to own lives here, at the only door a stranger can
+    # knock on.
+    #
+    # Nothing in this file changes what a Ruby `perform_async` may push. The
+    # boundary is the HTTP request, not the payload format — wire-compat is
+    # untouched.
+    module Validation
+      # Carries the problem it should be rendered as, so a route rescues one
+      # class and renders whatever it was handed instead of mapping message
+      # text back onto a status code.
+      class Invalid < StandardError
+        attr_reader :type, :status, :extra
+
+        def initialize(detail, type: Problem::INVALID_REQUEST, status: 400, **extra)
+          super(detail)
+          @type = type
+          @status = status
+          @extra = extra
+        end
+      end
+
+      # A Ruby constant path and nothing else. `class` reaches the consumer as
+      # a constantize plus `new.perform`, so the string is a code selector, not
+      # data: any shape that is not a constant path is either an attack or a
+      # bug, and both are better answered here than by a NameError in a worker
+      # process two hosts away.
+      #
+      # Linear, not backtracking: `:` is outside the character class, so each
+      # `::` boundary is unambiguous.
+      CLASS_FORMAT = /\A[A-Z][A-Za-z0-9_]*(?:::[A-Z][A-Za-z0-9_]*)*\z/
+
+      # Length is checked separately from shape so a megabyte of `A`s is
+      # refused on a fact about the string rather than matched, stored in a
+      # payload and echoed back in an error.
+      MAX_CLASS_LENGTH = 255
+
+      # A jid reaches Redis as a ZSCAN glob (JobSet#find_job wraps it in `*`),
+      # so an unbounded or metacharacter-carrying jid off the network is a scan
+      # this API runs on the client's behalf. Sidekiq's own jids are
+      # `SecureRandom.hex(12)`; admit any URL-safe token of a sane length and
+      # refuse the rest at the door.
+      JID_FORMAT = /\A[A-Za-z0-9_-]{1,255}\z/
+
+      # Same word the router uses for "any scope": here it turns the class
+      # allow-list off.
+      ANY = :any
+
+      # The top-level keys a job hash may carry in over HTTP.
+      #
+      # Anything absent is refused rather than dropped: a silently ignored
+      # `deadlin:` typo is a job that runs unbounded and a producer that never
+      # finds out. The server-written fields are absent on purpose —
+      # `created_at`/`enqueued_at` would let a client backdate its own queue
+      # latency, `retry_count`/`failed_at` would let it lie to the retrier,
+      # `expiry`/`deadline_at` are stamps derived from `expires_in`/`deadline`,
+      # `bid` would attach a job to a batch whose `pending` counter was never
+      # incremented for it, and `pool`/`client_class` name Ruby objects a JSON
+      # body cannot hold at all.
+      #
+      # Mutable for the same reason `TRANSIENT_ATTRIBUTES` is: a gem that adds
+      # a job option (sidekiq-unique-jobs' `lock:`) has to be able to append
+      # one without reopening this file. Baked into the literal rather than
+      # appended at load, so the parallel test runner never observes a
+      # half-built list.
+      # rubocop:disable Style/MutableConstant
+      JOB_KEYS = %w[
+        class args queue at retry jid backtrace tags dead
+        retry_for retry_queue expires_in track timeout deadline
+        encrypt unique_for unique_until collapse log_level locale wrapped
+      ]
+      # rubocop:enable Style/MutableConstant
+
+      # `push_bulk`'s envelope keys, on top of the job keys it shares.
+      BULK_KEYS = %w[batch_size spread_interval].freeze
+
+      # Echoing a rejected key back is the only way a client finds its typo,
+      # but the keys came off the network — bound how many and how long, for
+      # the same reason the JSON parser's own message is never forwarded.
+      MAX_REPORTED_KEYS = 10
+      MAX_REPORTED_KEY_LENGTH = 40
+
+      module_function
+
+      # Reads at most `limit + 1` bytes, so an oversized body is refused on the
+      # strength of what a cap-sized read already proved rather than by
+      # buffering the whole thing to measure it.
+      def body!(request, limit)
+        raw = request.read_body(limit + 1)
+        return raw unless raw.bytesize > limit
+
+        raise Invalid.new(
+          "The request body may not exceed #{limit} bytes.",
+          type: Problem::PAYLOAD_TOO_LARGE, status: 413, max_bytes: limit
+        )
+      end
+
+      # The body is the job hash with no envelope around it, so this only
+      # insists it is a JSON object at all — everything downstream indexes it
+      # by key.
+      def object!(raw)
+        parsed = ::JSON.parse(raw)
+        raise Invalid, 'The request body must be a JSON object.' unless parsed.is_a?(::Hash)
+
+        parsed
+      rescue ::JSON::ParserError
+        # Deliberately not the parser's own message: it quotes the unparsed
+        # remainder of the document, so a large malformed body would come back
+        # as a large error.
+        raise Invalid, 'The request body is not valid JSON.'
+      end
+
+      # One job hash, for `POST /jobs`.
+      def job!(payload, principal:, config:)
+        known_keys!(payload, JOB_KEYS)
+        jid!(payload['jid']) if payload.key?('jid')
+        allowed!(class!(payload), principal, config) if payload.key?('class')
+        args_size!(payload['args'], config.api_max_args_bytes)
+        payload
+      end
+
+      # The `push_bulk` envelope, for `POST /jobs/bulk`: the same job keys plus
+      # the two that describe the batch, and an `args` that is one array per
+      # job rather than one array of arguments.
+      def bulk!(payload, principal:, config:)
+        known_keys!(payload, JOB_KEYS + BULK_KEYS)
+        jid!(payload['jid']) if payload.key?('jid')
+        allowed!(class!(payload), principal, config) if payload.key?('class')
+        bulk_args_size!(payload['args'], config.api_max_args_bytes)
+        payload
+      end
+
+      # @raise [Invalid] unless `jid` is a URL-safe token of a sane length.
+      # @return [String] the jid.
+      def jid!(jid)
+        return jid if jid.is_a?(::String) && JID_FORMAT.match?(jid)
+
+        raise Invalid, 'A jid is a URL-safe token of up to 255 characters.'
+      end
+
+      # Validates the allow-list where it is declared, so a typo'd class name
+      # raises in the initializer that wrote it instead of 403ing a producer in
+      # production. Accepts Classes as well as names — a host listing the
+      # constant it already has in scope is spelling the same thing.
+      #
+      # @return [Array<String>, :any, nil] normalized allow-list.
+      def enqueueable_classes!(classes)
+        return nil if classes.nil?
+        return ANY if classes == ANY
+
+        list = Array(classes).map(&:to_s)
+        raise ArgumentError, 'api_enqueue_classes must name at least one class, :any, or nil' if list.empty?
+
+        unknown = list.reject { |name| class_name?(name) }
+        raise ArgumentError, "api_enqueue_classes entries must be Ruby class names: #{unknown.inspect}" if unknown.any?
+
+        list.freeze
+      end
+
+      def class_name?(value)
+        value.is_a?(::String) && value.length <= MAX_CLASS_LENGTH && CLASS_FORMAT.match?(value)
+      end
+
+      def known_keys!(payload, allowed)
+        unknown = payload.keys - allowed
+        return if unknown.empty?
+
+        reported = reportable(unknown)
+        raise Invalid.new("Unknown job keys: #{reported.join(', ')}.", unknown_keys: reported)
+      end
+
+      def reportable(keys)
+        keys.sort.first(MAX_REPORTED_KEYS).map { |key| key.to_s[0, MAX_REPORTED_KEY_LENGTH] }
+      end
+
+      def class!(payload)
+        job_class = payload['class']
+        return job_class if class_name?(job_class)
+
+        raise Invalid, %(Job 'class' must be a Ruby class name, e.g. "HardWorker" or "Billing::Charge".)
+      end
+
+      # The allow-list JobUtil has no reason to own:
+      #
+      #   nil   → only an `admin` token may enqueue, and it may enqueue anything
+      #   Array → exactly these names, for every token, `admin` included
+      #   :any  → the check is off
+      #
+      # Unset denies an enqueue-scoped producer everything, because `class`
+      # selects which of the host's jobs runs and a producer that can name any
+      # constant is choosing. `admin` is exempt only while no list exists: it
+      # already holds the destructive routes, so restricting which class it may
+      # enqueue would be theatre. Once a host writes a list, it means it.
+      def allowed!(job_class, principal, config)
+        return if enqueueable?(job_class, principal, config.api_enqueue_classes)
+
+        raise Invalid.new(
+          "#{job_class} may not be enqueued over HTTP; config.api_enqueue_classes names the classes that may.",
+          type: Problem::CLASS_NOT_ALLOWED, status: 403, job_class: job_class
+        )
+      end
+
+      def enqueueable?(job_class, principal, classes)
+        case classes
+        when nil then principal.permits?(:admin)
+        when ANY then true
+        else classes.include?(job_class)
+        end
+      end
+
+      # Only an Array is sizeable and only an Array is legal; Client names the
+      # other shapes, with the offending value in the message.
+      def args_size!(args, limit)
+        return unless args.is_a?(::Array)
+
+        size = ::JSON.generate(args).bytesize
+        return if size <= limit
+
+        raise Invalid.new(
+          "Job args may not exceed #{limit} bytes; these serialize to #{size}.",
+          type: Problem::PAYLOAD_TOO_LARGE, status: 413, max_bytes: limit
+        )
+      end
+
+      # The body cap bounds the request; this bounds each job the request turns
+      # into, which for a bulk push is the only one of the two that bounds what
+      # lands in Redis.
+      def bulk_args_size!(args, limit)
+        return unless args.is_a?(::Array)
+
+        args.each_with_index do |job_args, index|
+          next unless job_args.is_a?(::Array)
+
+          size = ::JSON.generate(job_args).bytesize
+          next if size <= limit
+
+          raise Invalid.new(
+            "Job #{index}'s args may not exceed #{limit} bytes; they serialize to #{size}.",
+            type: Problem::PAYLOAD_TOO_LARGE, status: 413, max_bytes: limit, job_index: index
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -71,7 +71,20 @@ module Wurk
       # never registers a token carries no new HTTP surface at all. Seeded here
       # rather than written on demand so the read side answers on a config that
       # `freeze!` has already closed.
-      api_tokens: {}
+      api_tokens: {},
+      # Boundary caps for the HTTP API's produce plane. A body larger than
+      # `api_max_body_bytes` is refused before it is parsed; a job whose args
+      # serialize larger than `api_max_args_bytes` before it is pushed — the
+      # second is the one that bounds what a bulk request lands in Redis, since
+      # one request becomes many payloads. `api_idempotency_ttl` is how long an
+      # `Idempotency-Key` is remembered: a replay window for a producer
+      # retrying a lost response, not an audit log.
+      api_max_body_bytes: 1_048_576,
+      api_max_args_bytes: 65_536,
+      api_idempotency_ttl: 3_600,
+      # Allow-list of classes the HTTP API may enqueue. nil (the default) means
+      # only an `admin` token may enqueue at all — see #api_enqueue_classes=.
+      api_enqueue_classes: nil
     }.freeze
 
     # :fork fires only inside swarm children, after fork + internal AR/Redis
@@ -471,6 +484,50 @@ module Wurk
     #   is conditional on this.
     def api_enabled? = !@options[:api_tokens].empty?
 
+    # @return [Integer] largest request body the produce plane will read.
+    def api_max_body_bytes = @options[:api_max_body_bytes]
+
+    def api_max_body_bytes=(bytes)
+      @options[:api_max_body_bytes] = api_limit!(:api_max_body_bytes, bytes)
+    end
+
+    # @return [Integer] largest `args` any single job may serialize to.
+    def api_max_args_bytes = @options[:api_max_args_bytes]
+
+    def api_max_args_bytes=(bytes)
+      @options[:api_max_args_bytes] = api_limit!(:api_max_args_bytes, bytes)
+    end
+
+    # @return [Integer] seconds an `Idempotency-Key` stays replayable.
+    def api_idempotency_ttl = @options[:api_idempotency_ttl]
+
+    def api_idempotency_ttl=(seconds)
+      @options[:api_idempotency_ttl] = api_limit!(:api_idempotency_ttl, seconds)
+    end
+
+    # @return [Array<String>, :any, nil] classes the HTTP API may enqueue.
+    def api_enqueue_classes = @options[:api_enqueue_classes]
+
+    # The allow-list `JobUtil::TRANSIENT_ATTRIBUTES` deliberately is not — that
+    # is a strip-list, right for a producer already running your code:
+    #
+    #   config.api_enqueue_classes = %w[Billing::Charge ReportJob]
+    #
+    # Unset, only an `admin` token may enqueue at all. `class` is a code
+    # selector — a producer token that can name any constant in the host is
+    # choosing which of its jobs to run — so an `enqueue`-scoped credential has
+    # to be told exactly what it is for. Once a list exists it binds every
+    # token, `admin` included: a host that writes one means it.
+    #
+    # `:any` turns the check off, which is what an enqueue-scoped relay that
+    # legitimately pushes arbitrary classes needs — the alternative is handing
+    # it `admin` and the destructive routes that come with it.
+    def api_enqueue_classes=(classes)
+      guard_frozen!
+      require_relative 'api/validation'
+      @options[:api_enqueue_classes] = Wurk::API::Validation.enqueueable_classes!(classes)
+    end
+
     # --- Web dashboard ----------------------------------------------------
 
     # Web UI configuration: the authorization hook and read-only mode. Returns
@@ -669,6 +726,17 @@ module Wurk
 
     def guard_frozen!
       raise FrozenError, 'Wurk::Configuration is frozen' if @frozen
+    end
+
+    # Boundary caps are refused where they are written, not where they are
+    # read: a cap that silently coerced to 0 is a cap that isn't one, and the
+    # request path is the wrong place to discover that.
+    def api_limit!(name, value)
+      guard_frozen!
+      size = Integer(value, exception: false)
+      raise ArgumentError, "#{name} must be a positive Integer" unless size&.positive?
+
+      size
     end
 
     def deep_dup_defaults

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -64,7 +64,14 @@ module Wurk
       # closed — and so a gem inspecting @options sees the same key set whether
       # or not the host traces. Flipping it is only half the gate; the
       # opentelemetry-api gem has to be present too (Wurk::Telemetry.enabled?).
-      telemetry: false
+      telemetry: false,
+      # Bearer tokens for the machine-facing HTTP API (Wurk::API), as
+      # `token => [scopes]`. Empty means the API does not exist: the engine
+      # skips the mount and a directly mounted app answers 404, so a host that
+      # never registers a token carries no new HTTP surface at all. Seeded here
+      # rather than written on demand so the read side answers on a config that
+      # `freeze!` has already closed.
+      api_tokens: {}
     }.freeze
 
     # :fork fires only inside swarm children, after fork + internal AR/Redis
@@ -435,6 +442,34 @@ module Wurk
 
       logger.warn { 'config.telemetry = true but opentelemetry-api is not installed; tracing stays off' }
     end
+
+    # --- Machine-facing HTTP API (Wurk::API) ------------------------------
+
+    # Registers a bearer token for the HTTP API and the scopes it grants —
+    # any of `:enqueue`, `:read`, `:admin` (which grants the other two):
+    #
+    #   Wurk.configure_server do |config|
+    #     config.api_token ENV.fetch('WURK_API_TOKEN'), scopes: %i[enqueue read]
+    #   end
+    #
+    # Registering the first token is what brings the API into existence; with
+    # none the app is never mounted. Re-registering a token replaces its
+    # scopes. Loading `wurk/api/auth` is deferred to this call so a host that
+    # serves no HTTP API never pays for openssl/digest in every swarm child.
+    def api_token(token, scopes:)
+      guard_frozen!
+      require_relative 'api/auth'
+      value, granted = Wurk::API::Auth.credential!(token, scopes)
+      @options[:api_tokens][value] = granted
+      nil
+    end
+
+    # @return [Hash{String => Array<Symbol>}] registered tokens and their scopes
+    def api_tokens = @options[:api_tokens]
+
+    # @return [Boolean] whether the HTTP API exists at all. The engine's mount
+    #   is conditional on this.
+    def api_enabled? = !@options[:api_tokens].empty?
 
     # --- Web dashboard ----------------------------------------------------
 

--- a/lib/wurk/keys.rb
+++ b/lib/wurk/keys.rb
@@ -88,6 +88,16 @@ module Wurk
     # `:threshold` / `:concurrency.v2`.
     THROTTLE_PREFIX = 'throttle:'
 
+    # `Idempotency-Key` replay records for the HTTP API: `idempotency:<digest>`
+    # STRING holding the response the first request produced. A Wurk extra like
+    # `status:` — nothing in the Sidekiq key schema lives here, and nothing
+    # outside Wurk::API::Idempotency reads it.
+    #
+    # The digest covers the credential, the route and the client's key, so the
+    # client's own string never reaches Redis in the clear and two producers
+    # that both chose `1` address two different records.
+    IDEMPOTENCY_PREFIX = 'idempotency:'
+
     # Build a queue list key from a queue name. Centralizing the concat keeps
     # the prefix in one place even though it's a constant — third-party gems
     # that grep for `"queue:"` still find it via the constant.
@@ -111,6 +121,11 @@ module Wurk
     # it, because only Redis can align every producer on the same boundary.
     def self.throttle(digest)
       "#{THROTTLE_PREFIX}#{digest}"
+    end
+
+    # Idempotency replay record for one request digest. Same reason as .queue.
+    def self.idempotency(digest)
+      "#{IDEMPOTENCY_PREFIX}#{digest}"
     end
   end
 end

--- a/test/engine/api_v1_auth_test.rb
+++ b/test/engine/api_v1_auth_test.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require_relative '../engine_test_helper'
+require 'wurk/api/app'
+require 'json'
+require 'stringio'
+
+# Slice 07, task 45 — the auth gate proven against the actual global
+# `Wurk.configuration` a booted host app resolves at request time.
+# `Wurk::API.call` (api.rb) and `Wurk::API::App#config` both read
+# `::Wurk.configuration` whenever no config is injected — the path every real
+# `mount Wurk::API => '/wurk-api'` or a conditionally mounted engine takes.
+# The exhaustive scheme/scope matrix and the credential registry itself are
+# already pinned in isolation in test/unit/api_auth_test.rb; this file
+# re-proves the four load-bearing claims the plan's "headline" test list
+# calls out, but under a fully booted Rails host (test/dummy) against the
+# process-wide singleton rather than a Configuration built just for the test.
+#
+# Mutates `Wurk.configuration.api_tokens` — the same process-global registry
+# every other engine test's dummy app shares — so this class does not declare
+# `parallelize_me!` (same reasoning as api_mutations_test.rb) and serializes
+# its own test methods through GLOBAL_STATE_MUTEX, the mutex every other
+# process-global-state test in this suite uses.
+class ApiV1AuthTest < Wurk::Test::EngineCase
+  READ_TOKEN  = 'engine-api-v1-read-token-aaaaaaaaa'
+  ADMIN_TOKEN = 'engine-api-v1-admin-token-bbbbbbbbb'
+
+  def app = ::Wurk::API
+
+  def run(*)
+    Wurk::Test::GLOBAL_STATE_MUTEX.synchronize { super }
+  end
+
+  def teardown
+    Wurk.configuration.api_tokens.delete(READ_TOKEN)
+    Wurk.configuration.api_tokens.delete(ADMIN_TOKEN)
+  ensure
+    super
+  end
+
+  # The 404 is the point: an app mounted without a token has to look exactly
+  # like an app that was never mounted at all — not a real surface guarded by
+  # a 401.
+  def test_no_token_configured_answers_404_not_401
+    get '/v1/jobs'
+
+    assert_equal 404, last_response.status
+    assert_equal 'not_found', json_body['type']
+    refute last_response.headers.key?('www-authenticate')
+  end
+
+  def test_a_missing_credential_is_401_once_a_token_exists
+    Wurk.configuration.api_token(READ_TOKEN, scopes: %i[read])
+
+    get '/v1'
+
+    assert_equal 401, last_response.status
+    assert_equal 'unauthorized', json_body['type']
+  end
+
+  def test_an_unregistered_token_is_401
+    Wurk.configuration.api_token(READ_TOKEN, scopes: %i[read])
+    header 'Authorization', 'Bearer not-a-registered-token-00000'
+
+    get '/v1'
+
+    assert_equal 401, last_response.status
+    assert_equal 'The bearer token presented is not valid.', json_body['detail']
+  end
+
+  def test_a_token_outside_the_routes_scope_is_403
+    Wurk.configuration.api_token(READ_TOKEN, scopes: %i[read])
+    header 'Authorization', "Bearer #{READ_TOKEN}"
+
+    post '/v1/jobs', JSON.generate('class' => 'EngineAuthDeniedJob', 'args' => []),
+         'CONTENT_TYPE' => 'application/json'
+
+    assert_equal 403, last_response.status
+    assert_equal 'insufficient_scope', json_body['type']
+    assert_equal 'enqueue', json_body['required_scope']
+  end
+
+  # Constant-time comparison, proven against the real global registry rather
+  # than a table built just for this test: every entry is still visited even
+  # after the presented token has already matched one earlier in the table.
+  def test_every_registered_token_is_walked_even_after_a_match
+    Wurk.configuration.api_token(READ_TOKEN, scopes: %i[read])
+    Wurk.configuration.api_token(ADMIN_TOKEN, scopes: %i[admin])
+    tokens = CountingTokens.new(Wurk.configuration.api_tokens)
+
+    principal = Wurk::API::Auth.authenticate(fake_request("Bearer #{READ_TOKEN}"), FakeConfig.new(tokens))
+
+    assert_equal %i[read], principal.scopes
+    assert_equal 2, tokens.visited
+  end
+
+  FakeConfig = Struct.new(:api_tokens)
+
+  private
+
+  # Records how many entries a lookup walked — a `tokens[presented]` hash
+  # regression would visit none of them.
+  class CountingTokens
+    attr_reader :visited
+
+    def initialize(pairs)
+      @pairs = pairs
+      @visited = 0
+    end
+
+    def empty? = @pairs.empty?
+
+    def each
+      @pairs.each do |token, scopes|
+        @visited += 1
+        yield(token, scopes)
+      end
+    end
+  end
+
+  def json_body = ::JSON.parse(last_response.body)
+
+  def fake_request(authorization)
+    Wurk::API::Request.new(
+      'REQUEST_METHOD' => 'GET', 'PATH_INFO' => '/v1', 'SCRIPT_NAME' => '', 'QUERY_STRING' => '',
+      'HTTP_AUTHORIZATION' => authorization, 'rack.input' => StringIO.new, 'rack.errors' => StringIO.new
+    )
+  end
+end

--- a/test/integration/api_v1_dropin_test.rb
+++ b/test/integration/api_v1_dropin_test.rb
@@ -1,0 +1,239 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'wurk/api/app'
+require 'json'
+require 'securerandom'
+require 'stringio'
+
+# Slice 07, task 45 — "the headline drop-in test" (07-http-producer-api.md):
+# an HTTP-enqueued job must be indistinguishable from a Ruby-enqueued one.
+# Three proofs, none of them mocking Redis:
+#
+#   1. byte-compare — the exact bytes POST /jobs writes to the queue list
+#      against what Wurk::Client#push writes for the same input.
+#   2. stock-Sidekiq oracle — the pinned, verbatim-fetched fragment of
+#      Sidekiq::Processor#dispatch / JobLogger#prepare (same SHA
+#      test/parity/.sidekiq_sha pins, e1f808a08645f9b8a194852a171b5667f5f877bd,
+#      previously fetched for TelemetryClientMiddlewareTest) resolves and
+#      dispatches an HTTP-enqueued payload unmodified.
+#   3. real fork — a real Wurk::Swarm, forked from this process, pops and
+#      runs a job this test enqueued over HTTP.
+class ApiV1DropinTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  ENQUEUE_TOKEN = 'api-dropin-enqueue-token-0123456789'
+
+  def setup
+    super
+    @ns = "apidropin-#{::Process.pid}-#{object_id}"
+    @queue = "#{@ns}-q"
+    # No '@' or '-': Validation::CLASS_FORMAT (a Ruby constant path) refuses
+    # both, and this class name has to clear the HTTP boundary's allow-list.
+    @class_name = "ApiDropinJob#{::Process.pid}#{object_id}".delete('-')
+  end
+
+  def teardown
+    Wurk.redis do |conn|
+      conn.call('DEL', "queue:#{@queue}")
+      conn.call('SREM', 'queues', @queue)
+    end
+  ensure
+    super
+  end
+
+  # --- 1. byte-compare -------------------------------------------------
+
+  # Same explicit jid on both pushes and the identical `fields` key order
+  # feeding both the JSON body and the direct Ruby call, so the only bytes
+  # that can legitimately differ are the two clock-stamped fields
+  # (`created_at`, `enqueued_at`) — everything else, key order and encoding
+  # included, has to match exactly or this fails.
+  def test_an_http_enqueued_payload_is_byte_identical_to_a_ruby_push
+    jid = SecureRandom.hex(12)
+    fields = {
+      'class' => @class_name, 'args' => [1, 'two', { 'nested' => [3, 4] }],
+      'queue' => @queue, 'jid' => jid, 'retry' => 3, 'tags' => %w[a b]
+    }
+
+    status, _headers, body = post_http('/v1/jobs', fields)
+
+    assert_equal 201, status
+    assert_equal jid, body['jid']
+    http_raw = pop_raw
+
+    Wurk::Client.new.push(fields.dup)
+    direct_raw = pop_raw
+
+    refute_nil http_raw, 'the HTTP push wrote nothing to the queue'
+    refute_nil direct_raw, 'the direct Client#push wrote nothing to the queue'
+    assert_equal scrub_timestamps(direct_raw), scrub_timestamps(http_raw),
+                 'an HTTP-enqueued payload must be byte-identical to Wurk::Client#push for the same input'
+  end
+
+  # --- 2. stock-Sidekiq oracle -------------------------------------------
+  #
+  # `Sidekiq::Processor#dispatch` and `Sidekiq::JobLogger#prepare`, pinned at
+  # test/parity/.sidekiq_sha (e1f808a08645f9b8a194852a171b5667f5f877bd):
+  #
+  #   # lib/sidekiq/processor.rb:137,148-150
+  #   @job_logger.prepare(job_hash) do
+  #     ...
+  #     klass = Object.const_get(job_hash["class"])
+  #     instance = klass.new
+  #     instance.jid = job_hash["jid"]
+  #
+  #   # lib/sidekiq/job_logger.rb:26-33
+  #   def prepare(job_hash, &block)
+  #     h = { jid: job_hash["jid"], class: job_hash["wrapped"] || job_hash["class"] }
+  #     @config[:logged_job_attributes].each do |attr|
+  #       h[attr.to_sym] = job_hash[attr] if job_hash.has_key?(attr)
+  #     end
+  #
+  # `Sidekiq.load_json` is a bare `JSON.parse` (lib/sidekiq.rb:62) and every
+  # access above is `Hash#[]`/`#has_key?` by known key name — nothing
+  # enumerates or validates the full key set. Running this exact fragment
+  # against a real HTTP-enqueued payload is what actually proves stock
+  # Sidekiq's own Processor can pick the job up, not just that the payload's
+  # shape looks right in isolation.
+  def stock_sidekiq_dispatch(jobstr)
+    job_hash = JSON.parse(jobstr)
+    prepared = { jid: job_hash['jid'], class: job_hash['wrapped'] || job_hash['class'] }
+    klass = Object.const_get(job_hash['class'])
+    instance = klass.new
+    instance.jid = job_hash['jid']
+    { instance: instance, args: job_hash['args'], prepared: prepared }
+  end
+
+  def test_an_http_enqueued_job_dispatches_unmodified_through_stock_sidekiqs_processor
+    status, _headers, body = post_http(
+      '/v1/jobs', 'class' => ApiDropinDispatchWorker.name, 'args' => [1, 'two'], 'queue' => @queue
+    )
+
+    assert_equal 201, status
+
+    dispatched = stock_sidekiq_dispatch(pop_raw)
+
+    assert_instance_of ApiDropinDispatchWorker, dispatched[:instance]
+    assert_equal body['jid'], dispatched[:instance].jid
+    assert_equal [1, 'two'], dispatched[:args]
+    assert_equal({ jid: body['jid'], class: ApiDropinDispatchWorker.name }, dispatched[:prepared])
+  end
+
+  # --- 3. a real Wurk swarm runs it ---------------------------------------
+  #
+  # #07 done-when: "A non-Ruby process can enqueue, and a Wurk swarm runs the
+  # job." Real fork, real Redis — this is the one test that proves it end to
+  # end rather than at the payload-shape or router level.
+  def test_a_wurk_swarm_runs_a_job_enqueued_over_http
+    sentinel_key = "#{@ns}-sentinel"
+    status, _headers, body = post_http(
+      '/v1/jobs',
+      'class' => ApiDropinForkWorker.name, 'args' => [Wurk::Test.redis_url, sentinel_key], 'queue' => @queue
+    )
+
+    assert_equal 201, status
+    jid = body['jid']
+
+    swarm = Wurk::Swarm.new(topology: topology_n(1), config: swarm_config, shutdown_timeout: 5)
+    supervisor = nil
+
+    begin
+      swarm.boot(install_signals: false)
+      supervisor = Thread.new { swarm.supervise }
+
+      pid = wait_for_sentinel(sentinel_key)
+
+      refute_nil pid, "job #{jid}, enqueued over HTTP, never ran within the wait window"
+      refute_equal ::Process.pid.to_s, pid, 'the job must run in a forked child, not the test process'
+    ensure
+      begin
+        swarm.shutdown(timeout: 5)
+      rescue StandardError
+        nil
+      end
+      stop_supervisor_thread(supervisor, 10)
+      Wurk.redis { |c| c.call('DEL', sentinel_key) }
+    end
+  end
+
+  private
+
+  def api_app
+    @api_app ||= Wurk::API::App.new(config: api_config)
+  end
+
+  def api_config
+    @api_config ||= Wurk::Configuration.new.tap do |cfg|
+      cfg.logger = ::Logger.new(IO::NULL)
+      cfg.api_token(ENQUEUE_TOKEN, scopes: %i[enqueue])
+      cfg.api_enqueue_classes = [@class_name, ApiDropinDispatchWorker.name, ApiDropinForkWorker.name]
+    end
+  end
+
+  def post_http(path, payload)
+    raw = JSON.generate(payload)
+    env = {
+      'REQUEST_METHOD' => 'POST', 'PATH_INFO' => path, 'SCRIPT_NAME' => '', 'QUERY_STRING' => '',
+      'CONTENT_TYPE' => 'application/json', 'CONTENT_LENGTH' => raw.bytesize.to_s,
+      'HTTP_AUTHORIZATION' => "Bearer #{ENQUEUE_TOKEN}",
+      'rack.input' => StringIO.new(raw), 'rack.errors' => StringIO.new
+    }
+    status, headers, body = api_app.call(env)
+    [status, headers, JSON.parse(body.join)]
+  end
+
+  # FIFO: LPUSH writes to the head, so the tail is the oldest (here, the only)
+  # entry — read right after each push so the two pushes in the byte-compare
+  # test can never be misattributed to each other.
+  def pop_raw
+    Wurk.redis { |c| c.call('RPOP', "queue:#{@queue}") }
+  end
+
+  def scrub_timestamps(raw)
+    raw.gsub(/"(created_at|enqueued_at)":[0-9.]+/, '"\1":<stamp>')
+  end
+
+  def topology_n(count) = Wurk::Topology.flat(count: count, queues: [@queue], concurrency: 1)
+
+  def swarm_config
+    @swarm_config ||= Wurk::Configuration.new.tap do |cfg|
+      cfg.logger = ::Logger.new(IO::NULL)
+      cfg[:timeout] = 5
+    end
+  end
+
+  def wait_for_sentinel(key, timeout: 20.0, interval: 0.1)
+    deadline = monotonic_now + timeout
+    while monotonic_now < deadline
+      value = Wurk.redis { |c| c.call('GET', key) }
+      return value if value
+
+      sleep interval
+    end
+    nil
+  end
+
+  def monotonic_now = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+end
+
+# A real, resolvable constant — `Object.const_get` needs an actual class on
+# the lookup path, not a per-test synthetic string name, and stock Sidekiq's
+# dispatch really does call `.new` and `.jid=` on it.
+class ApiDropinDispatchWorker
+  attr_accessor :jid
+end
+
+# Top-level so Object.const_get(name) resolves inside the forked swarm child,
+# which inherits the constant table but has no Minitest test-class lexical
+# scope (same reasoning as TelemetryForkWorker / StatusCrossProcessWorker).
+class ApiDropinForkWorker
+  include Wurk::Job
+
+  def perform(redis_url, sentinel_key)
+    client = RedisClient.config(url: redis_url).new_client
+    client.call('SET', sentinel_key, ::Process.pid.to_s, 'EX', 60)
+  ensure
+    client&.close
+  end
+end

--- a/test/unit/api_app_test.rb
+++ b/test/unit/api_app_test.rb
@@ -1,0 +1,238 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'wurk/api/app'
+require 'stringio'
+require 'logger'
+
+# Slice 07 — the Wurk::API Rack app skeleton: versioned under /v1, mount-
+# agnostic (every emitted URL derives from SCRIPT_NAME), RFC-9457-shaped
+# problem bodies. Route tables for jobs/queues/swarm land in later slices.
+class ApiAppTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  LIB = File.expand_path('../../lib', __dir__)
+
+  def test_version_root_reports_the_contract_it_serves
+    status, headers, body = get('/v1')
+
+    assert_equal 200, status
+    assert_equal 'application/json', headers['content-type']
+    assert_equal 'v1', body['api_version']
+    assert_equal Wurk::VERSION, body['wurk_version']
+  end
+
+  def test_every_response_forbids_content_sniffing
+    _status, ok_headers, = get('/v1')
+    _status, problem_headers, = get('/v1/nope')
+
+    assert_equal 'nosniff', ok_headers['x-content-type-options']
+    assert_equal 'nosniff', problem_headers['x-content-type-options']
+  end
+
+  # The mount-agnostic contract: '/wurk' appears nowhere in lib/wurk/api.
+  def test_emitted_url_is_derived_from_the_mount_point
+    _status, _headers, body = get('/v1', script_name: '/wurk/api')
+
+    assert_equal '/wurk/api/v1', body['url']
+  end
+
+  def test_emitted_url_follows_a_separate_mount
+    _status, _headers, body = get('/v1', script_name: '/wurk-api')
+
+    assert_equal '/wurk-api/v1', body['url']
+  end
+
+  def test_emitted_url_is_bare_when_mounted_at_the_root
+    _status, _headers, body = get('/v1')
+
+    assert_equal '/v1', body['url']
+  end
+
+  def test_trailing_slash_reaches_the_version_root
+    status, = get('/v1/')
+
+    assert_equal 200, status
+  end
+
+  def test_unknown_route_under_the_served_version_is_a_not_found_problem
+    status, headers, body = get('/v1/nope')
+
+    assert_equal 404, status
+    assert_equal 'application/problem+json', headers['content-type']
+    assert_equal 'not_found', body['type']
+    assert_equal 'Not Found', body['title']
+    assert_equal 404, body['status']
+  end
+
+  # `instance` is the request path as the client addressed it, mount included —
+  # a client behind a shared proxy needs to know which mount answered.
+  def test_problem_instance_carries_the_mounted_request_path
+    _status, _headers, body = get('/v1/nope', script_name: '/wurk/api')
+
+    assert_equal '/wurk/api/v1/nope', body['instance']
+  end
+
+  def test_unknown_version_names_the_versions_that_exist
+    status, _headers, body = get('/v2/jobs')
+
+    assert_equal 404, status
+    assert_equal 'unsupported_api_version', body['type']
+    assert_equal ['v1'], body['supported_versions']
+  end
+
+  def test_unversioned_path_is_an_unsupported_version_problem
+    status, _headers, body = get('/jobs')
+
+    assert_equal 404, status
+    assert_equal 'unsupported_api_version', body['type']
+  end
+
+  def test_app_root_does_not_serve_the_version_root
+    status, _headers, body = get('/')
+
+    assert_equal 404, status
+    assert_equal 'unsupported_api_version', body['type']
+  end
+
+  # A '/v1abc' prefix is not a version segment; only '/v1' and '/v1/…' are.
+  def test_version_prefix_matches_whole_segments_only
+    status, _headers, body = get('/v1abc')
+
+    assert_equal 404, status
+    assert_equal 'unsupported_api_version', body['type']
+  end
+
+  def test_wrong_verb_on_a_known_path_is_405_with_allow
+    status, headers, body = call(env_for('POST', '/v1'))
+
+    assert_equal 405, status
+    assert_equal 'GET, HEAD', headers['allow']
+    assert_equal 'method_not_allowed', JSON.parse(body.join)['type']
+  end
+
+  def test_allow_advertises_only_the_verbs_the_path_answers
+    _status, headers, = RoutesApp.new.call(env_for('GET', '/v1/create'))
+
+    assert_equal 'POST', headers['allow']
+  end
+
+  def test_router_captures_reach_the_handler_decoded
+    _status, _headers, body = RoutesApp.new.call(env_for('GET', '/v1/echo/two%20words'))
+
+    assert_equal 'two words', JSON.parse(body.join)['echoed']
+  end
+
+  def test_head_routes_as_get_but_sends_no_body
+    status, headers, body = call(env_for('HEAD', '/v1'))
+
+    assert_equal 200, status
+    assert_equal 'application/json', headers['content-type']
+    assert_empty body
+  end
+
+  def test_handler_failure_becomes_a_problem_without_leaking_the_exception
+    status, headers, body = BoomApp.new.call(env_for('GET', '/v1'))
+
+    assert_equal 500, status
+    assert_equal 'application/problem+json', headers['content-type']
+    payload = JSON.parse(body.join)
+
+    assert_equal 'internal_error', payload['type']
+    refute_includes payload.to_s, 'kaboom'
+  end
+
+  def test_handler_failure_is_logged_server_side
+    log = capture_log { BoomApp.new.call(env_for('GET', '/v1', script_name: '/wurk/api')) }
+
+    assert_includes log, 'kaboom'
+    assert_includes log, 'GET /wurk/api/v1'
+  end
+
+  # `mount Wurk::API => …` and `run Wurk::API` both go through this entry.
+  def test_module_level_rack_entry_serves_the_same_routes
+    status, _headers, body = Wurk::API.call(env_for('GET', '/v1'))
+
+    assert_equal 200, status
+    assert_equal 'v1', JSON.parse(body.join)['api_version']
+  end
+
+  # The additive invariant: a swarm that never serves HTTP must not carry the
+  # router or Rack::Request in its pre-fork heap. Subprocess, because this
+  # process has already required the app.
+  def test_requiring_wurk_does_not_load_the_http_api
+    loaded = ruby('require "wurk"; print $LOADED_FEATURES.grep(%r{wurk/api/(app|router|request)\.rb\z}).size')
+
+    assert_equal '0', loaded
+  end
+
+  def test_the_mount_point_loads_the_app_on_first_request
+    loaded = ruby(<<~RUBY)
+      require 'wurk'
+      Wurk::API.call('REQUEST_METHOD' => 'GET', 'PATH_INFO' => '/v1', 'SCRIPT_NAME' => '')
+      print $LOADED_FEATURES.grep(%r{wurk/api/(app|router|request)\\.rb\\z}).size
+    RUBY
+
+    assert_equal '3', loaded
+  end
+
+  private
+
+  # An App whose only route raises, to exercise the 500 path.
+  class BoomApp < Wurk::API::App
+    private
+
+    def draw(router)
+      router.get('/') { raise 'kaboom' }
+    end
+  end
+
+  # A second route table for the router↔request wiring the skeleton's own root
+  # route can't reach: a capture arriving at a handler, and a path with no GET.
+  class RoutesApp < Wurk::API::App
+    private
+
+    def draw(router)
+      router.get('/echo/:name') { |request| json(200, echoed: request.path_params[:name]) }
+      router.post('/create') { |_request| json(201, created: true) }
+    end
+  end
+
+  def call(env) = Wurk::API::App.new.call(env)
+
+  def ruby(script)
+    IO.popen([RbConfig.ruby, '-I', LIB, '-e', script], err: %i[child out], &:read)
+  end
+
+  def get(path, script_name: '')
+    status, headers, body = call(env_for('GET', path, script_name: script_name))
+    [status, headers, JSON.parse(body.join)]
+  end
+
+  def env_for(method, path, script_name: '')
+    {
+      'REQUEST_METHOD' => method,
+      'PATH_INFO' => path,
+      'SCRIPT_NAME' => script_name,
+      'QUERY_STRING' => '',
+      'rack.input' => StringIO.new,
+      'rack.errors' => StringIO.new
+    }
+  end
+
+  # Swaps the process-global logger, so it takes the suite-wide mutex the other
+  # global-state tests use rather than racing a parallel class's own swap.
+  def capture_log
+    io = StringIO.new
+    Wurk::Test::GLOBAL_STATE_MUTEX.synchronize do
+      previous = Wurk.logger
+      Wurk.logger = ::Logger.new(io)
+      begin
+        yield
+      ensure
+        Wurk.logger = previous
+      end
+    end
+    io.string
+  end
+end

--- a/test/unit/api_app_test.rb
+++ b/test/unit/api_app_test.rb
@@ -206,8 +206,10 @@ class ApiAppTest < Wurk::Test::UnitCase
     private
 
     def draw(router)
-      router.get('/echo/:name', scope: :read) { |request| json(200, echoed: request.path_params[:name]) }
-      router.post('/create', scope: :enqueue) { |_request| json(201, created: true) }
+      router.get('/echo/:name', scope: :read) do |request|
+        Wurk::API::Response.json(200, echoed: request.path_params[:name])
+      end
+      router.post('/create', scope: :enqueue) { |_request| Wurk::API::Response.json(201, created: true) }
     end
   end
 

--- a/test/unit/api_app_test.rb
+++ b/test/unit/api_app_test.rb
@@ -8,10 +8,14 @@ require 'logger'
 # Slice 07 — the Wurk::API Rack app skeleton: versioned under /v1, mount-
 # agnostic (every emitted URL derives from SCRIPT_NAME), RFC-9457-shaped
 # problem bodies. Route tables for jobs/queues/swarm land in later slices.
+#
+# Auth is exercised in api_auth_test.rb; every request here carries a valid
+# admin token so these tests speak only about routing and error shape.
 class ApiAppTest < Wurk::Test::UnitCase
   parallelize_me!
 
   LIB = File.expand_path('../../lib', __dir__)
+  TOKEN = 'api-app-test-token-0123456789'
 
   def test_version_root_reports_the_contract_it_serves
     status, headers, body = get('/v1')
@@ -112,13 +116,13 @@ class ApiAppTest < Wurk::Test::UnitCase
   end
 
   def test_allow_advertises_only_the_verbs_the_path_answers
-    _status, headers, = RoutesApp.new.call(env_for('GET', '/v1/create'))
+    _status, headers, = RoutesApp.new(config: config).call(env_for('GET', '/v1/create'))
 
     assert_equal 'POST', headers['allow']
   end
 
   def test_router_captures_reach_the_handler_decoded
-    _status, _headers, body = RoutesApp.new.call(env_for('GET', '/v1/echo/two%20words'))
+    _status, _headers, body = RoutesApp.new(config: config).call(env_for('GET', '/v1/echo/two%20words'))
 
     assert_equal 'two words', JSON.parse(body.join)['echoed']
   end
@@ -132,7 +136,7 @@ class ApiAppTest < Wurk::Test::UnitCase
   end
 
   def test_handler_failure_becomes_a_problem_without_leaking_the_exception
-    status, headers, body = BoomApp.new.call(env_for('GET', '/v1'))
+    status, headers, body = BoomApp.new(config: config).call(env_for('GET', '/v1'))
 
     assert_equal 500, status
     assert_equal 'application/problem+json', headers['content-type']
@@ -143,25 +147,34 @@ class ApiAppTest < Wurk::Test::UnitCase
   end
 
   def test_handler_failure_is_logged_server_side
-    log = capture_log { BoomApp.new.call(env_for('GET', '/v1', script_name: '/wurk/api')) }
+    log = capture_log do
+      BoomApp.new(config: config).call(env_for('GET', '/v1', script_name: '/wurk/api'))
+    end
 
     assert_includes log, 'kaboom'
     assert_includes log, 'GET /wurk/api/v1'
   end
 
-  # `mount Wurk::API => …` and `run Wurk::API` both go through this entry.
+  # `mount Wurk::API => …` and `run Wurk::API` both go through this entry, which
+  # reads the process-wide config — hence the global-state mutex and the
+  # deregistration in `ensure`.
   def test_module_level_rack_entry_serves_the_same_routes
-    status, _headers, body = Wurk::API.call(env_for('GET', '/v1'))
+    Wurk::Test::GLOBAL_STATE_MUTEX.synchronize do
+      Wurk.configuration.api_token(TOKEN, scopes: %i[read])
+      status, _headers, body = Wurk::API.call(env_for('GET', '/v1'))
 
-    assert_equal 200, status
-    assert_equal 'v1', JSON.parse(body.join)['api_version']
+      assert_equal 200, status
+      assert_equal 'v1', JSON.parse(body.join)['api_version']
+    ensure
+      Wurk.configuration.api_tokens.delete(TOKEN)
+    end
   end
 
   # The additive invariant: a swarm that never serves HTTP must not carry the
   # router or Rack::Request in its pre-fork heap. Subprocess, because this
   # process has already required the app.
   def test_requiring_wurk_does_not_load_the_http_api
-    loaded = ruby('require "wurk"; print $LOADED_FEATURES.grep(%r{wurk/api/(app|router|request)\.rb\z}).size')
+    loaded = ruby('require "wurk"; print $LOADED_FEATURES.grep(%r{wurk/api/(app|auth|router|request)\.rb\z}).size')
 
     assert_equal '0', loaded
   end
@@ -170,10 +183,10 @@ class ApiAppTest < Wurk::Test::UnitCase
     loaded = ruby(<<~RUBY)
       require 'wurk'
       Wurk::API.call('REQUEST_METHOD' => 'GET', 'PATH_INFO' => '/v1', 'SCRIPT_NAME' => '')
-      print $LOADED_FEATURES.grep(%r{wurk/api/(app|router|request)\\.rb\\z}).size
+      print $LOADED_FEATURES.grep(%r{wurk/api/(app|auth|router|request)\\.rb\\z}).size
     RUBY
 
-    assert_equal '3', loaded
+    assert_equal '4', loaded
   end
 
   private
@@ -183,7 +196,7 @@ class ApiAppTest < Wurk::Test::UnitCase
     private
 
     def draw(router)
-      router.get('/') { raise 'kaboom' }
+      router.get('/', scope: Wurk::API::Auth::ANY) { raise 'kaboom' }
     end
   end
 
@@ -193,12 +206,16 @@ class ApiAppTest < Wurk::Test::UnitCase
     private
 
     def draw(router)
-      router.get('/echo/:name') { |request| json(200, echoed: request.path_params[:name]) }
-      router.post('/create') { |_request| json(201, created: true) }
+      router.get('/echo/:name', scope: :read) { |request| json(200, echoed: request.path_params[:name]) }
+      router.post('/create', scope: :enqueue) { |_request| json(201, created: true) }
     end
   end
 
-  def call(env) = Wurk::API::App.new.call(env)
+  def call(env) = Wurk::API::App.new(config: config).call(env)
+
+  def config
+    @config ||= Wurk::Configuration.new.tap { |cfg| cfg.api_token(TOKEN, scopes: %i[admin]) }
+  end
 
   def ruby(script)
     IO.popen([RbConfig.ruby, '-I', LIB, '-e', script], err: %i[child out], &:read)
@@ -215,6 +232,7 @@ class ApiAppTest < Wurk::Test::UnitCase
       'PATH_INFO' => path,
       'SCRIPT_NAME' => script_name,
       'QUERY_STRING' => '',
+      'HTTP_AUTHORIZATION' => "Bearer #{TOKEN}",
       'rack.input' => StringIO.new,
       'rack.errors' => StringIO.new
     }

--- a/test/unit/api_auth_test.rb
+++ b/test/unit/api_auth_test.rb
@@ -312,10 +312,10 @@ class ApiAuthTest < Wurk::Test::UnitCase
     private
 
     def draw(router)
-      router.get('/', scope: Wurk::API::Auth::ANY) { |_request| json(200, ok: 'any') }
-      router.get('/reads', scope: :read) { |_request| json(200, ok: 'read') }
-      router.post('/enqueues', scope: :enqueue) { |_request| json(201, ok: 'enqueue') }
-      router.post('/admins', scope: :admin) { |_request| json(200, ok: 'admin') }
+      router.get('/', scope: Wurk::API::Auth::ANY) { |_request| Wurk::API::Response.json(200, ok: 'any') }
+      router.get('/reads', scope: :read) { |_request| Wurk::API::Response.json(200, ok: 'read') }
+      router.post('/enqueues', scope: :enqueue) { |_request| Wurk::API::Response.json(201, ok: 'enqueue') }
+      router.post('/admins', scope: :admin) { |_request| Wurk::API::Response.json(200, ok: 'admin') }
     end
   end
 

--- a/test/unit/api_auth_test.rb
+++ b/test/unit/api_auth_test.rb
@@ -1,0 +1,378 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'wurk/api/app'
+require 'stringio'
+
+# Slice 07 — bearer-token auth for the machine-facing HTTP API. The gate every
+# other API slice sits behind: no token registered means the API does not
+# exist, and nothing under /v1 answers without one.
+class ApiAuthTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  LIB = File.expand_path('../../lib', __dir__)
+
+  READ_TOKEN    = 'read-token-aaaaaaaaaaaaaaaaaa'
+  ENQUEUE_TOKEN = 'enqueue-token-bbbbbbbbbbbbbbb'
+  ADMIN_TOKEN   = 'admin-token-cccccccccccccccccc'
+
+  # --- The registry: no token, no API ------------------------------------
+
+  def test_a_fresh_configuration_registers_no_tokens
+    fresh = Wurk::Configuration.new
+
+    assert_empty fresh.api_tokens
+    refute_predicate fresh, :api_enabled?
+  end
+
+  def test_registering_a_token_brings_the_api_into_existence
+    assert_predicate config, :api_enabled?
+    assert_equal %i[read], config.api_tokens[READ_TOKEN]
+  end
+
+  # The 404 is the point: an app mounted without a token has to look exactly
+  # like an app that was never mounted, not like one guarding a real surface.
+  def test_no_token_configured_answers_404_not_401
+    status, headers, body = request('GET', '/v1', token: ADMIN_TOKEN, app: unconfigured_app)
+
+    assert_equal 404, status
+    assert_equal 'not_found', body['type']
+    refute headers.key?('www-authenticate')
+  end
+
+  def test_no_token_configured_hides_every_address_alike
+    %w[/v1 /v1/reads /v1/nope /v2/reads].each do |path|
+      _status, _headers, body = request('GET', path, app: unconfigured_app)
+
+      assert_equal 'not_found', body['type'], "#{path} leaked which addresses exist"
+    end
+  end
+
+  # --- Authentication ------------------------------------------------------
+
+  def test_a_missing_credential_is_challenged_without_claiming_one_was_wrong
+    status, headers, body = request('GET', '/v1/reads')
+
+    assert_equal 401, status
+    assert_equal 'unauthorized', body['type']
+    assert_equal 'Bearer realm="wurk"', headers['www-authenticate']
+    assert_equal 'A bearer token is required.', body['detail']
+  end
+
+  def test_an_unknown_token_is_rejected_as_invalid
+    status, headers, body = request('GET', '/v1/reads', token: 'not-a-registered-token-000000')
+
+    assert_equal 401, status
+    assert_equal 'Bearer realm="wurk", error="invalid_token"', headers['www-authenticate']
+    assert_equal 'The bearer token presented is not valid.', body['detail']
+  end
+
+  def test_a_token_of_a_different_length_is_rejected_like_any_other
+    status, = request('GET', '/v1/reads', token: 'x' * 400)
+
+    assert_equal 401, status
+  end
+
+  def test_another_scheme_or_a_bare_scheme_never_authenticates
+    ['Basic abc123', 'Bearer', 'Bearer ', READ_TOKEN, "Token #{READ_TOKEN}"].each do |header|
+      status, = request('GET', '/v1/reads', authorization: header)
+
+      assert_equal 401, status, "#{header.inspect} was accepted"
+    end
+  end
+
+  # RFC 9110 §11.1: the scheme is case-insensitive. The credential is not.
+  def test_the_scheme_is_case_insensitive_and_the_token_is_not
+    status, = request('GET', '/v1/reads', authorization: "bEaReR #{READ_TOKEN}")
+
+    assert_equal 200, status
+
+    status, = request('GET', '/v1/reads', token: READ_TOKEN.upcase)
+
+    assert_equal 401, status
+  end
+
+  def test_a_registered_token_reaches_the_handler
+    status, _headers, body = request('GET', '/v1/reads', token: READ_TOKEN)
+
+    assert_equal 200, status
+    assert_equal 'read', body['ok']
+  end
+
+  # --- Scopes --------------------------------------------------------------
+
+  def test_a_token_outside_the_routes_scope_is_403_with_the_scope_it_lacks
+    status, headers, body = request('POST', '/v1/enqueues', token: READ_TOKEN)
+
+    assert_equal 403, status
+    assert_equal 'insufficient_scope', body['type']
+    assert_equal 'enqueue', body['required_scope']
+    assert_equal 'Bearer realm="wurk", error="insufficient_scope", scope="enqueue"', headers['www-authenticate']
+  end
+
+  def test_scopes_are_not_interchangeable
+    status, = request('GET', '/v1/reads', token: ENQUEUE_TOKEN)
+
+    assert_equal 403, status
+  end
+
+  def test_admin_grants_the_other_scopes
+    %w[/v1/reads /v1/admins].each do |path|
+      status, = request(path == '/v1/admins' ? 'POST' : 'GET', path, token: ADMIN_TOKEN)
+
+      assert_equal 200, status, "admin was refused #{path}"
+    end
+
+    status, = request('POST', '/v1/enqueues', token: ADMIN_TOKEN)
+
+    assert_equal 201, status
+  end
+
+  def test_read_and_enqueue_do_not_grant_admin
+    [READ_TOKEN, ENQUEUE_TOKEN].each do |token|
+      status, = request('POST', '/v1/admins', token: token)
+
+      assert_equal 403, status
+    end
+  end
+
+  # The discovery document is the one route any authenticated client may read:
+  # a producer has to confirm the contract before it trusts what it posts to.
+  def test_the_discovery_document_answers_any_authenticated_token
+    [READ_TOKEN, ENQUEUE_TOKEN, ADMIN_TOKEN].each do |token|
+      status, = request('GET', '/v1', token: token)
+
+      assert_equal 200, status
+    end
+  end
+
+  # --- Ordering: authenticate before saying anything about addresses -------
+
+  def test_an_unauthenticated_client_cannot_enumerate_routes
+    status, = request('GET', '/v1/nope')
+
+    assert_equal 401, status
+
+    _status, _headers, body = request('GET', '/v1/nope', token: READ_TOKEN)
+
+    assert_equal 'not_found', body['type']
+  end
+
+  def test_an_unauthenticated_client_cannot_enumerate_versions
+    status, = request('GET', '/v2/reads')
+
+    assert_equal 401, status
+
+    _status, _headers, body = request('GET', '/v2/reads', token: READ_TOKEN)
+
+    assert_equal 'unsupported_api_version', body['type']
+  end
+
+  def test_the_wrong_verb_still_authenticates_first
+    status, = request('POST', '/v1/reads')
+
+    assert_equal 401, status
+
+    status, = request('POST', '/v1/reads', token: READ_TOKEN)
+
+    assert_equal 405, status
+  end
+
+  # --- Never the dashboard plane ------------------------------------------
+
+  # same_origin_guard.rb denies every unsafe request that doesn't carry
+  # `Sec-Fetch-Site: same-origin` — a header only a browser sets. A Python or
+  # Go producer sends none, so the API must not consult it: these POSTs carry
+  # no fetch metadata (and then hostile fetch metadata) and still go through.
+  def test_a_machine_client_needs_no_browser_fetch_metadata
+    status, = request('POST', '/v1/enqueues', token: ENQUEUE_TOKEN)
+
+    assert_equal 201, status
+
+    status, = request('POST', '/v1/enqueues', token: ENQUEUE_TOKEN, 'HTTP_SEC_FETCH_SITE' => 'cross-site')
+
+    assert_equal 201, status
+  end
+
+  # --- Constant-time comparison -------------------------------------------
+
+  # No early return on a hit: the first token registered is the one presented,
+  # and the walk still visits the rest. A Hash lookup would visit none.
+  def test_every_registered_token_is_compared_even_after_a_match
+    tokens = CountingTokens.new([[READ_TOKEN, %i[read]], [ADMIN_TOKEN, %i[admin]]])
+    principal = Wurk::API::Auth.authenticate(rack_request("Bearer #{READ_TOKEN}"), FakeConfig.new(tokens))
+
+    assert_equal %i[read], principal.scopes
+    assert_equal 2, tokens.visited
+  end
+
+  def test_a_miss_also_walks_the_whole_table
+    tokens = CountingTokens.new([[READ_TOKEN, %i[read]], [ADMIN_TOKEN, %i[admin]]])
+
+    assert_nil Wurk::API::Auth.authenticate(rack_request('Bearer nope-nope-nope-nope-nope'), FakeConfig.new(tokens))
+    assert_equal 2, tokens.visited
+  end
+
+  # Constant-time comparison leaves no runtime signature to assert against; a
+  # test can only pin that it is still the primitive in use. The walk tests
+  # above catch a regression to a Hash lookup — this one catches `==`, and the
+  # bytesize pre-check that makes Rack::Utils.secure_compare leak token length.
+  def test_token_comparison_stays_constant_time
+    code = File.readlines(File.expand_path('../../lib/wurk/api/auth.rb', __dir__)).grep_v(/^\s*#/).join
+
+    assert_includes code, 'OpenSSL.fixed_length_secure_compare'
+    refute_match(/tokens\[|\bbytesize\b/, code)
+  end
+
+  # --- Declaring a credential ---------------------------------------------
+
+  def test_a_token_short_enough_to_have_been_typed_is_refused
+    error = assert_raises(ArgumentError) { Wurk::Configuration.new.api_token('short', scopes: %i[read]) }
+
+    assert_match(/at least 20 characters/, error.message)
+    assert_raises(ArgumentError) { Wurk::Configuration.new.api_token(nil, scopes: %i[read]) }
+  end
+
+  def test_a_token_that_cannot_survive_a_header_is_refused
+    ["with space#{'a' * 20}", "tab\t#{'a' * 20}", "nul\0#{'a' * 20}", "hí#{'a' * 20}"].each do |value|
+      assert_raises(ArgumentError, "#{value.inspect} was accepted") do
+        Wurk::Configuration.new.api_token(value, scopes: %i[read])
+      end
+    end
+  end
+
+  def test_an_unknown_or_empty_scope_fails_where_it_is_declared
+    error = assert_raises(ArgumentError) { Wurk::Configuration.new.api_token(READ_TOKEN, scopes: %i[reed]) }
+
+    assert_match(/unknown api_token scope/, error.message)
+    assert_match(/enqueue/, error.message)
+    assert_raises(ArgumentError) { Wurk::Configuration.new.api_token(READ_TOKEN, scopes: []) }
+  end
+
+  def test_scopes_are_normalized_and_frozen
+    fresh = Wurk::Configuration.new
+    fresh.api_token(READ_TOKEN, scopes: ['read', :read, 'admin'])
+
+    assert_equal %i[read admin], fresh.api_tokens[READ_TOKEN]
+    assert_predicate fresh.api_tokens[READ_TOKEN], :frozen?
+  end
+
+  def test_re_registering_a_token_replaces_its_scopes
+    fresh = Wurk::Configuration.new
+    fresh.api_token(READ_TOKEN, scopes: %i[read])
+    fresh.api_token(READ_TOKEN, scopes: %i[admin])
+
+    assert_equal({ READ_TOKEN => %i[admin] }, fresh.api_tokens)
+  end
+
+  def test_a_frozen_configuration_refuses_new_tokens
+    frozen = Wurk::Configuration.new.tap(&:freeze!)
+
+    assert_raises(FrozenError) { frozen.api_token(READ_TOKEN, scopes: %i[read]) }
+  end
+
+  def test_the_registry_is_not_shared_between_configurations
+    config.api_tokens
+
+    assert_empty Wurk::Configuration.new.api_tokens
+  end
+
+  # The additive invariant, config-side: registering a token is what pulls the
+  # auth module (and openssl/digest with it) in. A host that serves no HTTP API
+  # carries none of it in a swarm child's pre-fork heap. Subprocess, because
+  # this process has already required it.
+  def test_registering_a_token_is_what_loads_the_auth_module
+    probe = 'print $LOADED_FEATURES.grep(%r{wurk/api/auth\.rb\z}).size'
+
+    assert_equal '0', ruby("require 'wurk'; #{probe}")
+    assert_equal '1', ruby(<<~RUBY)
+      require 'wurk'
+      Wurk.configuration.api_token('#{READ_TOKEN}', scopes: %i[read])
+      #{probe}
+    RUBY
+  end
+
+  # --- Principal -----------------------------------------------------------
+
+  def test_a_principal_reports_only_what_it_was_granted
+    principal = Wurk::API::Auth::Principal.new(%i[read])
+
+    assert principal.permits?(:read)
+    assert principal.permits?(Wurk::API::Auth::ANY)
+    refute principal.permits?(:enqueue)
+    refute principal.permits?(:admin)
+  end
+
+  FakeConfig = Struct.new(:api_tokens)
+
+  private
+
+  # One route per scope, so a token can be pointed at exactly the one it lacks.
+  class ScopedApp < Wurk::API::App
+    private
+
+    def draw(router)
+      router.get('/', scope: Wurk::API::Auth::ANY) { |_request| json(200, ok: 'any') }
+      router.get('/reads', scope: :read) { |_request| json(200, ok: 'read') }
+      router.post('/enqueues', scope: :enqueue) { |_request| json(201, ok: 'enqueue') }
+      router.post('/admins', scope: :admin) { |_request| json(200, ok: 'admin') }
+    end
+  end
+
+  # Records how many entries a lookup walked. A `tokens[presented]` regression
+  # visits none of them.
+  class CountingTokens
+    attr_reader :visited
+
+    def initialize(pairs)
+      @pairs = pairs
+      @visited = 0
+    end
+
+    def empty? = @pairs.empty?
+
+    def each
+      @pairs.each do |token, scopes|
+        @visited += 1
+        yield(token, scopes)
+      end
+    end
+  end
+
+  def config
+    @config ||= Wurk::Configuration.new.tap do |cfg|
+      cfg.api_token(READ_TOKEN, scopes: %i[read])
+      cfg.api_token(ENQUEUE_TOKEN, scopes: %i[enqueue])
+      cfg.api_token(ADMIN_TOKEN, scopes: %i[admin])
+    end
+  end
+
+  def unconfigured_app = ScopedApp.new(config: Wurk::Configuration.new)
+
+  def request(method, path, token: nil, authorization: nil, app: nil, **env_extra)
+    env = env_for(method, path).merge(env_extra)
+    credential = authorization || (token && "Bearer #{token}")
+    env['HTTP_AUTHORIZATION'] = credential if credential
+    status, headers, body = (app || ScopedApp.new(config: config)).call(env)
+    [status, headers, JSON.parse(body.join)]
+  end
+
+  def ruby(script)
+    IO.popen([RbConfig.ruby, '-I', LIB, '-e', script], err: %i[child out], &:read)
+  end
+
+  def rack_request(authorization)
+    Wurk::API::Request.new(env_for('GET', '/v1').merge('HTTP_AUTHORIZATION' => authorization))
+  end
+
+  def env_for(method, path)
+    {
+      'REQUEST_METHOD' => method,
+      'PATH_INFO' => path,
+      'SCRIPT_NAME' => '',
+      'QUERY_STRING' => '',
+      'rack.input' => StringIO.new,
+      'rack.errors' => StringIO.new
+    }
+  end
+end

--- a/test/unit/api_auth_test.rb
+++ b/test/unit/api_auth_test.rb
@@ -295,7 +295,7 @@ class ApiAuthTest < Wurk::Test::UnitCase
   # --- Principal -----------------------------------------------------------
 
   def test_a_principal_reports_only_what_it_was_granted
-    principal = Wurk::API::Auth::Principal.new(%i[read])
+    principal = Wurk::API::Auth::Principal.new('0123456789abcdef0123456789abcdef', %i[read])
 
     assert principal.permits?(:read)
     assert principal.permits?(Wurk::API::Auth::ANY)

--- a/test/unit/api_idempotency_test.rb
+++ b/test/unit/api_idempotency_test.rb
@@ -1,0 +1,313 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'wurk/api/app'
+require 'digest'
+require 'json'
+require 'stringio'
+
+# Slice 07 — `Idempotency-Key` replay protection on the produce plane.
+#
+# A producer whose connection drops mid-POST cannot tell a lost request from a
+# lost response, so it retries; without this that retry is a second job. Every
+# assertion below is on what actually landed in Redis, because a replay that
+# answered correctly and enqueued anyway would be the only failure worth
+# catching.
+#
+# Parallel safety: queue and class names carry a per-instance namespace, and
+# the worker's Redis DB is flushed after every test (RedisNamespace).
+class ApiIdempotencyTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  ADMIN_TOKEN = 'api-idem-admin-token-0123456789'
+  OTHER_TOKEN = 'api-idem-other-token-0123456789'
+
+  # A middleware that fails the push the way an unreachable Redis would: after
+  # the key is claimed, before there is an answer to pin to it.
+  BoomMiddleware = Class.new do
+    include Wurk::Middleware::ClientMiddleware
+
+    def call(*) = raise('boom')
+  end
+
+  # What a `collapse:`/`unique_for:` drop does to a duplicate.
+  HaltMiddleware = Class.new do
+    include Wurk::Middleware::ClientMiddleware
+
+    def call(*) = nil
+  end
+
+  def setup
+    super
+    @ns = "#{Process.pid}_#{object_id}"
+    @queue = "q-#{@ns}"
+    @class_name = "ApiIdemWorker#{@ns}"
+    @pool = Wurk.configuration.redis_pool
+  end
+
+  # --- The replay ---------------------------------------------------------
+
+  def test_a_repeated_key_enqueues_once_and_replays_the_first_answer
+    first = post('/v1/jobs', job, key: 'k1')
+    second = post('/v1/jobs', job, key: 'k1')
+
+    assert_equal 201, first[0]
+    assert_equal first[0], second[0]
+    assert_equal first[2], second[2]
+    assert_equal 1, queued_payloads.size
+    assert_equal first[2]['jid'], queued_payloads.fetch(0)['jid']
+  end
+
+  def test_a_replay_says_so
+    post('/v1/jobs', job, key: 'k1')
+    _status, headers, = post('/v1/jobs', job, key: 'k1')
+
+    assert_equal 'true', headers[Wurk::API::Idempotency::REPLAY_HEADER]
+    assert_equal 'application/json', headers['content-type']
+  end
+
+  def test_a_first_answer_is_not_marked_as_a_replay
+    _status, headers, = post('/v1/jobs', job, key: 'k1')
+
+    refute headers.key?(Wurk::API::Idempotency::REPLAY_HEADER)
+  end
+
+  def test_different_keys_are_different_requests
+    post('/v1/jobs', job, key: 'k1')
+    post('/v1/jobs', job, key: 'k2')
+
+    assert_equal 2, queued_payloads.size
+  end
+
+  def test_no_key_means_no_record_and_no_round_trip
+    post('/v1/jobs', job)
+    post('/v1/jobs', job)
+
+    assert_equal 2, queued_payloads.size
+    assert_empty idempotency_keys
+  end
+
+  def test_the_bulk_route_is_guarded_too
+    first = post('/v1/jobs/bulk', job(args: [[1], [2]]), key: 'k1')
+    second = post('/v1/jobs/bulk', job(args: [[1], [2]]), key: 'k1')
+
+    assert_equal first[2]['jids'], second[2]['jids']
+    assert_equal 2, queued_payloads.size
+  end
+
+  # --- Scoping ------------------------------------------------------------
+
+  # The key is a string the client chose: two producers that both sent `1` must
+  # not see each other's jids.
+  def test_a_key_belongs_to_the_credential_that_chose_it
+    mine = post('/v1/jobs', job, key: 'k1')
+    theirs = post('/v1/jobs', job, key: 'k1', token: OTHER_TOKEN)
+
+    refute_equal mine[2]['jid'], theirs[2]['jid']
+    assert_equal 2, queued_payloads.size
+  end
+
+  def test_the_same_key_on_two_routes_addresses_two_requests
+    post('/v1/jobs', job, key: 'k1')
+    status, = post('/v1/jobs/bulk', job(args: [[1]]), key: 'k1')
+
+    assert_equal 201, status
+    assert_equal 2, queued_payloads.size
+  end
+
+  # Hashed, so what a client chose never reaches Redis in the clear.
+  def test_the_clients_own_key_never_reaches_redis
+    post('/v1/jobs', job, key: 'a-very-recognisable-key')
+
+    assert_equal 1, idempotency_keys.size
+    refute_includes idempotency_keys.first, 'recognisable'
+  end
+
+  # --- Collisions ---------------------------------------------------------
+
+  def test_the_same_key_with_a_different_body_is_a_client_bug
+    post('/v1/jobs', job, key: 'k1')
+    status, headers, body = post('/v1/jobs', job(args: [1]), key: 'k1')
+
+    assert_equal 409, status
+    assert_equal 'application/problem+json', headers['content-type']
+    assert_equal 'idempotency_key_reused', body['type']
+    assert_equal 'Idempotency Key Reused', body['title']
+    assert_equal 1, queued_payloads.size
+  end
+
+  def test_a_claim_still_in_flight_answers_try_again
+    claim('k1', job)
+    status, headers, body = post('/v1/jobs', job, key: 'k1')
+
+    assert_equal 409, status
+    assert_equal 'request_in_progress', body['type']
+    assert_equal '1', headers['retry-after']
+    assert_empty queued_payloads
+  end
+
+  # A record has to be read back under contention, so an unreadable one
+  # degrades to "still in flight" rather than to an exception on the request
+  # path — the safe answer, since it never enqueues a second job.
+  def test_an_unreadable_record_degrades_to_in_progress
+    @pool.with { |conn| conn.call('SET', slot_for('k1'), 'not a record', 'EX', 60) }
+    status, _headers, body = post('/v1/jobs', job, key: 'k1')
+
+    assert_equal 'request_in_progress', body['type']
+    assert_equal 409, status
+    assert_empty queued_payloads
+  end
+
+  # --- Releasing --------------------------------------------------------
+
+  # A rejected body is a request the client should be able to correct and send
+  # again under the same key.
+  def test_a_refused_request_does_not_burn_the_key
+    status, = post('/v1/jobs', job(at: 'soon'), key: 'k1')
+
+    assert_equal 400, status
+    assert_empty idempotency_keys
+
+    status, = post('/v1/jobs', job, key: 'k1')
+
+    assert_equal 201, status
+  end
+
+  # A raise is a request whose outcome nobody knows, so nothing is pinned to
+  # the key — the client's retry gets a real attempt, not a replayed 500.
+  def test_a_raising_push_does_not_burn_the_key
+    status, = with_client_middleware(BoomMiddleware) { post('/v1/jobs', job, key: 'k1') }
+
+    assert_equal 500, status
+    assert_empty idempotency_keys
+
+    status, = post('/v1/jobs', job, key: 'k1')
+
+    assert_equal 201, status
+  end
+
+  # A middleware-halted push is a real, successful outcome — the producer's own
+  # policy working — so it is replayed like any other 2xx.
+  def test_a_halted_push_is_recorded_like_any_other_success
+    status, _headers, body = with_client_middleware(HaltMiddleware) { post('/v1/jobs', job, key: 'k1') }
+
+    assert_equal 200, status
+    assert_nil body['jid']
+
+    _status, headers, = post('/v1/jobs', job, key: 'k1')
+
+    assert_equal 'true', headers[Wurk::API::Idempotency::REPLAY_HEADER]
+  end
+
+  # --- Lifetime -----------------------------------------------------------
+
+  def test_a_record_expires_on_the_configured_window
+    @config = build_config { |cfg| cfg.api_idempotency_ttl = 120 }
+    post('/v1/jobs', job, key: 'k1')
+
+    assert_in_delta 120, ttl_of(slot_for('k1')), 5
+  end
+
+  # KEEPTTL, so the window belongs to the first request rather than restarting
+  # when its answer is written — and XX, so a claim whose window lapsed
+  # mid-flight is not resurrected as a record that never expires.
+  def test_the_answer_does_not_restart_the_window
+    @config = build_config { |cfg| cfg.api_idempotency_ttl = 120 }
+    post('/v1/jobs', job, key: 'k1')
+    slot = slot_for('k1')
+    @pool.with { |conn| conn.call('EXPIRE', slot, 30) }
+    post('/v1/jobs', job, key: 'k1')
+
+    assert_operator ttl_of(slot), :<=, 30
+  end
+
+  # --- The key itself -----------------------------------------------------
+
+  def test_a_key_that_could_not_survive_a_header_is_refused
+    ["has spaces#{'a' * 5}", "tab\there", "nul\0here", 'ü', 'x' * 256, ''].each do |key|
+      status, _headers, body = post('/v1/jobs', job, key: key)
+
+      assert_equal 400, status, "#{key.inspect} was accepted"
+      assert_equal 'invalid_request', body['type']
+    end
+    assert_empty queued_payloads
+  end
+
+  private
+
+  def app = @app ||= Wurk::API::App.new(config: config)
+
+  def config
+    @config ||= build_config
+  end
+
+  def build_config
+    Wurk::Configuration.new.tap do |cfg|
+      cfg.api_token(ADMIN_TOKEN, scopes: %i[admin])
+      cfg.api_token(OTHER_TOKEN, scopes: %i[admin])
+      cfg.api_enqueue_classes = [@class_name]
+      yield cfg if block_given?
+    end
+  end
+
+  def job(**overrides)
+    { 'class' => @class_name, 'args' => [], 'queue' => @queue }.merge(overrides.transform_keys(&:to_s))
+  end
+
+  def queued_payloads
+    @pool.with { |conn| conn.call('LRANGE', "queue:#{@queue}", 0, -1) }.map { |raw| JSON.parse(raw) }
+  end
+
+  def idempotency_keys
+    @pool.with { |conn| conn.call('KEYS', "#{Wurk::Keys::IDEMPOTENCY_PREFIX}*") }
+  end
+
+  def ttl_of(slot) = @pool.with { |conn| conn.call('TTL', slot) }
+
+  # Locates a record the way production does, rather than restating the digest
+  # here — a test that computed its own would still pass if the two drifted.
+  def slot_for(key, path: '/v1/jobs', token: ADMIN_TOKEN)
+    request = Wurk::API::Request.new(env_for('POST', path, token: token))
+    request.principal = Wurk::API::Auth.authenticate(request, config)
+    Wurk::API::Idempotency.slot_for(request, key)
+  end
+
+  # Leaves a claim with no answer pinned to it — what a request still in flight
+  # looks like from another process.
+  def claim(key, payload)
+    digest = Digest::SHA256.hexdigest(JSON.generate(payload))
+    record = Wurk::API::Idempotency.encode(Wurk::API::Idempotency::PENDING, digest, '')
+    @pool.with { |conn| conn.call('SET', slot_for(key), record, 'EX', 60) }
+  end
+
+  def with_client_middleware(klass)
+    Wurk::Test::GLOBAL_STATE_MUTEX.synchronize do
+      Wurk.configuration.client_middleware.add(klass)
+      yield
+    ensure
+      Wurk.configuration.client_middleware.remove(klass)
+    end
+  end
+
+  def post(path, payload, key: nil, token: ADMIN_TOKEN)
+    raw = JSON.generate(payload)
+    env = env_for('POST', path, body: raw, token: token)
+    env['HTTP_IDEMPOTENCY_KEY'] = key if key
+    status, headers, body = app.call(env)
+    [status, headers, JSON.parse(body.join)]
+  end
+
+  def env_for(method, path, body: '', token: ADMIN_TOKEN)
+    {
+      'REQUEST_METHOD' => method,
+      'PATH_INFO' => path,
+      'SCRIPT_NAME' => '',
+      'QUERY_STRING' => '',
+      'CONTENT_TYPE' => 'application/json',
+      'CONTENT_LENGTH' => body.bytesize.to_s,
+      'HTTP_AUTHORIZATION' => "Bearer #{token}",
+      'rack.input' => StringIO.new(body),
+      'rack.errors' => StringIO.new
+    }
+  end
+end

--- a/test/unit/api_jobs_test.rb
+++ b/test/unit/api_jobs_test.rb
@@ -1,0 +1,391 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'wurk/api/app'
+require 'json'
+require 'securerandom'
+require 'stringio'
+
+# Slice 07 — the HTTP API's produce plane: POST /jobs, POST /jobs/bulk,
+# DELETE /jobs/:jid. Every enqueue runs through Wurk::Client against real
+# Redis, and the assertions are on what actually landed there rather than on
+# the response alone — the point of these routes is that they add no second
+# way to write a job.
+#
+# Auth mechanics live in api_auth_test.rb and routing in api_app_test.rb; the
+# scope checks here only pin which scope each of these three routes demands.
+#
+# Parallel safety: queue and class names carry a per-instance namespace, and
+# the worker's Redis DB is flushed after every test (RedisNamespace).
+class ApiJobsTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  ADMIN_TOKEN = 'api-jobs-admin-token-0123456789'
+  ENQUEUE_TOKEN = 'api-jobs-enqueue-token-0123456789'
+  READ_TOKEN = 'api-jobs-read-token-0123456789'
+
+  JID_PATTERN = /\A[0-9a-f]{24}\z/
+
+  # Adds a field no route knows about, so its presence on the stored payload
+  # proves the client's chain ran rather than something here assembling a hash.
+  StampMiddleware = Class.new do
+    include Wurk::Middleware::ClientMiddleware
+
+    def call(_job_class, job, _queue, _pool)
+      job['api_jobs_stamp'] = 'stamped'
+      yield
+    end
+  end
+
+  # A halting middleware — what `collapse:`/`unique_for:` do to a duplicate.
+  HaltMiddleware = Class.new do
+    include Wurk::Middleware::ClientMiddleware
+
+    def call(*) = nil
+  end
+
+  def setup
+    super
+    @ns = "#{Process.pid}-#{object_id}"
+    @queue = "q-#{@ns}"
+    @class_name = "ApiJobsWorker@#{@ns}"
+    @pool = Wurk.configuration.redis_pool
+  end
+
+  # --- POST /jobs --------------------------------------------------------
+
+  def test_post_jobs_enqueues_the_body_verbatim
+    status, headers, body = post('/v1/jobs', job(args: [1, 'two']))
+
+    assert_equal 201, status
+    assert_equal 'application/json', headers['content-type']
+    assert_match JID_PATTERN, body['jid']
+
+    payload = queued_payloads.fetch(0)
+
+    assert_equal @class_name, payload['class']
+    assert_equal [1, 'two'], payload['args']
+    assert_equal @queue, payload['queue']
+    assert_equal body['jid'], payload['jid']
+  end
+
+  # The pillar-1 check at this layer: the payload came out of Wurk::Client, so
+  # a field only its middleware chain can add is on the stored job.
+  def test_post_jobs_payload_is_built_by_the_client_chain
+    with_client_middleware(StampMiddleware) { post('/v1/jobs', job) }
+
+    assert_equal 'stamped', queued_payloads.fetch(0)['api_jobs_stamp']
+  end
+
+  def test_post_jobs_carries_the_options_the_body_sets
+    post('/v1/jobs', job(retry: 5))
+
+    assert_equal 5, queued_payloads.fetch(0)['retry']
+  end
+
+  def test_post_jobs_with_at_schedules_instead_of_queueing
+    at = Time.now.to_f + 3600
+    _status, _headers, body = post('/v1/jobs', job(at: at))
+
+    entry = Wurk::ScheduledSet.new.find_job(body['jid'])
+
+    refute_nil entry
+    assert_in_delta at, entry.score, 0.001
+    assert_empty queued_payloads
+  end
+
+  # A push the chain dropped is the producer's own policy working, not a
+  # failure — so 200 with a null jid, not a 4xx.
+  def test_post_jobs_reports_a_middleware_halt_without_a_jid
+    status, _headers, body = with_client_middleware(HaltMiddleware) { post('/v1/jobs', job) }
+
+    assert_equal 200, status
+    assert_nil body['jid']
+    assert_empty queued_payloads
+  end
+
+  def test_post_jobs_rejects_a_body_that_is_not_json
+    status, headers, body = post_raw('/v1/jobs', 'not json')
+
+    assert_equal 400, status
+    assert_equal 'application/problem+json', headers['content-type']
+    assert_equal 'invalid_request', body['type']
+    assert_equal 'Invalid Request', body['title']
+    assert_equal 'The request body is not valid JSON.', body['detail']
+  end
+
+  # A parser message quotes the unparsed remainder of the document; a 10 MB
+  # malformed body must not come back as a 10 MB error.
+  def test_a_malformed_body_is_not_echoed_back
+    _status, _headers, body = post_raw('/v1/jobs', %({"class": "#{'z' * 400}))
+
+    refute_includes JSON.generate(body), 'zzzz'
+  end
+
+  def test_post_jobs_rejects_a_json_body_that_is_not_an_object
+    status, _headers, body = post_raw('/v1/jobs', '[1, 2]')
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+    assert_equal 'The request body must be a JSON object.', body['detail']
+  end
+
+  def test_post_jobs_rejects_an_empty_body
+    status, _headers, body = post_raw('/v1/jobs', '')
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+  end
+
+  # Rack 3.1 made `rack.input` optional, so a server may hand the app an env
+  # with no body stream at all. That is a bodyless request, not a crash.
+  def test_post_jobs_without_a_body_stream_is_a_bodyless_request
+    env = env_for('POST', '/v1/jobs')
+    env.delete('rack.input')
+    status, _headers, body = parse(call(env))
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+  end
+
+  # Client owns what a valid job hash is; the route surfaces its verdict rather
+  # than duplicating it.
+  def test_post_jobs_surfaces_client_validation_as_a_problem
+    status, _headers, body = post('/v1/jobs', { 'class' => @class_name })
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+    assert_includes body['detail'], "'class' and 'args'"
+    assert_empty queued_payloads
+  end
+
+  def test_post_jobs_rejects_a_non_numeric_at
+    status, _headers, body = post('/v1/jobs', job(at: 'soon'))
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+  end
+
+  def test_jobs_answers_post_only
+    status, headers, = call(env_for('GET', '/v1/jobs'))
+
+    assert_equal 405, status
+    assert_equal 'POST', headers['allow']
+  end
+
+  # --- POST /jobs/bulk ---------------------------------------------------
+
+  def test_post_bulk_enqueues_every_arg_set
+    status, _headers, body = post('/v1/jobs/bulk', job(args: [[1], [2], [3]]))
+
+    assert_equal 201, status
+    assert_equal 3, body['jids'].size
+    body['jids'].each { |jid| assert_match JID_PATTERN, jid }
+    assert_equal [[1], [2], [3]], queued_payloads.map { |p| p['args'] }.sort_by(&:first)
+  end
+
+  def test_post_bulk_jids_match_the_stored_payloads
+    _status, _headers, body = post('/v1/jobs/bulk', job(args: [[1], [2]]))
+
+    assert_equal body['jids'].sort, queued_payloads.map { |p| p['jid'] }.sort
+  end
+
+  def test_post_bulk_with_no_args_enqueues_nothing
+    status, _headers, body = post('/v1/jobs/bulk', job)
+
+    assert_equal 200, status
+    assert_empty body['jids']
+    assert_empty queued_payloads
+  end
+
+  def test_post_bulk_marks_halted_jobs_positionally
+    status, _headers, body = with_client_middleware(HaltMiddleware) do
+      post('/v1/jobs/bulk', job(args: [[1], [2]]))
+    end
+
+    assert_equal 200, status
+    assert_equal [nil, nil], body['jids']
+    assert_empty queued_payloads
+  end
+
+  def test_post_bulk_rejects_a_malformed_arg_shape
+    status, _headers, body = post('/v1/jobs/bulk', job(args: [1, 2]))
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+    assert_includes body['detail'], 'Array of Arrays'
+  end
+
+  def test_post_bulk_schedules_when_at_is_given
+    _status, _headers, body = post('/v1/jobs/bulk', job(args: [[1], [2]], at: Time.now.to_f + 600))
+
+    assert_empty queued_payloads
+    body['jids'].each { |jid| refute_nil Wurk::ScheduledSet.new.find_job(jid) }
+  end
+
+  # --- DELETE /jobs/:jid -------------------------------------------------
+
+  def test_delete_removes_a_scheduled_job
+    jid = schedule_into(Wurk::ScheduledSet.new)
+    status, _headers, body = delete("/v1/jobs/#{jid}")
+
+    assert_equal 200, status
+    assert_equal jid, body['jid']
+    assert_equal 'schedule', body['set']
+    assert_nil Wurk::ScheduledSet.new.find_job(jid)
+  end
+
+  def test_delete_removes_a_retrying_job
+    jid = schedule_into(Wurk::RetrySet.new)
+    status, _headers, body = delete("/v1/jobs/#{jid}")
+
+    assert_equal 200, status
+    assert_equal 'retry', body['set']
+    assert_nil Wurk::RetrySet.new.find_job(jid)
+  end
+
+  # Removing a dead job is an operator action against a different set, so this
+  # route leaves it alone rather than quietly widening its own reach.
+  def test_delete_leaves_the_dead_set_alone
+    jid = schedule_into(Wurk::DeadSet.new)
+    status, _headers, body = delete("/v1/jobs/#{jid}")
+
+    assert_equal 404, status
+    assert_equal 'job_not_found', body['type']
+    refute_nil Wurk::DeadSet.new.find_job(jid)
+  end
+
+  def test_delete_of_an_unknown_jid_is_a_job_not_found_problem
+    jid = SecureRandom.hex(12)
+    status, headers, body = delete("/v1/jobs/#{jid}")
+
+    assert_equal 404, status
+    assert_equal 'application/problem+json', headers['content-type']
+    assert_equal 'job_not_found', body['type']
+    assert_equal 'Job Not Found', body['title']
+    assert_equal jid, body['jid']
+  end
+
+  # find_job feeds the jid to ZSCAN as a glob, so a metacharacter never gets
+  # that far — decoded, because the router unescapes captures.
+  def test_delete_rejects_a_jid_that_is_not_url_safe
+    status, _headers, body = delete('/v1/jobs/%2A')
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+  end
+
+  def test_delete_rejects_an_oversized_jid
+    status, _headers, body = delete("/v1/jobs/#{'a' * 256}")
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+  end
+
+  # --- Scopes ------------------------------------------------------------
+
+  def test_enqueue_scope_may_produce
+    status, = post('/v1/jobs', job, token: ENQUEUE_TOKEN)
+
+    assert_equal 201, status
+  end
+
+  def test_read_scope_may_not_produce
+    status, _headers, body = post('/v1/jobs', job, token: READ_TOKEN)
+
+    assert_equal 403, status
+    assert_equal 'insufficient_scope', body['type']
+    assert_equal 'enqueue', body['required_scope']
+    assert_empty queued_payloads
+  end
+
+  def test_read_scope_may_not_bulk_produce
+    status, _headers, body = post('/v1/jobs/bulk', job(args: [[1]]), token: READ_TOKEN)
+
+    assert_equal 403, status
+    assert_equal 'enqueue', body['required_scope']
+  end
+
+  # A jid is not bound to the token that produced it, so cancelling one is an
+  # admin action — an enqueue-scoped producer holding it could walk the whole
+  # retry set.
+  def test_enqueue_scope_may_not_delete
+    jid = schedule_into(Wurk::ScheduledSet.new)
+    status, _headers, body = delete("/v1/jobs/#{jid}", token: ENQUEUE_TOKEN)
+
+    assert_equal 403, status
+    assert_equal 'insufficient_scope', body['type']
+    assert_equal 'admin', body['required_scope']
+    refute_nil Wurk::ScheduledSet.new.find_job(jid)
+  end
+
+  private
+
+  def app = @app ||= Wurk::API::App.new(config: config)
+
+  def config
+    @config ||= Wurk::Configuration.new.tap do |cfg|
+      cfg.api_token(ADMIN_TOKEN, scopes: %i[admin])
+      cfg.api_token(ENQUEUE_TOKEN, scopes: %i[enqueue])
+      cfg.api_token(READ_TOKEN, scopes: %i[read])
+    end
+  end
+
+  # The Sidekiq job hash the produce routes take, namespaced to this test.
+  def job(**overrides)
+    { 'class' => @class_name, 'args' => [], 'queue' => @queue }.merge(overrides.transform_keys(&:to_s))
+  end
+
+  def queued_payloads
+    @pool.with { |conn| conn.call('LRANGE', "queue:#{@queue}", 0, -1) }.map { |raw| JSON.parse(raw) }
+  end
+
+  # Puts a job into a sorted set the way the retrier and scheduler do — through
+  # JobSet#schedule — and hands back its jid.
+  def schedule_into(set)
+    jid = SecureRandom.hex(12)
+    set.schedule(Time.now.to_f + 3600, job.merge('jid' => jid))
+    jid
+  end
+
+  # Wurk::Client resolves the chain off the process-wide configuration at push
+  # time — the same one a Ruby producer in this process uses — so mutating it
+  # takes the suite-wide global-state mutex.
+  def with_client_middleware(klass)
+    Wurk::Test::GLOBAL_STATE_MUTEX.synchronize do
+      Wurk.configuration.client_middleware.add(klass)
+      yield
+    ensure
+      Wurk.configuration.client_middleware.remove(klass)
+    end
+  end
+
+  def call(env) = app.call(env)
+
+  def post(path, payload, token: ADMIN_TOKEN) = post_raw(path, JSON.generate(payload), token: token)
+
+  def post_raw(path, raw, token: ADMIN_TOKEN)
+    parse(call(env_for('POST', path, body: raw, token: token)))
+  end
+
+  def delete(path, token: ADMIN_TOKEN) = parse(call(env_for('DELETE', path, token: token)))
+
+  def parse(response)
+    status, headers, body = response
+    [status, headers, JSON.parse(body.join)]
+  end
+
+  def env_for(method, path, body: '', token: ADMIN_TOKEN)
+    {
+      'REQUEST_METHOD' => method,
+      'PATH_INFO' => path,
+      'SCRIPT_NAME' => '',
+      'QUERY_STRING' => '',
+      'CONTENT_TYPE' => 'application/json',
+      'CONTENT_LENGTH' => body.bytesize.to_s,
+      'HTTP_AUTHORIZATION' => "Bearer #{token}",
+      'rack.input' => StringIO.new(body),
+      'rack.errors' => StringIO.new
+    }
+  end
+end

--- a/test/unit/api_jobs_test.rb
+++ b/test/unit/api_jobs_test.rb
@@ -46,9 +46,9 @@ class ApiJobsTest < Wurk::Test::UnitCase
 
   def setup
     super
-    @ns = "#{Process.pid}-#{object_id}"
+    @ns = "#{Process.pid}_#{object_id}"
     @queue = "q-#{@ns}"
-    @class_name = "ApiJobsWorker@#{@ns}"
+    @class_name = "ApiJobsWorker#{@ns}"
     @pool = Wurk.configuration.redis_pool
   end
 
@@ -323,11 +323,15 @@ class ApiJobsTest < Wurk::Test::UnitCase
 
   def app = @app ||= Wurk::API::App.new(config: config)
 
+  # The allow-list names this instance's class, so every route below runs the
+  # same way a configured host's does. Boundary rules are pinned in
+  # api_validation_test.rb; here they only have to be out of the way.
   def config
     @config ||= Wurk::Configuration.new.tap do |cfg|
       cfg.api_token(ADMIN_TOKEN, scopes: %i[admin])
       cfg.api_token(ENQUEUE_TOKEN, scopes: %i[enqueue])
       cfg.api_token(READ_TOKEN, scopes: %i[read])
+      cfg.api_enqueue_classes = [@class_name]
     end
   end
 

--- a/test/unit/api_router_test.rb
+++ b/test/unit/api_router_test.rb
@@ -10,7 +10,7 @@ class ApiRouterTest < Wurk::Test::UnitCase
 
   def test_literal_path_matches_its_handler
     router = Wurk::API::Router.new
-    router.get('/queues') { :queues }
+    router.get('/queues', scope: :read) { :queues }
 
     match = router.match('GET', '/queues')
 
@@ -20,7 +20,7 @@ class ApiRouterTest < Wurk::Test::UnitCase
 
   def test_capture_binds_the_segment_by_name
     router = Wurk::API::Router.new
-    router.get('/jobs/:jid') { :job }
+    router.get('/jobs/:jid', scope: :read) { :job }
 
     match = router.match('GET', '/jobs/abc123')
 
@@ -29,7 +29,7 @@ class ApiRouterTest < Wurk::Test::UnitCase
 
   def test_capture_is_percent_decoded
     router = Wurk::API::Router.new
-    router.get('/queues/:name') { :queue }
+    router.get('/queues/:name', scope: :read) { :queue }
 
     match = router.match('GET', '/queues/low%2Fpriority')
 
@@ -38,14 +38,14 @@ class ApiRouterTest < Wurk::Test::UnitCase
 
   def test_capture_does_not_span_a_slash
     router = Wurk::API::Router.new
-    router.get('/jobs/:jid') { :job }
+    router.get('/jobs/:jid', scope: :read) { :job }
 
     assert_nil router.match('GET', '/jobs/abc/extra').handler
   end
 
   def test_unknown_path_reports_no_allowed_verbs
     router = Wurk::API::Router.new
-    router.get('/jobs') { :jobs }
+    router.get('/jobs', scope: :read) { :jobs }
 
     match = router.match('GET', '/nope')
 
@@ -55,9 +55,9 @@ class ApiRouterTest < Wurk::Test::UnitCase
 
   def test_known_path_wrong_verb_reports_the_verbs_it_accepts
     router = Wurk::API::Router.new
-    router.get('/queues/:name') { :show }
-    router.post('/queues/:name') { :update }
-    router.delete('/queues/:name') { :destroy }
+    router.get('/queues/:name', scope: :read) { :show }
+    router.post('/queues/:name', scope: :read) { :update }
+    router.delete('/queues/:name', scope: :read) { :destroy }
 
     match = router.match('PUT', '/queues/default')
 
@@ -67,7 +67,7 @@ class ApiRouterTest < Wurk::Test::UnitCase
 
   def test_head_is_served_by_the_get_route
     router = Wurk::API::Router.new
-    router.get('/jobs/:jid') { :job }
+    router.get('/jobs/:jid', scope: :read) { :job }
 
     match = router.match('HEAD', '/jobs/abc')
 
@@ -77,8 +77,8 @@ class ApiRouterTest < Wurk::Test::UnitCase
 
   def test_verbs_are_registered_independently_on_the_same_path
     router = Wurk::API::Router.new
-    router.get('/jobs/:jid') { :read }
-    router.delete('/jobs/:jid') { :remove }
+    router.get('/jobs/:jid', scope: :read) { :read }
+    router.delete('/jobs/:jid', scope: :read) { :remove }
 
     assert_equal :read, router.match('GET', '/jobs/x').handler.call
     assert_equal :remove, router.match('DELETE', '/jobs/x').handler.call
@@ -86,9 +86,32 @@ class ApiRouterTest < Wurk::Test::UnitCase
 
   def test_root_pattern_matches_with_and_without_a_trailing_slash
     router = Wurk::API::Router.new
-    router.get('/') { :root }
+    router.get('/', scope: :read) { :root }
 
     assert_equal :root, router.match('GET', '').handler.call
     assert_equal :root, router.match('GET', '/').handler.call
+  end
+
+  # The router records the scope; App#dispatch enforces it. A match that lost
+  # it would silently open the route to every token.
+  def test_a_match_carries_the_scope_its_route_declared
+    router = Wurk::API::Router.new
+    router.get('/jobs/:jid', scope: :read) { :read }
+    router.delete('/jobs/:jid', scope: :admin) { :remove }
+
+    assert_equal :read, router.match('GET', '/jobs/x').scope
+    assert_equal :admin, router.match('DELETE', '/jobs/x').scope
+  end
+
+  # Required keyword plus a closed vocabulary: adding an endpoint without
+  # deciding who may call it, or with a misspelled scope, fails at draw time.
+  def test_a_route_needs_a_scope_from_the_known_set
+    router = Wurk::API::Router.new
+
+    assert_raises(ArgumentError) { router.get('/x', scope: :reed) { :x } }
+    assert_raises(ArgumentError) { router.get('/x', scope: nil) { :x } }
+    assert_raises(ArgumentError) { router.post('/x', scope: 'read') { :x } }
+    assert_raises(ArgumentError) { router.delete('/x', scope: :reed) { :x } }
+    assert_raises(ArgumentError) { router.get('/x') { :x } }
   end
 end

--- a/test/unit/api_router_test.rb
+++ b/test/unit/api_router_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'wurk/api/router'
+
+# Slice 07 — the HTTP API's path table. Not ActionDispatch, because standalone
+# mode routes without Rails ever being loaded.
+class ApiRouterTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  def test_literal_path_matches_its_handler
+    router = Wurk::API::Router.new
+    router.get('/queues') { :queues }
+
+    match = router.match('GET', '/queues')
+
+    assert_equal :queues, match.handler.call
+    assert_empty match.params
+  end
+
+  def test_capture_binds_the_segment_by_name
+    router = Wurk::API::Router.new
+    router.get('/jobs/:jid') { :job }
+
+    match = router.match('GET', '/jobs/abc123')
+
+    assert_equal({ jid: 'abc123' }, match.params)
+  end
+
+  def test_capture_is_percent_decoded
+    router = Wurk::API::Router.new
+    router.get('/queues/:name') { :queue }
+
+    match = router.match('GET', '/queues/low%2Fpriority')
+
+    assert_equal({ name: 'low/priority' }, match.params)
+  end
+
+  def test_capture_does_not_span_a_slash
+    router = Wurk::API::Router.new
+    router.get('/jobs/:jid') { :job }
+
+    assert_nil router.match('GET', '/jobs/abc/extra').handler
+  end
+
+  def test_unknown_path_reports_no_allowed_verbs
+    router = Wurk::API::Router.new
+    router.get('/jobs') { :jobs }
+
+    match = router.match('GET', '/nope')
+
+    assert_nil match.handler
+    assert_empty match.allowed
+  end
+
+  def test_known_path_wrong_verb_reports_the_verbs_it_accepts
+    router = Wurk::API::Router.new
+    router.get('/queues/:name') { :show }
+    router.post('/queues/:name') { :update }
+    router.delete('/queues/:name') { :destroy }
+
+    match = router.match('PUT', '/queues/default')
+
+    assert_nil match.handler
+    assert_equal %w[GET POST DELETE], match.allowed
+  end
+
+  def test_head_is_served_by_the_get_route
+    router = Wurk::API::Router.new
+    router.get('/jobs/:jid') { :job }
+
+    match = router.match('HEAD', '/jobs/abc')
+
+    assert_equal :job, match.handler.call
+    assert_equal({ jid: 'abc' }, match.params)
+  end
+
+  def test_verbs_are_registered_independently_on_the_same_path
+    router = Wurk::API::Router.new
+    router.get('/jobs/:jid') { :read }
+    router.delete('/jobs/:jid') { :remove }
+
+    assert_equal :read, router.match('GET', '/jobs/x').handler.call
+    assert_equal :remove, router.match('DELETE', '/jobs/x').handler.call
+  end
+
+  def test_root_pattern_matches_with_and_without_a_trailing_slash
+    router = Wurk::API::Router.new
+    router.get('/') { :root }
+
+    assert_equal :root, router.match('GET', '').handler.call
+    assert_equal :root, router.match('GET', '/').handler.call
+  end
+end

--- a/test/unit/api_validation_test.rb
+++ b/test/unit/api_validation_test.rb
@@ -1,0 +1,439 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'wurk/api/app'
+require 'json'
+require 'stringio'
+
+# Slice 07 — what the produce plane refuses before Wurk::Client sees it.
+#
+# JobUtil validates a job hash written by Ruby running in this process; these
+# routes take one typed by a stranger, and `job_util.rb`'s TRANSIENT_ATTRIBUTES
+# is a strip-list with no allow-list behind it. Everything below is the
+# allow-list the API has to supply instead, asserted through the real Rack app
+# against real Redis — a rejection that still enqueued would be the only kind
+# worth catching.
+#
+# Parallel safety: queue and class names carry a per-instance namespace, and
+# the worker's Redis DB is flushed after every test (RedisNamespace).
+class ApiValidationTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  LIB = File.expand_path('../../lib', __dir__)
+
+  ADMIN_TOKEN = 'api-validation-admin-0123456789'
+  ENQUEUE_TOKEN = 'api-validation-enqueue-0123456789'
+
+  def setup
+    super
+    @ns = "#{Process.pid}_#{object_id}"
+    @queue = "q-#{@ns}"
+    @class_name = "ApiValidationWorker#{@ns}"
+    @pool = Wurk.configuration.redis_pool
+  end
+
+  # --- Class name is a code selector, not data ---------------------------
+
+  def test_a_namespaced_class_name_is_accepted
+    @class_name = "Billing#{@ns}::Charge"
+    status, = post('/v1/jobs', job)
+
+    assert_equal 201, status
+    assert_equal @class_name, queued_payloads.fetch(0)['class']
+  end
+
+  def test_anything_that_is_not_a_constant_path_is_refused
+    ['hardWorker', 'Hard Worker', 'Hard;Worker', '../../etc/passwd', 'Hard::worker', '', '9Lives',
+     'Kernel#system', "Hard\nWorker"].each do |name|
+      status, _headers, body = post('/v1/jobs', job.merge('class' => name))
+
+      assert_equal 400, status, "#{name.inspect} was accepted"
+      assert_equal 'invalid_request', body['type']
+    end
+    assert_empty queued_payloads
+  end
+
+  def test_a_class_that_is_not_a_string_is_refused
+    [123, ['HardWorker'], { 'name' => 'HardWorker' }, nil, true].each do |value|
+      status, = post('/v1/jobs', job.merge('class' => value))
+
+      assert_equal 400, status, "#{value.inspect} was accepted"
+    end
+  end
+
+  # Bounded before it is matched, stored in a payload, or echoed back in the
+  # error that refuses it.
+  def test_an_unbounded_class_name_is_refused
+    status, _headers, body = post('/v1/jobs', job.merge('class' => "A#{'a' * 300}"))
+
+    assert_equal 400, status
+    refute_includes JSON.generate(body), 'aaaaaaaaaa'
+  end
+
+  # A body with no `class` at all is Client's error to name: it says which
+  # required keys are missing, which is more useful than "that is not a class".
+  def test_a_missing_class_is_left_to_the_client_to_name
+    status, _headers, body = post('/v1/jobs', { 'args' => [] })
+
+    assert_equal 400, status
+    assert_includes body['detail'], "'class' and 'args'"
+  end
+
+  # --- Unknown top-level keys --------------------------------------------
+
+  def test_an_unknown_top_level_key_is_refused_and_named
+    status, _headers, body = post('/v1/jobs', job.merge('deadlin' => 30))
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+    assert_equal ['deadlin'], body['unknown_keys']
+    assert_empty queued_payloads
+  end
+
+  # Every one of these is written by the server or names a Ruby object, and
+  # accepting any of them lets a producer lie: about its own queue latency,
+  # about how often it has been retried, or about belonging to a batch whose
+  # `pending` counter was never incremented for it.
+  def test_server_owned_fields_are_not_settable_from_the_network
+    %w[created_at enqueued_at retry_count failed_at retried_at error_class expiry deadline_at bid
+       pool client_class].each do |key|
+      status, _headers, body = post('/v1/jobs', job.merge(key => 'x'))
+
+      assert_equal 400, status, "#{key} was accepted"
+      assert_equal [key], body['unknown_keys']
+    end
+    assert_empty queued_payloads
+  end
+
+  def test_every_documented_job_option_is_accepted
+    payload = Wurk::API::Validation::JOB_KEYS.to_h { |key| [key, nil] }
+
+    assert_nil Wurk::API::Validation.known_keys!(payload, Wurk::API::Validation::JOB_KEYS)
+  end
+
+  def test_the_bulk_envelope_keys_are_accepted_only_on_the_bulk_route
+    status, = post('/v1/jobs/bulk', job(args: [[1]], batch_size: 10, spread_interval: 60))
+
+    assert_equal 201, status
+
+    status, _headers, body = post('/v1/jobs', job.merge('batch_size' => 10))
+
+    assert_equal 400, status
+    assert_equal ['batch_size'], body['unknown_keys']
+  end
+
+  # The keys came off the network, so the echo that lets a client find its typo
+  # is bounded the same way the JSON parser's own message is never forwarded.
+  def test_the_report_of_unknown_keys_is_bounded
+    noise = (1..20).to_h { |i| ["zz#{i}#{'y' * 100}", 1] }
+    _status, _headers, body = post('/v1/jobs', job.merge(noise))
+
+    assert_equal Wurk::API::Validation::MAX_REPORTED_KEYS, body['unknown_keys'].size
+    body['unknown_keys'].each do |key|
+      assert_operator key.length, :<=, Wurk::API::Validation::MAX_REPORTED_KEY_LENGTH
+    end
+  end
+
+  # --- A jid in the body --------------------------------------------------
+
+  def test_a_body_jid_is_held_to_the_same_shape_as_a_path_one
+    status, = post('/v1/jobs', job(jid: 'abc-123_DEF'))
+
+    assert_equal 201, status
+
+    status, _headers, body = post('/v1/jobs', job(jid: 'has spaces'))
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+  end
+
+  # `push_bulk` takes a `jid` too, for a one-job bulk.
+  def test_the_bulk_route_holds_a_body_jid_to_the_same_shape
+    status, = post('/v1/jobs/bulk', job(args: [[1]], jid: 'abc-123_DEF'))
+
+    assert_equal 201, status
+
+    status, _headers, body = post('/v1/jobs/bulk', job(args: [[1]], jid: '*'))
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+  end
+
+  def test_a_bulk_with_no_class_is_left_to_the_client_to_name
+    status, _headers, body = post('/v1/jobs/bulk', { 'args' => [[1]] })
+
+    assert_equal 400, status
+    assert_includes body['detail'], "'class' and 'args'"
+    assert_empty queued_payloads
+  end
+
+  # --- Size caps ----------------------------------------------------------
+
+  def test_args_larger_than_the_cap_are_refused_before_the_push
+    status, headers, body = post('/v1/jobs', job(args: ['x' * 200]), config: capped(args: 100))
+
+    assert_equal 413, status
+    assert_equal 'application/problem+json', headers['content-type']
+    assert_equal 'payload_too_large', body['type']
+    assert_equal 'Payload Too Large', body['title']
+    assert_equal 100, body['max_bytes']
+    assert_empty queued_payloads
+  end
+
+  def test_args_at_the_cap_are_accepted
+    args = ['x' * 50]
+    status, = post('/v1/jobs', job(args: args), config: capped(args: JSON.generate(args).bytesize))
+
+    assert_equal 201, status
+  end
+
+  # For a bulk push the body cap bounds the request and this bounds each job it
+  # becomes — only the second bounds what lands in Redis.
+  def test_a_single_oversized_job_refuses_the_whole_bulk
+    payload = job(args: [[1], ['x' * 200], [3]])
+    status, _headers, body = post('/v1/jobs/bulk', payload, config: capped(args: 100))
+
+    assert_equal 413, status
+    assert_equal 'payload_too_large', body['type']
+    assert_equal 1, body['job_index']
+    assert_empty queued_payloads
+  end
+
+  # `args` that is not an array at all is Client's rejection to name, with the
+  # offending value in the message — there is nothing here to size.
+  def test_an_unsizeable_args_is_left_to_the_client
+    status, _headers, body = post('/v1/jobs/bulk', job(args: 'nope'), config: capped(args: 10))
+
+    assert_equal 400, status
+    assert_includes body['detail'], 'Array of Arrays'
+  end
+
+  def test_a_body_larger_than_the_cap_is_refused
+    status, _headers, body = post('/v1/jobs', job(args: ['x' * 500]), config: capped(body: 100))
+
+    assert_equal 413, status
+    assert_equal 'payload_too_large', body['type']
+    assert_equal 100, body['max_bytes']
+    assert_empty queued_payloads
+  end
+
+  # Refused on the strength of a cap-sized read, never by buffering the body to
+  # measure it — the whole point of a body cap is that an oversized request
+  # costs the process nothing.
+  def test_an_oversized_body_is_never_read_past_the_cap
+    input = CountingInput.new(JSON.generate(job(args: ['x' * 100_000])))
+    env = env_for('POST', '/v1/jobs')
+    env['rack.input'] = input
+    status, = parse(app(capped(body: 100)).call(env))
+
+    assert_equal 413, status
+    assert_equal [101], input.reads
+  end
+
+  # --- The class allow-list ----------------------------------------------
+
+  # `class` selects which of the host's jobs runs, so a producer credential
+  # that can name any constant is choosing.
+  def test_without_a_list_an_enqueue_token_may_enqueue_nothing
+    status, headers, body = post('/v1/jobs', job, token: ENQUEUE_TOKEN, config: unlisted)
+
+    assert_equal 403, status
+    assert_equal 'application/problem+json', headers['content-type']
+    assert_equal 'class_not_allowed', body['type']
+    assert_equal 'Class Not Allowed', body['title']
+    assert_equal @class_name, body['job_class']
+    assert_empty queued_payloads
+  end
+
+  # An admin token already holds the destructive routes, so restricting which
+  # class it may enqueue while no list exists would be theatre.
+  def test_without_a_list_an_admin_token_may_enqueue_anything
+    status, = post('/v1/jobs', job, config: unlisted)
+
+    assert_equal 201, status
+  end
+
+  def test_a_list_admits_exactly_what_it_names
+    status, = post('/v1/jobs', job, token: ENQUEUE_TOKEN)
+
+    assert_equal 201, status
+
+    status, _headers, body = post('/v1/jobs', job.merge('class' => 'SomethingElse'), token: ENQUEUE_TOKEN)
+
+    assert_equal 403, status
+    assert_equal 'SomethingElse', body['job_class']
+  end
+
+  # A host that writes a list means it.
+  def test_a_list_binds_an_admin_token_too
+    status, = post('/v1/jobs', job.merge('class' => 'SomethingElse'))
+
+    assert_equal 403, status
+  end
+
+  def test_the_bulk_route_is_held_to_the_same_list
+    status, = post('/v1/jobs/bulk', job(args: [[1]]).merge('class' => 'SomethingElse'), token: ENQUEUE_TOKEN)
+
+    assert_equal 403, status
+    assert_empty queued_payloads
+  end
+
+  # The escape hatch an enqueue-scoped relay needs, so the alternative isn't
+  # handing it `admin` and the destructive routes that come with it.
+  def test_any_turns_the_check_off_without_admitting_a_bad_name
+    status, = post('/v1/jobs', job.merge('class' => 'Whatever::Else'), token: ENQUEUE_TOKEN, config: unrestricted)
+
+    assert_equal 201, status
+
+    status, = post('/v1/jobs', job.merge('class' => 'not a class'), token: ENQUEUE_TOKEN, config: unrestricted)
+
+    assert_equal 400, status
+  end
+
+  # --- Declaring the boundary --------------------------------------------
+
+  def test_the_allow_list_is_validated_where_it_is_declared
+    fresh = Wurk::Configuration.new
+
+    assert_raises(ArgumentError) { fresh.api_enqueue_classes = ['not a class'] }
+    assert_raises(ArgumentError) { fresh.api_enqueue_classes = [] }
+    assert_raises(ArgumentError) { fresh.api_enqueue_classes = :anything }
+  end
+
+  def test_the_allow_list_accepts_names_classes_any_and_nil
+    fresh = Wurk::Configuration.new
+    fresh.api_enqueue_classes = ['Billing::Charge', Wurk::Configuration]
+
+    assert_equal ['Billing::Charge', 'Wurk::Configuration'], fresh.api_enqueue_classes
+    assert_predicate fresh.api_enqueue_classes, :frozen?
+
+    fresh.api_enqueue_classes = :any
+
+    assert_equal :any, fresh.api_enqueue_classes
+
+    fresh.api_enqueue_classes = nil
+
+    assert_nil fresh.api_enqueue_classes
+  end
+
+  # A cap that silently coerced to 0 is a cap that isn't one, and the request
+  # path is the wrong place to discover that.
+  def test_a_cap_must_be_a_positive_integer
+    fresh = Wurk::Configuration.new
+
+    %i[api_max_body_bytes= api_max_args_bytes= api_idempotency_ttl=].each do |writer|
+      [0, -1, nil, 'lots', ''].each do |value|
+        assert_raises(ArgumentError, "#{writer} accepted #{value.inspect}") { fresh.public_send(writer, value) }
+      end
+    end
+  end
+
+  def test_the_defaults_are_positive_and_the_writers_take
+    fresh = Wurk::Configuration.new
+
+    assert_operator fresh.api_max_body_bytes, :>, 0
+    assert_operator fresh.api_max_args_bytes, :>, 0
+    assert_operator fresh.api_idempotency_ttl, :>, 0
+
+    fresh.api_max_body_bytes = 2048
+
+    assert_equal 2048, fresh.api_max_body_bytes
+  end
+
+  def test_a_frozen_configuration_refuses_new_boundaries
+    frozen = Wurk::Configuration.new.tap(&:freeze!)
+
+    assert_raises(FrozenError) { frozen.api_max_body_bytes = 10 }
+    assert_raises(FrozenError) { frozen.api_enqueue_classes = ['HardWorker'] }
+  end
+
+  # The additive invariant, config-side: the caps are seeded in DEFAULTS so a
+  # frozen config still answers for them, but the module that reads them is
+  # only loaded by a host that declares an allow-list. A swarm child that
+  # serves no HTTP API carries none of it in its pre-fork heap. Subprocess,
+  # because this process has already required it.
+  def test_the_boundary_module_loads_only_when_a_boundary_is_declared
+    probe = 'print $LOADED_FEATURES.grep(%r{wurk/api/(validation|idempotency)\.rb\z}).size'
+
+    assert_equal '0', ruby("require 'wurk'; #{probe}")
+    assert_equal '1', ruby("require 'wurk'; Wurk.configuration.api_enqueue_classes = %w[HardWorker]; #{probe}")
+  end
+
+  private
+
+  # Records the length of every read the app asked for.
+  class CountingInput
+    attr_reader :reads
+
+    def initialize(string)
+      @io = StringIO.new(string)
+      @reads = []
+    end
+
+    def read(length = nil, buffer = nil)
+      @reads << length
+      @io.read(length, buffer)
+    end
+  end
+
+  def app(cfg = config) = Wurk::API::App.new(config: cfg)
+
+  def config
+    @config ||= build_config { |cfg| cfg.api_enqueue_classes = [@class_name] }
+  end
+
+  def unlisted = build_config
+  def unrestricted = build_config { |cfg| cfg.api_enqueue_classes = :any }
+
+  def capped(body: nil, args: nil)
+    build_config do |cfg|
+      cfg.api_enqueue_classes = [@class_name]
+      cfg.api_max_body_bytes = body if body
+      cfg.api_max_args_bytes = args if args
+    end
+  end
+
+  def build_config
+    Wurk::Configuration.new.tap do |cfg|
+      cfg.api_token(ADMIN_TOKEN, scopes: %i[admin])
+      cfg.api_token(ENQUEUE_TOKEN, scopes: %i[enqueue])
+      yield cfg if block_given?
+    end
+  end
+
+  def job(**overrides)
+    { 'class' => @class_name, 'args' => [], 'queue' => @queue }.merge(overrides.transform_keys(&:to_s))
+  end
+
+  def queued_payloads
+    @pool.with { |conn| conn.call('LRANGE', "queue:#{@queue}", 0, -1) }.map { |raw| JSON.parse(raw) }
+  end
+
+  def post(path, payload, token: ADMIN_TOKEN, config: nil)
+    raw = JSON.generate(payload)
+    parse(app(config || self.config).call(env_for('POST', path, body: raw, token: token)))
+  end
+
+  def parse(response)
+    status, headers, body = response
+    [status, headers, JSON.parse(body.join)]
+  end
+
+  def ruby(script)
+    IO.popen([RbConfig.ruby, '-I', LIB, '-e', script], err: %i[child out], &:read)
+  end
+
+  def env_for(method, path, body: '', token: ADMIN_TOKEN)
+    {
+      'REQUEST_METHOD' => method,
+      'PATH_INFO' => path,
+      'SCRIPT_NAME' => '',
+      'QUERY_STRING' => '',
+      'CONTENT_TYPE' => 'application/json',
+      'CONTENT_LENGTH' => body.bytesize.to_s,
+      'HTTP_AUTHORIZATION' => "Bearer #{token}",
+      'rack.input' => StringIO.new(body),
+      'rack.errors' => StringIO.new
+    }
+  end
+end


### PR DESCRIPTION
## Summary
- `Wurk::API` — mount-agnostic Rack app skeleton (`/v1`), lazy-loaded so a host that never configures a token pays nothing pre-fork.
- Bearer-token auth: no token configured → 404 (not 401); scoped `enqueue`/`read`/`admin`; constant-time credential comparison.
- Produce plane: `POST /jobs`, `POST /jobs/bulk`, `DELETE /jobs/:jid`, routed straight through `Wurk::Client#push`/`#push_bulk` — no second payload-building path.
- Boundary validation (class-name format, size caps, `strict_classes` allow-list, unknown-key rejection) + `Idempotency-Key` replay protection + RFC-9457 problem responses.
- The headline drop-in proof: an HTTP-enqueued job is byte-identical to a Ruby `Client#push` for the same input, dispatches unmodified through a pinned verbatim fragment of stock Sidekiq's `Processor#dispatch`/`JobLogger#prepare`, and is picked up and run by a real forked `Wurk::Swarm` — real Redis throughout, never mocked.

## Test plan
- [x] `bin/rake test` (3803 runs, 0 failures)
- [x] `bin/rake test:parity` (23 runs, 0 failures)
- [x] `bundle exec rubocop` (445 files, no offenses)
- [x] `rake bench` — enqueue/fetch+execute/bulk/swarm-boot/memory within noise (API stays off the hot path unless a token is configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788841448&installation_model_id=11168&pr_number=406&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F406&signature=a28800ae894b3575aa55b9ad6b9bd06589b12c582eadbc0cc3e7287191f38117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->