### PR TITLE
feat(api): HTTP API observe plane, mount modes, client (slice 07b)

### DIFF
--- a/clients/python/.gitignore
+++ b/clients/python/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+*.egg-info/
+dist/
+build/

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -1,0 +1,88 @@
+# wurk-client
+
+A thin, zero-dependency reference client for the [Wurk](https://github.com/developerz-ai/wurk)
+HTTP API (`/v1`) — see [`docs/api-http.md`](../../docs/api-http.md) for the
+full route reference this wraps.
+
+Not yet published to PyPI — the wire contract this client speaks to is part
+of an in-progress PR; install from the repo until it's declared frozen
+(`docs/plans/2026/08/07/101-beyond-sidekiq/07-http-producer-api.md`, step 8):
+
+```bash
+pip install ./clients/python
+# or, for local development on the client itself:
+pip install -e ./clients/python
+```
+
+## Usage
+
+```python
+from wurk_client import Client, WurkAPIError, RateLimitedError
+
+wurk = Client("https://jobs.example.com/wurk/api", token="...")
+
+# Enqueue one job — same Sidekiq job hash Wurk's Ruby producers push;
+# nothing is reshaped at the boundary.
+jid = wurk.enqueue("HardWorker", args=[1, "two"], queue="default", retry=5)
+
+# Enqueue many at once (the Lua bulk path)
+jids = wurk.bulk("HardWorker", [[1], [2], [3]], queue="default")
+
+# Poll a tracked job's status/progress/result (class must set track: True)
+record = wurk.status(jid)
+
+# Observe
+wurk.queues()             # every queue's name/size/latency/paused
+wurk.queue("default")     # one queue's gauges + a page of waiting jobs
+wurk.stats()              # processed/failed/enqueued/... counters
+
+# Pull a not-yet-run job back out of schedule/retry (requires an admin token)
+wurk.cancel(jid)
+```
+
+### Idempotent enqueue
+
+A dropped connection means "did this enqueue or not?" — send an
+`Idempotency-Key` and a resend replays the first response instead of
+enqueuing twice:
+
+```python
+wurk.enqueue("ChargeCard", args=[order_id], idempotency_key=f"charge-{order_id}")
+```
+
+### Errors
+
+Every non-2xx response raises `WurkAPIError`, carrying the same fields as the
+server's [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) problem document:
+
+```python
+try:
+    wurk.status(jid)
+except WurkAPIError as e:
+    print(e.status, e.type, e.detail)   # e.g. 404 "job_not_found" "..."
+```
+
+`e.type` is the stable slug to branch on (see the table in
+`docs/api-http.md#errors`) — never `e.detail`, which is prose for a human. A
+`429` raises the narrower `RateLimitedError`, which adds `.retry_after`
+(seconds, matching the `Retry-After` header).
+
+## What this is not
+
+Thin by design, matching the plan doc's brief: enqueue, bulk, status, queues
+— and a little more (`cancel`, `pause_queue`/`unpause_queue`, `stats`) since
+they're nearly free once the transport exists. No retries, no connection
+pooling, no async, no framework integration. Wrap this client, or reach for
+`requests`/`httpx` yourself, if you need any of that — keeping this package
+dependency-free means it never fights a host application's own pin.
+
+## Development
+
+```bash
+cd clients/python
+python -m unittest discover -s tests
+```
+
+Tests mock at the `urllib.request.urlopen` boundary, so they exercise the
+client's real request-building (headers, JSON body, query string) and
+response-parsing code — not a stub standing in for the client itself.

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "wurk-client"
+version = "0.1.0"
+description = "Reference Python client for the Wurk HTTP API (/v1) — enqueue, bulk, status, queues."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "MIT" }
+authors = [{ name = "developerz.ai" }]
+keywords = ["wurk", "sidekiq", "redis", "background-jobs", "queue"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Topic :: System :: Distributed Computing",
+]
+# Zero third-party dependencies on purpose — this client is a thin wrapper
+# over `urllib.request`, matching the "thin" brief in the plan doc
+# (docs/plans/2026/08/07/101-beyond-sidekiq/07-http-producer-api.md): enqueue,
+# bulk, status, queues, and nothing else. A consumer that wants retries,
+# connection pooling, or async should wrap this or reach for `requests`/`httpx`
+# themselves — this package stays dependency-free so it never fights a host
+# app's own pin.
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/developerz-ai/wurk"
+Documentation = "https://github.com/developerz-ai/wurk/blob/main/docs/api-http.md"
+Source = "https://github.com/developerz-ai/wurk"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/clients/python/src/wurk_client/__init__.py
+++ b/clients/python/src/wurk_client/__init__.py
@@ -1,0 +1,240 @@
+"""Reference client for the Wurk HTTP API (`/v1`).
+
+Thin on purpose: enqueue, bulk, status, queues — the four things
+`docs/api-http.md` calls the producer surface, plumbed straight over
+``urllib.request`` with zero third-party dependencies. It does not retry,
+pool connections, or hide the wire format; a job you enqueue here is the
+literal Sidekiq job hash the HTTP API documents, sent as JSON with no
+reshaping on either end.
+
+    from wurk_client import Client
+
+    wurk = Client("https://jobs.example.com/wurk/api", token="...")
+    jid = wurk.enqueue("HardWorker", args=[1, "two"], queue="default")
+    wurk.status(jid)  # -> {"jid": ..., "state": "running", ...} (track: True jobs only)
+
+``base_url`` is whatever prefix the deployment mounted the API under — see
+"Mounting" in docs/api-http.md for the three shapes. This client always
+appends the frozen ``/v1`` version prefix itself; never bake it into
+``base_url``.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+__all__ = [
+    "Client",
+    "WurkError",
+    "WurkAPIError",
+    "RateLimitedError",
+]
+
+__version__ = "0.1.0"
+
+_VERSION_PREFIX = "/v1"
+
+
+class WurkError(Exception):
+    """Base class for everything this client raises."""
+
+
+class WurkAPIError(WurkError):
+    """The server answered with an RFC-9457 problem+json document.
+
+    `type` is the stable slug documented in docs/api-http.md's error table
+    (e.g. ``"job_not_found"``, ``"read_only"``) — the field a caller should
+    branch on, never `detail`, which is prose for a human.
+    """
+
+    def __init__(self, status: int, problem: Mapping[str, Any]):
+        self.status = status
+        self.type = problem.get("type", "unknown")
+        self.title = problem.get("title", "")
+        self.detail = problem.get("detail", "")
+        self.problem = dict(problem)
+        super().__init__(f"{status} {self.type}: {self.detail}")
+
+
+class RateLimitedError(WurkAPIError):
+    """A 429. `retry_after` mirrors the `Retry-After` header, in seconds."""
+
+    def __init__(self, status: int, problem: Mapping[str, Any]):
+        super().__init__(status, problem)
+        self.retry_after = problem.get("retry_after")
+
+
+@dataclass
+class _Response:
+    status: int
+    body: Any
+
+
+class Client:
+    """One credential, one deployment.
+
+    :param base_url: scheme + host + mount prefix, **without** ``/v1``
+        (e.g. ``"https://host/wurk/api"``, ``"https://host/wurk-api"``, or
+        ``"http://host:7433"`` for standalone mode).
+    :param token: a bearer token registered on the server via
+        ``config.api_token``. Its granted scopes (``enqueue`` / ``read`` /
+        ``admin``) bound which methods below will succeed.
+    :param timeout: socket timeout in seconds for every request.
+    """
+
+    def __init__(self, base_url: str, token: str, timeout: float = 10.0):
+        self._base_url = base_url.rstrip("/")
+        self._token = token
+        self._timeout = timeout
+
+    # -- discovery -----------------------------------------------------
+
+    def discover(self) -> dict:
+        """`GET /v1` — api_version, wurk_version, read_only, rate_limit."""
+        return self._call("GET", "")
+
+    # -- produce ---------------------------------------------------------
+
+    def enqueue(
+        self,
+        job_class: str,
+        args: Sequence[Any] = (),
+        *,
+        queue: str = "default",
+        idempotency_key: str | None = None,
+        **job_options: Any,
+    ) -> str | None:
+        """`POST /jobs`. Returns the jid, or None if client-side middleware on
+        the server (`collapse:`, `unique_for:`) dropped the push — the same
+        distinction `Wurk::Client#push` makes.
+
+        Extra Sidekiq job options (``at``, ``retry``, ``tags``, ``timeout``,
+        ``deadline``, ``track``, ...) pass straight through as keyword
+        arguments; see docs/api-http.md's job-key table for the full set.
+        """
+        payload = {"class": job_class, "args": list(args), "queue": queue, **job_options}
+        response = self._call("POST", "/jobs", body=payload, idempotency_key=idempotency_key)
+        return response.get("jid")
+
+    def bulk(
+        self,
+        job_class: str,
+        args_list: Sequence[Sequence[Any]],
+        *,
+        queue: str = "default",
+        idempotency_key: str | None = None,
+        **envelope_options: Any,
+    ) -> list[str | None]:
+        """`POST /jobs/bulk`. Returns one jid per entry in `args_list`, in
+        order, with None marking a push that a server-side hook dropped —
+        never a shorter list, so the two stay index-aligned.
+        """
+        payload = {
+            "class": job_class,
+            "args": [list(args) for args in args_list],
+            "queue": queue,
+            **envelope_options,
+        }
+        response = self._call("POST", "/jobs/bulk", body=payload, idempotency_key=idempotency_key)
+        return response.get("jids", [])
+
+    def cancel(self, jid: str) -> dict:
+        """`DELETE /jobs/:jid`. Removes a not-yet-run job from `schedule` or
+        `retry` — not a cancel of one already handed to a processor.
+        Requires the `admin` scope. Raises WurkAPIError(type="job_not_found")
+        if it already ran, already died, or never existed.
+        """
+        return self._call("DELETE", f"/jobs/{jid}")
+
+    # -- status ------------------------------------------------------------
+
+    def status(self, jid: str) -> dict:
+        """`GET /jobs/:jid`. Only answers for a class that opted in with
+        `track: True`; raises WurkAPIError(type="job_not_found") for an
+        untracked, unknown, or expired jid — Redis holds nothing that tells
+        those apart.
+        """
+        return self._call("GET", f"/jobs/{jid}")
+
+    # -- queues --------------------------------------------------------
+
+    def queues(self) -> list[dict]:
+        """`GET /queues` — every queue's name, size, latency, paused state."""
+        return self._call("GET", "/queues").get("queues", [])
+
+    def queue(self, name: str, *, page: int = 0, count: int = 25) -> dict:
+        """`GET /queues/:name` — gauges plus a page of the jobs waiting in it."""
+        return self._call("GET", f"/queues/{name}", query={"page": page, "count": count})
+
+    def pause_queue(self, name: str) -> dict:
+        """`POST /queues/:name/pause`. Requires the `admin` scope."""
+        return self._call("POST", f"/queues/{name}/pause")
+
+    def unpause_queue(self, name: str) -> dict:
+        """`POST /queues/:name/unpause`. Requires the `admin` scope."""
+        return self._call("POST", f"/queues/{name}/unpause")
+
+    def stats(self) -> dict:
+        """`GET /stats` — the same counters `Wurk::Stats` feeds the dashboard."""
+        return self._call("GET", "/stats")
+
+    # -- transport -------------------------------------------------------
+
+    def _call(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: Any = None,
+        query: Mapping[str, Any] | None = None,
+        idempotency_key: str | None = None,
+    ) -> Any:
+        response = self._request(method, f"{_VERSION_PREFIX}{path}", body=body, query=query,
+                                  idempotency_key=idempotency_key)
+        if response.status >= 400:
+            problem = response.body if isinstance(response.body, dict) else {"detail": str(response.body)}
+            error_cls = RateLimitedError if response.status == 429 else WurkAPIError
+            raise error_cls(response.status, problem)
+        return response.body
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: Any,
+        query: Mapping[str, Any] | None,
+        idempotency_key: str | None,
+    ) -> _Response:
+        url = f"{self._base_url}{path}"
+        if query:
+            url += "?" + urllib.parse.urlencode({k: v for k, v in query.items() if v is not None})
+
+        headers = {"Authorization": f"Bearer {self._token}", "Accept": "application/json"}
+        data = None
+        if body is not None:
+            data = json.dumps(body).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        if idempotency_key is not None:
+            headers["Idempotency-Key"] = idempotency_key
+
+        request = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(request, timeout=self._timeout) as raw:
+                return _Response(status=raw.status, body=_parse(raw.read()))
+        except urllib.error.HTTPError as error:
+            return _Response(status=error.code, body=_parse(error.read()))
+
+
+def _parse(raw_bytes: bytes) -> Any:
+    if not raw_bytes:
+        return {}
+    try:
+        return json.loads(raw_bytes)
+    except json.JSONDecodeError:
+        return raw_bytes.decode("utf-8", errors="replace")

--- a/clients/python/src/wurk_client/__init__.py
+++ b/clients/python/src/wurk_client/__init__.py
@@ -149,7 +149,7 @@ class Client:
         Requires the `admin` scope. Raises WurkAPIError(type="job_not_found")
         if it already ran, already died, or never existed.
         """
-        return self._call("DELETE", f"/jobs/{jid}")
+        return self._call("DELETE", f"/jobs/{_path_segment(jid)}")
 
     # -- status ------------------------------------------------------------
 
@@ -159,7 +159,7 @@ class Client:
         untracked, unknown, or expired jid — Redis holds nothing that tells
         those apart.
         """
-        return self._call("GET", f"/jobs/{jid}")
+        return self._call("GET", f"/jobs/{_path_segment(jid)}")
 
     # -- queues --------------------------------------------------------
 
@@ -169,15 +169,15 @@ class Client:
 
     def queue(self, name: str, *, page: int = 0, count: int = 25) -> dict:
         """`GET /queues/:name` — gauges plus a page of the jobs waiting in it."""
-        return self._call("GET", f"/queues/{name}", query={"page": page, "count": count})
+        return self._call("GET", f"/queues/{_path_segment(name)}", query={"page": page, "count": count})
 
     def pause_queue(self, name: str) -> dict:
         """`POST /queues/:name/pause`. Requires the `admin` scope."""
-        return self._call("POST", f"/queues/{name}/pause")
+        return self._call("POST", f"/queues/{_path_segment(name)}/pause")
 
     def unpause_queue(self, name: str) -> dict:
         """`POST /queues/:name/unpause`. Requires the `admin` scope."""
-        return self._call("POST", f"/queues/{name}/unpause")
+        return self._call("POST", f"/queues/{_path_segment(name)}/unpause")
 
     def stats(self) -> dict:
         """`GET /stats` — the same counters `Wurk::Stats` feeds the dashboard."""
@@ -218,7 +218,12 @@ class Client:
         headers = {"Authorization": f"Bearer {self._token}", "Accept": "application/json"}
         data = None
         if body is not None:
-            data = json.dumps(body).encode("utf-8")
+            # `allow_nan=False` because Python's default emits the JavaScript
+            # literals NaN/Infinity, which are not JSON — Ruby's parser rejects
+            # them, so the server would answer 400 invalid_request. Better a
+            # ValueError here, naming the argument, than a round trip to learn
+            # the payload was never JSON in the first place.
+            data = json.dumps(body, allow_nan=False).encode("utf-8")
             headers["Content-Type"] = "application/json"
         if idempotency_key is not None:
             headers["Idempotency-Key"] = idempotency_key
@@ -229,6 +234,18 @@ class Client:
                 return _Response(status=raw.status, body=_parse(raw.read()))
         except urllib.error.HTTPError as error:
             return _Response(status=error.code, body=_parse(error.read()))
+
+
+def _path_segment(value: str) -> str:
+    """Percent-encode `value` as exactly one path segment.
+
+    A jid is hex and a queue name usually isn't exotic, but neither is
+    constrained to be: `/`, `?`, and `#` are all legal in a Sidekiq queue name
+    and each would silently re-address the request. `safe=""` escapes them,
+    and the server's router unescapes per segment (`lib/wurk/api/router.rb`),
+    so the name it binds is the one that was passed in here.
+    """
+    return urllib.parse.quote(str(value), safe="")
 
 
 def _parse(raw_bytes: bytes) -> Any:

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -146,6 +146,49 @@ class ClientTest(unittest.TestCase):
             self.assertIn("page=1", request.full_url)
             self.assertIn("count=10", request.full_url)
 
