### PR TITLE
chore(release): v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Wurk are recorded here. Format: [Keep a Changelog](https:
 
 ## [Unreleased]
 
+## [1.7.1] - 2026-08-10
+
+A correctness release about what Wurk says about itself. An audit of `lib/` against the Sidekiq revision the parity suite pins measured 0.47% overlapping code (66 matching 6-line windows out of 13,996); two files carried enough of it to be worth re-expressing, and they are now Wurk's own. The docs that described all of this were wrong in both directions — overstating Sidekiq's licence permissiveness while also claiming copying that had not happened — and are corrected. No Redis key, command sequence, job-JSON field, or public API changed: a 1.7.0 worker and a 1.7.1 worker can drain the same queue.
+
 ### Fixed
 
 - **Provenance claims in the docs were wrong, in both directions.** `docs/clean-room.md` stated that the `test/parity/` files were "lifted from Sidekiq's own MIT-licensed test suite". Two errors in one sentence: Sidekiq is **LGPL-3.0** (`sidekiq.gemspec`, `LICENSE.txt`), not MIT, and the parity tests are not copies of upstream test files — they are independently written oracles using Wurk's own helpers and class names. `test/parity/README.md` compounded it by instructing contributors to "copy it verbatim from upstream Sidekiq". Both are corrected: the page is now [`docs/compatibility.md`](docs/compatibility.md), it states Sidekiq's actual licence, and the parity README describes writing oracles from the documented behaviour rather than copying LGPL files into an MIT repository.
@@ -12,6 +16,10 @@ All notable changes to Wurk are recorded here. Format: [Keep a Changelog](https:
 
 ### Changed
 
+- **The README now shows the benchmark numbers instead of linking to them.** Two theme-aware SVGs built from the published measurements: throughput as a dot plot with min–max whiskers against a 1.00× parity line (the spread is the story — a bar chart hides it), and boot-to-first-job as a paired bar. Both lead with "Wurk is not faster than stock Sidekiq today" rather than cropping to the flattering rows. Method and per-invocation records stay in [`docs/benchmarks.md`](docs/benchmarks.md).
+- **The feature matrix is now a coverage table.** OSS / Pro / Ent / **Wurk** columns with checkmarks, mapped tier by tier off `docs/target/sidekiq-{pro,ent}.md`, plus a second table for the surface Sidekiq has no equivalent for at any tier. It replaces a prose "area → tier" table that never actually showed what a migration covers.
+- **The Kubernetes section covers the whole operational surface** — probes, StatsD/DogStatsD export, historical metrics, OpenTelemetry, the `/v1` API, and cluster-wide queue caps — and says plainly that there is **no native Prometheus `/metrics` endpoint**; StatsD or the `/v1` API is the path into a Prometheus/Grafana stack.
+- **The GitHub repository description no longer claims speed.** v1.7.0 removed "meaningfully faster" from every file, but the repo description is set in GitHub's settings rather than in the tree, so no grep or PR review reached it and it kept making the claim publicly. It now reads "fork-based multi-core swarm" — a true differentiator instead of an unsupported one.
 - Comments that described Wurk's code as matching Sidekiq's source "byte-for-byte" now describe the behaviour and the contract that fixes it (`redis_client_adapter.rb`, `iterable_job/active_record_enumerator.rb`, `lua.rb`). Where the interface genuinely leaves no room for a different expression — `Configuration::DEFAULTS` key names, the JSON log field names, `RedisClientAdapter::BaseError`, the `ServerMiddleware` accessors — `docs/compatibility.md` now names those fragments and says why they are fixed, rather than leaving the resemblance unexplained.
 
 ## [1.7.0] - 2026-08-10
@@ -418,7 +426,8 @@ First public (pre-1.0) release. Wurk is a 100% API-compatible drop-in replacemen
 - ActiveJob adapter, `IterableJob`, embedded mode, and a standalone `exe/wurk` runner.
 - Sidekiq client/server middleware contract; third-party ecosystem suites (sidekiq-cron, sidekiq-unique-jobs, sidekiq-scheduler, sidekiq-status, sidekiq-failures, sidekiq-throttled) pass against Wurk.
 
-[Unreleased]: https://github.com/developerz-ai/wurk/compare/v1.7.0...HEAD
+[Unreleased]: https://github.com/developerz-ai/wurk/compare/v1.7.1...HEAD
+[1.7.1]: https://github.com/developerz-ai/wurk/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/developerz-ai/wurk/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/developerz-ai/wurk/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/developerz-ai/wurk/compare/v1.4.0...v1.5.0

--- a/lib/wurk/version.rb
+++ b/lib/wurk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wurk
-  VERSION = '1.7.0'
+  VERSION = '1.7.1'
 end


### PR DESCRIPTION
Cuts **v1.7.1** — provenance and documentation correctness. No Redis key, command sequence, job-JSON field, or public API changed; a 1.7.0 worker and a 1.7.1 worker drain the same queue.

## Why this release exists

RubyGems versions are immutable. The two enumerator helpers rewritten in #416 are still in every published gem from 1.0.0 to 1.7.0, and shipping a new version is the only way to get a clean artifact onto RubyGems. That is the whole point of cutting this rather than waiting to bundle it with features.

## Contents

- `Wurk::VERSION` → `1.7.1`, CHANGELOG section + compare link.
- Everything merged in #416: corrected provenance docs (Sidekiq is LGPL-3.0, `docs/clean-room.md` → `docs/compatibility.md`, "clean-room" dropped for "independent reimplementation"), the rewritten `CsvEnumerator` / `ActiveRecordEnumerator`, the README benchmark charts, the OSS/Pro/Ent/Wurk coverage matrix, and the widened Kubernetes/observability section.

## Note for the tagger

A `v1.7.1` tag was auto-cut by `developerz-ai[bot]` on the #416 merge with `VERSION` still at 1.7.0, so [the release run failed](https://github.com/developerz-ai/wurk/actions/runs/31441784612) on `release:check ✗ tag v1.7.1 does not match Wurk::VERSION 1.7.0`. No gem was published, so the number was not burned; the bogus release and tag have been deleted with `gh release delete v1.7.1 --cleanup-tag` and 1.7.1 is reused here. Tag this merge commit once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiS55VKAaizMqqYxuMWAY5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788998729&installation_model_id=11168&pr_number=417&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F417&signature=f4267971c192893fda9c6f470d643cebb24e7a68fdb400d4348cb63bd9ad1711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->