### PR TITLE
fix(demo): fetch the queues the demo producer actually writes to

### DIFF
--- a/demo/config/initializers/wurk.rb
+++ b/demo/config/initializers/wurk.rb
@@ -29,6 +29,18 @@ if ENV["WURK_DEMO"] == "1"
     Wurk.configuration.server_middleware.add(Wurk::Metrics::History)
   end
 
+  # DemoProducer registers cron jobs onto `high` (ThrottledApiJob) and `low`
+  # (DailyReportJob), but the default capsule fetches `default` only — so those
+  # two queues were produced into and never consumed. The hourly demo:reset
+  # FLUSHDB hid it; when that CronJob started failing, `low` reached 598 jobs at
+  # ~10h latency on the public dashboard. Set before the swarm is built: the
+  # worker's `rails runner` reads Wurk.configuration.topology, which derives
+  # from this capsule's queue_specs, and initializers run first.
+  #
+  # Order is strict priority, and it is also the thing the demo exists to show:
+  # `high` drains before `default`, which drains before `low`.
+  Wurk.configuration.queues = %w[high default low]
+
   # Web side (non-forking process): run the traffic producer in a background
   # thread. Gated off the swarm so its Redis connection can't be inherited
   # across a fork (CLAUDE.md boot order). The worker process drains the traffic.


### PR DESCRIPTION
## The bug

`DemoProducer` registers cron jobs onto two queues the worker never fetched:

```ruby
demo/app/workloads/demo_producer.rb:80  Wurk::Cron.register("demo daily report", "* * * * *",   "DailyReportJob",  [], queue: "low")
demo/app/workloads/demo_producer.rb:81  Wurk::Cron.register("demo cache warmup", "*/5 * * * *", "ThrottledApiJob", [], queue: "high")
```

The default capsule fetches `default` only, so `high` and `low` were produced into and never consumed. The hourly `demo:reset` FLUSHDB truncated the backlog each hour, which is why nobody noticed.

Found while investigating why the public demo was stuck on 1.3.1. Once the reset CronJob started failing, nothing truncated them and the live dashboard showed:

```
queues: [('low', 598, 35879), ('high', 121, 35879), ('default', 0, 0)]
```

598 jobs at ~10 hours of latency, on the demo whose entire purpose is showing the dashboard working.

## Fix

Set the queue list on the configuration in the demo initializer. The worker entrypoint runs `rails runner "Wurk::Swarm.new(topology: Wurk.configuration.topology)"`, and `topology` derives from the default capsule's `queue_specs`, so an initializer assignment reaches it. Verified:

```
queues      = ["high", "default", "low"]
slot queues = [["high", "default", "low"]]
```

Order is strict priority — `high` before `default` before `low` — which is also the behaviour the demo exists to demonstrate.

## Not in scope

The reset CronJob's failures turned out to be the stale image; it succeeds on 1.7.1 (verified by a manual run: `Complete 1/1` in 6s). ArgoCD reports the app `Healthy` again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiS55VKAaizMqqYxuMWAY5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789002127&installation_model_id=11168&pr_number=419&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F419&signature=10cb5742a8d0cb458fd7ae1db0fcc668b04fd7ac2675623976f8392cf6ec56a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the demo worker to process high-, default-, and low-priority queues in strict priority order.
  * Ensured queues created by scheduled jobs are included in worker processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->