### PR TITLE
fix(demo): emit the sha-<7> tag Image Updater actually selects on

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -4,9 +4,10 @@ name: deploy-demo
 # release.yml call it after publishing a `v*` tag.
 #
 # DEPLOY MODEL: this workflow only BUILDS + PUSHES the image. Infra deploys it
-# via the in-cluster ArgoCD Image Updater, which watches the DOCR `:latest` tag
-# (digest strategy) and syncs automatically — CI holds NO cluster credentials
-# (infra repo rule). There is no ArgoCD step here, and no ARGOCD_* secrets.
+# via the in-cluster ArgoCD Image Updater, which selects the newest DOCR tag
+# matching `^sha-[0-9a-f]{7}$` (newest-build strategy, infrastructure#232) and
+# syncs automatically — CI holds NO cluster credentials (infra repo rule).
+# There is no ArgoCD step here, and no ARGOCD_* secrets.
 #
 # WHO CAN RUN IT — three layers, only-the-org by construction:
 #   1. workflow_dispatch on a PUBLIC repo can only be triggered by users with
@@ -41,7 +42,7 @@ on:
 # Hardcoded group: under workflow_call `github.workflow` is the CALLER's name,
 # which put this job in the caller's own group — GitHub detects that as a
 # deadlock and cancels the run. A fixed name also serializes every demo deploy,
-# so two builds can't race pushing the `:latest` digest Image Updater watches.
+# so two builds can't race pushing the tags Image Updater selects from.
 concurrency:
   group: deploy-demo
   cancel-in-progress: false
@@ -52,7 +53,7 @@ permissions:
 
 env:
   # DOCR is the deploy-critical registry: infra's Image Updater watches
-  # `registry.digitalocean.com/developerz-ai/wurk-demo:latest` and the demo's
+  # `registry.digitalocean.com/developerz-ai/wurk-demo` and the demo's
   # kustomization rewrites the manifests' ghcr.io ref onto it (infra #803 —
   # moved off GHCR 2026-07-12 when a dead org token broke fresh pulls). GHCR
   # stays a mirror so the manifests' literal image ref keeps resolving.
@@ -102,9 +103,22 @@ jobs:
       # github.sha is the SHA of the ref the WORKFLOW was loaded from (the
       # default branch on a dispatch), not of `inputs.ref` — tagging with it
       # mislabels the image whenever the two differ, e.g. deploying a tag.
+      #
+      # `short` is the deploy-critical one. Infra's Image Updater selects by
+      # `allow-tags: regexp:^sha-[0-9a-f]{7}$` (the fleet convention adopted in
+      # infrastructure#232 — immutable tags, because `latest` moves under you
+      # and a digest can be re-pushed). Nothing here matched that pattern, so
+      # Image Updater had no candidate and the demo sat on an old digest across
+      # several releases. Keep this format in lockstep with
+      # stacks/apps/wurk-demo/application.yml in the infrastructure repo.
       - name: resolve built commit
         id: built
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        run: |
+          sha="$(git rev-parse HEAD)"
+          {
+            echo "sha=$sha"
+            echo "short=sha-$(printf '%.7s' "$sha")"
+          } >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -123,8 +137,10 @@ jobs:
           file: Dockerfile
           push: true
           tags: |
+            ${{ env.IMAGE }}:${{ steps.built.outputs.short }}
             ${{ env.IMAGE }}:${{ steps.built.outputs.sha }}
             ${{ env.IMAGE }}:latest
+            ${{ env.MIRROR }}:${{ steps.built.outputs.short }}
             ${{ env.MIRROR }}:${{ steps.built.outputs.sha }}
             ${{ env.MIRROR }}:latest
           cache-from: type=gha
@@ -159,9 +175,10 @@ jobs:
       - name: verify retained images still resolve
         env:
           SHA: ${{ steps.built.outputs.sha }}
+          SHORT: ${{ steps.built.outputs.short }}
         run: |
-          for ref in "${IMAGE}:latest" "${IMAGE}:${SHA}" \
-                     "${MIRROR}:latest" "${MIRROR}:${SHA}"; do
+          for ref in "${IMAGE}:${SHORT}" "${IMAGE}:latest" "${IMAGE}:${SHA}" \
+                     "${MIRROR}:${SHORT}" "${MIRROR}:latest" "${MIRROR}:${SHA}"; do
             echo "==> inspecting $ref"
             docker buildx imagetools inspect "$ref" >/dev/null
           done

--- a/docs/demo-deploy.md
+++ b/docs/demo-deploy.md
@@ -33,8 +33,9 @@ internet ──►│                                                     ├─
 ## Deploy: who can trigger it
 
 `.github/workflows/deploy-demo.yml` **builds and pushes the image only** — it
-holds no cluster credentials. The in-cluster **ArgoCD Image Updater** watches the
-DOCR `:latest` digest and syncs the deployment automatically; the pushed digest
+holds no cluster credentials. The in-cluster **ArgoCD Image Updater** selects the
+newest DOCR tag matching `^sha-[0-9a-f]{7}$` and syncs the deployment
+automatically; the pushed digest
 *is* the deploy trigger. It runs two ways — `workflow_dispatch` by hand, or
 called by `release.yml` after a `v*` tag publishes — and is gated three ways so
 only the org can ship an image:
@@ -68,8 +69,8 @@ The image is pushed to **two** registries from one build:
 
 | Registry | Tag | Role |
 |---|---|---|
-| `registry.digitalocean.com/developerz-ai/wurk-demo` | `latest` + `<sha>` | **Deploy-critical.** Image Updater watches this digest. |
-| `ghcr.io/developerz-ai/wurk-demo` | `latest` + `<sha>` | Mirror, so the manifests' literal `ghcr.io` image ref still resolves. |
+| `registry.digitalocean.com/developerz-ai/wurk-demo` | `sha-<7>` + `latest` + `<sha>` | **Deploy-critical.** Image Updater selects on `sha-<7>`; the other two are for humans and rollback. |
+| `ghcr.io/developerz-ai/wurk-demo` | `sha-<7>` + `latest` + `<sha>` | Mirror, so the manifests' literal `ghcr.io` image ref still resolves. |
 
 Infra moved the demo to DOCR on 2026-07-12 (infra #803) after a dead GHCR org
 token broke fresh pulls; `stacks/apps/wurk-demo/manifests/kustomization.yml`
@@ -89,7 +90,7 @@ also the rebuild recipe. Items marked **(app)** live in this repo.
 - [x] **`SECRET_KEY_BASE`** — a strong random value injected at runtime (k8s secret) so the Rails app boots in production. Not baked into the image.
 - [x] **Registry pull access** — sealed `docr-pull` / `ghcr-pull` imagePullSecrets in ns `wurk-demo`.
 - [x] **ArgoCD Application `wurk-demo`** in `../infrastructure` — Deployments for `web` (cmd `web`) and `worker` (cmd `worker`), a Service, and the Redis dependency.
-- [x] **ArgoCD Image Updater** watching `registry.digitalocean.com/developerz-ai/wurk-demo:latest` (digest strategy) so a pushed image auto-syncs. CI holds no cluster credentials, so there are no `ARGOCD_*` secrets.
+- [x] **ArgoCD Image Updater** watching `registry.digitalocean.com/developerz-ai/wurk-demo` with `update-strategy: newest-build` and `allow-tags: regexp:^sha-[0-9a-f]{7}$` so a pushed image auto-syncs. The `sha-<7>` tag format is the contract — if CI stops emitting it, Image Updater silently has no candidate and the demo freezes on its current digest (this happened, and is what #418 fixes). CI holds no cluster credentials, so there are no `ARGOCD_*` secrets.
 - [x] **DNS** — `wurk.demo.developerz.ai` → the cluster ingress / Traefik.
 - [x] **Ingress (Traefik) + TLS** — route the host to the `web` Service, Let's Encrypt cert.
 - [x] **Public rate-limit** — a Traefik rate-limit middleware on the ingress to discourage abuse.


### PR DESCRIPTION
## The bug

The demo at wurk.demo.developerz.ai serves **1.3.1**. Main has shipped 1.4.0, 1.5.0, 1.6.0, 1.7.0 and 1.7.1 since.

Every `deploy-demo` run was **green**, including the one v1.7.1 just triggered — it built and pushed `sha256:1245371f` to DOCR fine. That is why nobody caught it: this workflow only builds and pushes. The actual deploy is ArgoCD Image Updater running in-cluster, from the infrastructure repo.

## Root cause

`infrastructure#232` converted the Image Updater fleet to immutable tags:

```yaml
argocd-image-updater.argoproj.io/app.update-strategy: newest-build
argocd-image-updater.argoproj.io/app.allow-tags: regexp:^sha-[0-9a-f]{7}$
```

This workflow was never converted alongside it. It pushes:

| Tag pushed | Matches `^sha-[0-9a-f]{7}$` |
|---|---|
| `:latest` | no |
| `:79024fe4e329e1f8b09b0a40bd0de19a207c80b6` | no — bare 40-char SHA, no `sha-` prefix |

So Image Updater had **no candidate tag**, selected nothing, and left the demo on whatever digest predated the conversion. Silent on both sides: CI reports a successful push, Image Updater reports nothing to do.

**Infra is not at fault and needs no change** — `discord-server`, `designer`, and `vvvenom-api` all carry the identical regexp and deploy fine. The drift is in this repo.

## Fix

Emit `sha-<7>` to both registries and cover it in the retention check. `:latest` and the full SHA stay — humans and rollback use them, and the manifests' literal ref still resolves. Pruning is unaffected: three tags on one digest is one GHCR version, so `min-versions-to-keep: 5` still means five builds.

Comments and `docs/demo-deploy.md` still described the old digest-on-`:latest` model; they now describe the tag contract and state what breaks when CI stops emitting it.

## After this lands

This repairs future releases. v1.7.1 is already tagged, so the demo needs one manual roll-forward:

```
gh workflow run deploy-demo.yml --ref main -f ref=v1.7.1
```

(dispatching from `main` picks up the fixed workflow while building the v1.7.1 tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiS55VKAaizMqqYxuMWAY5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788999810&installation_model_id=11168&pr_number=418&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F418&signature=4d38e2764c4c4493f946e3c0931b07d64841acb060a6af373999e5f89959f6e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->