+    # A queue name is an opaque Redis string, so `/`, `?` and `#` are all legal
+    # in one. Interpolated raw they would re-address the request — a `/` splits
+    # into two segments and misses the route, a `?` starts a query string.
+    def test_a_queue_name_with_reserved_characters_is_encoded_as_one_segment(self):
+        with unittest.mock.patch("urllib.request.urlopen") as urlopen:
+            urlopen.return_value = _json_response(200, {"name": "a/b?c#d", "jobs": []})
+
+            self.client.queue("a/b?c#d")
+
+            request = urlopen.call_args[0][0]
+            self.assertIn("/v1/queues/a%2Fb%3Fc%23d?", request.full_url)
+
+    def test_reserved_characters_are_encoded_in_every_dynamic_segment(self):
+        calls = [
+            (lambda: self.client.status("a/b"), "/v1/jobs/a%2Fb"),
+            (lambda: self.client.cancel("a/b"), "/v1/jobs/a%2Fb"),
+            (lambda: self.client.pause_queue("a/b"), "/v1/queues/a%2Fb/pause"),
+            (lambda: self.client.unpause_queue("a/b"), "/v1/queues/a%2Fb/unpause"),
+        ]
+        for call, expected_path in calls:
+            with unittest.mock.patch("urllib.request.urlopen") as urlopen:
+                urlopen.return_value = _json_response(200, {})
+
+                call()
+
+                self.assertEqual(
+                    f"https://wurk.example.com/wurk/api{expected_path}",
+                    urlopen.call_args[0][0].full_url,
+                )
+
+    # -- serialization -----------------------------------------------------
+
+    # Python's json.dumps emits the JavaScript literals NaN/Infinity by
+    # default, which are not JSON: the server's parser rejects them and answers
+    # 400 invalid_request. Fail here instead, before the round trip.
+    def test_a_non_finite_argument_raises_before_a_request_is_sent(self):
+        for value in (float("nan"), float("inf"), float("-inf")):
+            with unittest.mock.patch("urllib.request.urlopen") as urlopen:
+                with self.assertRaises(ValueError):
+                    self.client.enqueue("HardWorker", args=[value])
+
+                urlopen.assert_not_called()
+
     # -- errors ------------------------------------------------------------
 
     def test_rate_limited_raises_with_retry_after(self):

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -1,0 +1,171 @@
+"""Unit tests for wurk_client.Client — mocks urllib at the socket boundary
+(urlopen) so every test exercises the client's real request-building and
+response-parsing code, not a stubbed method on the client itself.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import unittest
+import unittest.mock
+import urllib.error
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from wurk_client import Client, RateLimitedError, WurkAPIError  # noqa: E402
+
+
+class _FakeHTTPResponse(io.BytesIO):
+    def __init__(self, status: int, payload: bytes):
+        super().__init__(payload)
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _json_response(status: int, body: dict) -> _FakeHTTPResponse:
+    return _FakeHTTPResponse(status, json.dumps(body).encode("utf-8"))
+
+
+class ClientTest(unittest.TestCase):
+    def setUp(self):
+        self.client = Client("https://wurk.example.com/wurk/api", token="test-token-0123456789")
+
+    # -- enqueue -----------------------------------------------------
+
+    def test_enqueue_posts_the_job_hash_verbatim_and_returns_the_jid(self):
+        with unittest.mock.patch("urllib.request.urlopen") as urlopen:
+            urlopen.return_value = _json_response(201, {"jid": "abc123"})
+
+            jid = self.client.enqueue("HardWorker", args=[1, "two"], queue="critical", retry=5)
+
+            request = urlopen.call_args[0][0]
+            sent = json.loads(request.data)
+
+            self.assertEqual("abc123", jid)
+            self.assertEqual("POST", request.get_method())
+            self.assertEqual("https://wurk.example.com/wurk/api/v1/jobs", request.full_url)
+            self.assertEqual("Bearer test-token-0123456789", request.get_header("Authorization"))
+            self.assertEqual(
+                {"class": "HardWorker", "args": [1, "two"], "queue": "critical", "retry": 5}, sent
+            )
+
+    def test_enqueue_returns_none_when_the_server_reports_no_jid(self):
+        # A collapse:/unique_for: drop on the server answers 200 with jid: null
+        # — the producer's own policy working, not a failure.
+        with unittest.mock.patch("urllib.request.urlopen") as urlopen:
+            urlopen.return_value = _json_response(200, {"jid": None})
+
+            self.assertIsNone(self.client.enqueue("HardWorker", args=[1]))
+
+    def test_enqueue_sends_the_idempotency_key_header_when_given(self):
+        with unittest.mock.patch("urllib.request.urlopen") as urlopen:
+            urlopen.return_value = _json_response(201, {"jid": "abc123"})
+
+            self.client.enqueue("HardWorker", args=[1], idempotency_key="retry-1")
+
+            request = urlopen.call_args[0][0]
+            self.assertEqual("retry-1", request.get_header("Idempotency-key"))
+
+    # -- bulk ----------------------------------------------------------
+
+    def test_bulk_sends_one_args_array_per_job_and_returns_index_aligned_jids(self):
+        with unittest.mock.patch("urllib.request.urlopen") as urlopen:
+            urlopen.return_value = _json_response(201, {"jids": ["a", None, "c"]})
+
+            jids = self.client.bulk("HardWorker", [[1], [2], [3]], batch_size=100)
+
+            request = urlopen.call_args[0][0]
+            sent = json.loads(request.data)
+
+            self.assertEqual(["a", None, "c"], jids)
+            self.assertEqual([[1], [2], [3]], sent["args"])
+            self.assertEqual(100, sent["batch_size"])
+            self.assertEqual("https://wurk.example.com/wurk/api/v1/jobs/bulk", request.full_url)
+
+    # -- status ----------------------------------------------------------
+
+    def test_status_returns_the_record(self):
+        record = {"jid": "abc123", "state": "complete", "result": {"ok": True}}
+        with unittest.mock.patch("urllib.request.urlopen") as urlopen:
+            urlopen.return_value = _json_response(200, record)
+
+            self.assertEqual(record, self.client.status("abc123"))
+            request = urlopen.call_args[0][0]
+            self.assertEqual("GET", request.get_method())
+            self.assertEqual("https://wurk.example.com/wurk/api/v1/jobs/abc123", request.full_url)
+
+    def test_status_raises_a_typed_error_for_an_untracked_or_unknown_jid(self):
+        problem = {
+            "type": "job_not_found",
+            "title": "Job Not Found",
+            "status": 404,
+            "detail": "No status is recorded for jid abc123.",
+        }
+        with unittest.mock.patch("urllib.request.urlopen") as urlopen:
+            urlopen.side_effect = urllib.error.HTTPError(
+                "url", 404, "Not Found", {}, io.BytesIO(json.dumps(problem).encode("utf-8"))
+            )
+
+            with self.assertRaises(WurkAPIError) as ctx:
+                self.client.status("abc123")
+
+            self.assertEqual(404, ctx.exception.status)
+            self.assertEqual("job_not_found", ctx.exception.type)
+
+    # -- queues ----------------------------------------------------------
+
+    def test_queues_returns_the_listing(self):
+        with unittest.mock.patch("urllib.request.urlopen") as urlopen:
+            urlopen.return_value = _json_response(
+                200, {"queues": [{"name": "default", "size": 3, "latency": 0.1, "paused": False}]}
+            )
+
+            queues = self.client.queues()
+
+            self.assertEqual(1, len(queues))
+            self.assertEqual("default", queues[0]["name"])
+
+    def test_queue_pages_by_name_with_query_params(self):
+        with unittest.mock.patch("urllib.request.urlopen") as urlopen:
+            urlopen.return_value = _json_response(
+                200, {"name": "default", "size": 1, "latency": 0.0, "paused": False, "page": 1, "count": 10,
+                      "jobs": []}
+            )
+
+            self.client.queue("default", page=1, count=10)
+
+            request = urlopen.call_args[0][0]
+            self.assertIn("page=1", request.full_url)
+            self.assertIn("count=10", request.full_url)
+
+    # -- errors ------------------------------------------------------------
+
+    def test_rate_limited_raises_with_retry_after(self):
+        problem = {
+            "type": "rate_limited",
+            "title": "Too Many Requests",
+            "status": 429,
+            "detail": "This token is limited to 10 requests per minute.",
+            "retry_after": 7,
+        }
+        with unittest.mock.patch("urllib.request.urlopen") as urlopen:
+            urlopen.side_effect = urllib.error.HTTPError(
+                "url", 429, "Too Many Requests", {}, io.BytesIO(json.dumps(problem).encode("utf-8"))
+            )
+
+            with self.assertRaises(RateLimitedError) as ctx:
+                self.client.enqueue("HardWorker", args=[])
+
+            self.assertEqual(7, ctx.exception.retry_after)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,7 +78,7 @@ Wurk::Engine.routes.draw do
   # own routes, declared BEFORE the engine when its path extends the engine's —
   # Rails matches a mounted app by bare string prefix, so `mount Wurk::Engine =>
   # '/wurk'` declared first swallows every `/wurk-api/...` request.
-  mount Wurk::API => '/api', constraints: ->(request) { Wurk::API.serves?(request.path_info) }
+  mount Wurk::API => Wurk::API::ENGINE_MOUNT, constraints: ->(request) { Wurk::API.serves?(request.path_info) }
 
   # Profiles (v8.0+) — not under /api: `:key/data` streams the gzipped gecko
   # blob with a gzip Content-Encoding, and `:key` POST-uploads the profile to

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,22 @@ Wurk::Engine.routes.draw do
     get  'stream',           to: 'api#stream' # SSE
   end
 
+  # The machine-facing HTTP API (lib/wurk/api/) — mount mode 1 of three. An app
+  # that already mounts the engine gets it at `<mount>/api/v1` for free once a
+  # token exists; `Wurk::API.serves?` decides per request, so with none the
+  # constraint fails, Rails falls through, and there is no surface to find. It
+  # shares the /api prefix with the dashboard's own JSON API above; the
+  # constraint — not the declaration order — is what keeps those matching.
+  #
+  # Nested here it also inherits the engine's middleware — the host's
+  # `Wurk::Web.use` chain and the read-only gate — so a dashboard behind Devise
+  # keeps gating this path too. A machine client that cannot pass a browser
+  # login wants mode 2 instead: `mount Wurk::API => '/wurk-api'` in the host's
+  # own routes, declared BEFORE the engine when its path extends the engine's —
+  # Rails matches a mounted app by bare string prefix, so `mount Wurk::Engine =>
+  # '/wurk'` declared first swallows every `/wurk-api/...` request.
+  mount Wurk::API => '/api', constraints: ->(request) { Wurk::API.serves?(request.path_info) }
+
   # Profiles (v8.0+) — not under /api: `:key/data` streams the gzipped gecko
   # blob with a gzip Content-Encoding, and `:key` POST-uploads the profile to
   # the Firefox profiler then 302s to its public view. `:key` is "<token>-<jid>".

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,10 @@ Wurk::Engine.routes.draw do
   # token exists; `Wurk::API.serves?` decides per request, so with none the
   # constraint fails, Rails falls through, and there is no surface to find. It
   # shares the /api prefix with the dashboard's own JSON API above; the
-  # constraint — not the declaration order — is what keeps those matching.
+  # constraint — not the declaration order — is what keeps those matching. It
+  # claims every version-shaped path rather than `/v1` alone, so an unknown
+  # version reaches the app and comes back as the same `unsupported_api_version`
+  # problem document the other two mounts answer with.
   #
   # Nested here it also inherits the engine's middleware — the host's
   # `Wurk::Web.use` chain and the read-only gate — so a dashboard behind Devise

--- a/docs/api-http.md
+++ b/docs/api-http.md
@@ -205,7 +205,10 @@ client's own logs instead of halfway through a batch.
 
 An unrecognized version prefix (`/v2/...`) is a `404`
 (`unsupported_api_version`), not a `400` — the address doesn't exist, the
-client's request was otherwise well-formed.
+client's request was otherwise well-formed. All three mounts answer it the
+same way: the engine-nested mount claims every version-shaped path, not only
+the one it serves, so a wrong version never degrades into the host app's own
+route miss.
 
 ## Errors
 

--- a/docs/api-http.md
+++ b/docs/api-http.md
@@ -1,0 +1,436 @@
+# Wurk HTTP API (`/v1`)
+
+A machine-facing, polyglot HTTP surface over the same Redis a Wurk swarm reads
+and writes. A Python, Go, Node, or any other non-Ruby service can enqueue a
+job here and a Ruby (or stock Sidekiq) worker runs it — same Redis keys, same
+job JSON, nothing invented at the boundary.
+
+**Off unless a token is configured.** With no `config.api_token` registered,
+none of this exists: no route is mounted, no port opens, nothing changes on
+the hot path. This is the additive invariant the whole surface is built on —
+see [`docs/plans/2026/08/07/101-beyond-sidekiq/07-http-producer-api.md`](plans/2026/08/07/101-beyond-sidekiq/07-http-producer-api.md)
+for the design rationale.
+
+## Contents
+
+- [Enabling it](#enabling-it)
+- [Mounting](#mounting) — three ways, one implementation
+- [Authentication & scopes](#authentication--scopes)
+- [Versioning](#versioning)
+- [Errors](#errors)
+- [Idempotency](#idempotency)
+- [Read-only mode](#read-only-mode)
+- [Rate limiting](#rate-limiting)
+- [Routes](#routes) — produce, observe (queues & sets), observe (swarm)
+- [Reference clients](#reference-clients)
+
+## Enabling it
+
+```ruby
+# config/initializers/wurk.rb, or any app boot code that runs in every
+# process that should serve the API
+Wurk.configuration.api_token ENV.fetch('WURK_API_TOKEN'), scopes: %i[enqueue read]
+```
+
+Register the token **unconditionally** — not inside `configure_server` /
+`configure_client`. Neither block runs in every process type; in particular a
+Puma-cluster web process never enters "server mode", so a token set only in
+`configure_server` would be absent from exactly the process serving the
+engine-nested mount (mode 1 below). Registering the first token is what
+brings the API into existence at all; call it again to replace a token's
+scopes.
+
+`scopes:` is any non-empty subset of `%i[enqueue read admin]` — see
+[Authentication & scopes](#authentication--scopes).
+
+## Mounting
+
+`Wurk::API` is a plain Rack app (`lib/wurk/api/app.rb`) with no reference to
+Rails. One implementation serves all three mounts; nothing in it hardcodes a
+prefix — every URL it emits (including the discovery document's `url` field)
+is derived from `SCRIPT_NAME`.
+
+### 1. Inside the engine (default)
+
+Any app that already mounts the engine gets the API for free at
+`<mount>/api/v1`, once a token exists:
+
+```ruby
+# config/routes.rb
+mount Wurk::Engine => '/wurk'   # dashboard at /wurk, API at /wurk/api/v1
+```
+
+With no token registered, the route does not exist — Rails falls through to
+whatever `/wurk/api/...` would have answered before (a 404, same as any other
+unmounted path), never a bearer challenge advertising a surface that isn't
+there.
+
+The dashboard's own JSON API lives under the same `/api` prefix
+(`config/routes.rb`'s `scope :api`) and is declared first, so
+`/wurk/api/queues` (dashboard, SPA-shaped, session-authenticated) and
+`/wurk/api/v1/queues` (machine plane, bearer-authenticated) coexist without
+conflict — the machine plane only claims paths under `/v1`.
+
+Read-only mode is inherited here: `WURK_WEB_READ_ONLY=1` (or
+`Wurk::Web.config.read_only`) freezes the dashboard *and* this mount's writes
+— see [Read-only mode](#read-only-mode).
+
+### 2. Mounted separately
+
+Useful to put the machine API on its own path, subdomain, or middleware
+stack — e.g. the dashboard behind a login on the app domain, the API on an
+internal-only route with its own network policy:
+
+```ruby
+mount Wurk::API => '/wurk-api'   # API at /wurk-api/v1, dashboard untouched
+```
+
+Rails matches a mounted app by string prefix, so if an engine is also mounted
+at a prefix your separate mount extends (`mount Wurk::Engine => '/wurk'` and
+`mount Wurk::API => '/wurk-api'`), **declare the more specific route first**.
+Declared after, the engine's own catch-all would answer `/wurk-api/...`
+requests instead (for `html`-format requests only — a JSON request still
+cascades past it via `X-Cascade`, but a browser hitting the API's root would
+otherwise see the dashboard shell).
+
+This mount has no engine `Authorization` layer in front of it, so read-only
+mode is *not* inherited from `WURK_WEB_READ_ONLY`. Opt in explicitly with
+`config.api_read_only = true` or `WURK_API_READ_ONLY=1` if you want it.
+
+### 3. Standalone, no Rails
+
+`CLAUDE.md`: standalone mode must run without loading the engine.
+`Wurk::API` is plain Rack under `lib/`, so it runs on its own:
+
+```bash
+bundle exec wurk api --port 7433 -r ./config/environment.rb
+# or, in any config.ru:
+run Wurk::API
+```
+
+```
+$ bundle exec wurk api --help
+Usage: wurk api [options]
+    -b, --bind ADDRESS               Address to bind (default 0.0.0.0)
+    -p, --port PORT                  Listen on PORT
+    -s, --server NAME                Rack handler to serve with (default: the first installed)
+    -r, --require [PATH|DIR]         Location of Rails app or .rb file to require
+    -e, --environment ENV            Application environment
+    -C, --config PATH                path to YAML config file
+```
+
+`wurk api` starts **only** the HTTP surface — no fetcher, no heartbeat, no
+job ever runs in this process. It binds `0.0.0.0` by default (the point of
+the machine API is for another service to reach it — it's bearer-gated and
+answers 404 to everything until a token exists); narrow it with `--bind
+127.0.0.1` behind your own proxy if you'd rather. The web server itself
+(`Rack::Handler::*`) is not a Wurk dependency, same as it isn't for a Rails
+app — install `puma`, `webrick`, or whichever handler you prefer and `wurk
+api` resolves it at boot, or name one explicitly with `--server`.
+
+With no token registered, `wurk api` refuses to boot rather than binding a
+port that would 404 every request:
+
+```
+No API token is registered, so every request would answer 404.
+Register one where the app loaded by -r configures wurk:
+
+    Wurk.configuration.api_token ENV.fetch('WURK_API_TOKEN'), scopes: %i[enqueue read]
+```
+
+## Authentication & scopes
+
+Every request needs `Authorization: Bearer <token>`. Compared in constant
+time against every registered token — no early exit on a match — so timing
+can't leak which token, or how much of one, a caller guessed right.
+
+Three scopes, one implication:
+
+| Scope | Grants |
+|---|---|
+| `enqueue` | `POST /jobs`, `POST /jobs/bulk` |
+| `read` | every `GET`, plus `GET /jobs/:jid` |
+| `admin` | everything — implies `enqueue` and `read`, plus the destructive routes (`DELETE /jobs/:jid`, queue pause/unpause, process quiet/stop) |
+
+```ruby
+Wurk.configuration.api_token ENV.fetch('WURK_PRODUCER_TOKEN'), scopes: %i[enqueue read]
+Wurk.configuration.api_token ENV.fetch('WURK_OPERATOR_TOKEN'), scopes: %i[admin]
+```
+
+- **No token presented** → `401`, `WWW-Authenticate: Bearer realm="wurk"`.
+- **Unrecognized token** → `401`, `WWW-Authenticate: Bearer realm="wurk", error="invalid_token"`.
+- **Valid token, wrong scope** → `403` (`insufficient_scope`), `WWW-Authenticate` names the scope required — never a `404` hiding the route, since the caller already proved a valid credential and only needs to know what to ask their operator for.
+- **No token configured on the server at all** → the whole surface is `404` — see [Enabling it](#enabling-it).
+
+`class` in an enqueued job selects which of the host's code runs, so a
+polyglot producer that can name *any* class is remote code selection.
+`config.api_enqueue_classes` is a class allow-list layered on top of scopes:
+
+```ruby
+# Only these two classes may be enqueued over HTTP, by any token including admin
+Wurk.configuration.api_enqueue_classes = %w[Billing::Charge ReportJob]
+
+# Turn the check off entirely (an internal relay that legitimately enqueues anything)
+Wurk.configuration.api_enqueue_classes = :any
+```
+
+Unset (the default), only an `admin` token may enqueue at all — an
+`enqueue`-scoped token enqueues nothing until you either grant it `admin` or
+write a list.
+
+## Versioning
+
+Everything lives under `/v1`. The discovery document is the first thing a
+client should call to confirm which mount and contract it's talking to:
+
+```
+GET /v1
+```
+```json
+{
+  "api_version": "v1",
+  "wurk_version": "8.4.0",
+  "url": "/wurk/api/v1",
+  "read_only": false,
+  "rate_limit": { "limit": 600, "interval_seconds": 60 }
+}
+```
+
+`url` is built from the actual mount prefix the request arrived through —
+never hardcoded — so a client can trust it as the base for every subsequent
+request. `read_only` and `rate_limit` are reported here because both are
+things a producer would otherwise only discover by having a write refused;
+reading them at startup means a misconfigured deployment fails in the
+client's own logs instead of halfway through a batch.
+
+An unrecognized version prefix (`/v2/...`) is a `404`
+(`unsupported_api_version`), not a `400` — the address doesn't exist, the
+client's request was otherwise well-formed.
+
+## Errors
+
+Every error is an [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) problem
+document, `Content-Type: application/problem+json`:
+
+```json
+{
+  "type": "job_not_found",
+  "title": "Job Not Found",
+  "status": 404,
+  "detail": "No scheduled or retrying job has jid abc123.",
+  "instance": "/v1/jobs/abc123",
+  "jid": "abc123"
+}
+```
+
+`type` is a **bare, stable slug** — not a URI. It's the field a client
+branches on; renaming one is a breaking change, adding one is not.
+
+| `type` | HTTP status | Meaning |
+|---|---|---|
+| `not_found` | 404 | No route matches this path. |
+| `method_not_allowed` | 405 | Route exists, wrong verb — `Allow` header lists what does. |
+| `unsupported_api_version` | 404 | Not `/v1`. |
+| `unauthorized` | 401 | Missing or invalid bearer token. |
+| `insufficient_scope` | 403 | Valid token, missing scope. |
+| `invalid_request` | 400 | Malformed body, bad query param, unknown top-level job key. |
+| `payload_too_large` | 413 | Body, `args`, or one bulk job's `args` exceeded its configured cap (`max_bytes` extension member). |
+| `class_not_allowed` | 403 | `class` is not on `config.api_enqueue_classes`. |
+| `job_not_found` | 404 | No scheduled/retrying job, or no tracked status, for this jid. |
+| `batch_not_found` | 404 | No batch with this bid. |
+| `process_not_found` | 404 | No live process with this identity. |
+| `process_not_signalable` | 409 | Process is embedded in its host app; signalling it would signal the host. |
+| `idempotency_key_reused` | 409 | Same `Idempotency-Key`, different request body — rotate the key. |
+| `request_in_progress` | 409 | Another request under this `Idempotency-Key` hasn't answered yet — retry shortly (`Retry-After: 1`). |
+| `read_only` | 403 | This deployment (or mount) answers reads only. |
+| `rate_limited` | 429 | Per-token ceiling exceeded — `Retry-After` header and `retry_after` body field agree. |
+| `internal_error` | 500 | Unexpected server error; details are in the server log, never the response. |
+
+## Idempotency
+
+A producer whose connection drops mid-`POST /jobs` can't tell a lost request
+from a lost response, so its only safe move is to resend — which, without
+help, enqueues the job twice. Send an `Idempotency-Key` and a resend replays
+the *first* response verbatim instead:
+
+```
+POST /v1/jobs
+Idempotency-Key: order-42-charge
+```
+
+- The first request with a key runs normally; its response (status + body) is
+  recorded for `config.api_idempotency_ttl` seconds (default 3600).
+- A repeat with the **same** key and **same** body gets the recorded response
+  back, with `Idempotency-Replayed: true`, and nothing is enqueued twice.
+- A repeat with the same key and a **different** body is a client bug:
+  `409 idempotency_key_reused`. Fix the request or use a new key.
+- A repeat that arrives while the first request is still in flight gets
+  `409 request_in_progress` with `Retry-After: 1`.
+- Only a *successful* (2xx) response is recorded. A rejected request (`400`,
+  `413`, ...) releases the key, so the corrected request can reuse it.
+
+No header, no behavior change and no extra round trip — this is entirely
+opt-in.
+
+The key is scoped to the credential and the route: two different tokens
+sending the same key string don't collide, and the same key sent to `/jobs`
+and `/jobs/bulk` addresses two independent claims.
+
+## Read-only mode
+
+One rule, same word, same meaning as the dashboard's:
+`Wurk::Web.config.read_only` / `WURK_WEB_READ_ONLY=1` freezes every
+non-`GET`/`HEAD`/`OPTIONS` request — enqueue included, not only the
+`admin`-scoped destructive routes. A deployment an operator can't retry a job
+on shouldn't let a stranger start a thousand new ones on it.
+
+| Mount | Inherits `WURK_WEB_READ_ONLY`? | Its own switch |
+|---|---|---|
+| 1. Engine-nested | Yes, automatically | `config.api_read_only = false` overrides it back to live |
+| 2. Mounted separately | No — different deployment, nothing to inherit from | `config.api_read_only = true` / `WURK_API_READ_ONLY=1` |
+| 3. Standalone (`wurk api`) | No | same as mode 2 |
+
+A refused write is `403 read_only` — distinct from `insufficient_scope`
+because the fix is different: nothing the client can send changes the answer,
+where a scope error is fixable by asking for a wider token.
+
+## Rate limiting
+
+Off by default. Set a per-token ceiling with:
+
+```ruby
+Wurk.configuration.api_rate_limit = 600
+Wurk.configuration.api_rate_limit_interval = :minute   # or :second/:hour/:day, or raw seconds
+```
+
+Enforced by the same `Wurk::Limiter` sliding window jobs use — it shows up on
+`GET /v1/limiters` and the dashboard's Limiters page beside every other one,
+and its verdict is shared across every process in the fleet off one Redis
+clock. Over the ceiling: `429 rate_limited`, `Retry-After` header (whole
+seconds, never `0`), and the same number echoed in the body as `retry_after`.
+
+## Routes
+
+Body is always the literal Sidekiq job hash — nothing invented, nothing
+reshaped. An HTTP-enqueued job is byte-identical to one pushed by
+`perform_async` in this process and runs unmodified on stock Sidekiq.
+
+### Produce
+
+| Route | Scope | Notes |
+|---|---|---|
+| `POST /jobs` | `enqueue` | One job. `201` + `{"jid": "..."}`, or `200` + `{"jid": null}` if server-side middleware (`collapse:`, `unique_for:`) dropped the push — that's the producer's own policy working, not a failure. |
+| `POST /jobs/bulk` | `enqueue` | Many, via the Lua bulk path. `{"class": ..., "args": [[...], [...]], "batch_size": 1000, "spread_interval": 5}`. `201`/`200` + `{"jids": [...]}`, index-aligned with `args`; `null` entries mark drops. |
+| `GET /jobs/:jid` | `read` | State, progress, result, error — from `Wurk::Status`. Only answers for a class with `track: true`; an untracked, unknown, or TTL-expired jid all read the same `404 job_not_found`, because Redis holds nothing that tells them apart. |
+| `DELETE /jobs/:jid` | `admin` | Removes a not-yet-run job from `schedule` or `retry` by jid. **Not** a running-job cancel — a job already handed to a processor keeps running, and one that already died stays in `dead`. |
+
+Job body, all keys optional except `class`:
+
+```json
+{
+  "class": "HardWorker",
+  "args": [1, "two"],
+  "queue": "default",
+  "at": 1786000000,
+  "retry": 5,
+  "tags": ["billing"],
+  "track": true,
+  "timeout": 30,
+  "deadline": 1786000600,
+  "unique_for": 300,
+  "collapse": "user-42-digest"
+}
+```
+
+Allowed top-level keys: `class args queue at retry jid backtrace tags dead
+retry_for retry_queue expires_in track timeout deadline encrypt unique_for
+unique_until collapse log_level locale wrapped` (plus `batch_size` and
+`spread_interval` for `/jobs/bulk`). An unknown key is `400 invalid_request`
+rather than silently dropped — a typo'd `deadlin:` would otherwise run
+unbounded with the producer none the wiser. Fields the server derives or
+stamps itself (`created_at`, `enqueued_at`, `bid`, `expiry`, ...) are not
+accepted from the client.
+
+Caps (all configurable): request body (`config.api_max_body_bytes`, default 1
+MiB), one job's `args` (`config.api_max_args_bytes`, default 64 KiB) —
+checked per job for `/jobs/bulk`, so one oversized entry in a large batch
+doesn't cost reading the whole body to find.
+
+### Observe — queues & sets
+
+Every route reads through the same canonical inspector the dashboard uses
+(`Wurk::Stats`, `Queue`, `RetrySet`, `ScheduledSet`, `DeadSet`,
+`Batch::Status`) — the API and the dashboard can never disagree about how
+deep a queue is.
+
+| Route | Scope | Notes |
+|---|---|---|
+| `GET /stats` | `read` | Processed/failed/expired/enqueued counters, queue summaries. |
+| `GET /queues` | `read` | Every queue: name, size, latency, paused. Size-descending. |
+| `GET /queues/:name` | `read` | Gauges + a page of waiting jobs. No `404` for an unused name — a queue is a Redis LIST that exists only while it has members, so "never enqueued" and "just drained" are the same state. |
+| `POST /queues/:name/pause` | `admin` | Stops the fleet fetching from this queue. |
+| `POST /queues/:name/unpause` | `admin` | |
+| `GET /retries` | `read` | Paged `retry` set. |
+| `GET /scheduled` | `read` | Paged `schedule` set. |
+| `GET /dead` | `read` | Paged `dead` set. |
+| `GET /batches/:bid` | `read` | Batch status/counters. `404 batch_not_found` if never created or expired. |
+
+Paged routes take `?page=` (0-based) and `?count=` (default 25, max 200);
+out-of-range values are clamped, not refused, and the effective values are
+echoed back so the clamp is visible.
+
+### Observe — swarm & topology
+
+Read-only against structures that already exist — no new Redis key, no new
+heartbeat field, and watching the swarm through these routes costs it nothing
+(`Wurk::ProcessSet.new(false)`, the same non-mutating read the dashboard's
+live poll uses). A monitoring client hitting `GET /swarm` every few seconds
+adds zero write traffic.
+
+| Route | Scope | Notes |
+|---|---|---|
+| `GET /swarm` | `read` | Cluster roll-up: process/quiet/stale counts, total concurrency & utilization, queues & versions in play, leader identity, per-host breakdown, observed slot table, oldest beat age. |
+| `GET /processes` | `read` | Paged, one row per live process: identity, hostname, pid, tag, version, concurrency, queues, busy, RSS, `beat_age_seconds`, `stale`, `quiet`. |
+| `GET /processes/:identity` | `read` | One process's row plus its in-flight work. `404 process_not_found` if it's exited or its heartbeat lapsed. |
+| `POST /processes/:identity/quiet` | `admin` | SIGTSTP-equivalent — stop fetching, finish in-flight. `identity=all` broadcasts. Asynchronous: `200` means queued, applied on the target's next beat. |
+| `POST /processes/:identity/stop` | `admin` | SIGTERM-equivalent — graceful shutdown. Same broadcast/async rules. |
+| `GET /busy` | `read` | Paged, every in-flight job cluster-wide. |
+| `GET /health` | `read` | Redis reachability + live/stale/quiet process counts — the same question `lib/wurk/health.rb`'s TCP probe answers, re-derived for a process that has no probe of its own. `503` when Redis is unreachable or no process is live. **Not** a substitute for `config.health_check(port:)` — a Kubernetes probe must never carry a bearer token. |
+| `GET /limiters` | `read` | Paged; supports `?filter=` (substring). |
+| `GET /cron` | `read` | Paged registered cron loops with `next_fire_at`. |
+
+Heartbeat staleness: a process that died between beats is still in
+`processes` until its TTL lapses. Every row and the roll-up both carry
+`beat_age_seconds` and a derived `stale` boolean (age past three missed beats,
+`30s` at the default heartbeat cadence) so a client never has to compare its
+own clock against a `beat` timestamp.
+
+Signalling an **embedded** process (one running inside the host web process,
+not a forked swarm child) is refused with `409 process_not_signalable` — a
+TSTP or TERM aimed at it would hit the web server around it, not just the job
+loop.
+
+## Reference clients
+
+**Python** — [`clients/python/`](../clients/python/), zero third-party
+dependencies (`urllib.request` under the hood):
+
+```python
+from wurk_client import Client
+
+wurk = Client("https://jobs.example.com/wurk/api", token=API_TOKEN)
+jid = wurk.enqueue("HardWorker", args=[1, "two"], queue="default")
+wurk.status(jid)      # {"jid": ..., "state": "running", ...} — track: True jobs only
+wurk.queues()          # [{"name": "default", "size": 3, ...}, ...]
+```
+
+See [`clients/python/README.md`](../clients/python/README.md) for the full
+surface (`enqueue`, `bulk`, `status`, `cancel`, `queues`, `queue`,
+`pause_queue`/`unpause_queue`, `stats`) and error handling
+(`WurkAPIError`/`RateLimitedError`).
+
+Thin on purpose: no retries, no connection pooling, no framework
+integration — wrap it, or reach for `requests`/`httpx` yourself, for
+anything beyond a straight `/v1` call. Not yet published to PyPI; install
+from the repo (`pip install ./clients/python`) until the surface above is
+declared frozen.

--- a/exe/wurk
+++ b/exe/wurk
@@ -2,7 +2,8 @@
 # frozen_string_literal: true
 
 # Standalone runner. Does NOT load the Rails engine.
-# Usage: `exe/wurk -C config/wurk.yml`
+# Usage: `exe/wurk -C config/wurk.yml`     — worker: one process, thread pool
+#        `exe/wurk api --port 7433`        — machine HTTP API, runs no jobs
 
 $stdout.sync = true
 $LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
@@ -12,7 +13,10 @@ require 'wurk'
 begin
   cli = Wurk::CLI.instance
   cli.parse
-  cli.run
+  case cli.command
+  when 'api' then cli.run_api
+  else            cli.run
+  end
 rescue StandardError => e
   raise e if $DEBUG
 

--- a/lib/wurk/api.rb
+++ b/lib/wurk/api.rb
@@ -5,6 +5,15 @@ module Wurk
   # data-API Lua extensions (API::Fast, required by lib/wurk.rb at its
   # load-order-sensitive point) and the machine-facing HTTP API (API::App).
   module API
+    # The one prefix the machine plane answers under, and the version it pins.
+    # They live on the namespace rather than on App because the engine's mount
+    # constraint has to answer "is this path mine?" on every routing pass, and
+    # loading App to ask would undo the lazy load below.
+    API_VERSION = 'v1'
+    VERSION_PREFIX = "/#{API_VERSION}".freeze
+    NESTED_PREFIX = "#{VERSION_PREFIX}/".freeze
+    SUPPORTED_VERSIONS = [API_VERSION].freeze
+
     class << self
       # Class-level Rack entry, the same shape as Wurk::Web.call, so
       # `mount Wurk::API => '/wurk-api'` and `run Wurk::API` both work.
@@ -15,6 +24,28 @@ module Wurk
       # pre-fork heap and measurably slower boot for a surface it never serves.
       def call(env)
         app.call(env)
+      end
+
+      # Whether the API should answer for `path` — the request path relative to
+      # wherever it was mounted. The engine's conditional mount (config/
+      # routes.rb) is a constraint over this, which settles two things a bare
+      # `mount` could not:
+      #
+      #   * Off means absent. With no token registered the constraint fails,
+      #     Rails falls through to the next route, and the surface does not
+      #     exist — not a 401 advertising one that does (07 plan, step 1).
+      #     Asked per request, not at draw time: routes load once at boot, and
+      #     a host is free to register its token after that (a Puma-cluster web
+      #     process never enters server mode, so its `configure_server` block
+      #     has not run by then).
+      #   * Nested in the engine, this plane shares the /api prefix with the
+      #     dashboard's own JSON API. Without the version check a mistyped
+      #     dashboard path would fall through to the machine plane and draw a
+      #     bearer challenge for a route that was never part of this contract.
+      def serves?(path, config = ::Wurk.configuration)
+        return false unless config.api_enabled?
+
+        path == VERSION_PREFIX || path.start_with?(NESTED_PREFIX)
       end
 
       private

--- a/lib/wurk/api.rb
+++ b/lib/wurk/api.rb
@@ -14,6 +14,17 @@ module Wurk
     NESTED_PREFIX = "#{VERSION_PREFIX}/".freeze
     SUPPORTED_VERSIONS = [API_VERSION].freeze
 
+    # A path that names *some* version of this plane — `/v1`, `/v2/jobs`, not
+    # `/v1x` and not the dashboard's own `/stats`. Version-shaped rather than
+    # `v1`-only because the mount has to claim a version it does not serve in
+    # order for App to answer it `unsupported_api_version`, which is what the
+    # standalone and separately-mounted modes already do. Claiming only `/v1`
+    # would leave mode 1 alone in falling through to the host's router, and a
+    # client would learn "wrong version" from Rails' 404 in one deployment
+    # shape and from a problem document naming the supported versions in the
+    # other two.
+    VERSION_PATH = %r{\A/v\d+(?:/|\z)}
+
     # Where mount mode 1 puts this plane inside the engine (config/routes.rb).
     # Named here because two callers have to agree on it: the mount itself, and
     # `Wurk::Web::Authorization`, which runs before routing and so sees the
@@ -54,10 +65,12 @@ module Wurk
       #     dashboard's own JSON API. Without the version check a mistyped
       #     dashboard path would fall through to the machine plane and draw a
       #     bearer challenge for a route that was never part of this contract.
+      #     A version-shaped path is never one of the dashboard's, so this
+      #     claims every version and lets App refuse the ones it cannot serve.
       def serves?(path, config = ::Wurk.configuration)
         return false unless config.api_enabled?
 
-        path == VERSION_PREFIX || path.start_with?(NESTED_PREFIX)
+        VERSION_PATH.match?(path)
       end
 
       # The same question asked one prefix out, for callers that run before the

--- a/lib/wurk/api.rb
+++ b/lib/wurk/api.rb
@@ -14,6 +14,18 @@ module Wurk
     NESTED_PREFIX = "#{VERSION_PREFIX}/".freeze
     SUPPORTED_VERSIONS = [API_VERSION].freeze
 
+    # Where mount mode 1 puts this plane inside the engine (config/routes.rb).
+    # Named here because two callers have to agree on it: the mount itself, and
+    # `Wurk::Web::Authorization`, which runs before routing and so sees the
+    # engine-relative path with this prefix still on it.
+    ENGINE_MOUNT = '/api'
+
+    # Rack env key the engine's Authorization middleware stamps when the
+    # dashboard is read-only. It is how mount mode 1 — and only mode 1 —
+    # inherits `WURK_WEB_READ_ONLY`: a separately mounted or standalone API is
+    # a different deployment and opts in on its own (`config.api_read_only`).
+    READ_ONLY_ENV = 'wurk.web.read_only'
+
     class << self
       # Class-level Rack entry, the same shape as Wurk::Web.call, so
       # `mount Wurk::API => '/wurk-api'` and `run Wurk::API` both work.
@@ -46,6 +58,14 @@ module Wurk
         return false unless config.api_enabled?
 
         path == VERSION_PREFIX || path.start_with?(NESTED_PREFIX)
+      end
+
+      # The same question asked one prefix out, for callers that run before the
+      # engine's mount has stripped it — `Wurk::Web::Authorization` is the only
+      # one. It has to tell a machine-plane path from a dashboard one (both live
+      # under /api) without loading App, which is why this is here and not there.
+      def engine_serves?(path, config = ::Wurk.configuration)
+        path.start_with?(ENGINE_MOUNT) && serves?(path.delete_prefix(ENGINE_MOUNT), config)
       end
 
       private

--- a/lib/wurk/api/app.rb
+++ b/lib/wurk/api/app.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rack'
+require_relative '../api'
 require_relative '../version'
 require_relative 'auth'
 require_relative 'jobs'
@@ -22,10 +23,6 @@ module Wurk
     # SCRIPT_NAME (Request#url_for) — the same mount-agnostic rule the SPA shell
     # follows in dashboard_controller.rb.
     class App
-      API_VERSION = 'v1'
-      VERSION_PREFIX = "/#{API_VERSION}".freeze
-      SUPPORTED_VERSIONS = [API_VERSION].freeze
-
       # `config` is read on every request rather than captured, so a token
       # registered after the first request still takes effect. Injectable
       # because a test must be able to hand this app its own token table
@@ -102,7 +99,7 @@ module Wurk
       end
 
       def versioned?(path)
-        path == VERSION_PREFIX || path.start_with?("#{VERSION_PREFIX}/")
+        path == VERSION_PREFIX || path.start_with?(NESTED_PREFIX)
       end
 
       def route_miss(request, match)

--- a/lib/wurk/api/app.rb
+++ b/lib/wurk/api/app.rb
@@ -9,6 +9,7 @@ require_relative 'queues'
 require_relative 'request'
 require_relative 'response'
 require_relative 'router'
+require_relative 'swarm'
 
 module Wurk
   module API
@@ -57,6 +58,7 @@ module Wurk
         router.get('/', scope: Auth::ANY) { |request| root(request) }
         Jobs.draw(router)
         Queues.draw(router)
+        Swarm.draw(router)
       end
 
       # Authentication runs before the version gate and before routing, so an

--- a/lib/wurk/api/app.rb
+++ b/lib/wurk/api/app.rb
@@ -7,10 +7,12 @@ require_relative 'auth'
 require_relative 'jobs'
 require_relative 'problem'
 require_relative 'queues'
+require_relative 'read_only'
 require_relative 'request'
 require_relative 'response'
 require_relative 'router'
 require_relative 'swarm'
+require_relative 'throttle'
 
 module Wurk
   module API
@@ -61,6 +63,13 @@ module Wurk
       # Authentication runs before the version gate and before routing, so an
       # unauthenticated prober can't enumerate which paths or versions exist
       # from the difference between a 404 and a 405.
+      #
+      # Then two refusals that are true of the whole deployment rather than of
+      # any one route, in cost order. Read-only is a fact this process already
+      # holds, so it answers without touching Redis. The throttle needs a
+      # credential to charge, which is why it cannot run before authentication —
+      # and it charges every authenticated request, routed or not: a client
+      # walking paths that don't exist is exactly the traffic a ceiling is for.
       def handle(request)
         config = request.config
         return not_found(request) unless Auth.configured?(config)
@@ -69,7 +78,8 @@ module Wurk
         return Auth.unauthorized(request) unless principal
 
         request.principal = principal
-        route(request)
+        refusal = ReadOnly.refuse(request) || Throttle.refuse(request)
+        refusal || route(request)
       rescue StandardError => e
         internal_error(request, e)
       end
@@ -91,11 +101,26 @@ module Wurk
       end
 
       # The document a client hits to confirm which mount and which contract it
-      # is talking to before it starts guessing paths.
+      # is talking to before it starts guessing paths. It carries the two
+      # deployment-wide refusals as well: both are things a producer would
+      # otherwise only learn by having a write refused, and a client that can
+      # read "this one is frozen" at startup fails in its own logs instead of
+      # halfway through a batch.
       def root(request)
         Response.json(
-          200, api_version: API_VERSION, wurk_version: ::Wurk::VERSION, url: request.url_for(VERSION_PREFIX)
+          200,
+          api_version: API_VERSION, wurk_version: ::Wurk::VERSION, url: request.url_for(VERSION_PREFIX),
+          read_only: ReadOnly.enabled?(request), rate_limit: rate_limit(request.config)
         )
+      end
+
+      # nil, not an object with nil members: "there is no ceiling here" and
+      # "there is one, of unknown size" are different answers.
+      def rate_limit(config)
+        limit = config.api_rate_limit
+        return nil unless limit
+
+        { limit: limit, interval_seconds: Throttle.interval_seconds(config.api_rate_limit_interval) }
       end
 
       def versioned?(path)

--- a/lib/wurk/api/app.rb
+++ b/lib/wurk/api/app.rb
@@ -5,6 +5,7 @@ require_relative '../version'
 require_relative 'auth'
 require_relative 'jobs'
 require_relative 'problem'
+require_relative 'queues'
 require_relative 'request'
 require_relative 'response'
 require_relative 'router'
@@ -50,11 +51,12 @@ module Wurk
         @config || ::Wurk.configuration
       end
 
-      # One table per plane, each owning its own routes and handlers. Queues and
-      # swarm join Jobs here.
+      # One table per plane, each owning its own routes and handlers. Swarm
+      # joins Jobs and Queues here.
       def draw(router)
         router.get('/', scope: Auth::ANY) { |request| root(request) }
         Jobs.draw(router)
+        Queues.draw(router)
       end
 
       # Authentication runs before the version gate and before routing, so an

--- a/lib/wurk/api/jobs.rb
+++ b/lib/wurk/api/jobs.rb
@@ -7,8 +7,8 @@ require_relative 'validation'
 
 module Wurk
   module API
-    # The produce plane: enqueue one job, enqueue many, take a not-yet-run job
-    # back out.
+    # The produce plane: enqueue one job, enqueue many, ask what became of one,
+    # take a not-yet-run job back out.
     #
     # The request body *is* the Sidekiq job hash — `{"class", "args", "queue",
     # "at", "retry"}` — and every write below hands it to {Wurk::Client}, the
@@ -34,6 +34,11 @@ module Wurk
       def draw(router)
         router.post('/jobs', scope: :enqueue) { |request| create(request) }
         router.post('/jobs/bulk', scope: :enqueue) { |request| create_bulk(request) }
+        # :read. A producer that wants to poll what it pushed is granted
+        # `%i[enqueue read]` — the same pair the configuration docs show —
+        # rather than having every enqueue token able to read a jid it did not
+        # produce, which is what folding this into :enqueue would mean.
+        router.get('/jobs/:jid', scope: :read) { |request| show(request) }
         # :admin, not :enqueue. A jid is not bound to the token that produced
         # it, so an enqueue-scoped producer holding this route could walk the
         # retry set one jid at a time. Widening a scope later is additive to
@@ -96,6 +101,22 @@ module Wurk
         invalid_request(request, e.message)
       end
 
+      # The record {Wurk::Status} keeps for one jid: state, progress, result,
+      # error. Sidekiq keeps nothing at all about a job once it succeeds, so
+      # this route can only answer for a class that opted in with
+      # `track: true`; an untracked jid, an unknown one and a row whose TTL has
+      # lapsed are all the same answer, because Redis holds nothing that tells
+      # them apart.
+      def show(request)
+        jid = Validation.jid!(request.path_params[:jid].to_s)
+        record = ::Wurk::Status.get(jid)
+        return status_not_found(request, jid) unless record
+
+        Response.json(200, record.to_h)
+      rescue Validation::Invalid => e
+        problem(request, e)
+      end
+
       # Removes a job that has not run yet from `schedule` or `retry`. Not a
       # cancel: a job already handed to a processor keeps running, and one that
       # has already died stays in `dead`, where deleting it is an operator
@@ -128,9 +149,7 @@ module Wurk
 
       # Validation decided which problem this is; rendering it is all that is
       # left, so a new rejection never needs a new arm here.
-      def problem(request, error)
-        Problem.render(error.type, status: error.status, detail: error.message, instance: request.path, **error.extra)
-      end
+      def problem(request, error) = Problem.from(error, instance: request.path)
 
       def invalid_request(request, detail)
         Problem.render(Problem::INVALID_REQUEST, status: 400, detail: detail, instance: request.path)
@@ -141,6 +160,17 @@ module Wurk
           Problem::JOB_NOT_FOUND,
           status: 404,
           detail: "No scheduled or retrying job has jid #{jid}.",
+          instance: request.path,
+          jid: jid
+        )
+      end
+
+      def status_not_found(request, jid)
+        Problem.render(
+          Problem::JOB_NOT_FOUND,
+          status: 404,
+          detail: "No status is recorded for jid #{jid}; the job is unknown, its class does not set " \
+                  'track: true, or its record has expired.',
           instance: request.path,
           jid: jid
         )

--- a/lib/wurk/api/page.rb
+++ b/lib/wurk/api/page.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rack'
+require_relative 'validation'
+
+module Wurk
+  module API
+    # Offset paging for the observe plane's listings.
+    #
+    # Deliberately not the dashboard's Wurk::Api::Pagination. That module is
+    # autoloaded out of app/ by the engine, and the API has to page in
+    # standalone mode where Rails is never loaded (CLAUDE.md); requiring an
+    # autoloadable file by hand is exactly what Zeitwerk forbids. The contracts
+    # differ too — the dashboard's may change whenever the SPA does, everything
+    # under /v1 may not — so one shared module would tie a frozen contract to a
+    # mutable one.
+    module Page
+      DEFAULT_COUNT = 25
+      MAX_COUNT = 200
+
+      # Offset paging reaches page N by walking N*count members through Ruby,
+      # and their Redis round trips with them, so an unclamped `page` lets one
+      # request drag an entire million-row set through this process. A
+      # thousand pages is past any real client's depth and still bounds the
+      # worst case.
+      MAX_PAGE = 1_000
+
+      Window = Data.define(:page, :count) do
+        def offset = page * count
+      end
+
+      module_function
+
+      # @raise [Validation::Invalid] when a paging parameter is present but is
+      #   not an integer. Out of range is clamped instead of refused — a client
+      #   asking for more rows than the API will give is not a client bug — and
+      #   every listing echoes the effective values back, so the clamp is
+      #   visible rather than silent.
+      def window!(request)
+        query = query!(request)
+        Window.new(
+          page: integer!(query['page'], 'page', 0).clamp(0, MAX_PAGE),
+          count: integer!(query['count'], 'count', DEFAULT_COUNT).clamp(1, MAX_COUNT)
+        )
+      end
+
+      # Rack::Request#params merges the POST body in, which the paged routes
+      # must never read. parse_query is also flat: `?page[]=1` arrives as the
+      # key it literally is instead of nesting into a Hash that reaches
+      # Integer().
+      #
+      # Rack's own refusals (InvalidParameterError on bad %-encoding,
+      # QueryLimitError on an oversized one) are ArgumentError and RangeError
+      # respectively; caught here so a malformed query string is the 400 it is
+      # rather than the 500 App's catch-all would make of it.
+      def query!(request)
+        ::Rack::Utils.parse_query(request.query_string)
+      rescue ::ArgumentError, ::TypeError, ::RangeError
+        raise Validation::Invalid, 'The query string could not be parsed.'
+      end
+
+      # A repeated parameter (`?page=1&page=2`) parses to an Array, which is
+      # the TypeError arm — an ambiguous request, answered rather than guessed.
+      def integer!(raw, name, default)
+        return default if raw.nil? || raw == ''
+
+        Integer(raw, 10)
+      rescue ::ArgumentError, ::TypeError
+        raise Validation::Invalid, "The '#{name}' parameter must be an integer."
+      end
+
+      # Walks `enumerable`, skips `window.offset` members, and hands at most
+      # `window.count` of them to the block, which returns the row to emit.
+      #
+      # Skipped members are never yielded, so nothing before the offset is
+      # serialized: on a queue page that is a JobRecord whose JSON is never
+      # parsed, which is most of the cost of a deep page.
+      def slice(enumerable, window)
+        rows = []
+        skipped = 0
+        enumerable.each do |member|
+          if skipped < window.offset
+            skipped += 1
+            next
+          end
+
+          rows << yield(member)
+          break if rows.size >= window.count
+        end
+        rows
+      end
+    end
+  end
+end

--- a/lib/wurk/api/page.rb
+++ b/lib/wurk/api/page.rb
@@ -36,8 +36,12 @@ module Wurk
       #   asking for more rows than the API will give is not a client bug — and
       #   every listing echoes the effective values back, so the clamp is
       #   visible rather than silent.
-      def window!(request)
-        query = query!(request)
+      def window!(request) = window(query!(request))
+
+      # The parsed-query half, for a route that reads a parameter of its own
+      # (`?filter=`) beside the paging ones: it parses once and hands the same
+      # Hash to both, rather than re-parsing the query string per parameter.
+      def window(query)
         Window.new(
           page: integer!(query['page'], 'page', 0).clamp(0, MAX_PAGE),
           count: integer!(query['count'], 'count', DEFAULT_COUNT).clamp(1, MAX_COUNT)

--- a/lib/wurk/api/problem.rb
+++ b/lib/wurk/api/problem.rb
@@ -51,6 +51,16 @@ module Wurk
       # not answered yet, which it fixes by waiting.
       IDEMPOTENCY_KEY_REUSED = 'idempotency_key_reused'
       REQUEST_IN_PROGRESS = 'request_in_progress'
+      # Not `insufficient_scope`: the credential is granted everything it needs
+      # and would work against another deployment unchanged. Nothing the client
+      # can send fixes this one, which is why it gets its own slug — a producer
+      # that retried a 403 forever on a frozen deployment is the failure this
+      # avoids.
+      READ_ONLY = 'read_only'
+      # The one refusal that comes with a time attached. `retry_after` repeats
+      # the header as a number so a client that already parses this body does
+      # not have to reach back into the headers for it.
+      RATE_LIMITED = 'rate_limited'
 
       # Every slug needs a human title; `fetch` below turns a missing one into a
       # loud failure in the test suite rather than a half-formed error body.
@@ -69,7 +79,9 @@ module Wurk
         PAYLOAD_TOO_LARGE => 'Payload Too Large',
         CLASS_NOT_ALLOWED => 'Class Not Allowed',
         IDEMPOTENCY_KEY_REUSED => 'Idempotency Key Reused',
-        REQUEST_IN_PROGRESS => 'Request In Progress'
+        REQUEST_IN_PROGRESS => 'Request In Progress',
+        READ_ONLY => 'Read-Only Mode',
+        RATE_LIMITED => 'Too Many Requests'
       }.freeze
 
       module_function

--- a/lib/wurk/api/problem.rb
+++ b/lib/wurk/api/problem.rb
@@ -24,6 +24,9 @@ module Wurk
       # client that asked to cancel a job needs to tell "you addressed nothing"
       # apart from "that job already ran".
       JOB_NOT_FOUND = 'job_not_found'
+      # The same distinction one addressable resource over: a well-formed bid
+      # the `batches` set has never held, as opposed to a mistyped path.
+      BATCH_NOT_FOUND = 'batch_not_found'
       # Named for RFC 6750 §3.1 so the slug and the `error=` the 403 carries in
       # WWW-Authenticate are the same word.
       INSUFFICIENT_SCOPE = 'insufficient_scope'
@@ -53,6 +56,7 @@ module Wurk
         INSUFFICIENT_SCOPE => 'Insufficient Scope',
         INVALID_REQUEST => 'Invalid Request',
         JOB_NOT_FOUND => 'Job Not Found',
+        BATCH_NOT_FOUND => 'Batch Not Found',
         PAYLOAD_TOO_LARGE => 'Payload Too Large',
         CLASS_NOT_ALLOWED => 'Class Not Allowed',
         IDEMPOTENCY_KEY_REUSED => 'Idempotency Key Reused',
@@ -69,6 +73,14 @@ module Wurk
         }
         body.merge!(extra)
         [status, response_headers(headers), [::JSON.generate(body)]]
+      end
+
+      # Renders a refusal that already knows which problem it is — the shape
+      # Validation::Invalid carries. The mapping from a rejection to a status
+      # code stays with the check that made it, so a new rejection never needs
+      # a new arm in the route that surfaces it.
+      def from(error, instance:)
+        render(error.type, status: error.status, detail: error.message, instance: instance, **error.extra)
       end
 
       # nosniff so a browser pointed at an error can never be talked into

--- a/lib/wurk/api/problem.rb
+++ b/lib/wurk/api/problem.rb
@@ -27,6 +27,13 @@ module Wurk
       # The same distinction one addressable resource over: a well-formed bid
       # the `batches` set has never held, as opposed to a mistyped path.
       BATCH_NOT_FOUND = 'batch_not_found'
+      # A well-formed identity that no live heartbeat answers to — the process
+      # exited, or its beat lapsed and Redis reaped the row.
+      PROCESS_NOT_FOUND = 'process_not_found'
+      # The process is live and the caller may signal it, but this one cannot
+      # be signalled at all: an embedded process shares its host application's
+      # PID, so a TSTP or TERM aimed at it would hit the web server around it.
+      PROCESS_NOT_SIGNALABLE = 'process_not_signalable'
       # Named for RFC 6750 §3.1 so the slug and the `error=` the 403 carries in
       # WWW-Authenticate are the same word.
       INSUFFICIENT_SCOPE = 'insufficient_scope'
@@ -57,6 +64,8 @@ module Wurk
         INVALID_REQUEST => 'Invalid Request',
         JOB_NOT_FOUND => 'Job Not Found',
         BATCH_NOT_FOUND => 'Batch Not Found',
+        PROCESS_NOT_FOUND => 'Process Not Found',
+        PROCESS_NOT_SIGNALABLE => 'Process Not Signalable',
         PAYLOAD_TOO_LARGE => 'Payload Too Large',
         CLASS_NOT_ALLOWED => 'Class Not Allowed',
         IDEMPOTENCY_KEY_REUSED => 'Idempotency Key Reused',

--- a/lib/wurk/api/queues.rb
+++ b/lib/wurk/api/queues.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require_relative 'page'
+require_relative 'problem'
+require_relative 'response'
+require_relative 'serializers'
+require_relative 'validation'
+
+module Wurk
+  module API
+    # The observe plane: how deep the queues are, what is waiting to retry,
+    # what died, and the counters over the lot.
+    #
+    # Every route reads through a canonical inspector — {Wurk::Stats},
+    # {Wurk::Queue}, {Wurk::RetrySet}, {Wurk::ScheduledSet}, {Wurk::DeadSet},
+    # {Wurk::Batch::Status} — the same objects the dashboard reads. Not to save
+    # code: a second reader over the same Redis keys is a second place for the
+    # size-descending queue order, the latency math, the `paused` set and the
+    # ActiveJob unwrapping to drift, and a dashboard and an API that disagree
+    # about how deep a queue is are worse than either on its own.
+    #
+    # Pause and unpause are the only writes, and they go through
+    # {Wurk::Queue#pause!} / {Wurk::Queue#unpause!}, which expire this
+    # process's fetcher cache of the `paused` set. A bare SADD here would leave
+    # the swarm fetching from a queue the API had just reported paused.
+    module Queues
+      module_function
+
+      # Verb, pattern, the scope a caller must hold, handler. A table rather
+      # than nine `router.get` calls because the scope column is the part that
+      # has to be read at a glance: the two writes take :admin, not :read.
+      # Pausing `default` stops the fleet from working without enqueueing or
+      # deleting anything, so it belongs with the destructive routes rather
+      # than with the listings it sits beside.
+      TABLE = [
+        [:get, '/stats', :read, :stats],
+        [:get, '/queues', :read, :index],
+        [:get, '/queues/:name', :read, :show],
+        [:get, '/retries', :read, :retries],
+        [:get, '/scheduled', :read, :scheduled],
+        [:get, '/dead', :read, :dead],
+        [:get, '/batches/:bid', :read, :batch],
+        [:post, '/queues/:name/pause', :admin, :pause],
+        [:post, '/queues/:name/unpause', :admin, :unpause]
+      ].freeze
+
+      # The refusal rendering wraps every handler here rather than sitting in
+      # each one: they all validate something that came off the network, and a
+      # rescue repeated per route is one a new route gets written without.
+      def draw(router)
+        TABLE.each do |verb, pattern, scope, handler|
+          router.public_send(verb, pattern, scope: scope) do |request|
+            public_send(handler, request)
+          rescue Validation::Invalid => e
+            Problem.from(e, instance: request.path)
+          end
+        end
+      end
+
+      def stats(_request)
+        Response.json(200, Serializers.stats(::Wurk::Stats.new))
+      end
+
+      # Stats#queue_summaries rather than Queue.all: one pipeline instead of an
+      # LLEN round trip per queue, and it comes back in the size-descending
+      # order every other Wurk surface lists queues in.
+      def index(_request)
+        Response.json(200, queues: ::Wurk::Stats.new.queue_summaries.map { |q| Serializers.queue_summary(q) })
+      end
+
+      # No 404 for a name nothing was ever enqueued under. A queue is not an
+      # entity in the Sidekiq schema — it is a LIST that exists only while it
+      # has members — so "never used" and "drained" are the same state in
+      # Redis, and `size: 0` is the honest reading of both. Pausing one before
+      # its first job is a legitimate pre-deploy move for the same reason.
+      def show(request)
+        window = Page.window!(request)
+        queue = ::Wurk::Queue.new(Validation.queue_name!(request.path_params[:name]))
+        jobs = Page.slice(queue, window) { |record| Serializers.job_record(record) }
+        Response.json(200, Serializers.queue_gauges(queue).merge(page: window.page, count: window.count, jobs: jobs))
+      end
+
+      def retries(request) = sorted_set(request, ::Wurk::RetrySet.new)
+      def scheduled(request) = sorted_set(request, ::Wurk::ScheduledSet.new)
+      def dead(request) = sorted_set(request, ::Wurk::DeadSet.new)
+
+      def pause(request) = toggle(request, paused: true)
+      def unpause(request) = toggle(request, paused: false)
+
+      # Idempotent both ways (SADD/SREM), and the resulting state comes back so
+      # a client does not need a second request to confirm the toggle.
+      def toggle(request, paused:)
+        queue = ::Wurk::Queue.new(Validation.queue_name!(request.path_params[:name]))
+        paused ? queue.pause! : queue.unpause!
+        Response.json(200, name: queue.name, paused: paused)
+      end
+
+      # `total` is read before the page is walked, so it describes the set the
+      # page was taken from rather than the one left after a poller drained it.
+      def sorted_set(request, set)
+        window = Page.window!(request)
+        total = set.size
+        jobs = Page.slice(set, window) { |entry| Serializers.sorted_entry(entry) }
+        Response.json(200, name: set.name, total: total, page: window.page, count: window.count, jobs: jobs)
+      end
+
+      def batch(request)
+        bid = Validation.bid!(request.path_params[:bid])
+        status = ::Wurk::Batch::Status.new(bid)
+        return batch_not_found(request, bid) unless status.exists?
+
+        Response.json(200, status.data)
+      end
+
+      def batch_not_found(request, bid)
+        Problem.render(
+          Problem::BATCH_NOT_FOUND,
+          status: 404,
+          detail: "No batch has bid #{bid}; it was never created, or it has expired.",
+          instance: request.path,
+          bid: bid
+        )
+      end
+    end
+  end
+end

--- a/lib/wurk/api/read_only.rb
+++ b/lib/wurk/api/read_only.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require_relative '../api'
+require_relative 'problem'
+
+module Wurk
+  module API
+    # Whether this deployment answers anything but reads.
+    #
+    # The dashboard has had a read-only mode since the beginning
+    # (`Wurk::Web.config.read_only`, `WURK_WEB_READ_ONLY=1`): a viewer-only
+    # deploy — the public demo is one — where every non-safe verb 403s. The
+    # machine plane keeps exactly that rule, verb for verb, so "read-only"
+    # means one thing across Wurk instead of two. That freezes `admin`'s
+    # destructive routes and `enqueue` alike: a deployment an operator may not
+    # retry a job on is not one a stranger should be able to start a thousand
+    # on, and the alternative is a word whose meaning depends on which plane
+    # you are standing in.
+    #
+    # Only the *mount* differs, and it has to — see `Configuration#api_read_only`
+    # for the three states. Nested in the engine, this API is part of the
+    # dashboard's deployment and inherits its flag through the Rack env
+    # (`Wurk::Web::Authorization` stamps {Wurk::API::READ_ONLY_ENV}). Mounted on
+    # its own path or run standalone it is a different deployment, has no engine
+    # in front of it to stamp anything, and says so itself or not at all.
+    module ReadOnly
+      # RFC 9110 §9.2.1 — the verbs with no side effects the client asked for.
+      # The same three the dashboard's Authorization middleware allows; the API
+      # registers no OPTIONS route, but a read-only deploy refusing a preflight
+      # would be a lie about why.
+      SAFE_METHODS = %w[GET HEAD OPTIONS].freeze
+
+      module_function
+
+      # An explicit setting wins both ways — `false` is how a host keeps its
+      # producer live under a read-only dashboard, so it has to outrank what the
+      # engine stamped, not merely be OR'd into it.
+      #
+      # @return [Boolean] whether writes are frozen for this request's mount.
+      def enabled?(request)
+        explicit = request.config.api_read_only
+        return explicit unless explicit.nil?
+
+        inherited?(request) || request.config.api_read_only?
+      end
+
+      # @return [Array, nil] a 403 problem triple, or nil to let the request on.
+      def refuse(request)
+        return nil if SAFE_METHODS.include?(request.request_method)
+        return nil unless enabled?(request)
+
+        Problem.render(
+          Problem::READ_ONLY,
+          status: 403,
+          detail: 'This Wurk deployment is read-only; it answers GET and HEAD only.',
+          instance: request.path
+        )
+      end
+
+      # Checked before routing, so a write to a path that does not exist is
+      # refused for the reason that applies to every write here rather than
+      # 404ing and leaving a client to discover the freeze one route later.
+      def inherited?(request)
+        !!request.get_header(::Wurk::API::READ_ONLY_ENV)
+      end
+    end
+  end
+end

--- a/lib/wurk/api/roll_up.rb
+++ b/lib/wurk/api/roll_up.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require_relative 'serializers'
+
+module Wurk
+  module API
+    # `GET /swarm`: many heartbeats folded into one answer to "how is the
+    # swarm actually working". Serializers shapes one process; this shapes the
+    # cluster, and it is the only place the two differ in kind.
+    #
+    # A pure function of the {Wurk::Process} list it is handed — no Redis of
+    # its own — so the roll-up and the `/processes` listing beside it can only
+    # ever describe the same fleet.
+    #
+    # What it deliberately does not report: the swarm parent's rolling-restart
+    # state. `Wurk::Swarm::Restart` is a state machine in the parent's memory —
+    # which slot is being replaced, whether its replacement has beaten yet —
+    # and no part of it is ever written to Redis. The API usually runs in a
+    # different process entirely (a Rails web worker, or standalone `wurk
+    # api`), so the only way to serve it would be new heartbeat traffic, which
+    # is exactly what this plane may not add. The observable signature is here
+    # instead: `versions` holds more than one entry while a deploy is
+    # mid-flight, `processes.quiet` counts the children already told to drain,
+    # and `hosts` shows the per-host child count the replacements land in.
+    module RollUp
+      module_function
+
+      # @param processes [Array<Wurk::Process>] live heartbeats, already
+      #   filtered of identities whose `info` has expired (ProcessSet#each).
+      # @param leader_identity [String] the `dear-leader` value, read once.
+      # @param now [Float] epoch seconds, taken once for the whole answer.
+      def cluster(processes, leader_identity:, now:)
+        ages = processes.map { |process| Serializers.beat_age_seconds(process['beat'], now) }
+        {
+          processes: process_counts(processes, ages),
+          **totals(processes),
+          queues: processes.flat_map(&:queues).compact.uniq.sort,
+          versions: processes.filter_map(&:version).uniq.sort,
+          leader: leader(processes, leader_identity),
+          hosts: hosts(processes),
+          slots: slots(processes),
+          beat: beat(ages)
+        }
+      end
+
+      def totals(processes)
+        concurrency = sum(processes, 'concurrency')
+        busy = sum(processes, 'busy')
+        {
+          concurrency: concurrency, busy: busy,
+          utilization: utilization(busy, concurrency), rss_kb: sum(processes, 'rss')
+        }
+      end
+
+      def sum(processes, field) = processes.sum { |process| process[field].to_i }
+
+      def process_counts(processes, ages)
+        {
+          total: processes.size,
+          quiet: processes.count(&:stopping?),
+          stale: ages.count { |age| Serializers.stale?(age) }
+        }
+      end
+
+      # Busy threads over total threads, as a fraction. Zero rather than a
+      # division by zero when nothing is running: an empty fleet is 0% busy,
+      # and a null here would only push the special case onto every client.
+      def utilization(busy, concurrency)
+        return 0.0 if concurrency.zero?
+
+        (busy.to_f / concurrency).round(4)
+      end
+
+      # `live` distinguishes a leader that is still beating from a lock left
+      # behind by a process that died holding it — the key outlives the
+      # heartbeat by up to its own TTL, and during that gap the cluster has a
+      # recorded leader and no leader.
+      def leader(processes, identity)
+        identity = identity.to_s
+        return { identity: nil, live: false } if identity.empty?
+
+        { identity: identity, live: processes.any? { |process| process.identity == identity } }
+      end
+
+      # Per-host roll-up, which is what "how many children is this box
+      # running" actually asks. Hardware facts ride here rather than on every
+      # process row: they describe the box, and repeating them per child would
+      # invite a client to average them.
+      def hosts(processes)
+        grouped = processes.group_by { |process| process['hostname'] }
+        grouped.map { |hostname, group| host(hostname, group) }.sort_by { |host| host[:hostname].to_s }
+      end
+
+      def host(hostname, group)
+        facts = group.first
+        {
+          hostname: hostname, processes: group.size,
+          concurrency: sum(group, 'concurrency'), busy: sum(group, 'busy'), rss_kb: sum(group, 'rss'),
+          cpu_model: facts['cpu_model'], cores: facts['cores'], memory_total_kb: facts['memory_total_kb']
+        }
+      end
+
+      # The topology as the heartbeats describe it, in {Wurk::Topology::Slot}'s
+      # own vocabulary: how many children of each (queues, concurrency) kind
+      # are live. Observed rather than read off `config.topology`, because the
+      # declaration lives in the swarm parent's configuration and the process
+      # answering this request may not share it — a standalone `wurk api` would
+      # otherwise report a slot table derived from its own CPU count, which
+      # describes nothing that is running.
+      def slots(processes)
+        grouped = processes.group_by { |process| [process.queues.to_a.sort, process['concurrency'].to_i] }
+        rows = grouped.map do |(queues, concurrency), group|
+          { count: group.size, queues: queues, concurrency: concurrency }
+        end
+        rows.sort_by { |slot| [-slot[:count], slot[:queues]] }
+      end
+
+      # The oldest beat is the one that says whether anything has gone quiet on
+      # the wire; the threshold ships with it so a client reads the verdict and
+      # the rule behind it in the same document.
+      def beat(ages)
+        { oldest_age_seconds: ages.max, stale_after_seconds: Serializers::STALE_AFTER_SECONDS }
+      end
+    end
+  end
+end

--- a/lib/wurk/api/serializers.rb
+++ b/lib/wurk/api/serializers.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'json'
+
 module Wurk
   module API
     # Wire shapes for the observe plane.
@@ -13,7 +15,119 @@ module Wurk
     # extension rows — an engine dependency the API cannot take, because it
     # also runs standalone. Under /v1 these field names are a contract.
     module Serializers
+      # Three missed beats at {Wurk::Heartbeat::BEAT_PAUSE} cadence, which is
+      # also the window Wurk::Health calls a heartbeat stale, and half the
+      # heartbeat key's TTL — so a process that stopped beating is reported
+      # stale for ~30s before Redis reaps the row out from under this API.
+      STALE_AFTER_SECONDS = ::Wurk::Heartbeat::BEAT_PAUSE * 3
+
       module_function
+
+      # Seconds since this process last beat, measured against a `now` the
+      # caller took once for the whole listing so rows never disagree by a
+      # round trip. Floored at zero: `beat` is stamped by the beating process's
+      # clock and this is read on another host's, so a skew of a few
+      # milliseconds must not surface as a negative age.
+      def beat_age_seconds(beat, now)
+        [now - beat.to_f, 0.0].max.round(3)
+      end
+
+      def stale?(age) = age > STALE_AFTER_SECONDS
+
+      # One live process. `beat_age_seconds` and `stale` are derived here
+      # rather than left to the client: a client comparing `beat` against its
+      # own clock is comparing two clocks, which is the one comparison this
+      # roll-up exists to save it from.
+      #
+      # `leader` is passed in because the two callers learn it differently — a
+      # listing compares against one memoized `dear-leader` read, a single
+      # process asks itself — and neither should pay the other's round trips.
+      def process_row(process, leader:, now:)
+        declared(process, now).merge(measured(process, now)).merge(leader: leader)
+      end
+
+      # The half a process wrote about itself in the `info` JSON: who it is and
+      # what it was configured to do. Split along the same seam the heartbeat
+      # itself uses (Heartbeat#info_hash versus #beat_hash_args), so a field
+      # that moves between the two halves upstream moves between these.
+      def declared(process, now)
+        {
+          identity: process.identity, hostname: process['hostname'], pid: process['pid'],
+          tag: process.tag, version: process.version, embedded: process.embedded?,
+          concurrency: process['concurrency'], queues: process.queues,
+          weights: process.weights, labels: process.labels,
+          started_at: process['started_at'], uptime_seconds: uptime_seconds(process['started_at'], now)
+        }
+      end
+
+      # The half its last beat measured, plus the two values derived from it.
+      def measured(process, now)
+        age = beat_age_seconds(process['beat'], now)
+        {
+          busy: process['busy'], rss_kb: process['rss'], rtt_us: process['rtt_us'],
+          beat: process['beat'], beat_age_seconds: age, stale: stale?(age),
+          quiet: process.stopping?
+        }
+      end
+
+      # One in-flight job. `class`/`args` are the display view for the reason
+      # {#job_record} gives, and `elapsed_seconds` is derived for the reason
+      # `beat_age_seconds` is — the client's clock is not the swarm's.
+      def work_row(process_id, thread_id, work, now:)
+        record = work.job
+        run_at = work.run_at.to_f
+        {
+          process_id: process_id, thread_id: thread_id, queue: work.queue,
+          jid: record.jid, class: record.display_class, args: record.display_args,
+          run_at: run_at, elapsed_seconds: [now - run_at, 0.0].max.round(3)
+        }
+      end
+
+      # `available`, not the `available?` {Wurk::Limiter::Base#build_status}
+      # keys it with: a trailing `?` is Ruby's convention for a predicate, not
+      # JSON's for a Boolean field. `status` is null when the limiter's
+      # metadata expired between the listing that named it and this read.
+      def limiter_row(name, meta, status)
+        {
+          name: name,
+          type: meta['type'].to_s,
+          fingerprint: meta['fingerprint'].to_s,
+          options: parse_options(meta['options']),
+          status: status && {
+            used: status[:used], limit: status[:limit],
+            reset_at: status[:reset_at], available: status[:available?]
+          }
+        }
+      end
+
+      # One registered cron loop. `next_fire_at` is evaluated against a `now`
+      # the caller took once, so every row in a listing answers "next after the
+      # same instant" rather than drifting a row at a time.
+      def cron_loop(loop_obj, now:)
+        {
+          lid: loop_obj.lid, schedule: loop_obj.schedule, class: loop_obj.klass,
+          queue: loop_obj.queue, args: loop_obj.args, tz: loop_obj.tz_name,
+          paused: loop_obj.paused?,
+          last_fired_at: loop_obj.last_fired_at,
+          next_fire_at: loop_obj.next_fire_at(now)
+        }
+      end
+
+      def parse_options(raw)
+        return {} if raw.nil? || raw.to_s.empty?
+
+        ::JSON.parse(raw)
+      rescue ::JSON::ParserError
+        {}
+      end
+
+      # nil rather than 0 when the heartbeat carries no `started_at`: a process
+      # of unknown age is not one that just booted.
+      def uptime_seconds(started_at, now)
+        return nil if started_at.nil?
+
+        [now - started_at.to_f, 0.0].max.round(3)
+      end
 
       # `default_queue_latency`, not the dashboard's `latency`: sitting beside
       # a `queues` array, a bare `latency` reads as the whole fleet's rather

--- a/lib/wurk/api/serializers.rb
+++ b/lib/wurk/api/serializers.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Wurk
+  module API
+    # Wire shapes for the observe plane.
+    #
+    # Every value below is read off a canonical inspector — Stats, Queue,
+    # JobRecord, SortedEntry — so the API and the dashboard cannot report
+    # different numbers for the same Redis. Only the shape differs, and it
+    # differs on purpose: the dashboard's serializers
+    # (app/controllers/wurk/api/serializers.rb) answer to the SPA and change
+    # whenever it does, and they reach into Wurk::Web for host-registered
+    # extension rows — an engine dependency the API cannot take, because it
+    # also runs standalone. Under /v1 these field names are a contract.
+    module Serializers
+      module_function
+
+      # `default_queue_latency`, not the dashboard's `latency`: sitting beside
+      # a `queues` array, a bare `latency` reads as the whole fleet's rather
+      # than the `default` queue's, which is what Stats measures.
+      def stats(snapshot)
+        {
+          processed: snapshot.processed,
+          failed: snapshot.failed,
+          expired: snapshot.expired,
+          enqueued: snapshot.enqueued,
+          busy: snapshot.workers_size,
+          scheduled: snapshot.scheduled_size,
+          retries: snapshot.retry_size,
+          dead: snapshot.dead_size,
+          processes: snapshot.processes_size,
+          default_queue_latency: snapshot.default_queue_latency,
+          queues: snapshot.queue_summaries.map { |summary| queue_summary(summary) }
+        }
+      end
+
+      def queue_summary(summary)
+        { name: summary.name, size: summary.size, latency: summary.latency, paused: summary.paused? }
+      end
+
+      # The same four gauges read off a Wurk::Queue instead of a pipelined
+      # Stats::QueueSummary — three round trips rather than a share of one,
+      # which is what asking about a single queue costs. Same field names on
+      # purpose: a client that read a queue out of the listing and then fetched
+      # it should not have to reshape anything.
+      def queue_gauges(queue)
+        { name: queue.name, size: queue.size, latency: queue.latency, paused: queue.paused? }
+      end
+
+      # `class` and `args` are the *display* view, the same one the dashboard
+      # renders: an ActiveJob wrapper is unwrapped to the job the host actually
+      # wrote, and an `encrypt: true` job's ciphertext argument is masked.
+      # Serving `record.args` here would publish the raw encrypted envelope of
+      # every such job over HTTP.
+      def job_record(record)
+        {
+          jid: record.jid,
+          class: record.display_class,
+          args: record.display_args,
+          queue: record.queue,
+          enqueued_at: record.enqueued_at&.to_f,
+          created_at: record.created_at&.to_f
+        }
+      end
+
+      # `at` is the member's ZSET score in epoch seconds — when it is due to
+      # retry, due to run, or when it died, depending on which set it came out
+      # of. Emitted once: the score and the timestamp are the same number, and
+      # a contract that ships both invites clients to disagree about which is
+      # authoritative.
+      def sorted_entry(entry)
+        job_record(entry).merge(
+          at: entry.at.to_f,
+          retry_count: entry['retry_count'],
+          error_class: entry['error_class'],
+          error_message: entry['error_message'],
+          failed_at: entry.failed_at&.to_f,
+          retried_at: entry.retried_at&.to_f,
+          error_backtrace: entry.error_backtrace
+        )
+      end
+    end
+  end
+end

--- a/lib/wurk/api/swarm.rb
+++ b/lib/wurk/api/swarm.rb
@@ -1,0 +1,297 @@
+# frozen_string_literal: true
+
+require_relative '../web/enterprise'
+require_relative 'page'
+require_relative 'problem'
+require_relative 'response'
+require_relative 'roll_up'
+require_relative 'serializers'
+require_relative 'validation'
+
+module Wurk
+  module API
+    # The swarm plane: how the fleet is laid out, what each process is doing
+    # right now, and the two signals an operator sends it.
+    #
+    # Read-only against Redis structures that already exist — the `processes`
+    # SET and its per-identity heartbeat HASHes, `<identity>:work`,
+    # `dear-leader`, the limiter and cron registries. No new key, no new field
+    # on the beat, and nothing here makes a process beat more often. A
+    # monitoring client polling `GET /swarm` every few seconds must cost the
+    # swarm nothing, so every route reads through the canonical inspectors
+    # ({Wurk::ProcessSet}, {Wurk::WorkSet}, {Wurk::Cron::LoopSet},
+    # Web::Enterprise::Limits) exactly as the dashboard does.
+    #
+    # One deliberate divergence from the dashboard: `ProcessSet.new(false)`
+    # everywhere. The default constructor also runs the SREM sweep for expired
+    # identities, which is a write, rate-limited by a `SET NX EX` that is
+    # itself a write. Every count reported here comes from `#each`, which
+    # already skips identities whose `info` has expired, so the sweep would buy
+    # no accuracy — only a Redis write on each poll of a plane that is supposed
+    # to be free to watch. The dashboard keeps the sweep; an operator has it
+    # open for minutes, not milliseconds.
+    module Swarm
+      # Signal targets. An identity is `<hostname>:<pid>:<nonce>`, so nothing
+      # live can be named `all` and the sentinel needs no escaping.
+      ALL = 'all'
+      QUIET_SIGNAL = 'TSTP'
+      STOP_SIGNAL = 'TERM'
+
+      MAX_FILTER_LENGTH = 255
+
+      # The two signals take :admin. Quieting the fleet stops it working
+      # without enqueueing or deleting anything — the same reasoning that puts
+      # queue pausing with the destructive routes rather than the listings.
+      TABLE = [
+        [:get, '/swarm', :read, :cluster],
+        [:get, '/processes', :read, :index],
+        [:get, '/processes/:identity', :read, :show],
+        [:post, '/processes/:identity/quiet', :admin, :quiet],
+        [:post, '/processes/:identity/stop', :admin, :stop],
+        [:get, '/busy', :read, :busy],
+        [:get, '/health', :read, :health],
+        [:get, '/limiters', :read, :limiters],
+        [:get, '/cron', :read, :cron]
+      ].freeze
+
+      module_function
+
+      def draw(router)
+        TABLE.each do |verb, pattern, scope, handler|
+          router.public_send(verb, pattern, scope: scope) do |request|
+            public_send(handler, request)
+          rescue Validation::Invalid => e
+            Problem.from(e, instance: request.path)
+          end
+        end
+      end
+
+      def cluster(_request)
+        set = ::Wurk::ProcessSet.new(false)
+        Response.json(200, RollUp.cluster(set.to_a, leader_identity: set.leader, now: ::Time.now.to_f))
+      end
+
+      # Materialized before paging so `total` counts live processes rather
+      # than `SCARD processes`, which still holds identities whose heartbeat
+      # lapsed. ProcessSet#each already costs one pipeline for the whole set,
+      # so walking it in full buys the accurate count for nothing.
+      def index(request)
+        window = Page.window!(request)
+        set = ::Wurk::ProcessSet.new(false)
+        live = set.to_a
+        leader = set.leader
+        now = ::Time.now.to_f
+        rows = Page.slice(live, window) do |process|
+          Serializers.process_row(process, leader: leader?(process, leader), now: now)
+        end
+        Response.json(200, total: live.size, page: window.page, count: window.count, processes: rows)
+      end
+
+      # The same row the listing emits, plus what this process is running, so
+      # a client that read a row out of `/processes` and then fetched it does
+      # not have to reshape anything.
+      def show(request)
+        identity = Validation.identity!(request.path_params[:identity].to_s)
+        process = ::Wurk::ProcessSet[identity]
+        return process_not_found(request, identity) unless process
+
+        now = ::Time.now.to_f
+        Response.json(
+          200,
+          process: Serializers.process_row(process, leader: process.leader?, now: now),
+          work: work_for(identity, now)
+        )
+      end
+
+      def busy(request)
+        window = Page.window!(request)
+        now = ::Time.now.to_f
+        rows = ::Wurk::WorkSet.new.to_a
+        jobs = Page.slice(rows, window) { |row| Serializers.work_row(*row, now: now) }
+        Response.json(200, total: rows.size, page: window.page, count: window.count, jobs: jobs)
+      end
+
+      # Re-derived, not proxied. {Wurk::Health} is a raw TCPServer inside each
+      # worker process, answering about its own launcher and its own
+      # heartbeat; this runs in a process that has neither, so it answers the
+      # same two questions — is Redis reachable, is anything beating — about
+      # the cluster instead. `quiet` is reported but not folded into the
+      # verdict: a draining process is still finishing work, and Health does
+      # not fail readiness for it either.
+      #
+      # Not a Kubernetes probe replacement — a probe must not carry a bearer
+      # token. `config.health_check(port:)` is still that surface.
+      def health(_request)
+        redis = ping_redis
+        return unhealthy(redis, nil, 'redis unreachable') unless redis[:ok]
+
+        counts = process_health
+        return unhealthy(redis, counts, 'no live processes') if counts[:live].zero?
+
+        Response.json(200, health_body('ok', redis, counts))
+      end
+
+      def limiters(request)
+        query = Page.query!(request)
+        window = Page.window(query)
+        names = ::Wurk::Web::Enterprise::Limits.list(filter: filter!(query))
+        rows = Page.slice(names, window) { |name| limiter_row(name) }
+        Response.json(200, total: names.size, page: window.page, count: window.count, limiters: rows)
+      end
+
+      # Walked in full before serializing. LoopSet#each yields from inside its
+      # own Redis checkout and Loop#last_fired_at takes another, so serializing
+      # mid-iteration would hold a pool slot for the length of the listing.
+      # The registry is a deploy-sized list, not a job-sized one.
+      def cron(request)
+        window = Page.window!(request)
+        loops = ::Wurk::Cron::LoopSet.new.to_a
+        now = ::Time.now.to_i
+        rows = Page.slice(loops, window) { |loop_obj| Serializers.cron_loop(loop_obj, now: now) }
+        Response.json(200, total: loops.size, page: window.page, count: window.count, cron: rows)
+      end
+
+      def quiet(request) = signal(request, :quiet!, QUIET_SIGNAL)
+      def stop(request) = signal(request, :stop!, STOP_SIGNAL)
+
+      # Both signals go through {Wurk::Process#quiet!} / `#stop!` — the same
+      # `<identity>-signals` LPUSH the Busy page sends — rather than a second
+      # writer to that list. Asynchronous by construction: the target picks the
+      # entry up on its next beat, so 200 means queued, never applied.
+      def signal(request, method, name)
+        identity = request.path_params[:identity].to_s
+        return broadcast(method, name) if identity == ALL
+
+        Validation.identity!(identity)
+        process = ::Wurk::ProcessSet[identity]
+        return process_not_found(request, identity) unless process
+        return process_not_signalable(request, identity) if process.embedded?
+
+        process.public_send(method)
+        signal_result(name, [identity], [])
+      end
+
+      # One answer shape for both ways of addressing, so a client that
+      # broadcasts and a client that names one process parse the same body.
+      # An embedded process is skipped here rather than refused: a broadcast
+      # asks about the fleet, and one member that cannot be signalled is no
+      # reason to refuse the rest.
+      def broadcast(method, name)
+        sent = []
+        skipped = []
+        ::Wurk::ProcessSet.new(false).each do |process|
+          next skipped << process.identity if process.embedded?
+
+          process.public_send(method)
+          sent << process.identity
+        end
+        signal_result(name, sent, skipped)
+      end
+
+      def signal_result(name, sent, skipped)
+        Response.json(200, signal: name, signalled: sent, skipped: skipped)
+      end
+
+      def leader?(process, leader_identity)
+        !leader_identity.to_s.empty? && process.identity == leader_identity
+      end
+
+      # Filtered out of the canonical WorkSet rather than read straight off
+      # `<identity>:work`: a second reader of that hash is a second place for
+      # the run_at ordering and the JobRecord unwrapping to drift.
+      def work_for(identity, now)
+        ::Wurk::WorkSet.new.filter_map do |process_id, thread_id, work|
+          next unless process_id == identity
+
+          Serializers.work_row(process_id, thread_id, work, now: now)
+        end
+      end
+
+      def process_health
+        now = ::Time.now.to_f
+        live = ::Wurk::ProcessSet.new(false).to_a
+        stale = live.count { |entry| Serializers.stale?(Serializers.beat_age_seconds(entry['beat'], now)) }
+        { total: live.size, live: live.size - stale, stale: stale, quiet: live.count(&:stopping?) }
+      end
+
+      # A 503 whose body is the report itself, not a problem document: an
+      # unhealthy cluster is the answer this route was asked for, and Health's
+      # own `{"status":"down","reason":…}` is the shape operators already read.
+      def unhealthy(redis, processes, reason)
+        Response.json(503, health_body('down', redis, processes).merge(reason: reason))
+      end
+
+      def health_body(status, redis, processes)
+        { status: status, redis: redis, processes: processes,
+          stale_after_seconds: Serializers::STALE_AFTER_SECONDS }
+      end
+
+      # Its own PING rather than a byproduct of another read: "is Redis
+      # reachable" has to stay answerable when every other read would raise.
+      def ping_redis
+        started = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC, :microsecond)
+        pong = ::Wurk.redis(idempotent: true) { |conn| conn.call('PING') } == 'PONG'
+        elapsed = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC, :microsecond) - started
+        { ok: pong, rtt_ms: (elapsed / 1000.0).round(3) }
+      rescue ::StandardError
+        { ok: false, rtt_ms: nil }
+      end
+
+      # Two reads per row — the metadata HASH, then the limiter's own counters
+      # — which is what the page cap bounds. Limits owns the metadata and only
+      # the limiter type knows where its state lives, so there is no single key
+      # to pipeline both out of. Rebuilt from the metadata already in hand
+      # rather than through Limits.rebuild, which would re-read it.
+      def limiter_row(name)
+        meta = ::Wurk::Web::Enterprise::Limits.metadata(name)
+        Serializers.limiter_row(name, meta, limiter_status(name, meta))
+      end
+
+      # Best-effort in the two ways a persisted limiter can refuse to come
+      # back: `build` answers nil for a type this version no longer knows, and
+      # the constructor raises ArgumentError on options it cannot accept (a
+      # `bucket` whose `interval` is gone, a name written by a later release).
+      # A row with a null status is a better answer than a 500 for the whole
+      # page. Deliberately not `rescue StandardError` — a broader net would
+      # also swallow a bug in the rebuild and report it as a missing status.
+      def limiter_status(name, meta)
+        ::Wurk::Limiter.build(name, meta['type'], Serializers.parse_options(meta['options']))&.status
+      rescue ::ArgumentError, ::TypeError
+        nil
+      end
+
+      # A repeated `?filter=a&filter=b` parses to an Array, and an unbounded
+      # one is a substring scan over every limiter name run on the caller's
+      # behalf — both answered rather than coerced.
+      def filter!(query)
+        raw = query['filter']
+        return nil if raw.nil? || raw == ''
+        return raw if raw.is_a?(::String) && raw.length <= MAX_FILTER_LENGTH
+
+        raise Validation::Invalid, "The 'filter' parameter is a string of up to #{MAX_FILTER_LENGTH} characters."
+      end
+
+      def process_not_found(request, identity)
+        Problem.render(
+          Problem::PROCESS_NOT_FOUND,
+          status: 404,
+          detail: "No live process has identity #{identity}; it has exited, or its heartbeat expired.",
+          instance: request.path,
+          identity: identity
+        )
+      end
+
+      # 409, not 400: the request is well-formed and the caller is entitled to
+      # make it — the target is simply in a state that cannot accept it.
+      def process_not_signalable(request, identity)
+        Problem.render(
+          Problem::PROCESS_NOT_SIGNALABLE,
+          status: 409,
+          detail: "Process #{identity} is embedded in its host application; signalling it would signal the host.",
+          instance: request.path,
+          identity: identity
+        )
+      end
+    end
+  end
+end

--- a/lib/wurk/api/throttle.rb
+++ b/lib/wurk/api/throttle.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require_relative '../limiter'
+require_relative 'problem'
+
+module Wurk
+  module API
+    # Per-token request ceiling for the HTTP API.
+    #
+    # A {Wurk::Limiter::Window} per credential, not a second limiter: Wurk
+    # already owns a sliding window whose trim-count-add step is one atomic Lua
+    # call timed off the Redis clock, so a fleet of web processes shares one
+    # verdict and a producer's own clock cannot argue with it. Reusing it also
+    # means an API ceiling is a limiter like any other — it registers into
+    # `lmtr-list`, and `GET /v1/limiters` and the dashboard's Limiters page show
+    # it beside the ones the jobs use.
+    #
+    # The window is named for the token's fingerprint (a truncated,
+    # domain-separated digest — {Auth#fingerprint}), never the token: the name
+    # is a Redis key and shows up in the dashboard.
+    #
+    # Off unless `config.api_rate_limit` is set, and then it is exactly one
+    # extra round trip per request. Nothing here rescues a Redis failure: a
+    # window that cannot be read cannot limit, and an API that quietly drops
+    # its ceiling the moment Redis is in trouble sheds it precisely when the
+    # load matters. The error surfaces as App's 500, which a client retries.
+    module Throttle
+      NAME_PREFIX = 'api-token:'
+
+      # No waiting. `within_limit` sleeps until a slot frees, which is right for
+      # a worker thread and wrong for a socket a client is holding open — an
+      # over-limit request has an answer already (429 + Retry-After), and it is
+      # cheaper for both ends than a held connection.
+      NO_WAIT = 0
+
+      # Retry-After is a whole number of seconds (RFC 9110 §10.2.3) and must
+      # never be 0: a client that reads "wait 0" retries immediately, which is
+      # what got it throttled.
+      MIN_RETRY_AFTER = 1
+
+      LOCK = Mutex.new
+
+      module_function
+
+      # @return [Array, nil] a 429 problem triple, or nil when the request may
+      #   proceed (including when no limit is configured).
+      def refuse(request)
+        limit = request.config.api_rate_limit
+        return nil unless limit
+
+        interval = request.config.api_rate_limit_interval
+        limiter = for_principal(request.principal, limit, interval)
+        limiter.within_limit { nil }
+      rescue ::Wurk::Limiter::OverLimit => e
+        over_limit(request, e.limiter, limit, interval)
+      end
+
+      # Limiters are stateless Ruby objects — every operation is a Lua call — so
+      # one per (credential, ceiling) is safe to keep and share across threads
+      # and across a fork. Kept because constructing one writes its metadata
+      # hash, and paying that round trip per request would double the cost of
+      # the feature. Keyed by the ceiling too, so a host that changes it gets a
+      # limiter that agrees with the config rather than the one built first.
+      def for_principal(principal, limit, interval)
+        key = [principal.id, limit, interval]
+        found = LOCK.synchronize { cache[key] }
+        return found if found
+
+        # Built outside the lock: registration is a Redis round trip, and a
+        # racing second build only rewrites the same metadata hash.
+        built = ::Wurk::Limiter.window("#{NAME_PREFIX}#{principal.id}", limit, interval, wait_timeout: NO_WAIT)
+        LOCK.synchronize { cache[key] ||= built }
+      end
+
+      def cache
+        @cache ||= {}
+      end
+
+      # `reset_at` is when the window's oldest entry slides out — the first
+      # moment a slot exists — read fresh rather than guessed from the interval,
+      # which would tell a client that trickled up to the ceiling to wait a full
+      # window for a slot that frees in a second. One extra read, on the refused
+      # path only.
+      def retry_after(limiter, interval)
+        reset_at = limiter.status[:reset_at]
+        seconds = reset_at ? (reset_at - ::Time.now.to_f).ceil : interval_seconds(interval)
+        [seconds, MIN_RETRY_AFTER].max
+      end
+
+      def interval_seconds(interval)
+        ::Wurk::Limiter.interval_seconds(interval, allow_integer: true)
+      end
+
+      def over_limit(request, limiter, limit, interval)
+        seconds = retry_after(limiter, interval)
+        Problem.render(
+          Problem::RATE_LIMITED,
+          status: 429,
+          detail: "This token is limited to #{limit} requests per #{interval}.",
+          instance: request.path,
+          headers: { 'retry-after' => seconds.to_s },
+          limit: limit,
+          interval_seconds: interval_seconds(interval),
+          retry_after: seconds
+        )
+      end
+    end
+  end
+end

--- a/lib/wurk/api/validation.rb
+++ b/lib/wurk/api/validation.rb
@@ -65,6 +65,14 @@ module Wurk
       # it is echoed back on every listing.
       QUEUE_NAME_FORMAT = /\A[^[:space:][:cntrl:]]{1,255}\z/
 
+      # A process identity is `<hostname>:<pid>:<nonce>` and is itself a Redis
+      # key — the heartbeat HASH, `<identity>:work` and `<identity>-signals`
+      # are all built by interpolating it. The same shape as a queue name for
+      # the same reason, spelled separately because the two doors are
+      # independent: bounding what may be addressed as a queue says nothing
+      # about what may be addressed as a process.
+      IDENTITY_FORMAT = /\A[^[:space:][:cntrl:]]{1,255}\z/
+
       # Same word the router uses for "any scope": here it turns the class
       # allow-list off.
       ANY = :any
@@ -175,6 +183,14 @@ module Wurk
         return name if name.is_a?(::String) && QUEUE_NAME_FORMAT.match?(name)
 
         raise Invalid, 'A queue name is up to 255 characters with no whitespace or control characters.'
+      end
+
+      # @raise [Invalid] unless `identity` fits {IDENTITY_FORMAT}.
+      # @return [String] the process identity.
+      def identity!(identity)
+        return identity if identity.is_a?(::String) && IDENTITY_FORMAT.match?(identity)
+
+        raise Invalid, 'A process identity is up to 255 characters with no whitespace or control characters.'
       end
 
       # Validates the allow-list where it is declared, so a typo'd class name

--- a/lib/wurk/api/validation.rb
+++ b/lib/wurk/api/validation.rb
@@ -5,7 +5,7 @@ require_relative 'problem'
 
 module Wurk
   module API
-    # Everything the produce plane refuses before {Wurk::Client} sees it.
+    # Everything the API refuses at its boundary, before a Wurk object sees it.
     #
     # Client validates a job hash written by Ruby running in this process. This
     # validates one typed by a stranger, and the two are different jobs.
@@ -55,6 +55,15 @@ module Wurk
       # `SecureRandom.hex(12)`; admit any URL-safe token of a sane length and
       # refuse the rest at the door.
       JID_FORMAT = /\A[A-Za-z0-9_-]{1,255}\z/
+
+      # A queue name arrives as one path segment (percent-decoded by the
+      # router, so a name containing '/' is reachable) and reaches Redis as
+      # `queue:<name>`. The Sidekiq schema bounds it nowhere, so this door
+      # does: whitespace and control characters are out because a name
+      # carrying them is one no operator can type back into the dashboard or a
+      # CLI flag, and the length cap exists for the same reason a jid's does —
+      # it is echoed back on every listing.
+      QUEUE_NAME_FORMAT = /\A[^[:space:][:cntrl:]]{1,255}\z/
 
       # Same word the router uses for "any scope": here it turns the class
       # allow-list off.
@@ -146,10 +155,26 @@ module Wurk
 
       # @raise [Invalid] unless `jid` is a URL-safe token of a sane length.
       # @return [String] the jid.
-      def jid!(jid)
-        return jid if jid.is_a?(::String) && JID_FORMAT.match?(jid)
+      def jid!(jid) = url_safe!(jid, 'jid')
 
-        raise Invalid, 'A jid is a URL-safe token of up to 255 characters.'
+      # A bid indexes `b-<bid>` and its satellite keys, and Batch::Status
+      # builds every one of them by interpolation — the same key-fragment
+      # exposure a jid has, so the same door.
+      # @return [String] the bid.
+      def bid!(bid) = url_safe!(bid, 'batch id')
+
+      def url_safe!(value, label)
+        return value if value.is_a?(::String) && JID_FORMAT.match?(value)
+
+        raise Invalid, "A #{label} is a URL-safe token of up to 255 characters."
+      end
+
+      # @raise [Invalid] unless `name` fits {QUEUE_NAME_FORMAT}.
+      # @return [String] the queue name.
+      def queue_name!(name)
+        return name if name.is_a?(::String) && QUEUE_NAME_FORMAT.match?(name)
+
+        raise Invalid, 'A queue name is up to 255 characters with no whitespace or control characters.'
       end
 
       # Validates the allow-list where it is declared, so a typo'd class name

--- a/lib/wurk/cli.rb
+++ b/lib/wurk/cli.rb
@@ -24,6 +24,27 @@ module Wurk
     # format and Lua scripts rely on commands introduced in Redis 7.
     MIN_REDIS_VERSION = '7.0.0'
 
+    # Subcommands. Bare `wurk` runs the worker — the historical shape, and the
+    # only one the swarm binaries accept — so a subcommand is never anything
+    # but the first argument, and every argument after it is that command's.
+    COMMANDS = %w[api].freeze
+
+    # `wurk api` defaults. 0.0.0.0 because the point of the machine API is for
+    # another service to reach it; it is bearer-gated, and answers 404 to
+    # everything until a token exists. `--bind 127.0.0.1` narrows it.
+    DEFAULT_API_BIND = '0.0.0.0'
+    DEFAULT_API_PORT = 7433
+
+    # Serving the API with nothing registered would bind a port and 404 every
+    # request — the surface is off until a token exists, so say so at boot
+    # rather than leaving an operator to diagnose it over HTTP.
+    NO_API_TOKEN_MESSAGE = <<~MSG
+      No API token is registered, so every request would answer 404.
+      Register one where the app loaded by -r configures wurk:
+
+          Wurk.configuration.api_token(ENV.fetch('WURK_API_TOKEN'), scopes: %i[enqueue read])
+    MSG
+
     # Thread-backtrace dumper used by both TTIN and INFO. Same body — INFO is
     # the modern name, TTIN is kept for parity with older Sidekiq users.
     BACKTRACE_DUMPER = lambda do |cli|
@@ -68,7 +89,19 @@ module Wurk
       ['-C', '--config PATH',          :config_file, 'path to YAML config file']
     ].freeze
 
+    # Same table shape, offered only when `api` is the subcommand: none of it
+    # means anything to a worker process, and `wurk --help` stays the worker's.
+    API_OPTION_FLAGS = [
+      ['-b', '--bind ADDRESS', :api_bind,   "Address to bind (default #{DEFAULT_API_BIND})"],
+      ['-p', '--port PORT',    :api_port,   "Port to listen on (default #{DEFAULT_API_PORT})", :to_i],
+      ['-s', '--server NAME',  :api_server, 'Rack handler to serve with (default: the first installed)']
+    ].freeze
+
     attr_accessor :launcher, :environment, :config
+
+    # The subcommand `parse` pulled off argv, or nil for the worker runner.
+    # The binary picks the mode from it — `exe/wurk` runs the API for `api`.
+    attr_reader :command
 
     def self.instance
       @instance ||= new
@@ -84,12 +117,14 @@ module Wurk
       @launcher = nil
       @environment = nil
       @parser = nil
+      @command = nil
     end
 
     # `parse` is split from `run` so tests can drive option parsing without
     # touching Redis or booting the host app.
     def parse(args = ARGV.dup)
       @config ||= Wurk.default_configuration
+      @command = extract_command!(args)
       setup_options(args)
       initialize_logger
       validate!
@@ -137,6 +172,8 @@ module Wurk
     # `SIDEKIQ_PRELOAD_APP` whole-app eager-load) and boots `Process.warmup`
     # before the fork so children share warmed pages (copy-on-write). Spec §7.
     def run_swarm(boot_app: true, warmup: true)
+      raise ArgumentError, "the swarm runner takes no subcommand; run `wurk #{@command}` instead" if @command
+
       # Server mode before the app loads — see #run. The flag rides through the
       # fork into every child (the config object is copied), so configure_server
       # blocks registered in the parent take effect in the workers.
@@ -163,6 +200,32 @@ module Wurk
       end
     end
 
+    # `wurk api` — serve the machine-facing HTTP API and nothing else: no
+    # fetcher, no heartbeat, no job ever runs here. This is mount mode 3, the
+    # standalone one: the same Rack app the engine nests and a host can mount
+    # itself, served without Rails.
+    #
+    # Server mode is entered for the reason #run does it — a host that
+    # registers its token inside a `configure_server` block would otherwise
+    # boot an API with no credential and 404 every request. Nothing starts as a
+    # side effect: no lifecycle event fires and no Launcher is ever built.
+    #
+    # `handler:` is a test seam; production resolves one from the installed
+    # gems.
+    def run_api(boot_app: true, handler: nil)
+      enter_server_mode
+      boot_application if boot_app
+      validate_redis!
+      # Load the app here, not on the first request: a broken load should fail
+      # the boot an operator is watching, not the first client to call.
+      require_relative 'api/app'
+      raise ArgumentError, NO_API_TOKEN_MESSAGE unless @config.api_enabled?
+
+      handler ||= api_handler(@config[:api_server])
+      logger.info { "Wurk API listening on http://#{api_bind}:#{api_port}#{Wurk::API::VERSION_PREFIX}" }
+      handler.run(Wurk::API, Host: api_bind, Port: api_port)
+    end
+
     def handle_signal(sig)
       logger.debug { "Got #{sig} signal" }
       handler = SIGNAL_HANDLERS[sig]
@@ -186,6 +249,29 @@ module Wurk
       return unless ::Process.respond_to?(:warmup) && ENV['RUBY_DISABLE_WARMUP'] != '1'
 
       ::Process.warmup
+    end
+
+    def api_bind = @config[:api_bind] || DEFAULT_API_BIND
+    def api_port = @config[:api_port] || DEFAULT_API_PORT
+
+    # Rack 3 moved the server handlers out to the `rackup` gem; rack 2 still
+    # ships them itself. Neither is a wurk dependency — the web server is the
+    # host's choice here exactly as it is for the app this sits next to — so
+    # resolve one at run time and name the fix when there is none.
+    def api_handler(name)
+      registry = handler_registry
+      name ? registry.get(name) : registry.default
+    rescue ::LoadError, ::NameError, ::ArgumentError => e
+      raise ArgumentError, "wurk api could not start a web server (#{e.message}). Add one to your Gemfile " \
+                           '— puma, falcon, or rackup + webrick — or name an installed one with --server.'
+    end
+
+    def handler_registry
+      require 'rackup/handler'
+      ::Rackup::Handler
+    rescue ::LoadError
+      require 'rack/handler'
+      ::Rack::Handler
     end
 
     def launch(self_read)
@@ -270,6 +356,14 @@ module Wurk
 
     # --- options + config-file --------------------------------------------
 
+    # Pulled off before OptionParser sees argv, so the banner and the flag
+    # table can depend on which command was named. A bare word OptionParser
+    # doesn't recognize would otherwise survive `parse!` and be silently
+    # ignored, which is how `wurk api` would look like it worked.
+    def extract_command!(args)
+      COMMANDS.include?(args.first) ? args.shift : nil
+    end
+
     def setup_options(args)
       opts = parse_options(args)
       set_environment(opts[:environment])
@@ -351,14 +445,15 @@ module Wurk
 
     def option_parser(opts)
       ::OptionParser.new do |o|
-        o.banner = 'wurk [options]'
-        define_value_flags(o, opts)
+        o.banner = @command ? "wurk #{@command} [options]" : 'wurk [options]'
+        define_value_flags(o, opts, OPTION_FLAGS)
+        define_value_flags(o, opts, API_OPTION_FLAGS) if @command == 'api'
         define_meta_flags(o, opts)
       end
     end
 
-    def define_value_flags(parser, opts)
-      OPTION_FLAGS.each do |short, long, key, desc, transform|
+    def define_value_flags(parser, opts, flags)
+      flags.each do |short, long, key, desc, transform|
         parser.on(short, long, desc) { |arg| assign_flag(opts, key, arg, transform) }
       end
     end

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -84,7 +84,15 @@ module Wurk
       api_idempotency_ttl: 3_600,
       # Allow-list of classes the HTTP API may enqueue. nil (the default) means
       # only an `admin` token may enqueue at all — see #api_enqueue_classes=.
-      api_enqueue_classes: nil
+      api_enqueue_classes: nil,
+      # Three-state on purpose — see #api_read_only=. nil is "inherit", which
+      # only mount mode 1 has anything to inherit from.
+      api_read_only: nil,
+      # Per-token request ceiling. nil is off: the API adds no Redis work to a
+      # request until a host asks for a limit, and no number picked here would
+      # be right for both a cron relay and a fan-out producer.
+      api_rate_limit: nil,
+      api_rate_limit_interval: :minute
     }.freeze
 
     # :fork fires only inside swarm children, after fork + internal AR/Redis
@@ -534,6 +542,63 @@ module Wurk
       @options[:api_enqueue_classes] = Wurk::API::Validation.enqueueable_classes!(classes)
     end
 
+    # @return [Boolean, nil] true/false when the host said so, nil to inherit.
+    def api_read_only = @options[:api_read_only]
+
+    # Freezes the API's writes — enqueue included, not only the destructive
+    # `admin` routes. Same rule as the dashboard's `Wurk::Web.config.read_only`
+    # and deliberately the same sentence: a read-only deployment answers reads.
+    # Carving enqueue out would mean a viewer-only deploy could still be made
+    # to run arbitrary work, and would leave an operator holding two different
+    # definitions of the same word.
+    #
+    # Three states, because the two planes are not always one deployment:
+    #
+    #   nil (default)  inherit. Mounted inside the engine, the API is part of
+    #                  the dashboard's deployment and `WURK_WEB_READ_ONLY=1`
+    #                  freezes both. Mounted on its own path or run standalone
+    #                  there is nothing to inherit from and this means off.
+    #   true           frozen wherever it is mounted. `WURK_API_READ_ONLY=1`
+    #                  sets it, which is the only door mode 3 has.
+    #   false          live even inside a read-only dashboard — the host that
+    #                  wants a viewer-only UI and a working producer on the
+    #                  same mount, said out loud.
+    def api_read_only=(value)
+      guard_frozen!
+      @options[:api_read_only] = value.nil? ? nil : truthy_setting?(value)
+    end
+
+    # @return [Boolean] the resolved verdict for a mount with nothing to
+    #   inherit; App layers mode 1's inherited flag over it.
+    def api_read_only?
+      value = @options[:api_read_only]
+      value.nil? ? ENV['WURK_API_READ_ONLY'] == '1' : value
+    end
+
+    # @return [Integer, nil] requests one token may make per interval.
+    def api_rate_limit = @options[:api_rate_limit]
+
+    # Requests per `api_rate_limit_interval`, per token, across the fleet —
+    # enforced by a `Wurk::Limiter` sliding window rather than a second
+    # limiter, so an API ceiling shows up on the Limiters page beside every
+    # other one and resets on the same Redis clock. nil turns it off.
+    def api_rate_limit=(count)
+      guard_frozen!
+      @options[:api_rate_limit] = count.nil? ? nil : api_limit!(:api_rate_limit, count)
+    end
+
+    # @return [Symbol, Integer] the window the limit is counted over.
+    def api_rate_limit_interval = @options[:api_rate_limit_interval]
+
+    # `:second :minute :hour :day` or a raw Integer of seconds — whatever
+    # `Limiter.window` accepts, validated here so a typo raises in the
+    # initializer that wrote it rather than on the first throttled request.
+    def api_rate_limit_interval=(interval)
+      guard_frozen!
+      Wurk::Limiter.interval_seconds(interval, allow_integer: true)
+      @options[:api_rate_limit_interval] = interval
+    end
+
     # --- Web dashboard ----------------------------------------------------
 
     # Web UI configuration: the authorization hook and read-only mode. Returns
@@ -732,6 +797,17 @@ module Wurk
 
     def guard_frozen!
       raise FrozenError, 'Wurk::Configuration is frozen' if @frozen
+    end
+
+    # `config.api_read_only = ENV['SOMETHING']` is the shape a host reaches for,
+    # and `!!'false'` is true. Borrow the dashboard's list of strings that mean
+    # off rather than growing a second one that could disagree with it about the
+    # same env var.
+    def truthy_setting?(value)
+      return !!value unless value.is_a?(String)
+
+      require_relative 'web/config'
+      !Wurk::Web::Config::FALSEY_STRINGS.include?(value.strip.downcase)
     end
 
     # Boundary caps are refused where they are written, not where they are

--- a/lib/wurk/configuration.rb
+++ b/lib/wurk/configuration.rb
@@ -461,9 +461,15 @@ module Wurk
     # Registers a bearer token for the HTTP API and the scopes it grants —
     # any of `:enqueue`, `:read`, `:admin` (which grants the other two):
     #
-    #   Wurk.configure_server do |config|
-    #     config.api_token ENV.fetch('WURK_API_TOKEN'), scopes: %i[enqueue read]
-    #   end
+    #   # config/initializers/wurk.rb
+    #   Wurk.configuration.api_token ENV.fetch('WURK_API_TOKEN'), scopes: %i[enqueue read]
+    #
+    # Registered unconditionally, not inside `configure_server`/`configure_client`
+    # — the process that serves the API has to be the one holding the credential,
+    # and neither block runs in every such process. A Puma-cluster web process
+    # never enters server mode (Wurk::RailsBoot refuses to fork a swarm from
+    # one), so a token registered in `configure_server` would be absent from the
+    # exact process serving the engine-nested mount.
     #
     # Registering the first token is what brings the API into existence; with
     # none the app is never mounted. Re-registering a token replaces its

--- a/lib/wurk/web/config.rb
+++ b/lib/wurk/web/config.rb
@@ -409,6 +409,19 @@ module Wurk
         path = env['PATH_INFO'].to_s
         config = Wurk::Web.config
         return forbidden(FORBIDDEN_BODY) unless config.authorized?(env, method, path)
+
+        # The machine API's own read-only refusal is an RFC-9457 problem
+        # document with a slug a client can branch on; this one is the string
+        # "Read-only mode" in text/plain. Same verdict either way, so hand the
+        # decision down rather than answering here — stamping the env is what
+        # makes mount mode 1 (and nothing else) inherit `WURK_WEB_READ_ONLY`.
+        # The host's `authorized?` block above still applies: it gates the
+        # mount, and a machine client reaching this path chose that mount.
+        if ::Wurk::API.engine_serves?(path)
+          env[::Wurk::API::READ_ONLY_ENV] = true if config.read_only?
+          return @app.call(env)
+        end
+
         return forbidden(READ_ONLY_BODY) if config.read_only? && !SAFE_METHODS.include?(method)
 
         @app.call(env)

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  # Mount mode 2: the machine API on its own path, dashboard untouched.
+  # Declared before the engine on purpose — Rails matches a mounted app by bare
+  # string prefix, so `mount Wurk::Engine => '/wurk'` first also claims every
+  # `/wurk-api/...` path, and its SPA catch-all answers the html-format ones
+  # with the dashboard shell. Exercised by ApiMountModesTest.
+  mount Wurk::API => '/wurk-api'
   mount Wurk::Engine => '/wurk'
   # Second mount at a non-default path proves the dashboard is mount-agnostic:
   # the SPA reads window.__WURK_BASE__ (injected from request.script_name) rather

--- a/test/engine/api_mount_modes_test.rb
+++ b/test/engine/api_mount_modes_test.rb
@@ -79,6 +79,21 @@ class ApiMountModesTest < Wurk::Test::EngineCase
     end
   end
 
+  # A version this build does not serve is the app's refusal to make, and it
+  # has to read the same from all three mounts: a problem document naming the
+  # versions that do exist, never a bare Rails route miss that leaves a client
+  # guessing whether it got the version wrong or the address.
+  def test_every_mount_refuses_an_unsupported_version_by_name
+    (RAILS_MOUNTS + [STANDALONE_MOUNT]).each do |mount|
+      refused = get_at(mount, '/v2/jobs')
+
+      assert_equal 404, refused.status, mount
+      assert_equal 'application/problem+json', refused.content_type, mount
+      assert_equal 'unsupported_api_version', json(refused)['type'], mount
+      assert_equal ['v1'], json(refused)['supported_versions'], mount
+    end
+  end
+
   def test_every_mount_reports_the_same_allowed_methods
     (RAILS_MOUNTS + [STANDALONE_MOUNT]).each do |mount|
       refused = post_at(mount, '/v1')

--- a/test/engine/api_mount_modes_test.rb
+++ b/test/engine/api_mount_modes_test.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require_relative '../engine_test_helper'
+require 'json'
+
+# Slice 07, task 48 — the three mounts, proven to be one implementation:
+#
+#   1. nested in the engine at `<mount>/api/v1`, conditional on a token
+#      (config/routes.rb)
+#   2. mounted on its own path by the host — `mount Wurk::API => '/wurk-api'`
+#      (test/dummy/config/routes.rb), dashboard untouched
+#   3. standalone Rack, no Rails — `run Wurk::API` in any config.ru
+#
+# Each has to serve the same routes and emit URLs correct for where it was
+# mounted: nothing in lib/wurk/api may hardcode a prefix. The auth gate itself
+# is pinned in api_v1_auth_test.rb; this file speaks only about mounting.
+#
+# Registers a token on the process-wide `Wurk.configuration` — the same global
+# registry the whole engine suite shares — so, like api_v1_auth_test.rb, this
+# class does not declare `parallelize_me!` and serializes its own methods
+# through GLOBAL_STATE_MUTEX.
+class ApiMountModesTest < Wurk::Test::EngineCase
+  TOKEN = 'engine-api-mount-modes-token-cccc'
+
+  # Where each mode answers, and the URL prefix it must emit from there. The
+  # dummy host mounts the engine twice (/wurk and /sidekiq) and Wurk::API once
+  # on its own path; standalone is the module served directly, prefix-free.
+  ENGINE_MOUNT     = '/wurk/api'
+  ALT_ENGINE_MOUNT = '/sidekiq/api'
+  SEPARATE_MOUNT   = '/wurk-api'
+  STANDALONE_MOUNT = ''
+
+  RAILS_MOUNTS = [ENGINE_MOUNT, ALT_ENGINE_MOUNT, SEPARATE_MOUNT].freeze
+
+  def run(*)
+    Wurk::Test::GLOBAL_STATE_MUTEX.synchronize { super }
+  end
+
+  def setup
+    super
+    Wurk.configuration.api_token(TOKEN, scopes: %i[admin])
+  end
+
+  def teardown
+    Wurk.configuration.api_tokens.delete(TOKEN)
+  ensure
+    super
+  end
+
+  # --- one implementation, three addresses -----------------------------
+
+  def test_every_mount_serves_the_discovery_document
+    (RAILS_MOUNTS + [STANDALONE_MOUNT]).each do |mount|
+      body = json(get_at(mount, '/v1'))
+
+      assert_equal 200, response_at(mount).status, "#{mount} must serve the version root"
+      assert_equal 'v1', body['api_version'], mount
+      assert_equal Wurk::VERSION, body['wurk_version'], mount
+    end
+  end
+
+  # The mount-agnostic contract: the URL a client is handed has to point back
+  # at the prefix it actually reached the API through, never a baked-in /wurk.
+  def test_every_mount_emits_urls_for_its_own_prefix
+    (RAILS_MOUNTS + [STANDALONE_MOUNT]).each do |mount|
+      assert_equal "#{mount}/v1", json(get_at(mount, '/v1'))['url'], mount
+    end
+  end
+
+  def test_every_mount_serves_the_same_route_table
+    (RAILS_MOUNTS + [STANDALONE_MOUNT]).each do |mount|
+      assert_equal 200, get_at(mount, '/v1/queues').status, "#{mount} must route past the version root"
+      assert_includes json(get_at(mount, '/v1/queues')), 'queues', mount
+
+      missed = get_at(mount, '/v1/nope')
+
+      assert_equal 404, missed.status, mount
+      assert_equal 'not_found', json(missed)['type'], mount
+    end
+  end
+
+  def test_every_mount_reports_the_same_allowed_methods
+    (RAILS_MOUNTS + [STANDALONE_MOUNT]).each do |mount|
+      refused = post_at(mount, '/v1')
+
+      assert_equal 405, refused.status, mount
+      assert_equal 'GET, HEAD', refused.headers['allow'], mount
+    end
+  end
+
+  # --- mode 1: nested in the engine ------------------------------------
+
+  # The additive invariant, at the mount rather than in the app: with no token
+  # the constraint fails, Rails falls through, and the path answers exactly as
+  # it did before — a route miss for a machine client, the SPA shell for a
+  # browser. Never a bearer challenge advertising a surface that is switched
+  # off.
+  def test_the_engine_nested_mount_does_not_exist_without_a_token
+    Wurk.configuration.api_tokens.delete(TOKEN)
+
+    response = rails.get("#{ENGINE_MOUNT}/v1", {}, 'HTTP_ACCEPT' => 'application/json')
+
+    assert_equal 404, response.status
+    refute_equal 'application/problem+json', response.content_type
+    refute response.headers.key?('www-authenticate'), 'a switched-off API must not challenge for a token'
+  end
+
+  # The machine plane is nested under the same /api prefix the dashboard's own
+  # JSON API owns. Those routes are declared first and must keep matching.
+  def test_the_dashboards_own_api_still_wins_under_the_engine_mount
+    response = rails.get("#{ENGINE_MOUNT}/queues", {}, 'HTTP_ACCEPT' => 'application/json')
+
+    assert_equal 200, response.status
+    assert_kind_of Array, JSON.parse(response.body), 'the SPA-shaped payload, not the machine plane'
+  end
+
+  # ...and a path that misses them stays a Rails route miss. Claiming the whole
+  # /api prefix would answer a mistyped dashboard path with a 401 challenge for
+  # a route that was never part of this contract.
+  def test_a_dashboard_api_miss_is_not_answered_by_the_machine_plane
+    response = rails.get("#{ENGINE_MOUNT}/queuez", {}, 'HTTP_ACCEPT' => 'application/json')
+
+    assert_equal 404, response.status
+    refute_equal 'application/problem+json', response.content_type
+  end
+
+  # --- mode 2: mounted separately --------------------------------------
+
+  def test_the_separate_mount_leaves_the_dashboard_alone
+    assert_equal 200, rails.get('/wurk/').status
+    assert_includes rails.last_response.body, '<div id="wurk-root"', 'the dashboard shell, unchanged'
+  end
+
+  # Rails matches a mounted app by bare string prefix, so an engine at /wurk
+  # claims every /wurk-api path too. It only *answers* what its own routes
+  # match — a JSON request misses them and cascades back out — but the SPA
+  # catch-all matches any html-format path, so with the engine declared first a
+  # browser pointed at the machine API is handed the dashboard shell instead.
+  # Hence the declaration order in test/dummy/config/routes.rb.
+  def test_the_separate_mount_outranks_an_engine_whose_prefix_it_extends
+    response = rails.get("#{SEPARATE_MOUNT}/v1")
+
+    assert_equal 200, response.status
+    assert_equal 'v1', json(response)['api_version'], 'the machine API, not the dashboard shell'
+  end
+
+  private
+
+  # Rack::Test::Methods binds one session to `app`; three of these mounts are
+  # reached through the host app and the fourth is the bare module, so each
+  # gets its own explicit session instead.
+  def rails
+    @rails ||= ::Rack::Test::Session.new(::Rails.application).tap { |s| s.header('Authorization', "Bearer #{TOKEN}") }
+  end
+
+  def standalone
+    @standalone ||= ::Rack::Test::Session.new(::Wurk::API).tap { |s| s.header('Authorization', "Bearer #{TOKEN}") }
+  end
+
+  def session_for(mount) = mount == STANDALONE_MOUNT ? standalone : rails
+
+  def get_at(mount, path)
+    session_for(mount).get("#{mount}#{path}", {}, 'HTTP_ACCEPT' => 'application/json')
+  end
+
+  def post_at(mount, path)
+    session_for(mount).post("#{mount}#{path}", {}, 'HTTP_ACCEPT' => 'application/json')
+  end
+
+  def response_at(mount) = session_for(mount).last_response
+
+  def json(response) = ::JSON.parse(response.body)
+end

--- a/test/engine/api_read_only_test.rb
+++ b/test/engine/api_read_only_test.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require_relative '../engine_test_helper'
+require 'json'
+
+# Slice 07, task 49 — how `WURK_WEB_READ_ONLY=1` reaches the machine plane,
+# proven under a booted host rather than by handing the app a Rack env.
+#
+# The rule itself (every write refused, `enqueue` included) is pinned in
+# test/unit/api_read_only_test.rb. What only a real mount can show is which
+# deployments inherit it: nested in the engine the API sits behind
+# `Wurk::Web::Authorization` and is part of the dashboard's deployment; mounted
+# on its own path it is not, and says so for itself or not at all.
+#
+# Mutates the process-wide `Wurk.configuration` and `Wurk::Web.config`, so —
+# like api_mount_modes_test.rb — this class does not declare `parallelize_me!`
+# and serializes its own methods through GLOBAL_STATE_MUTEX.
+class ApiReadOnlyEngineTest < Wurk::Test::EngineCase
+  TOKEN = 'engine-api-read-only-token-dddddd'
+
+  ENGINE_MOUNT = '/wurk/api'
+  SEPARATE_MOUNT = '/wurk-api'
+
+  def run(*)
+    Wurk::Test::GLOBAL_STATE_MUTEX.synchronize { super }
+  end
+
+  def setup
+    super
+    @queue = "q-#{Process.pid}-#{object_id}"
+    Wurk.configuration.api_token(TOKEN, scopes: %i[admin])
+    ::Wurk::Web.configure { |c| c.read_only = true }
+  end
+
+  def teardown
+    Wurk.configuration.api_tokens.delete(TOKEN)
+    Wurk.configuration.api_read_only = nil
+    ::Wurk::Web.config.reset!
+  ensure
+    super
+  end
+
+  # --- mode 1 inherits ----------------------------------------------------
+
+  def test_the_engine_nested_mount_inherits_the_dashboard_freeze
+    response = post("#{ENGINE_MOUNT}/v1/queues/#{@queue}/pause")
+
+    assert_equal 403, response.status
+    assert_equal 'read_only', JSON.parse(response.body)['type']
+  end
+
+  # The reason the middleware hands the decision down instead of answering:
+  # its own refusal is the string "Read-only mode" in text/plain, which a
+  # machine client can neither branch on nor log usefully.
+  def test_the_inherited_refusal_is_a_problem_document
+    response = post("#{ENGINE_MOUNT}/v1/jobs")
+
+    assert_equal 'application/problem+json', response.content_type
+    body = JSON.parse(response.body)
+
+    assert_equal 'Read-Only Mode', body['title']
+    assert_equal "#{ENGINE_MOUNT}/v1/jobs", body['instance']
+    refute_includes response.body, 'Read-only mode'
+  end
+
+  def test_the_engine_nested_mount_still_answers_reads
+    response = get("#{ENGINE_MOUNT}/v1/queues")
+
+    assert_equal 200, response.status
+    assert_same true, JSON.parse(get("#{ENGINE_MOUNT}/v1").body)['read_only']
+  end
+
+  # The other half of "inherits": with the dashboard live, the stamp must not
+  # be there. A middleware that marked every API request would freeze mode 1
+  # permanently and still pass every assertion above.
+  def test_the_engine_nested_mount_is_live_while_the_dashboard_is
+    ::Wurk::Web.configure { |c| c.read_only = false }
+
+    response = post("#{ENGINE_MOUNT}/v1/queues/#{@queue}/pause")
+
+    assert_equal 200, response.status
+  ensure
+    Wurk::Queue.new(@queue).unpause!
+  end
+
+  # Handing API paths past the read-only arm leaves them behind the host's own
+  # gate: `Wurk::Web.use`/`authorization` guard the mount, and a machine client
+  # reaching this path chose that mount. Skipping both checks rather than the
+  # one would have opened a dashboard behind Devise to any bearer token.
+  def test_the_engine_nested_mount_still_obeys_the_hosts_authorization_hook
+    ::Wurk::Web.configure { |c| c.authorization { |_env, _method, _path| false } }
+
+    response = get("#{ENGINE_MOUNT}/v1/queues")
+
+    assert_equal 403, response.status
+    assert_equal 'Forbidden', response.body
+  end
+
+  # Handing API paths past the read-only arm must not change what the arm does
+  # for the dashboard the middleware was written for.
+  def test_the_dashboards_own_mutations_are_refused_exactly_as_before
+    response = post("/wurk/api/queues/#{@queue}/pause")
+
+    assert_equal 403, response.status
+    assert_equal 'Read-only mode', response.body
+    assert_includes response.content_type, 'text/plain'
+  end
+
+  # --- modes 2 and 3 opt in -----------------------------------------------
+
+  # No engine in front, so nothing stamps the env: a separately mounted API is
+  # a different deployment and the dashboard's flag does not reach it.
+  def test_a_separate_mount_does_not_inherit_the_dashboard_freeze
+    response = post("#{SEPARATE_MOUNT}/v1/queues/#{@queue}/pause")
+
+    assert_equal 200, response.status
+    assert_same false, JSON.parse(get("#{SEPARATE_MOUNT}/v1").body)['read_only']
+  ensure
+    Wurk::Queue.new(@queue).unpause!
+  end
+
+  def test_a_separate_mount_freezes_when_it_opts_in
+    Wurk.configuration.api_read_only = true
+
+    response = post("#{SEPARATE_MOUNT}/v1/queues/#{@queue}/pause")
+
+    assert_equal 403, response.status
+    assert_equal 'read_only', JSON.parse(response.body)['type']
+  end
+
+  # A viewer-only dashboard and a working producer on the same mount — the one
+  # combination the inheritance would otherwise make unreachable.
+  def test_the_engine_nested_mount_can_opt_out_of_the_inherited_freeze
+    Wurk.configuration.api_read_only = false
+
+    response = post("#{ENGINE_MOUNT}/v1/queues/#{@queue}/pause")
+
+    assert_equal 200, response.status
+  ensure
+    Wurk::Queue.new(@queue).unpause!
+  end
+
+  private
+
+  def rails
+    @rails ||= ::Rack::Test::Session.new(::Rails.application).tap { |s| s.header('Authorization', "Bearer #{TOKEN}") }
+  end
+
+  def get(path) = rails.get(path, {}, 'HTTP_ACCEPT' => 'application/json')
+  def post(path) = rails.post(path, {}, 'HTTP_ACCEPT' => 'application/json')
+end

--- a/test/integration/api_cli_test.rb
+++ b/test/integration/api_cli_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'English'
+require 'timeout'
+
+# Slice 07, task 48 — `wurk api` driven through the real binary, in a real
+# subprocess: the entry point mount mode 3 actually ships as. The option
+# surface itself is unit-tested in test/unit/cli_api_command_test.rb; what only
+# a spawned process can prove is that exe/wurk dispatches the subcommand to
+# run_api instead of the worker runner, and that the swarm binaries refuse it.
+class ApiCliTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  # Requiring the gem's own entrypoint is a no-op — it is already loaded by the
+  # time boot_application runs — but it satisfies `-r`, which every wurk
+  # invocation needs, without a fixture app.
+  ENTRYPOINT = ::File.expand_path('../../lib/wurk.rb', __dir__)
+
+  CLI_TIMEOUT = 30
+
+  def test_the_api_subcommand_documents_its_own_flags
+    output, status = run_cli('wurk', 'api', '--help')
+
+    assert_equal 0, status
+    assert_includes output, 'wurk api [options]'
+    assert_includes output, '--port'
+    assert_includes output, '--bind'
+  end
+
+  # The worker's help stays the worker's: a flag that only means something to
+  # the API server has no business in it.
+  def test_the_worker_help_does_not_offer_the_api_flags
+    output, status = run_cli('wurk', '--help')
+
+    assert_equal 0, status
+    assert_includes output, 'wurk [options]'
+    refute_includes output, '--port'
+  end
+
+  # The dispatch proof. Only run_api refuses to start over a missing token —
+  # the worker runner would have gone on to build a Launcher and block.
+  def test_the_binary_dispatches_the_subcommand_to_the_api_runner
+    output, status = run_cli('wurk', 'api', '-r', ENTRYPOINT)
+
+    refute_equal 0, status
+    assert_includes output, 'No API token is registered'
+  end
+
+  def test_the_swarm_binary_refuses_the_subcommand
+    output, status = run_cli('wurkswarm', 'api', '-r', ENTRYPOINT)
+
+    refute_equal 0, status
+    assert_includes output, 'takes no subcommand'
+    assert_includes output, 'wurk api'
+  end
+
+  private
+
+  # Runs the shipped binary the way an operator does, under this suite's bundle
+  # and this worker's Redis DB. Bounded because every command here is supposed
+  # to exit on its own: a dispatch regression that lands `wurk api` in the
+  # worker runner blocks forever, and that has to fail this test rather than
+  # hang the suite.
+  def run_cli(binary, *args)
+    exe = ::File.expand_path("../../exe/#{binary}", __dir__)
+    io = ::IO.popen({ 'REDIS_URL' => Wurk::Test.redis_url }, [RbConfig.ruby, exe, *args], err: %i[child out])
+    begin
+      output = ::Timeout.timeout(CLI_TIMEOUT) { io.read }
+    rescue ::Timeout::Error
+      ::Process.kill('KILL', io.pid)
+
+      flunk "#{binary} #{args.join(' ')} never exited within #{CLI_TIMEOUT}s"
+    ensure
+      io.close
+    end
+    [output, $CHILD_STATUS.exitstatus]
+  end
+end

--- a/test/integration/api_v1_swarm_test.rb
+++ b/test/integration/api_v1_swarm_test.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'wurk/api/app'
+require 'rack/test'
+require 'json'
+
+# Slice 07, task 50 — `GET /v1/swarm` and `GET /v1/processes` against a real
+# forked swarm (CLAUDE.md: never mock Redis in integration tests).
+#
+# test/unit/api_swarm_test.rb pins the roll-up math and the field shapes
+# against hand-written heartbeat fixtures — the same technique
+# test/unit/swarm_test.rb and friends use for the swarm internals. What only a
+# real fork can prove is the thing the plan doc (07-http-producer-api.md
+# "Tests") calls out by name: watching the swarm through the API costs the
+# swarm nothing (Swarm.draw's module comment — `ProcessSet.new(false)`, no
+# extra beat), and the process rows the API reports for real children are the
+# same bytes `Wurk::Heartbeat#write_beat` put in Redis, not a shape the test
+# invented. A synthetic ghost heartbeat sits beside them so the same request
+# proves both a live row (`stale: false`) and a stale one (`stale: true`) came
+# out of the identical code path.
+class ApiV1SwarmTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  include ::Rack::Test::Methods
+
+  ADMIN_TOKEN = 'api-v1-swarm-admin-token-0123456789'
+
+  POLL_TIMEOUT = 15.0
+  POLL_INTERVAL = 0.1
+
+  # Comfortably past Serializers::STALE_AFTER_SECONDS (3 x BEAT_PAUSE = 30s)
+  # so the ghost is unambiguously stale regardless of scheduling jitter.
+  GHOST_BEAT_AGE = 90
+
+  def setup
+    super
+    @ns = "apiswarm-#{Process.pid}-#{object_id}"
+    @queue_name = "#{@ns}-q"
+    @now = Time.now.to_f
+    @config = Wurk::Configuration.new
+    @config.logger = ::Logger.new(IO::NULL)
+    @config[:timeout] = 5
+    @config.api_token(ADMIN_TOKEN, scopes: %i[admin])
+    @observer_pool = RedisClient.config(url: Wurk::Test.redis_url).new_client
+    @ghost_identity = "ghost-box-#{@ns}:9999:a"
+  end
+
+  def teardown
+    begin
+      @swarm&.shutdown(timeout: 5)
+    rescue StandardError
+      nil
+    end
+    stop_supervisor_thread(@supervisor, 10)
+    @observer_pool&.call('SREM', 'processes', @ghost_identity)
+    @observer_pool&.call('DEL', @ghost_identity, "queue:#{@queue_name}")
+    @observer_pool&.close
+    @config&.reset_redis_pools!
+  ensure
+    super
+  end
+
+  def test_processes_lists_real_forked_children_and_reports_a_stale_ghost
+    pids = boot_swarm(2)
+    write_ghost_heartbeat
+
+    body = get_json('/v1/processes', count: 200)
+    rows = body.fetch('processes')
+    identities_by_pid = rows.to_h { |row| [row['identity'], row] }
+
+    pids.each do |pid|
+      row = identities_by_pid.values.find { |r| r['identity'].to_s.include?(":#{pid}:") }
+
+      assert row, "expected a live process row for forked child pid #{pid} in #{rows.map { |r| r['identity'] }}"
+      refute row['stale'], "a real child that just beat must not be reported stale: #{row}"
+      assert_operator row['beat_age_seconds'], :<, 15.0, 'a child that just booted should have a fresh beat'
+      assert_equal @queue_name, row['queues'].first
+    end
+
+    ghost = identities_by_pid[@ghost_identity]
+    seen = rows.map { |r| r['identity'] }
+
+    assert ghost, "expected the synthetic ghost heartbeat #{@ghost_identity} to appear in #{seen}"
+    assert ghost['stale'], "a heartbeat #{GHOST_BEAT_AGE}s old must be reported stale: #{ghost}"
+    assert_in_delta GHOST_BEAT_AGE, ghost['beat_age_seconds'], 5.0
+  end
+
+  def test_swarm_rolls_up_real_children_and_the_stale_ghost_into_one_answer
+    pids = boot_swarm(2)
+    write_ghost_heartbeat
+
+    body = get_json('/v1/swarm')
+
+    assert_equal pids.size + 1, body.dig('processes', 'total'),
+                 'the roll-up must count every live process plus the stale ghost'
+    assert_equal 1, body.dig('processes', 'stale')
+    assert_includes body['queues'], @queue_name
+    assert_operator body['concurrency'], :>=, pids.size
+    assert_equal 30, body.dig('beat', 'stale_after_seconds')
+    assert_operator body.dig('beat', 'oldest_age_seconds'), :>=, GHOST_BEAT_AGE - 5.0
+  end
+
+  private
+
+  def boot_swarm(count)
+    topology = Wurk::Topology.flat(count: count, queues: [@queue_name], concurrency: 1)
+    @swarm = Wurk::Swarm.new(topology: topology, config: @config, shutdown_timeout: 5)
+    pids = @swarm.boot(install_signals: false)
+    @supervisor = Thread.new { @swarm.supervise }
+
+    assert wait_for_pids?(pids), "expected heartbeats for #{pids} within #{POLL_TIMEOUT}s"
+    pids
+  end
+
+  # Same bytes Wurk::Heartbeat#write_beat leaves — see test/unit/api_swarm_test.rb's
+  # `beat` helper, which this mirrors — with a `beat` timestamp old enough that
+  # Serializers.stale? reports it stale without waiting out a real heartbeat lapse.
+  def write_ghost_heartbeat
+    info = {
+      'hostname' => "ghost-box-#{@ns}", 'started_at' => @now - 3600, 'pid' => 9999, 'tag' => 'ghost',
+      'concurrency' => 1, 'capsules' => { 'default' => { 'weights' => { @queue_name => 1 } } },
+      'labels' => [], 'identity' => @ghost_identity, 'version' => Wurk::VERSION, 'embedded' => false,
+      'cpu_model' => 'Fake CPU', 'cores' => 1, 'memory_total_kb' => 1_000_000
+    }
+    @observer_pool.call('SADD', 'processes', @ghost_identity)
+    @observer_pool.call('HSET', @ghost_identity, 'info', Wurk.dump_json(info), 'concurrency', '1',
+                        'busy', '0', 'beat', (@now - GHOST_BEAT_AGE).to_s, 'quiet', 'false',
+                        'rss', '10000', 'rtt_us', '400')
+  end
+
+  # Each forked child's identity is `<hostname>:<pid>:<nonce>` (swarm.rb) —
+  # the hostname is the real machine's, not namespaced, so a pid substring
+  # match is the only way to tell "this test's children" from a peer test
+  # worker's live heartbeats on the same shared `processes` SET.
+  def wait_for_pids?(pids)
+    deadline = monotonic_now + POLL_TIMEOUT
+    while monotonic_now < deadline
+      members = @observer_pool.call('SMEMBERS', 'processes')
+      return true if pids.all? { |pid| members.any? { |identity| identity.include?(":#{pid}:") } }
+
+      sleep POLL_INTERVAL
+    end
+    false
+  end
+
+  def monotonic_now = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+
+  def stop_supervisor_thread(thread, timeout)
+    return unless thread
+
+    thread.join(timeout)
+    thread.kill if thread.alive?
+  end
+
+  def app = @app ||= Wurk::API::App.new(config: @config)
+
+  def get_json(path, **query)
+    query_string = query.empty? ? '' : "?#{Rack::Utils.build_query(query)}"
+    header 'Authorization', "Bearer #{ADMIN_TOKEN}"
+    get("#{path}#{query_string}")
+
+    assert_equal 200, last_response.status, last_response.body
+    JSON.parse(last_response.body)
+  end
+end

--- a/test/unit/api_jobs_test.rb
+++ b/test/unit/api_jobs_test.rb
@@ -223,6 +223,74 @@ class ApiJobsTest < Wurk::Test::UnitCase
     body['jids'].each { |jid| refute_nil Wurk::ScheduledSet.new.find_job(jid) }
   end
 
+  # --- GET /jobs/:jid ----------------------------------------------------
+
+  def test_get_job_returns_the_status_record
+    jid = SecureRandom.hex(12)
+    Wurk::Status.write(jid, state: 'complete', queue: @queue, class: @class_name,
+                            progress: 7, total: 10, result: JSON.generate('ok'))
+
+    status, headers, body = get("/v1/jobs/#{jid}")
+
+    assert_equal 200, status
+    assert_equal 'application/json', headers['content-type']
+    assert_equal jid, body['jid']
+    assert_equal 'complete', body['state']
+    assert_equal @class_name, body['class']
+    assert_equal @queue, body['queue']
+    assert_equal 7, body['progress']
+    assert_equal 10, body['total']
+    assert_equal 'ok', body['result']
+  end
+
+  # The same object the dashboard reads, so the two can never disagree about
+  # what a job did.
+  def test_get_job_agrees_with_the_status_record_it_reads
+    jid = SecureRandom.hex(12)
+    Wurk::Status.write(jid, state: 'failed', error_class: 'RuntimeError', error_message: 'boom')
+
+    _status, _headers, body = get("/v1/jobs/#{jid}")
+
+    assert_equal Wurk::Status.get(jid).to_h, body
+  end
+
+  # An untracked jid, an unknown one and a lapsed row are one answer: Redis
+  # holds nothing that tells them apart.
+  def test_get_job_of_an_untracked_jid_is_a_job_not_found_problem
+    jid = SecureRandom.hex(12)
+    status, headers, body = get("/v1/jobs/#{jid}")
+
+    assert_equal 404, status
+    assert_equal 'application/problem+json', headers['content-type']
+    assert_equal 'job_not_found', body['type']
+    assert_equal jid, body['jid']
+    assert_includes body['detail'], 'track: true'
+  end
+
+  def test_get_job_rejects_a_jid_that_is_not_url_safe
+    status, _headers, body = get('/v1/jobs/%2A')
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+  end
+
+  # A producer polling what it pushed is granted %i[enqueue read]; enqueue
+  # alone does not carry a jid it may not have produced.
+  def test_read_scope_may_get_a_job
+    jid = SecureRandom.hex(12)
+    Wurk::Status.write(jid, state: 'running')
+    status, = get("/v1/jobs/#{jid}", token: READ_TOKEN)
+
+    assert_equal 200, status
+  end
+
+  def test_enqueue_scope_may_not_get_a_job
+    status, _headers, body = get("/v1/jobs/#{SecureRandom.hex(12)}", token: ENQUEUE_TOKEN)
+
+    assert_equal 403, status
+    assert_equal 'read', body['required_scope']
+  end
+
   # --- DELETE /jobs/:jid -------------------------------------------------
 
   def test_delete_removes_a_scheduled_job
@@ -373,6 +441,8 @@ class ApiJobsTest < Wurk::Test::UnitCase
   end
 
   def delete(path, token: ADMIN_TOKEN) = parse(call(env_for('DELETE', path, token: token)))
+
+  def get(path, token: ADMIN_TOKEN) = parse(call(env_for('GET', path, token: token)))
 
   def parse(response)
     status, headers, body = response

--- a/test/unit/api_mount_test.rb
+++ b/test/unit/api_mount_test.rb
@@ -54,6 +54,38 @@ class ApiMountTest < Wurk::Test::UnitCase
     assert_equal ['v1'], Wurk::API::SUPPORTED_VERSIONS
   end
 
+  # The same question one prefix out, for `Wurk::Web::Authorization` — it runs
+  # before routing, so the engine's mount has not stripped anything yet and it
+  # has to tell a machine-plane path from a dashboard one to know whose
+  # read-only refusal this is.
+  def test_the_engine_mount_prefix_is_the_one_the_engine_mounts_under
+    assert_equal '/api', Wurk::API::ENGINE_MOUNT
+  end
+
+  def test_the_unstripped_form_claims_the_machine_plane
+    assert Wurk::API.engine_serves?('/api/v1', config)
+    assert Wurk::API.engine_serves?('/api/v1/jobs', config)
+  end
+
+  def test_the_unstripped_form_leaves_the_dashboards_own_api_alone
+    refute Wurk::API.engine_serves?('/api/stats', config)
+    refute Wurk::API.engine_serves?('/api', config)
+  end
+
+  # Nested in the engine the machine plane lives under /api and nowhere else. A
+  # path that looks like the version prefix on its own is some other engine
+  # route, and handing it over would take it out from behind the read-only gate
+  # it belongs to.
+  def test_the_unstripped_form_requires_the_mount_prefix
+    refute Wurk::API.engine_serves?('/v1', config)
+    refute Wurk::API.engine_serves?('/v1/jobs', config)
+    refute Wurk::API.engine_serves?('/apiary/v1', config)
+  end
+
+  def test_the_unstripped_form_claims_nothing_without_a_token
+    refute Wurk::API.engine_serves?('/api/v1/jobs', bare_config)
+  end
+
   private
 
   def config

--- a/test/unit/api_mount_test.rb
+++ b/test/unit/api_mount_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'wurk/api'
+
+# Slice 07, task 48 — the predicate the engine's conditional mount hangs off
+# (config/routes.rb). Two questions answered without loading App: is the API on
+# at all, and is this path part of its contract. The three mounts themselves are
+# proven end-to-end in test/engine/api_mount_modes_test.rb.
+class ApiMountTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  TOKEN = 'api-mount-test-token-0123456789'
+
+  # The whole additive invariant in one assertion: no token, no surface. The
+  # engine's constraint fails, Rails falls through to the next route, and the
+  # path answers exactly as it did before wurk was mounted.
+  def test_no_token_registered_claims_nothing
+    refute Wurk::API.serves?('/v1', bare_config)
+    refute Wurk::API.serves?('/v1/jobs', bare_config)
+  end
+
+  def test_a_registered_token_claims_the_version_root_and_everything_under_it
+    assert Wurk::API.serves?('/v1', config)
+    assert Wurk::API.serves?('/v1/jobs', config)
+    assert Wurk::API.serves?('/v1/queues/critical', config)
+  end
+
+  # Nested in the engine this plane shares the /api prefix with the dashboard's
+  # own JSON API, whose routes are declared first. A path that misses those must
+  # stay a Rails route miss rather than reaching the machine plane's auth gate
+  # and coming back as a bearer challenge for a route that never existed.
+  def test_a_dashboard_api_path_is_not_claimed
+    refute Wurk::API.serves?('/stats', config)
+    refute Wurk::API.serves?('/queues/critical', config)
+    refute Wurk::API.serves?('/', config)
+  end
+
+  # `start_with?('/v1')` alone would claim these.
+  def test_a_path_that_merely_starts_with_the_version_string_is_not_claimed
+    refute Wurk::API.serves?('/v10', config)
+    refute Wurk::API.serves?('/v1x/jobs', config)
+  end
+
+  # An unknown version is the App's 404 to answer (unsupported_api_version, with
+  # the versions it does serve), so the mount has to hand it over rather than
+  # leaving the client a bare Rails route miss.
+  def test_an_unknown_version_is_not_claimed_here
+    refute Wurk::API.serves?('/v2/jobs', config)
+  end
+
+  def test_the_version_prefix_is_the_one_the_app_serves_under
+    assert_equal '/v1', Wurk::API::VERSION_PREFIX
+    assert_equal ['v1'], Wurk::API::SUPPORTED_VERSIONS
+  end
+
+  private
+
+  def config
+    @config ||= Wurk::Configuration.new.tap { |cfg| cfg.api_token(TOKEN, scopes: %i[admin]) }
+  end
+
+  def bare_config = @bare_config ||= Wurk::Configuration.new
+end

--- a/test/unit/api_mount_test.rb
+++ b/test/unit/api_mount_test.rb
@@ -34,19 +34,25 @@ class ApiMountTest < Wurk::Test::UnitCase
     refute Wurk::API.serves?('/stats', config)
     refute Wurk::API.serves?('/queues/critical', config)
     refute Wurk::API.serves?('/', config)
+    # A queue may legally be named "v2". Only the first segment names a version.
+    refute Wurk::API.serves?('/queues/v2', config)
   end
 
-  # `start_with?('/v1')` alone would claim these.
+  # `start_with?('/v1')` alone would claim these: neither names a version, so
+  # both belong to whatever else is mounted here.
   def test_a_path_that_merely_starts_with_the_version_string_is_not_claimed
-    refute Wurk::API.serves?('/v10', config)
     refute Wurk::API.serves?('/v1x/jobs', config)
+    refute Wurk::API.serves?('/version', config)
+    refute Wurk::API.serves?('/v', config)
   end
 
   # An unknown version is the App's 404 to answer (unsupported_api_version, with
-  # the versions it does serve), so the mount has to hand it over rather than
-  # leaving the client a bare Rails route miss.
-  def test_an_unknown_version_is_not_claimed_here
-    refute Wurk::API.serves?('/v2/jobs', config)
+  # the versions it does serve), so the mount hands it over rather than leaving
+  # the client a bare Rails route miss — the answer the other two mounts give.
+  def test_an_unknown_version_is_claimed_so_the_app_can_refuse_it_by_name
+    assert Wurk::API.serves?('/v2', config)
+    assert Wurk::API.serves?('/v2/jobs', config)
+    assert Wurk::API.serves?('/v10/jobs', config)
   end
 
   def test_the_version_prefix_is_the_one_the_app_serves_under
@@ -65,6 +71,7 @@ class ApiMountTest < Wurk::Test::UnitCase
   def test_the_unstripped_form_claims_the_machine_plane
     assert Wurk::API.engine_serves?('/api/v1', config)
     assert Wurk::API.engine_serves?('/api/v1/jobs', config)
+    assert Wurk::API.engine_serves?('/api/v2/jobs', config), 'an unknown version is still the machine plane'
   end
 
   def test_the_unstripped_form_leaves_the_dashboards_own_api_alone

--- a/test/unit/api_queues_test.rb
+++ b/test/unit/api_queues_test.rb
@@ -1,0 +1,578 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'wurk/api/app'
+require 'base64'
+require 'json'
+require 'securerandom'
+require 'stringio'
+require 'zlib'
+
+# Slice 07 — the HTTP API's observe plane: GET /stats, /queues, /queues/:name,
+# /retries, /scheduled, /dead, /batches/:bid and the two pause toggles.
+#
+# The point of these routes is that they add no second reader over Redis, so
+# the assertions run against state written by the canonical objects themselves
+# (Wurk::Client, JobSet#schedule, Queue#pause!) and check that the HTTP answer
+# is the one those objects give.
+#
+# Auth mechanics live in api_auth_test.rb and routing in api_app_test.rb; the
+# scope checks here only pin which scope each route demands.
+#
+# Isolation: every test starts against a freshly flushed worker DB
+# (RedisNamespace), and queue and class names still carry a per-instance
+# namespace so nothing collides with a peer worker's fixtures.
+class ApiQueuesTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  ADMIN_TOKEN = 'api-queues-admin-token-0123456789'
+  READ_TOKEN = 'api-queues-read-token-0123456789'
+  ENQUEUE_TOKEN = 'api-queues-enqueue-token-0123456789'
+
+  def setup
+    super
+    @ns = "#{Process.pid}_#{object_id}"
+    @queue = "q-#{@ns}"
+    @other_queue = "q2-#{@ns}"
+    @class_name = "ApiQueuesWorker#{@ns}"
+    @pool = Wurk.configuration.redis_pool
+  end
+
+  # --- GET /stats --------------------------------------------------------
+
+  def test_stats_reports_the_canonical_counters
+    @pool.with { |conn| conn.call('MSET', 'stat:processed', '12', 'stat:failed', '3', 'stat:expired', '1') }
+    enqueue(2)
+    Wurk::ScheduledSet.new.schedule(Time.now.to_f + 60, job.merge('jid' => SecureRandom.hex(12)))
+    Wurk::RetrySet.new.schedule(Time.now.to_f + 60, job.merge('jid' => SecureRandom.hex(12)))
+    Wurk::DeadSet.new.schedule(Time.now.to_f, job.merge('jid' => SecureRandom.hex(12)))
+
+    status, headers, body = get('/v1/stats')
+
+    assert_equal 200, status
+    assert_equal 'application/json', headers['content-type']
+    assert_equal 12, body['processed']
+    assert_equal 3, body['failed']
+    assert_equal 1, body['expired']
+    assert_equal 2, body['enqueued']
+    assert_equal 1, body['scheduled']
+    assert_equal 1, body['retries']
+    assert_equal 1, body['dead']
+    assert_equal 0, body['busy']
+    assert_equal 0, body['processes']
+  end
+
+  # The same object the dashboard's stats endpoint reads, so the two can only
+  # ever report the same numbers.
+  def test_stats_agrees_with_the_inspector_it_reads
+    enqueue(3)
+    snapshot = Wurk::Stats.new
+    _status, _headers, body = get('/v1/stats')
+
+    assert_equal snapshot.enqueued, body['enqueued']
+    assert_equal snapshot.queue_summaries.map(&:name).sort, body['queues'].map { |q| q['name'] }.sort
+  end
+
+  # `latency` beside a `queues` array would read as the fleet's; Stats measures
+  # the `default` queue specifically, so the field says so.
+  def test_stats_names_the_default_queue_latency_explicitly
+    _status, _headers, body = get('/v1/stats')
+
+    assert_in_delta 0.0, body['default_queue_latency'], 0.001
+    refute body.key?('latency')
+  end
+
+  def test_stats_embeds_the_queue_summaries
+    enqueue(1)
+    _status, _headers, body = get('/v1/stats')
+    summary = body['queues'].find { |q| q['name'] == @queue }
+
+    assert_equal 1, summary['size']
+    refute summary['paused']
+  end
+
+  # --- GET /queues -------------------------------------------------------
+
+  def test_queues_lists_every_known_queue_largest_first
+    enqueue(1)
+    enqueue(3, queue: @other_queue)
+
+    status, _headers, body = get('/v1/queues')
+
+    assert_equal 200, status
+    names = body['queues'].map { |q| q['name'] }
+    sizes = body['queues'].map { |q| q['size'] }
+
+    assert_equal [@other_queue, @queue], names
+    assert_equal [3, 1], sizes
+  end
+
+  def test_queues_reports_the_paused_flag
+    enqueue(1)
+    Wurk::Queue.new(@queue).pause!
+
+    _status, _headers, body = get('/v1/queues')
+
+    assert body['queues'].find { |q| q['name'] == @queue }['paused']
+  end
+
+  def test_queues_is_empty_when_nothing_was_ever_enqueued
+    _status, _headers, body = get('/v1/queues')
+
+    assert_empty body['queues']
+  end
+
+  # --- GET /queues/:name -------------------------------------------------
+
+  def test_queue_reports_depth_and_its_jobs
+    jids = enqueue(2, args: [1])
+
+    status, _headers, body = get("/v1/queues/#{@queue}")
+
+    assert_equal 200, status
+    assert_equal @queue, body['name']
+    assert_equal 2, body['size']
+    refute body['paused']
+    rows = body['jobs']
+    classes = rows.map { |j| j['class'] }
+    args = rows.map { |j| j['args'] }
+    queues = rows.map { |j| j['queue'] }
+
+    assert_equal jids.sort, rows.map { |j| j['jid'] }.sort
+    assert_equal [@class_name, @class_name], classes
+    assert_equal [[1], [1]], args
+    assert_equal [@queue, @queue], queues
+  end
+
+  # The display view, not the stored one: serving `record.args` here would put
+  # the ciphertext envelope of every `encrypt: true` job on an HTTP response.
+  def test_queue_job_rows_mask_an_encrypted_argument
+    Wurk::Client.new.push(job('args' => ['plain', { 'wurk_encrypted' => 'ciphertext' }], 'encrypt' => true))
+
+    _status, _headers, body = get("/v1/queues/#{@queue}")
+
+    assert_equal ['plain', '<encrypted>'], body['jobs'].fetch(0)['args']
+  end
+
+  def test_queue_job_rows_carry_the_enqueue_timestamps
+    enqueue(1)
+    _status, _headers, body = get("/v1/queues/#{@queue}")
+    row = body['jobs'].fetch(0)
+
+    assert_in_delta Time.now.to_f, row['enqueued_at'], 30
+    assert_in_delta Time.now.to_f, row['created_at'], 30
+  end
+
+  # A never-used name and a drained one are the same state in Redis, so both
+  # answer with an empty queue rather than a 404 that only one of them earns.
+  def test_queue_of_an_unknown_name_is_an_empty_queue
+    status, _headers, body = get('/v1/queues/never-used')
+
+    assert_equal 200, status
+    assert_equal 0, body['size']
+    assert_empty body['jobs']
+  end
+
+  # The router percent-decodes a captured segment, so a name containing '/'
+  # is addressable — the same constraint config/routes.rb puts on the
+  # dashboard's :name.
+  def test_queue_name_may_be_percent_encoded
+    slashed = "#{@queue}/sub"
+    enqueue(1, queue: slashed)
+
+    _status, _headers, body = get("/v1/queues/#{@queue}%2Fsub")
+
+    assert_equal slashed, body['name']
+    assert_equal 1, body['size']
+  end
+
+  def test_queue_rejects_a_name_carrying_whitespace
+    status, headers, body = get('/v1/queues/two%20words')
+
+    assert_equal 400, status
+    assert_equal 'application/problem+json', headers['content-type']
+    assert_equal 'invalid_request', body['type']
+  end
+
+  def test_queue_rejects_an_oversized_name
+    status, _headers, body = get("/v1/queues/#{'a' * 256}")
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+  end
+
+  def test_queue_reports_being_paused
+    enqueue(1)
+    Wurk::Queue.new(@queue).pause!
+
+    _status, _headers, body = get("/v1/queues/#{@queue}")
+
+    assert body['paused']
+  end
+
+  # --- paging ------------------------------------------------------------
+
+  def test_queue_pages_with_count_and_page
+    enqueue(5)
+    _status, _headers, first = get("/v1/queues/#{@queue}?count=2&page=0")
+    _status, _headers, second = get("/v1/queues/#{@queue}?count=2&page=1")
+    _status, _headers, last = get("/v1/queues/#{@queue}?count=2&page=2")
+
+    assert_equal 2, first['jobs'].size
+    assert_equal 2, second['jobs'].size
+    assert_equal 1, last['jobs'].size
+    assert_empty(first['jobs'].map { |j| j['jid'] } & second['jobs'].map { |j| j['jid'] })
+  end
+
+  def test_queue_page_defaults_to_the_first_twenty_five
+    enqueue(1)
+    _status, _headers, body = get("/v1/queues/#{@queue}")
+
+    assert_equal 0, body['page']
+    assert_equal 25, body['count']
+  end
+
+  # Out of range is a client asking for more than the API gives, not a client
+  # bug — clamped, and echoed back so the clamp is visible.
+  def test_queue_clamps_an_out_of_range_window
+    enqueue(1)
+    _status, _headers, body = get("/v1/queues/#{@queue}?count=9999&page=-4")
+
+    assert_equal Wurk::API::Page::MAX_COUNT, body['count']
+    assert_equal 0, body['page']
+  end
+
+  def test_queue_clamps_a_page_beyond_the_walk_bound
+    _status, _headers, body = get("/v1/queues/#{@queue}?page=99999")
+
+    assert_equal Wurk::API::Page::MAX_PAGE, body['page']
+  end
+
+  def test_queue_refuses_a_non_integer_page
+    status, _headers, body = get("/v1/queues/#{@queue}?page=soon")
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+    assert_includes body['detail'], "'page'"
+  end
+
+  def test_queue_refuses_a_non_integer_count
+    status, _headers, body = get("/v1/queues/#{@queue}?count=all")
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+    assert_includes body['detail'], "'count'"
+  end
+
+  # A repeated parameter is an ambiguous request, so it is answered rather
+  # than silently resolved to one of the two values.
+  def test_queue_refuses_a_repeated_paging_parameter
+    status, _headers, body = get("/v1/queues/#{@queue}?count=1&count=2")
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+  end
+
+  # Rack refuses a bad %-encoding before any paging value exists to clamp, and
+  # that refusal is a 400 rather than the 500 the app's catch-all would make.
+  def test_queue_refuses_a_malformed_query_string
+    status, _headers, body = get("/v1/queues/#{@queue}?page=%")
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+    assert_includes body['detail'], 'query string'
+  end
+
+  def test_queue_ignores_an_empty_paging_parameter
+    enqueue(1)
+    status, _headers, body = get("/v1/queues/#{@queue}?page=&count=")
+
+    assert_equal 200, status
+    assert_equal 25, body['count']
+  end
+
+  # --- pause / unpause ---------------------------------------------------
+
+  def test_pause_puts_the_queue_in_the_paused_set
+    status, _headers, body = post("/v1/queues/#{@queue}/pause")
+
+    assert_equal 200, status
+    assert_equal @queue, body['name']
+    assert body['paused']
+    assert_predicate Wurk::Queue.new(@queue), :paused?
+  end
+
+  def test_unpause_takes_it_back_out
+    Wurk::Queue.new(@queue).pause!
+    status, _headers, body = post("/v1/queues/#{@queue}/unpause")
+
+    assert_equal 200, status
+    refute body['paused']
+    refute_predicate Wurk::Queue.new(@queue), :paused?
+  end
+
+  def test_pause_is_idempotent
+    post("/v1/queues/#{@queue}/pause")
+    status, _headers, body = post("/v1/queues/#{@queue}/pause")
+
+    assert_equal 200, status
+    assert body['paused']
+  end
+
+  def test_pause_rejects_a_malformed_queue_name
+    status, _headers, body = post('/v1/queues/two%20words/pause')
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+  end
+
+  def test_pause_answers_post_only
+    status, headers, = call(env_for('GET', "/v1/queues/#{@queue}/pause"))
+
+    assert_equal 405, status
+    assert_equal 'POST', headers['allow']
+  end
+
+  # --- GET /retries /scheduled /dead -------------------------------------
+
+  def test_retries_lists_the_retry_set_newest_first
+    older = seed(Wurk::RetrySet.new, Time.now.to_f + 60)
+    newer = seed(Wurk::RetrySet.new, Time.now.to_f + 600)
+
+    status, _headers, body = get('/v1/retries')
+
+    assert_equal 200, status
+    assert_equal 'retry', body['name']
+    assert_equal 2, body['total']
+    assert_equal [newer, older], jids(body)
+  end
+
+  def test_scheduled_lists_the_schedule_set
+    jid = seed(Wurk::ScheduledSet.new, Time.now.to_f + 60)
+
+    _status, _headers, body = get('/v1/scheduled')
+
+    assert_equal 'schedule', body['name']
+    assert_equal [jid], jids(body)
+  end
+
+  def test_dead_lists_the_dead_set
+    jid = seed(Wurk::DeadSet.new, Time.now.to_f)
+
+    _status, _headers, body = get('/v1/dead')
+
+    assert_equal 'dead', body['name']
+    assert_equal [jid], jids(body)
+  end
+
+  # `at` is the member's ZSET score in epoch seconds — the one timestamp the
+  # contract ships, rather than the score and a duplicate of it.
+  def test_sorted_entries_report_the_score_as_at
+    at = Time.now.to_f + 900
+    seed(Wurk::RetrySet.new, at)
+
+    _status, _headers, body = get('/v1/retries')
+
+    assert_in_delta at, body['jobs'].fetch(0)['at'], 0.001
+  end
+
+  def test_sorted_entries_report_the_failure_that_put_them_there
+    backtrace = ['lib/foo.rb:1', 'lib/bar.rb:42']
+    seed(
+      Wurk::RetrySet.new, Time.now.to_f + 60,
+      'error_class' => 'RuntimeError', 'error_message' => 'boom', 'retry_count' => 2,
+      'failed_at' => 1_700_000_000.5, 'retried_at' => 1_700_000_100.5,
+      'error_backtrace' => Base64.encode64(Zlib.deflate(Wurk.dump_json(backtrace)))
+    )
+
+    _status, _headers, body = get('/v1/retries')
+    row = body['jobs'].fetch(0)
+
+    assert_equal 'RuntimeError', row['error_class']
+    assert_equal 'boom', row['error_message']
+    assert_equal 2, row['retry_count']
+    assert_in_delta 1_700_000_000.5, row['failed_at'], 0.001
+    assert_in_delta 1_700_000_100.5, row['retried_at'], 0.001
+    assert_equal backtrace, row['error_backtrace']
+  end
+
+  # A row that never failed says so with nulls rather than empty strings — the
+  # dashboard's `.to_s` is a rendering choice a machine client should not
+  # inherit.
+  def test_sorted_entries_leave_absent_failure_fields_null
+    seed(Wurk::ScheduledSet.new, Time.now.to_f + 60)
+
+    _status, _headers, body = get('/v1/scheduled')
+    row = body['jobs'].fetch(0)
+
+    assert_nil row['error_class']
+    assert_nil row['retry_count']
+    assert_nil row['failed_at']
+    assert_nil row['retried_at']
+    assert_nil row['error_backtrace']
+  end
+
+  def test_sorted_sets_page_like_queues_do
+    3.times { |i| seed(Wurk::RetrySet.new, Time.now.to_f + (60 * (i + 1))) }
+
+    _status, _headers, body = get('/v1/retries?count=1&page=1')
+
+    assert_equal 3, body['total']
+    assert_equal 1, body['page']
+    assert_equal 1, body['jobs'].size
+  end
+
+  def test_sorted_sets_refuse_a_malformed_window
+    status, _headers, body = get('/v1/retries?count=lots')
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+  end
+
+  # --- GET /batches/:bid -------------------------------------------------
+
+  def test_batch_reports_the_status_data
+    bid = seed_batch(total: 5, pending: 2, failures: 1, live_jids: %w[jid-a jid-b])
+
+    status, _headers, body = get("/v1/batches/#{bid}")
+
+    assert_equal 200, status
+    assert_equal bid, body['bid']
+    assert_equal 5, body['total']
+    assert_equal 2, body['pending']
+    assert_equal 1, body['failures']
+    refute body['complete']
+  end
+
+  def test_batch_agrees_with_the_inspector_it_reads
+    bid = seed_batch(total: 1, pending: 0, description: 'nightly')
+    _status, _headers, body = get("/v1/batches/#{bid}")
+
+    assert_equal Wurk::Batch::Status.new(bid).data, body
+  end
+
+  def test_batch_of_an_unknown_bid_is_a_batch_not_found_problem
+    bid = SecureRandom.urlsafe_base64(10)
+    status, headers, body = get("/v1/batches/#{bid}")
+
+    assert_equal 404, status
+    assert_equal 'application/problem+json', headers['content-type']
+    assert_equal 'batch_not_found', body['type']
+    assert_equal 'Batch Not Found', body['title']
+    assert_equal bid, body['bid']
+  end
+
+  def test_batch_rejects_a_bid_that_is_not_url_safe
+    status, _headers, body = get('/v1/batches/%2A')
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+    assert_includes body['detail'], 'batch id'
+  end
+
+  # --- scopes ------------------------------------------------------------
+
+  def test_read_scope_may_observe
+    %w[/v1/stats /v1/queues /v1/retries /v1/scheduled /v1/dead].each do |path|
+      status, = get(path, token: READ_TOKEN)
+
+      assert_equal 200, status, path
+    end
+  end
+
+  def test_enqueue_scope_may_not_observe
+    status, _headers, body = get('/v1/stats', token: ENQUEUE_TOKEN)
+
+    assert_equal 403, status
+    assert_equal 'insufficient_scope', body['type']
+    assert_equal 'read', body['required_scope']
+  end
+
+  # Pausing `default` stops the fleet without enqueueing or deleting anything,
+  # so it sits with the destructive routes rather than the listings.
+  def test_read_scope_may_not_pause
+    status, _headers, body = post("/v1/queues/#{@queue}/pause", token: READ_TOKEN)
+
+    assert_equal 403, status
+    assert_equal 'admin', body['required_scope']
+    refute_predicate Wurk::Queue.new(@queue), :paused?
+  end
+
+  def test_read_scope_may_not_unpause
+    Wurk::Queue.new(@queue).pause!
+    status, _headers, body = post("/v1/queues/#{@queue}/unpause", token: READ_TOKEN)
+
+    assert_equal 403, status
+    assert_equal 'admin', body['required_scope']
+    assert_predicate Wurk::Queue.new(@queue), :paused?
+  end
+
+  private
+
+  def app = @app ||= Wurk::API::App.new(config: config)
+
+  def config
+    @config ||= Wurk::Configuration.new.tap do |cfg|
+      cfg.api_token(ADMIN_TOKEN, scopes: %i[admin])
+      cfg.api_token(READ_TOKEN, scopes: %i[read])
+      cfg.api_token(ENQUEUE_TOKEN, scopes: %i[enqueue])
+    end
+  end
+
+  def job(**overrides)
+    { 'class' => @class_name, 'args' => [], 'queue' => @queue }.merge(overrides.transform_keys(&:to_s))
+  end
+
+  # Enqueues through the client, so the `queues` SET membership, the payload
+  # shape and the timestamps are all the ones a Ruby producer would write.
+  def enqueue(count, queue: @queue, args: [])
+    Array.new(count) { Wurk::Client.new.push(job('queue' => queue, 'args' => args)) }
+  end
+
+  def seed(set, at, fields = {})
+    jid = SecureRandom.hex(12)
+    set.schedule(at, job.merge('jid' => jid).merge(fields))
+    jid
+  end
+
+  # `live_jids` seeds `b-<bid>-jids`, which Batch::Status recomputes
+  # completeness from when the hash carries no `complete` flag yet.
+  def seed_batch(live_jids: [], **fields)
+    bid = SecureRandom.urlsafe_base64(10)
+    row = { 'created_at' => Time.now.to_f.to_s, 'tags' => '[]' }.merge(fields.transform_keys(&:to_s))
+    @pool.with do |conn|
+      conn.call('HSET', "b-#{bid}", *row.flatten.map(&:to_s))
+      conn.call('SADD', "b-#{bid}-jids", *live_jids) if live_jids.any?
+    end
+    bid
+  end
+
+  def jids(body) = body['jobs'].map { |job| job['jid'] }
+
+  def call(env) = app.call(env)
+
+  def get(path, token: ADMIN_TOKEN) = request('GET', path, token: token)
+  def post(path, token: ADMIN_TOKEN) = request('POST', path, token: token)
+
+  def request(method, path, token:)
+    info, _, query = path.partition('?')
+    parse(call(env_for(method, info, query: query, token: token)))
+  end
+
+  def parse(response)
+    status, headers, body = response
+    [status, headers, JSON.parse(body.join)]
+  end
+
+  def env_for(method, path, query: '', token: ADMIN_TOKEN)
+    {
+      'REQUEST_METHOD' => method,
+      'PATH_INFO' => path,
+      'SCRIPT_NAME' => '',
+      'QUERY_STRING' => query,
+      'rack.input' => StringIO.new,
+      'rack.errors' => StringIO.new,
+      'HTTP_AUTHORIZATION' => "Bearer #{token}"
+    }
+  end
+end

--- a/test/unit/api_read_only_test.rb
+++ b/test/unit/api_read_only_test.rb
@@ -1,0 +1,291 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'wurk/api/app'
+require 'json'
+require 'stringio'
+
+# Slice 07, task 49 — what `read-only` means once there are two planes.
+#
+# The dashboard has frozen its non-safe verbs since the beginning
+# (`WURK_WEB_READ_ONLY=1`). The decision pinned here is that the machine plane
+# keeps the same rule rather than inventing a second one: every write is
+# refused, `enqueue` as well as the destructive `admin` routes, so a viewer-only
+# deployment cannot be talked into starting work by whoever holds a token.
+#
+# Which deployments that binds is the other half. Mounted inside the engine the
+# API is part of the dashboard's deployment and inherits its flag; mounted on
+# its own path or run standalone it is a different one and opts in explicitly.
+# `Wurk::Web::Authorization` stamping that inheritance is proven under a real
+# host in test/engine/api_read_only_test.rb; this file speaks about what the
+# app does with the answer.
+class ApiReadOnlyTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  ADMIN_TOKEN = 'api-read-only-admin-token-01234567'
+  ENQUEUE_TOKEN = 'api-read-only-enqueue-token-012345'
+
+  def setup
+    super
+    @ns = "#{Process.pid}_#{object_id}"
+    @queue = "q-#{@ns}"
+    @class_name = "ApiReadOnlyWorker#{@ns}"
+    @pool = Wurk.configuration.redis_pool
+  end
+
+  # --- what it freezes ----------------------------------------------------
+
+  # Every write the API has, under one flag. `enqueue` is in the list on
+  # purpose: it is the case a scope-shaped rule would have let through.
+  def test_every_write_is_refused
+    frozen!
+    writes = [
+      ['POST', '/v1/jobs'],
+      ['POST', '/v1/jobs/bulk'],
+      ['DELETE', '/v1/jobs/abc123'],
+      ['POST', "/v1/queues/#{@queue}/pause"],
+      ['POST', "/v1/queues/#{@queue}/unpause"],
+      ['POST', '/v1/processes/host:1:abc/quiet'],
+      ['POST', '/v1/processes/host:1:abc/stop']
+    ]
+
+    writes.each do |method, path|
+      status, headers, body = call(method, path)
+
+      assert_equal 403, status, "#{method} #{path}"
+      assert_equal 'application/problem+json', headers['content-type'], path
+      assert_equal 'read_only', body['type'], path
+      assert_equal 'Read-Only Mode', body['title'], path
+      assert_equal path, body['instance'], path
+    end
+  end
+
+  def test_a_frozen_deployment_still_answers_reads
+    frozen!
+
+    %w[/v1 /v1/stats /v1/queues /v1/swarm /v1/processes /v1/busy].each do |path|
+      status, = call('GET', path)
+
+      assert_equal 200, status, path
+    end
+  end
+
+  def test_head_is_a_read
+    frozen!
+    status, = call('HEAD', '/v1/queues')
+
+    assert_equal 200, status
+  end
+
+  # The refusal is a property of the deployment, not of the credential, so the
+  # scope a token holds changes nothing about it. An `insufficient_scope` here
+  # would send a producer to its operator for a grant that cannot help.
+  def test_the_verdict_does_not_depend_on_the_scope_presented
+    frozen!
+    status, _headers, body = call('POST', '/v1/jobs', token: ENQUEUE_TOKEN)
+
+    assert_equal 403, status
+    assert_equal 'read_only', body['type']
+  end
+
+  # Nothing reaches Client, so nothing lands — the assertion the status code
+  # alone would not make.
+  def test_a_refused_enqueue_writes_nothing
+    frozen!
+    call('POST', '/v1/jobs', body: JSON.generate('class' => @class_name, 'args' => [], 'queue' => @queue))
+
+    assert_empty queued_payloads
+  end
+
+  # Before routing, so a write to a path that does not exist is answered with
+  # the fact that applies to every write here rather than a 404 that invites a
+  # client to go looking for the right path.
+  def test_a_write_to_an_unknown_path_is_refused_for_being_a_write
+    frozen!
+    status, _headers, body = call('POST', '/v1/nope')
+
+    assert_equal 403, status
+    assert_equal 'read_only', body['type']
+  end
+
+  # Authentication still runs first: a stranger learns nothing about the
+  # deployment's mode, and the 401 is the same one a live deployment gives.
+  def test_an_unauthenticated_write_is_still_401
+    frozen!
+    status, _headers, body = call('POST', '/v1/jobs', token: nil)
+
+    assert_equal 401, status
+    assert_equal 'unauthorized', body['type']
+  end
+
+  # --- which deployments it binds -----------------------------------------
+
+  # Modes 2 and 3: no engine in front, nothing configured, so nothing is frozen.
+  def test_a_standalone_mount_is_live_by_default
+    status, = call('POST', "/v1/queues/#{@queue}/pause")
+
+    assert_equal 200, status
+  end
+
+  # Mode 1: the engine stamps the dashboard's flag onto the Rack env.
+  def test_an_engine_nested_mount_inherits_the_dashboard_flag
+    status, _headers, body = call('POST', "/v1/queues/#{@queue}/pause", inherited: true)
+
+    assert_equal 403, status
+    assert_equal 'read_only', body['type']
+  end
+
+  # The same stamp on a mount that said it is live: an explicit `false` is the
+  # host asking for a viewer-only dashboard and a working producer on one mount,
+  # and it has to outrank what the engine passed down or it means nothing.
+  def test_an_explicit_false_outranks_the_inherited_flag
+    @config = build_config { |cfg| cfg.api_read_only = false }
+    status, = call('POST', "/v1/queues/#{@queue}/pause", inherited: true)
+
+    assert_equal 200, status
+  end
+
+  def test_an_explicit_true_freezes_a_mount_with_nothing_to_inherit
+    @config = build_config { |cfg| cfg.api_read_only = true }
+    status, = call('POST', "/v1/queues/#{@queue}/pause")
+
+    assert_equal 403, status
+  end
+
+  # The only door mode 3 has — `wurk api` reads no Ruby config file.
+  def test_the_environment_freezes_a_standalone_mount
+    with_env('WURK_API_READ_ONLY', '1') do
+      status, _headers, body = call('POST', "/v1/queues/#{@queue}/pause")
+
+      assert_equal 403, status
+      assert_equal 'read_only', body['type']
+    end
+  end
+
+  def test_the_environment_variable_is_exact
+    %w[0 true yes on].each do |value|
+      with_env('WURK_API_READ_ONLY', value) do
+        assert_equal 200, call('POST', "/v1/queues/#{@queue}/pause")[0], value
+      end
+    end
+  end
+
+  # --- the setting itself -------------------------------------------------
+
+  def test_the_setting_is_three_state
+    config = Wurk::Configuration.new
+
+    assert_nil config.api_read_only
+
+    config.api_read_only = true
+
+    assert_same true, config.api_read_only
+
+    config.api_read_only = false
+
+    assert_same false, config.api_read_only
+
+    config.api_read_only = nil
+
+    assert_nil config.api_read_only
+  end
+
+  # `config.api_read_only = ENV['X']` is the shape a host reaches for, and
+  # `!!'false'` is true.
+  def test_a_string_that_means_off_does_not_turn_it_on
+    ['', '0', 'false', 'no', 'off', ' OFF '].each do |value|
+      config = Wurk::Configuration.new
+      config.api_read_only = value
+
+      assert_same false, config.api_read_only, value.inspect
+    end
+  end
+
+  def test_a_string_that_means_on_turns_it_on
+    %w[1 true yes on].each do |value|
+      config = Wurk::Configuration.new
+      config.api_read_only = value
+
+      assert_same true, config.api_read_only, value.inspect
+    end
+  end
+
+  def test_it_cannot_be_changed_after_boot
+    config = Wurk::Configuration.new
+    config.freeze!
+
+    assert_raises(FrozenError) { config.api_read_only = true }
+  end
+
+  # --- telling a client in advance ----------------------------------------
+
+  # A producer that can read "frozen" at startup fails in its own logs rather
+  # than halfway through a batch.
+  def test_the_discovery_document_reports_the_mode
+    assert_same false, call('GET', '/v1')[2]['read_only']
+
+    frozen!
+
+    assert_same true, call('GET', '/v1')[2]['read_only']
+  end
+
+  def test_the_discovery_document_reports_an_inherited_freeze
+    assert_same true, call('GET', '/v1', inherited: true)[2]['read_only']
+  end
+
+  private
+
+  def frozen!
+    @config = build_config { |cfg| cfg.api_read_only = true }
+  end
+
+  def app = Wurk::API::App.new(config: config)
+
+  def config
+    @config ||= build_config
+  end
+
+  def build_config
+    Wurk::Configuration.new.tap do |cfg|
+      cfg.api_token(ADMIN_TOKEN, scopes: %i[admin])
+      cfg.api_token(ENQUEUE_TOKEN, scopes: %i[enqueue])
+      cfg.api_enqueue_classes = [@class_name]
+      yield cfg if block_given?
+    end
+  end
+
+  def queued_payloads
+    @pool.with { |conn| conn.call('LRANGE', "queue:#{@queue}", 0, -1) }
+  end
+
+  def call(method, path, token: ADMIN_TOKEN, body: '', inherited: false)
+    env = {
+      'REQUEST_METHOD' => method,
+      'PATH_INFO' => path,
+      'SCRIPT_NAME' => '',
+      'QUERY_STRING' => '',
+      'CONTENT_TYPE' => 'application/json',
+      'CONTENT_LENGTH' => body.bytesize.to_s,
+      'rack.input' => StringIO.new(body),
+      'rack.errors' => StringIO.new
+    }
+    env['HTTP_AUTHORIZATION'] = "Bearer #{token}" if token
+    env[Wurk::API::READ_ONLY_ENV] = true if inherited
+    status, headers, raw = app.call(env)
+    [status, headers, raw.empty? ? {} : JSON.parse(raw.join)]
+  end
+
+  # ENV is process-global; the suite-wide mutex is the same one every other
+  # global-state test takes.
+  def with_env(name, value)
+    Wurk::Test::GLOBAL_STATE_MUTEX.synchronize do
+      previous = ENV.fetch(name, nil)
+      ENV[name] = value
+      begin
+        yield
+      ensure
+        ENV[name] = previous
+      end
+    end
+  end
+end

--- a/test/unit/api_swarm_test.rb
+++ b/test/unit/api_swarm_test.rb
@@ -264,7 +264,7 @@ class ApiSwarmTest < Wurk::Test::UnitCase
     identity = beat('a')
     @pool.with do |c|
       info = Wurk.load_json(c.call('HGET', identity, 'info'))
-      c.call('HSET', identity, 'info', Wurk.dump_json(info.reject { |key, _| key == 'started_at' }))
+      c.call('HSET', identity, 'info', Wurk.dump_json(info.except('started_at')))
     end
 
     _status, _headers, body = get('/v1/processes')
@@ -614,7 +614,7 @@ class ApiSwarmTest < Wurk::Test::UnitCase
 
     _status, _headers, body = get('/v1/limiters')
 
-    assert_equal [{}, {}], body['limiters'].map { |row| row['options'] }
+    assert_equal([{}, {}], body['limiters'].map { |row| row['options'] })
   end
 
   def test_limiters_filter_by_substring

--- a/test/unit/api_swarm_test.rb
+++ b/test/unit/api_swarm_test.rb
@@ -1,0 +1,825 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'wurk/api/app'
+require 'json'
+require 'securerandom'
+require 'stringio'
+
+# Slice 07 — the HTTP API's swarm plane: GET /swarm, /processes,
+# /processes/:identity, /busy, /health, /limiters, /cron and the two process
+# signals.
+#
+# The plane's contract is that watching the swarm costs the swarm nothing: no
+# new Redis key, no new heartbeat field, no extra beat. So the fixtures below
+# write the heartbeat HASHes exactly as Wurk::Heartbeat#write_beat does and the
+# assertions check that the HTTP answer is the one ProcessSet, WorkSet,
+# Cron::LoopSet and the limiter registry give for the same bytes.
+#
+# Auth mechanics live in api_auth_test.rb and routing in api_app_test.rb; the
+# scope checks here only pin which scope each route demands.
+#
+# Isolation: each test runs against a freshly flushed worker DB
+# (RedisNamespace), and identities still carry a per-instance namespace so a
+# fixture reads the way production data would.
+class ApiSwarmTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  ADMIN_TOKEN = 'api-swarm-admin-token-0123456789'
+  READ_TOKEN = 'api-swarm-read-token-0123456789'
+  ENQUEUE_TOKEN = 'api-swarm-enqueue-token-0123456789'
+
+  READ_ROUTES = %w[/v1/swarm /v1/processes /v1/busy /v1/health /v1/limiters /v1/cron].freeze
+
+  def setup
+    super
+    @ns = "#{Process.pid}-#{object_id}"
+    @pool = Wurk.configuration.redis_pool
+    @now = Time.now.to_f
+  end
+
+  # --- GET /swarm --------------------------------------------------------
+
+  def test_swarm_rolls_up_the_live_processes
+    beat('a', concurrency: 10, busy: 3, rss: 120_000)
+    beat('b', concurrency: 6, busy: 0, rss: 90_000)
+
+    status, headers, body = get('/v1/swarm')
+
+    assert_equal 200, status
+    assert_equal 'application/json', headers['content-type']
+    assert_equal({ 'total' => 2, 'quiet' => 0, 'stale' => 0 }, body['processes'])
+    assert_equal 16, body['concurrency']
+    assert_equal 3, body['busy']
+    assert_in_delta 0.1875, body['utilization'], 0.0001
+    assert_equal 210_000, body['rss_kb']
+  end
+
+  def test_swarm_reports_the_union_of_queues_and_versions
+    beat('a', queues: %w[critical default], version: '1.2.3')
+    beat('b', queues: %w[default bulk], version: '1.2.4')
+
+    _status, _headers, body = get('/v1/swarm')
+
+    assert_equal %w[bulk critical default], body['queues']
+    assert_equal %w[1.2.3 1.2.4], body['versions']
+  end
+
+  # Nothing running is 0% busy, not a division by zero and not a null the
+  # client has to special-case.
+  def test_swarm_utilization_is_zero_for_an_empty_fleet
+    _status, _headers, body = get('/v1/swarm')
+
+    assert_equal({ 'total' => 0, 'quiet' => 0, 'stale' => 0 }, body['processes'])
+    assert_in_delta 0.0, body['utilization'], 0.0001
+    assert_nil body['beat']['oldest_age_seconds']
+  end
+
+  def test_swarm_counts_quiet_and_stale_processes
+    beat('live')
+    beat('draining', quiet: true)
+    beat('gone', beat_at: @now - 120)
+
+    _status, _headers, body = get('/v1/swarm')
+
+    assert_equal({ 'total' => 3, 'quiet' => 1, 'stale' => 1 }, body['processes'])
+  end
+
+  # The threshold rides along with the verdict, so a client reads the rule and
+  # the reading it produced in the same document.
+  def test_swarm_ships_the_staleness_threshold_with_the_oldest_beat
+    beat('a', beat_at: @now - 45)
+
+    _status, _headers, body = get('/v1/swarm')
+
+    assert_equal 30, body['beat']['stale_after_seconds']
+    assert_in_delta 45.0, body['beat']['oldest_age_seconds'], 1.0
+  end
+
+  def test_swarm_names_the_leader_and_whether_it_is_live
+    identity = beat('a')
+    beat('b')
+    @pool.with { |c| c.call('SET', 'dear-leader', identity) }
+
+    _status, _headers, body = get('/v1/swarm')
+
+    assert_equal identity, body['leader']['identity']
+    assert body['leader']['live']
+  end
+
+  # `dear-leader` outlives the heartbeat that took it, so between the two
+  # expiries the cluster has a recorded leader and no leader — a state the
+  # roll-up has to be able to say out loud.
+  def test_swarm_reports_an_orphaned_leader_lock_as_not_live
+    beat('a')
+    @pool.with { |c| c.call('SET', 'dear-leader', "gone-#{@ns}:1:x") }
+
+    _status, _headers, body = get('/v1/swarm')
+
+    assert_equal "gone-#{@ns}:1:x", body['leader']['identity']
+    refute body['leader']['live']
+  end
+
+  def test_swarm_reports_no_leader_when_the_lock_is_unset
+    beat('a')
+
+    _status, _headers, body = get('/v1/swarm')
+
+    assert_nil body['leader']['identity']
+    refute body['leader']['live']
+  end
+
+  def test_swarm_groups_processes_by_host
+    beat('a', hostname: 'box-a', concurrency: 4, busy: 1, rss: 100)
+    beat('b', hostname: 'box-a', concurrency: 4, busy: 2, rss: 200)
+    beat('c', hostname: 'box-b', concurrency: 8, busy: 0, rss: 300)
+
+    _status, _headers, body = get('/v1/swarm')
+    first, second = body['hosts']
+
+    assert_equal(%w[box-a box-b], body['hosts'].map { |host| host['hostname'] })
+    assert_equal 2, first['processes']
+    assert_equal 8, first['concurrency']
+    assert_equal 3, first['busy']
+    assert_equal 300, first['rss_kb']
+    assert_equal 1, second['processes']
+  end
+
+  # Host hardware facts belong to the box, so they ride the host roll-up once
+  # rather than repeating on every child the box is running.
+  def test_swarm_reports_host_hardware_once_per_host
+    beat('a', hostname: 'box-a')
+    beat('b', hostname: 'box-a')
+
+    _status, _headers, body = get('/v1/swarm')
+    host = body['hosts'].fetch(0)
+
+    assert_equal 'Fake CPU', host['cpu_model']
+    assert_equal 8, host['cores']
+    assert_equal 16_000_000, host['memory_total_kb']
+  end
+
+  # The slot table is the one the heartbeats describe, not the one this
+  # process's own configuration declares: a standalone `wurk api` shares no
+  # config with the swarm parent and would otherwise report a topology derived
+  # from its own CPU count.
+  def test_swarm_reports_the_slot_shape_the_heartbeats_describe
+    beat('a', queues: %w[critical default], concurrency: 5)
+    beat('b', queues: %w[default critical], concurrency: 5)
+    beat('c', queues: %w[bulk], concurrency: 2)
+
+    _status, _headers, body = get('/v1/swarm')
+
+    assert_equal(
+      [{ 'count' => 2, 'queues' => %w[critical default], 'concurrency' => 5 },
+       { 'count' => 1, 'queues' => %w[bulk], 'concurrency' => 2 }],
+      body['slots']
+    )
+  end
+
+  # An identity whose heartbeat HASH expired is still in the `processes` SET
+  # until something prunes it, and this plane deliberately never prunes.
+  def test_swarm_skips_identities_whose_heartbeat_expired
+    beat('a')
+    @pool.with { |c| c.call('SADD', 'processes', "ghost-#{@ns}:1:x") }
+
+    _status, _headers, body = get('/v1/swarm')
+
+    assert_equal 1, body['processes']['total']
+  end
+
+  # The sweep is a Redis write behind a Redis write; a monitor polling this
+  # plane must not pay either.
+  def test_swarm_does_not_run_the_process_sweep
+    beat('a')
+    get('/v1/swarm')
+
+    assert_nil(@pool.with { |c| c.call('GET', 'process_cleanup') })
+  end
+
+  # --- GET /processes ----------------------------------------------------
+
+  def test_processes_lists_what_each_process_declared_about_itself
+    identity = beat('a', hostname: 'box-a', pid: 4321, tag: 'web', concurrency: 10,
+                         queues: %w[critical default], version: '9.9.9')
+
+    status, _headers, body = get('/v1/processes')
+    row = body['processes'].fetch(0)
+
+    assert_equal 200, status
+    assert_equal 1, body['total']
+    assert_equal identity, row['identity']
+    assert_equal 'box-a', row['hostname']
+    assert_equal 4321, row['pid']
+    assert_equal 'web', row['tag']
+    assert_equal 10, row['concurrency']
+    assert_equal %w[critical default], row['queues']
+    assert_equal({ 'critical' => 2, 'default' => 1 }, row['weights'])
+    assert_equal '9.9.9', row['version']
+    refute row['embedded']
+  end
+
+  def test_processes_reports_what_the_last_beat_measured
+    beat('a', busy: 4, rss: 123_456, rtt_us: 900, quiet: true)
+
+    _status, _headers, body = get('/v1/processes')
+    row = body['processes'].fetch(0)
+
+    assert_equal 4, row['busy']
+    assert_equal 123_456, row['rss_kb']
+    assert_equal 900, row['rtt_us']
+    assert row['quiet']
+  end
+
+  # Derived here so a client never has to compare the swarm's clock against
+  # its own — the one comparison this plane exists to save it from.
+  def test_processes_derive_beat_age_uptime_and_staleness
+    beat('fresh', beat_at: @now - 2, started_at: @now - 600)
+    beat('stale', beat_at: @now - 90, started_at: @now - 900)
+
+    _status, _headers, body = get('/v1/processes')
+    fresh = row_for(body['processes'], 'fresh')
+    stale = row_for(body['processes'], 'stale')
+
+    assert_in_delta 2.0, fresh['beat_age_seconds'], 1.0
+    assert_in_delta 600.0, fresh['uptime_seconds'], 1.0
+    refute fresh['stale']
+    assert_in_delta 90.0, stale['beat_age_seconds'], 1.0
+    assert stale['stale']
+  end
+
+  # `beat` is stamped by the beating process's clock and read on another's, so
+  # a skew of a few milliseconds must not surface as a negative age.
+  def test_processes_never_report_a_negative_beat_age
+    beat('a', beat_at: @now + 5)
+
+    _status, _headers, body = get('/v1/processes')
+
+    assert_in_delta 0.0, body['processes'].fetch(0)['beat_age_seconds'], 0.0001
+  end
+
+  # A heartbeat written before `started_at` existed reports a null uptime: a
+  # process of unknown age is not one that just booted.
+  def test_processes_report_a_null_uptime_when_the_beat_carries_no_start
+    identity = beat('a')
+    @pool.with do |c|
+      info = Wurk.load_json(c.call('HGET', identity, 'info'))
+      c.call('HSET', identity, 'info', Wurk.dump_json(info.reject { |key, _| key == 'started_at' }))
+    end
+
+    _status, _headers, body = get('/v1/processes')
+
+    assert_nil body['processes'].fetch(0)['started_at']
+    assert_nil body['processes'].fetch(0)['uptime_seconds']
+  end
+
+  def test_processes_flag_the_leader
+    identity = beat('a')
+    beat('b')
+    @pool.with { |c| c.call('SET', 'dear-leader', identity) }
+
+    _status, _headers, body = get('/v1/processes')
+
+    assert_equal([identity], body['processes'].select { |row| row['leader'] }.map { |row| row['identity'] })
+  end
+
+  def test_processes_count_only_the_live_ones
+    beat('a')
+    @pool.with { |c| c.call('SADD', 'processes', "ghost-#{@ns}:1:x") }
+
+    _status, _headers, body = get('/v1/processes')
+
+    assert_equal 1, body['total']
+    assert_equal 1, body['processes'].size
+  end
+
+  def test_processes_page_and_echo_the_effective_window
+    3.times { |i| beat("p#{i}") }
+
+    _status, _headers, body = get('/v1/processes?page=1&count=2')
+
+    assert_equal 3, body['total']
+    assert_equal 1, body['page']
+    assert_equal 2, body['count']
+    assert_equal 1, body['processes'].size
+  end
+
+  def test_processes_refuse_a_malformed_paging_parameter
+    status, _headers, body = get('/v1/processes?count=all')
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+  end
+
+  # --- GET /processes/:identity ------------------------------------------
+
+  def test_process_detail_returns_the_listing_row_plus_its_work
+    identity = beat('a')
+    work(identity, jid: 'abc123def4567890abcdef01', queue: 'critical', run_at: @now - 5)
+
+    status, _headers, body = get("/v1/processes/#{identity}")
+
+    assert_equal 200, status
+    assert_equal identity, body['process']['identity']
+    assert_equal 1, body['work'].size
+    entry = body['work'].fetch(0)
+
+    assert_equal 'abc123def4567890abcdef01', entry['jid']
+    assert_equal 'critical', entry['queue']
+    assert_in_delta 5.0, entry['elapsed_seconds'], 1.0
+  end
+
+  # A client that read a row out of the listing and then fetched it should not
+  # have to reshape anything.
+  def test_process_detail_row_has_the_same_shape_as_the_listing_row
+    identity = beat('a')
+
+    _status, _headers, listing = get('/v1/processes')
+    _status, _headers, detail = get("/v1/processes/#{identity}")
+
+    assert_equal listing['processes'].fetch(0).keys.sort, detail['process'].keys.sort
+  end
+
+  def test_process_detail_shows_only_that_process_work
+    first = beat('a')
+    second = beat('b')
+    work(first, jid: 'aaaaaaaaaaaaaaaaaaaaaaaa')
+    work(second, jid: 'bbbbbbbbbbbbbbbbbbbbbbbb')
+
+    _status, _headers, body = get("/v1/processes/#{first}")
+
+    assert_equal(%w[aaaaaaaaaaaaaaaaaaaaaaaa], body['work'].map { |entry| entry['jid'] })
+  end
+
+  def test_process_detail_of_an_unknown_identity_is_a_process_not_found_problem
+    status, headers, body = get("/v1/processes/nobody-#{@ns}:1:x")
+
+    assert_equal 404, status
+    assert_equal 'application/problem+json', headers['content-type']
+    assert_equal 'process_not_found', body['type']
+    assert_equal 'Process Not Found', body['title']
+    assert_equal "nobody-#{@ns}:1:x", body['identity']
+  end
+
+  def test_process_detail_rejects_a_malformed_identity
+    status, _headers, body = get('/v1/processes/two%20words')
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+    assert_includes body['detail'], 'process identity'
+  end
+
+  # --- POST /processes/:identity/quiet|stop ------------------------------
+
+  def test_quiet_queues_a_tstp_on_the_targets_signal_list
+    identity = beat('a')
+
+    status, _headers, body = post("/v1/processes/#{identity}/quiet")
+
+    assert_equal 200, status
+    assert_equal 'TSTP', body['signal']
+    assert_equal [identity], body['signalled']
+    assert_empty body['skipped']
+    assert_equal %w[TSTP], signals(identity)
+  end
+
+  def test_stop_queues_a_term_on_the_targets_signal_list
+    identity = beat('a')
+
+    _status, _headers, body = post("/v1/processes/#{identity}/stop")
+
+    assert_equal 'TERM', body['signal']
+    assert_equal %w[TERM], signals(identity)
+  end
+
+  def test_signalling_all_broadcasts_to_every_live_process
+    first = beat('a')
+    second = beat('b')
+
+    _status, _headers, body = post('/v1/processes/all/quiet')
+
+    assert_equal [first, second].sort, body['signalled'].sort
+    assert_equal %w[TSTP], signals(first)
+    assert_equal %w[TSTP], signals(second)
+  end
+
+  # One member that cannot be signalled is no reason to refuse the fleet.
+  def test_broadcast_skips_an_embedded_process
+    normal = beat('a')
+    embedded = beat('b', embedded: true)
+
+    _status, _headers, body = post('/v1/processes/all/stop')
+
+    assert_equal [normal], body['signalled']
+    assert_equal [embedded], body['skipped']
+    assert_empty signals(embedded)
+  end
+
+  # Addressed directly, though, the caller asked about that process and gets a
+  # verdict about it: 409, because the request is well-formed and permitted
+  # and only the target's state refuses it.
+  def test_signalling_an_embedded_process_is_a_conflict
+    identity = beat('a', embedded: true)
+
+    status, headers, body = post("/v1/processes/#{identity}/quiet")
+
+    assert_equal 409, status
+    assert_equal 'application/problem+json', headers['content-type']
+    assert_equal 'process_not_signalable', body['type']
+    assert_equal identity, body['identity']
+    assert_empty signals(identity)
+  end
+
+  def test_signalling_an_unknown_process_is_a_process_not_found_problem
+    status, _headers, body = post("/v1/processes/nobody-#{@ns}:1:x/quiet")
+
+    assert_equal 404, status
+    assert_equal 'process_not_found', body['type']
+  end
+
+  def test_signalling_rejects_a_malformed_identity
+    status, _headers, body = post('/v1/processes/two%20words/stop')
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+  end
+
+  # --- GET /busy ---------------------------------------------------------
+
+  def test_busy_lists_the_in_flight_jobs_cluster_wide
+    first = beat('a')
+    second = beat('b')
+    work(first, jid: 'aaaaaaaaaaaaaaaaaaaaaaaa', run_at: @now - 30)
+    work(second, jid: 'bbbbbbbbbbbbbbbbbbbbbbbb', run_at: @now - 5)
+
+    status, _headers, body = get('/v1/busy')
+
+    assert_equal 200, status
+    assert_equal 2, body['total']
+    # WorkSet orders oldest first so the job most likely to be stuck leads.
+    assert_equal(%w[aaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbb], body['jobs'].map { |job| job['jid'] })
+    assert_equal first, body['jobs'].fetch(0)['process_id']
+    assert_in_delta 30.0, body['jobs'].fetch(0)['elapsed_seconds'], 1.0
+  end
+
+  def test_busy_pages
+    identity = beat('a')
+    3.times { |i| work(identity, jid: format('%024d', i), thread_id: "t#{i}", run_at: @now - i) }
+
+    _status, _headers, body = get('/v1/busy?count=2')
+
+    assert_equal 3, body['total']
+    assert_equal 2, body['jobs'].size
+  end
+
+  # The display view, exactly as the queue listings serve it: publishing
+  # `payload['args']` here would put every encrypted job's envelope on the wire.
+  def test_busy_masks_an_encrypted_jobs_arguments
+    identity = beat('a')
+    work(identity, jid: 'cccccccccccccccccccccccc', payload_overrides: { 'encrypt' => true })
+
+    _status, _headers, body = get('/v1/busy')
+
+    refute_includes body['jobs'].fetch(0)['args'].inspect, 'secret-value'
+  end
+
+  # --- GET /health -------------------------------------------------------
+
+  def test_health_is_ok_when_redis_answers_and_something_is_beating
+    beat('a')
+
+    status, _headers, body = get('/v1/health')
+
+    assert_equal 200, status
+    assert_equal 'ok', body['status']
+    assert body['redis']['ok']
+    assert_operator body['redis']['rtt_ms'], :>=, 0
+    assert_equal({ 'total' => 1, 'live' => 1, 'stale' => 0, 'quiet' => 0 }, body['processes'])
+    assert_equal 30, body['stale_after_seconds']
+  end
+
+  def test_health_is_down_when_nothing_is_beating
+    status, _headers, body = get('/v1/health')
+
+    assert_equal 503, status
+    assert_equal 'down', body['status']
+    assert_equal 'no live processes', body['reason']
+    assert body['redis']['ok']
+  end
+
+  def test_health_is_down_when_every_beat_is_stale
+    beat('a', beat_at: @now - 120)
+
+    status, _headers, body = get('/v1/health')
+
+    assert_equal 503, status
+    assert_equal 'no live processes', body['reason']
+    assert_equal({ 'total' => 1, 'live' => 0, 'stale' => 1, 'quiet' => 0 }, body['processes'])
+  end
+
+  # A draining process is still finishing work, and Wurk::Health does not fail
+  # readiness for one either — so `quiet` is reported, not folded into the
+  # verdict.
+  def test_health_reports_quiet_processes_without_failing_on_them
+    beat('a', quiet: true)
+
+    status, _headers, body = get('/v1/health')
+
+    assert_equal 200, status
+    assert_equal 1, body['processes']['quiet']
+  end
+
+  # Not a stub: a real RedisPool dialing a closed port, installed through the
+  # per-thread capsule override Wurk.redis_pool already honours, so no sibling
+  # test's connection is touched.
+  def test_health_is_down_when_redis_is_unreachable
+    status, _headers, body = with_unreachable_redis { get('/v1/health') }
+
+    assert_equal 503, status
+    assert_equal 'down', body['status']
+    assert_equal 'redis unreachable', body['reason']
+    refute body['redis']['ok']
+    assert_nil body['redis']['rtt_ms']
+    assert_nil body['processes']
+  end
+
+  # --- GET /limiters -----------------------------------------------------
+
+  def test_limiters_lists_the_registry_with_each_limiters_status
+    name = "lim-#{@ns}"
+    Wurk::Limiter.concurrent(name, 5)
+
+    status, _headers, body = get('/v1/limiters')
+    row = body['limiters'].fetch(0)
+
+    assert_equal 200, status
+    assert_equal 1, body['total']
+    assert_equal name, row['name']
+    assert_equal 'concurrent', row['type']
+    refute_empty row['fingerprint']
+    assert_equal 5, row['options']['limit']
+    assert_equal 0, row['status']['used']
+    assert_equal 5, row['status']['limit']
+    assert row['status']['available']
+  end
+
+  # `available?` is Ruby's spelling of a predicate, not JSON's.
+  def test_limiter_status_uses_a_json_shaped_boolean_key
+    Wurk::Limiter.concurrent("lim-#{@ns}", 1)
+
+    _status, _headers, body = get('/v1/limiters')
+
+    refute body['limiters'].fetch(0)['status'].key?('available?')
+  end
+
+  # Metadata a limiter type can no longer be rebuilt from yields a null status
+  # rather than a 500 for the whole page — the dashboard's Limits tab is
+  # best-effort for the same reason.
+  def test_limiter_status_is_null_when_the_type_cannot_be_rebuilt
+    name = "lim-#{@ns}"
+    @pool.with do |c|
+      c.call('HSET', "lmtr:#{name}", 'type', 'from-the-future', 'options', '{}')
+      c.call('SADD', 'lmtr-list', name)
+    end
+
+    _status, _headers, body = get('/v1/limiters')
+
+    assert_equal 'from-the-future', body['limiters'].fetch(0)['type']
+    assert_nil body['limiters'].fetch(0)['status']
+  end
+
+  # The other half of the same refusal: a known type whose persisted options
+  # no longer satisfy its constructor (a bucket with no interval).
+  def test_limiter_status_is_null_when_the_options_no_longer_build
+    name = "lim-#{@ns}"
+    @pool.with do |c|
+      c.call('HSET', "lmtr:#{name}", 'type', 'bucket', 'options', '{}')
+      c.call('SADD', 'lmtr-list', name)
+    end
+
+    _status, _headers, body = get('/v1/limiters')
+
+    assert_equal 'bucket', body['limiters'].fetch(0)['type']
+    assert_nil body['limiters'].fetch(0)['status']
+  end
+
+  # Options the registry can no longer parse are an empty object, not a 500
+  # and not the raw string — the row's other fields are still worth serving.
+  def test_limiter_options_survive_unreadable_metadata
+    @pool.with do |c|
+      c.call('HSET', "lmtr:a-unparseable-#{@ns}", 'type', 'concurrent', 'options', '{not json')
+      c.call('HSET', "lmtr:b-optionless-#{@ns}", 'type', 'concurrent')
+      c.call('SADD', 'lmtr-list', "a-unparseable-#{@ns}", "b-optionless-#{@ns}")
+    end
+
+    _status, _headers, body = get('/v1/limiters')
+
+    assert_equal [{}, {}], body['limiters'].map { |row| row['options'] }
+  end
+
+  def test_limiters_filter_by_substring
+    Wurk::Limiter.concurrent("stripe-#{@ns}", 1)
+    Wurk::Limiter.concurrent("mailer-#{@ns}", 1)
+
+    _status, _headers, body = get('/v1/limiters?filter=STRIPE')
+
+    assert_equal 1, body['total']
+    assert_equal "stripe-#{@ns}", body['limiters'].fetch(0)['name']
+  end
+
+  def test_limiters_refuse_an_oversized_filter
+    status, _headers, body = get("/v1/limiters?filter=#{'x' * 256}")
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+    assert_includes body['detail'], "'filter'"
+  end
+
+  def test_limiters_refuse_a_repeated_filter
+    status, _headers, body = get('/v1/limiters?filter=a&filter=b')
+
+    assert_equal 400, status
+    assert_equal 'invalid_request', body['type']
+  end
+
+  def test_limiters_page
+    3.times { |i| Wurk::Limiter.concurrent("lim#{i}-#{@ns}", 1) }
+
+    _status, _headers, body = get('/v1/limiters?count=2')
+
+    assert_equal 3, body['total']
+    assert_equal 2, body['limiters'].size
+  end
+
+  # --- GET /cron ---------------------------------------------------------
+
+  def test_cron_lists_the_registered_loops
+    loop_obj = register_cron('*/5 * * * *', queue: 'critical', args: [1, 'two'])
+
+    status, _headers, body = get('/v1/cron')
+    row = body['cron'].fetch(0)
+
+    assert_equal 200, status
+    assert_equal 1, body['total']
+    assert_equal loop_obj.lid, row['lid']
+    assert_equal '*/5 * * * *', row['schedule']
+    assert_equal loop_obj.klass, row['class']
+    assert_equal 'critical', row['queue']
+    assert_equal [1, 'two'], row['args']
+    refute row['paused']
+    assert_nil row['last_fired_at']
+    assert_operator row['next_fire_at'], :>, Time.now.to_i - 1
+  end
+
+  def test_cron_reports_the_last_fire_the_poller_recorded
+    loop_obj = register_cron('*/5 * * * *')
+    fired_at = Time.now.to_i - 300
+    key = "#{Wurk::Cron::HISTORY_PREFIX}#{loop_obj.lid}"
+    @pool.with { |c| c.call('LPUSH', key, Wurk.dump_json([fired_at, 'abc'])) }
+
+    _status, _headers, body = get('/v1/cron')
+
+    assert_equal fired_at, body['cron'].fetch(0)['last_fired_at']
+  end
+
+  def test_cron_pages
+    3.times { |i| register_cron("#{i} * * * *") }
+
+    _status, _headers, body = get('/v1/cron?count=2')
+
+    assert_equal 3, body['total']
+    assert_equal 2, body['cron'].size
+  end
+
+  # --- scopes ------------------------------------------------------------
+
+  def test_read_scope_may_observe
+    beat('a')
+    READ_ROUTES.each do |path|
+      status, = get(path, token: READ_TOKEN)
+
+      assert_equal 200, status, path
+    end
+  end
+
+  def test_enqueue_scope_may_not_observe
+    status, _headers, body = get('/v1/swarm', token: ENQUEUE_TOKEN)
+
+    assert_equal 403, status
+    assert_equal 'insufficient_scope', body['type']
+    assert_equal 'read', body['required_scope']
+  end
+
+  # Quieting the fleet stops it working without enqueueing or deleting
+  # anything, so both signals sit with the destructive routes.
+  def test_read_scope_may_not_signal
+    identity = beat('a')
+
+    %w[quiet stop].each do |action|
+      status, _headers, body = post("/v1/processes/#{identity}/#{action}", token: READ_TOKEN)
+
+      assert_equal 403, status, action
+      assert_equal 'admin', body['required_scope']
+    end
+    assert_empty signals(identity)
+  end
+
+  private
+
+  def app = @app ||= Wurk::API::App.new(config: config)
+
+  def config
+    @config ||= Wurk::Configuration.new.tap do |cfg|
+      cfg.api_token(ADMIN_TOKEN, scopes: %i[admin])
+      cfg.api_token(READ_TOKEN, scopes: %i[read])
+      cfg.api_token(ENQUEUE_TOKEN, scopes: %i[enqueue])
+    end
+  end
+
+  # Writes one heartbeat exactly as Wurk::Heartbeat#write_beat does — same SET
+  # membership, same HASH fields, same `info` JSON — so the routes read
+  # production bytes rather than a shape invented for the test.
+  def beat(label, hostname: "box-#{@ns}", pid: 4321, tag: 'web', concurrency: 10, busy: 0,
+           queues: %w[critical default], version: '1.2.3', embedded: false, quiet: false,
+           rss: 100_000, rtt_us: 400, beat_at: nil, started_at: nil)
+    identity = "#{hostname}:#{pid}:#{label}#{@ns}"
+    info = {
+      'hostname' => hostname, 'started_at' => started_at || (@now - 600), 'pid' => pid, 'tag' => tag,
+      'concurrency' => concurrency, 'capsules' => { 'default' => { 'weights' => weights_for(queues) } },
+      'labels' => ['x'], 'identity' => identity, 'version' => version, 'embedded' => embedded,
+      'cpu_model' => 'Fake CPU', 'cores' => 8, 'memory_total_kb' => 16_000_000
+    }
+    @pool.with do |c|
+      c.call('SADD', 'processes', identity)
+      c.call('HSET', identity, 'info', Wurk.dump_json(info), 'concurrency', concurrency.to_s,
+             'busy', busy.to_s, 'beat', (beat_at || @now).to_s, 'quiet', quiet.to_s,
+             'rss', rss.to_s, 'rtt_us', rtt_us.to_s)
+    end
+    identity
+  end
+
+  # Descending weights, so the fixture exercises the capsule-derived `queues`
+  # and `weights` accessors rather than the pre-capsule fallback fields.
+  def weights_for(queues)
+    queues.each_with_index.to_h { |queue, index| [queue, queues.size - index] }
+  end
+
+  def work(identity, jid:, queue: 'default', run_at: nil, thread_id: 'T0', payload_overrides: {})
+    payload = {
+      'class' => "SwarmWorker#{@ns}", 'args' => ['secret-value'], 'jid' => jid,
+      'queue' => queue, 'created_at' => @now - 10
+    }.merge(payload_overrides)
+    entry = { 'queue' => queue, 'run_at' => run_at || @now, 'payload' => Wurk.dump_json(payload) }
+    @pool.with { |c| c.call('HSET', "#{identity}:work", thread_id, Wurk.dump_json(entry)) }
+  end
+
+  def register_cron(schedule, queue: 'default', args: [])
+    Wurk::Cron::Loop.new(schedule: schedule, klass: "CronWorker#{@ns}",
+                         options: { 'queue' => queue, 'args' => args }).tap do |loop_obj|
+      Wurk::Cron.persist(loop_obj)
+    end
+  end
+
+  def signals(identity) = @pool.with { |c| c.call('LRANGE', "#{identity}-signals", 0, -1) }
+
+  def row_for(rows, label) = rows.find { |row| row['identity'].include?(":#{label}#{@ns}") }
+
+  # Wurk.redis_pool honours a per-thread capsule override, so a pool aimed at a
+  # closed port reaches only this test's own calls.
+  def with_unreachable_redis
+    capsule = Struct.new(:redis_pool).new(
+      Wurk::RedisPool.new(size: 1, url: 'redis://127.0.0.1:6399/0', name: 'unreachable')
+    )
+    Thread.current[:wurk_capsule] = capsule
+    yield
+  ensure
+    Thread.current[:wurk_capsule] = nil
+  end
+
+  def call(env) = app.call(env)
+
+  def get(path, token: ADMIN_TOKEN) = request('GET', path, token: token)
+  def post(path, token: ADMIN_TOKEN) = request('POST', path, token: token)
+
+  def request(method, path, token:)
+    info, _, query = path.partition('?')
+    parse(call(env_for(method, info, query: query, token: token)))
+  end
+
+  def parse(response)
+    status, headers, body = response
+    [status, headers, JSON.parse(body.join)]
+  end
+
+  def env_for(method, path, query: '', token: ADMIN_TOKEN)
+    {
+      'REQUEST_METHOD' => method,
+      'PATH_INFO' => path,
+      'SCRIPT_NAME' => '',
+      'QUERY_STRING' => query,
+      'rack.input' => StringIO.new,
+      'rack.errors' => StringIO.new,
+      'HTTP_AUTHORIZATION' => "Bearer #{token}"
+    }
+  end
+end

--- a/test/unit/api_throttle_test.rb
+++ b/test/unit/api_throttle_test.rb
@@ -1,0 +1,301 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'wurk/api/app'
+require 'json'
+require 'stringio'
+
+# Slice 07, task 49 — the per-token ceiling on the HTTP API.
+#
+# Built on `Wurk::Limiter::Window` rather than a second limiter, so the two
+# claims worth pinning are that it behaves like one (a sliding window on the
+# Redis clock, registered where every other limiter is listed) and that it costs
+# nothing until a host asks for it.
+#
+# Parallel safety: tokens and queue names carry a per-instance namespace, and
+# the worker's Redis DB is flushed after every test (RedisNamespace).
+class ApiThrottleTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  TOKEN = 'api-throttle-token-0123456789abcd'
+  OTHER_TOKEN = 'api-throttle-other-token-0123456'
+  # Registration writes metadata once per limiter object, and the objects are
+  # cached for the life of the process — so the test that reads that metadata
+  # back needs a credential no earlier test has already built one for.
+  REGISTRY_TOKEN = 'api-throttle-registry-token-01234'
+
+  def setup
+    super
+    @pool = Wurk.configuration.redis_pool
+  end
+
+  # --- off unless asked for -----------------------------------------------
+
+  def test_no_limit_configured_lets_everything_through
+    10.times { assert_equal 200, get('/v1')[0] }
+  end
+
+  # The zero-cost claim, read off Redis rather than inferred from the status
+  # codes: an unconfigured ceiling leaves no window and no registry entry.
+  def test_no_limit_configured_touches_no_limiter_key
+    5.times { get('/v1') }
+
+    assert_empty limiter_keys
+    assert_empty registered_limiters
+  end
+
+  def test_the_discovery_document_reports_no_ceiling
+    assert_nil get('/v1')[2]['rate_limit']
+  end
+
+  # --- the ceiling --------------------------------------------------------
+
+  def test_requests_up_to_the_limit_pass_and_the_next_is_refused
+    limited!(3)
+
+    3.times { |i| assert_equal 200, get('/v1')[0], "request #{i + 1}" }
+
+    assert_equal 429, get('/v1')[0]
+  end
+
+  def test_the_refusal_says_how_long_to_wait
+    limited!(1, interval: 60)
+    get('/v1')
+    status, headers, body = get('/v1')
+
+    assert_equal 429, status
+    assert_equal 'application/problem+json', headers['content-type']
+    assert_equal 'rate_limited', body['type']
+    assert_equal 'Too Many Requests', body['title']
+    assert_equal 1, body['limit']
+    assert_equal 60, body['interval_seconds']
+    assert_equal body['retry_after'], headers['retry-after'].to_i
+    assert_operator body['retry_after'], :<=, 60
+    assert_operator body['retry_after'], :>, 55
+  end
+
+  # Derived from when the window's oldest entry slides out, not from the
+  # interval: a client that trickled up to the ceiling must not be told to wait
+  # a full window for a slot that frees in a second.
+  def test_the_wait_shrinks_as_the_window_ages
+    limited!(1, interval: 4)
+    get('/v1')
+    sleep 2
+    _status, _headers, body = get('/v1')
+
+    assert_operator body['retry_after'], :>=, 1
+    assert_operator body['retry_after'], :<, 4
+  end
+
+  # Never 0 — a client that reads "wait 0 seconds" retries immediately, which
+  # is what got it throttled. A window whose oldest entry aged out between the
+  # refusal and the read back is the case that produces one.
+  def test_the_wait_is_never_zero
+    lapsed = Struct.new(:status).new({ reset_at: ::Time.now.to_f - 30 })
+
+    assert_equal 1, Wurk::API::Throttle.retry_after(lapsed, :minute)
+  end
+
+  # A window that emptied between the refusal and the read back has no oldest
+  # entry to date the answer from, so the interval is the only honest wait left.
+  def test_an_emptied_window_falls_back_to_the_interval
+    empty = Struct.new(:status).new({ reset_at: nil })
+
+    assert_equal 60, Wurk::API::Throttle.retry_after(empty, :minute)
+    assert_equal 15, Wurk::API::Throttle.retry_after(empty, 15)
+  end
+
+  # `within_limit` sleeps until a slot frees, which is right for a worker
+  # thread and wrong for a socket a client is holding open: the refusal is
+  # already known, and holding the connection for a window helps nobody.
+  def test_a_refusal_answers_immediately_rather_than_waiting_for_a_slot
+    limited!(1, interval: 60)
+    get('/v1')
+    started = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+    get('/v1')
+    elapsed = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) - started
+
+    assert_operator elapsed, :<, 1.0
+  end
+
+  # Sliding, not a counter that has to be reset: the slot comes back on its own.
+  def test_a_slot_frees_once_the_window_slides_past_it
+    limited!(1, interval: 1)
+    get('/v1')
+
+    assert_equal 429, get('/v1')[0]
+
+    sleep 1.1
+
+    assert_equal 200, get('/v1')[0]
+  end
+
+  def test_the_discovery_document_advertises_the_ceiling
+    limited!(30, interval: :minute)
+
+    assert_equal({ 'limit' => 30, 'interval_seconds' => 60 }, get('/v1')[2]['rate_limit'])
+  end
+
+  # --- what gets charged --------------------------------------------------
+
+  def test_the_ceiling_is_per_token
+    limited!(1)
+    get('/v1')
+
+    assert_equal 429, get('/v1')[0]
+    assert_equal 200, get('/v1', token: OTHER_TOKEN)[0]
+  end
+
+  # A client walking paths that do not exist is exactly the traffic a ceiling
+  # is for, so a route miss costs a slot like anything else.
+  def test_a_route_miss_is_charged
+    limited!(1)
+
+    assert_equal 404, get('/v1/nope')[0]
+    assert_equal 429, get('/v1')[0]
+  end
+
+  # There is no credential to charge, and a stranger must not be able to spend
+  # a real client's quota by guessing at its token.
+  def test_an_unauthenticated_request_is_not_charged
+    limited!(1)
+
+    assert_equal 401, get('/v1', token: nil)[0]
+    assert_equal 401, get('/v1', token: 'Bearer-shaped-but-wrong-0123456')[0]
+    assert_equal 200, get('/v1')[0]
+  end
+
+  # Read-only is a fact this process already holds; the throttle is a Redis
+  # round trip. The cheaper refusal runs first and the request never reaches
+  # the window.
+  def test_a_read_only_refusal_is_not_charged
+    @config = build_config do |cfg|
+      cfg.api_rate_limit = 1
+      cfg.api_read_only = true
+    end
+
+    3.times { assert_equal 403, post('/v1/jobs')[0] }
+    assert_empty limiter_keys
+  end
+
+  # --- it is a limiter like any other -------------------------------------
+
+  # So `GET /v1/limiters` and the dashboard's Limiters page list an API ceiling
+  # beside the ones the jobs use, instead of it being invisible state.
+  def test_the_window_registers_itself_in_the_shared_registry
+    limited!(2)
+    get('/v1', token: REGISTRY_TOKEN)
+
+    assert_equal [limiter_name(REGISTRY_TOKEN)], registered_limiters
+  end
+
+  # The name is a Redis key and shows up on a dashboard: it carries the
+  # credential's fingerprint, never the credential.
+  def test_the_window_is_named_for_the_fingerprint_not_the_token
+    limited!(1)
+    get('/v1')
+    keys = limiter_keys
+
+    assert_equal ["lmtr-w:#{limiter_name(TOKEN)}"], keys
+    refute_includes keys.join, TOKEN
+    assert_includes keys.join, Wurk::API::Auth.fingerprint(TOKEN)
+  end
+
+  # One limiter per credential and ceiling, kept: constructing one writes its
+  # metadata, and paying that round trip per request would double the cost of
+  # the whole feature.
+  def test_a_limiter_is_built_once_per_credential_and_ceiling
+    principal = Wurk::API::Auth::Principal.new(Wurk::API::Auth.fingerprint(TOKEN), %i[admin])
+    first = Wurk::API::Throttle.for_principal(principal, 5, :minute)
+
+    assert_same first, Wurk::API::Throttle.for_principal(principal, 5, :minute)
+    refute_same first, Wurk::API::Throttle.for_principal(principal, 6, :minute)
+    refute_same first, Wurk::API::Throttle.for_principal(principal, 5, :hour)
+  end
+
+  # --- the settings -------------------------------------------------------
+
+  def test_a_ceiling_that_is_not_one_is_refused_where_it_is_written
+    config = Wurk::Configuration.new
+
+    [0, -5, 'lots', nil.to_s].each do |value|
+      assert_raises(ArgumentError, value.inspect) { config.api_rate_limit = value }
+    end
+  end
+
+  def test_nil_turns_the_ceiling_off
+    config = Wurk::Configuration.new
+    config.api_rate_limit = 10
+    config.api_rate_limit = nil
+
+    assert_nil config.api_rate_limit
+  end
+
+  def test_an_interval_the_limiter_cannot_read_is_refused_where_it_is_written
+    config = Wurk::Configuration.new
+
+    assert_raises(ArgumentError) { config.api_rate_limit_interval = :fortnight }
+    assert_equal :minute, config.api_rate_limit_interval
+
+    config.api_rate_limit_interval = 30
+
+    assert_equal 30, config.api_rate_limit_interval
+  end
+
+  def test_the_settings_cannot_be_changed_after_boot
+    config = Wurk::Configuration.new
+    config.freeze!
+
+    assert_raises(FrozenError) { config.api_rate_limit = 10 }
+    assert_raises(FrozenError) { config.api_rate_limit_interval = :hour }
+  end
+
+  private
+
+  def limited!(count, interval: :minute)
+    @config = build_config do |cfg|
+      cfg.api_rate_limit = count
+      cfg.api_rate_limit_interval = interval
+    end
+  end
+
+  def app = @app ||= Wurk::API::App.new(config: config)
+
+  def config
+    @config ||= build_config
+  end
+
+  def build_config
+    Wurk::Configuration.new.tap do |cfg|
+      [TOKEN, OTHER_TOKEN, REGISTRY_TOKEN].each { |token| cfg.api_token(token, scopes: %i[admin]) }
+      yield cfg if block_given?
+    end
+  end
+
+  def limiter_name(token)
+    "#{Wurk::API::Throttle::NAME_PREFIX}#{Wurk::API::Auth.fingerprint(token)}"
+  end
+
+  def limiter_keys = @pool.with { |conn| conn.call('KEYS', 'lmtr-w:*') }
+
+  def registered_limiters = @pool.with { |conn| conn.call('SMEMBERS', Wurk::Limiter::LIST_KEY) }
+
+  def get(path, token: TOKEN) = request('GET', path, token: token)
+  def post(path, token: TOKEN) = request('POST', path, token: token)
+
+  def request(method, path, token:)
+    env = {
+      'REQUEST_METHOD' => method,
+      'PATH_INFO' => path,
+      'SCRIPT_NAME' => '',
+      'QUERY_STRING' => '',
+      'CONTENT_TYPE' => 'application/json',
+      'CONTENT_LENGTH' => '0',
+      'rack.input' => StringIO.new,
+      'rack.errors' => StringIO.new
+    }
+    env['HTTP_AUTHORIZATION'] = "Bearer #{token}" if token
+    status, headers, body = app.call(env)
+    [status, headers, JSON.parse(body.join)]
+  end
+end

--- a/test/unit/cli_api_command_test.rb
+++ b/test/unit/cli_api_command_test.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'wurk/api'
+
+# Slice 07, task 48 — `wurk api`, the CLI's first subcommand: mount mode 3,
+# the machine HTTP API served standalone with no Rails and no worker. The
+# worker's own option surface is covered in cli_test.rb; this file speaks only
+# about the subcommand seam and what run_api does with it.
+class CLIApiCommandTest < Wurk::Test::UnitCase
+  parallelize_me!
+
+  TOKEN = 'cli-api-command-test-token-0123456789'
+
+  def setup
+    super
+    Wurk::CLI.reset_instance!
+    @cli = Wurk::CLI.new
+    @cli.config = Wurk::Configuration.new
+    @cli.config.logger = ::Logger.new(IO::NULL)
+    @cli.config.redis = { url: Wurk::Test.redis_url }
+  end
+
+  def teardown
+    Wurk::CLI.reset_instance!
+    # run_api flips the process-global `Wurk.server` flag, same as the worker
+    # runner — reset it so server mode can't leak into a sibling test class
+    # sharing this worker process.
+    Wurk.server = false
+  ensure
+    super
+  end
+
+  # --- the subcommand seam ---------------------------------------------
+
+  def test_bare_wurk_names_no_command
+    parse([])
+
+    assert_nil @cli.command
+  end
+
+  def test_api_is_recognized_as_the_first_argument
+    parse(%w[api])
+
+    assert_equal 'api', @cli.command
+  end
+
+  # The command is pulled off argv before OptionParser runs, so the flags that
+  # follow it are parsed as flags rather than left behind as stray arguments.
+  def test_the_command_is_consumed_before_its_flags_are_parsed
+    args = %w[api --port 9999]
+    parse(args)
+
+    assert_empty args
+    assert_equal 9999, @cli.config[:api_port]
+  end
+
+  def test_a_word_that_names_no_command_is_not_taken_as_one
+    parse(%w[--queue default])
+
+    assert_nil @cli.command
+  end
+
+  def test_api_flags_are_offered_only_to_the_api_command
+    assert_raises(::OptionParser::InvalidOption) { parse(%w[--port 9999]) }
+  end
+
+  def test_the_banner_names_the_command_being_run
+    parse(%w[api])
+
+    assert_includes @cli.send(:option_parser, {}).banner, 'wurk api [options]'
+  end
+
+  def test_the_bare_banner_is_unchanged
+    parse([])
+
+    assert_includes @cli.send(:option_parser, {}).banner, 'wurk [options]'
+  end
+
+  def test_bind_port_and_server_are_all_parseable
+    parse(%w[api --bind 127.0.0.1 --port 8080 --server puma])
+
+    assert_equal '127.0.0.1', @cli.config[:api_bind]
+    assert_equal 8080, @cli.config[:api_port]
+    assert_equal 'puma', @cli.config[:api_server]
+  end
+
+  # The swarm binaries take no subcommand. Silently booting a job-consuming
+  # swarm for someone who asked for an API server is the worst answer here.
+  #
+  # The pinned one-connection pool is a backstop, not part of the claim: it
+  # makes the very next check (`validate_pool_sizes!`) raise, so a regression
+  # that drops the guard fails this test on the message instead of forking a
+  # real swarm and supervising it forever.
+  def test_the_swarm_runner_refuses_a_subcommand
+    @cli.config.redis = { url: Wurk::Test.redis_url, size: 1 }
+    @cli.config.default_capsule.concurrency = 5
+    parse(%w[api])
+
+    error = assert_raises(ArgumentError) { @cli.run_swarm(boot_app: false, warmup: false) }
+
+    assert_match(/no subcommand/, error.message)
+  end
+
+  # --- run_api ----------------------------------------------------------
+
+  def test_run_api_serves_the_same_rack_app_every_other_mount_does
+    @cli.config.api_token(TOKEN, scopes: %i[read])
+    handler = RecordingHandler.new
+
+    @cli.run_api(boot_app: false, handler: handler)
+
+    assert_same Wurk::API, handler.app, 'standalone must serve the module a config.ru would run'
+  end
+
+  def test_run_api_binds_every_interface_on_7433_by_default
+    @cli.config.api_token(TOKEN, scopes: %i[read])
+    handler = RecordingHandler.new
+
+    @cli.run_api(boot_app: false, handler: handler)
+
+    assert_equal '0.0.0.0', handler.options[:Host]
+    assert_equal 7433, handler.options[:Port]
+  end
+
+  def test_run_api_binds_where_the_flags_said
+    @cli.config.api_token(TOKEN, scopes: %i[read])
+    parse(%w[api --bind 127.0.0.1 --port 8080])
+    handler = RecordingHandler.new
+
+    @cli.run_api(boot_app: false, handler: handler)
+
+    assert_equal '127.0.0.1', handler.options[:Host]
+    assert_equal 8080, handler.options[:Port]
+  end
+
+  # Same reason #run does it: `configure_server` blocks gate on `config.server?`,
+  # so a host that registers its credential in one would otherwise serve an API
+  # with no token at all. Stands in for the app `-r` loads — the block only
+  # fires if server mode was entered before the app booted.
+  def test_run_api_enters_server_mode_before_booting_the_app
+    handler = RecordingHandler.new
+    def @cli.boot_application
+      config.configure_server { |config| config.api_token(TOKEN, scopes: %i[read]) }
+    end
+
+    @cli.run_api(handler: handler)
+
+    assert_equal %i[read], @cli.config.api_tokens[TOKEN], 'configure_server must have fired'
+    assert_same Wurk::API, handler.app
+  end
+
+  # Binding a port that answers 404 to everything is not a server, it is a
+  # misconfiguration an operator would have to diagnose over HTTP.
+  def test_run_api_refuses_to_serve_with_no_token_registered
+    handler = RecordingHandler.new
+
+    error = assert_raises(ArgumentError) { @cli.run_api(boot_app: false, handler: handler) }
+
+    assert_match(/No API token is registered/, error.message)
+    assert_match(/api_token/, error.message)
+    assert_nil handler.app, 'nothing may be served'
+  end
+
+  # --- handler resolution ------------------------------------------------
+
+  # Neither rack 2's handlers nor rack 3's `rackup` gem are wurk dependencies:
+  # the web server is the host's choice. Say which gem is missing rather than
+  # letting a bare LoadError out.
+  def test_an_unresolvable_handler_names_the_fix
+    error = assert_raises(ArgumentError) { @cli.send(:api_handler, 'no-such-web-server') }
+
+    assert_match(/could not start a web server/, error.message)
+    assert_match(/puma/, error.message)
+  end
+
+  def test_a_named_handler_is_resolved_through_the_installed_registry
+    registry = @cli.send(:handler_registry)
+
+    assert_respond_to registry, :get
+    assert_respond_to registry, :default
+  end
+
+  private
+
+  # Stands in for Rackup::Handler::Puma and friends: records what it was asked
+  # to serve instead of binding a socket.
+  class RecordingHandler
+    attr_reader :app, :options
+
+    def run(app, **options)
+      @app = app
+      @options = options
+    end
+  end
+
+  def parse(args)
+    @cli.config[:require] = ::File.expand_path('../../lib/wurk.rb', __dir__)
+    @cli.parse(args)
+  end
+end

--- a/test/unit/watchdog_test.rb
+++ b/test/unit/watchdog_test.rb
@@ -189,11 +189,17 @@ class WatchdogTest < Wurk::Test::UnitCase
 
   # --- one thread, many bounds ------------------------------------------
 
+  # Every spawn attempt has run once four bounds are armed — #arm spawns under
+  # the same lock it registers under. Only the *name* trails: safe_thread sets
+  # it from inside the thread, so `scanners` is empty until the scanner is first
+  # scheduled, and the size check above can be satisfied on its first poll
+  # without ever yielding the GVL. Wait for the name rather than racing it.
   def test_one_scanner_serves_every_bounded_thread
     wd = build
     gate = Queue.new
     threads = Array.new(4) { Thread.new { wd.watch(5, Bound) { gate.pop } } }
     wait_until { wd.size == 4 }
+    wait_until { scanners.any? }
 
     assert_equal 1, scanners.size
   ensure


### PR DESCRIPTION
## Summary
- Queue/set/stat routes, swarm/topology routes, three mount modes + CLI subcommand, and read-only/rate-limit interactions (all landed in prior commits on this branch)
- This PR's task: reference Python client (`clients/python/`, thin/zero-dep), full HTTP API route reference (`docs/api-http.md`), and a real-forked-swarm integration test for `GET /swarm`/`/processes` proving stale-heartbeat reporting

## Test plan
- [x] `bin/rake test` — 4003 runs, 0 failures
- [x] `bin/rake test:parity` — 23 runs, 0 failures
- [x] `bin/rake test:ecosystem` — green (prior commits)
- [x] `bundle exec rubocop` — 462 files, no offenses
- [x] `python -m unittest discover -s clients/python/tests` — 9/9 passing (mocked transport)
- [x] Manual: reference client's request-building matches the server's actual `Validation`/`Jobs`/`Queues` route contracts (read against source, not just mocks)

Closes out slice 07 (HTTP producer API) — last task in this PR group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788849664&installation_model_id=11168&pr_number=407&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F407&signature=eb3c1a15d7f9273b092e2fc0ed6e61429ee6376e9307b9f609e42ea6ba6389f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a versioned HTTP API for job submission, status tracking, queue management, batch inspection, process monitoring, health checks, and control signals.
  * Added the `wurk api` command for launching the API.
  * Added a dependency-free Python client supporting enqueueing, bulk jobs, cancellation, status, queues, and statistics.
  * Added configurable read-only mode and per-token rate limiting with retry information.

* **Documentation**
  * Added comprehensive HTTP API and Python client documentation.

* **Chores**
  * Added Python packaging metadata and build-file exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->