### PR TITLE
chore(release): v1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,21 @@ All notable changes to Wurk are recorded here. Format: [Keep a Changelog](https:
 
 ## [Unreleased]
 
+## [1.7.2] - 2026-08-11
+
+A delivery release: nothing in the runtime changed, but the three things that carry Wurk from a merged PR to a running worker — the release lane, the demo image, and the demo's own queues — each had a defect that let a green CI run mean less than it looked. No Redis key, command sequence, job-JSON field, or public API changed: a 1.7.1 worker and a 1.7.2 worker can drain the same queue.
+
 ### Fixed
 
 - **The release lane no longer takes a tag as input, so a stray tag can't break it.** Seven times in three weeks (v1.2.1, v1.5.0, v1.6.0, v1.7.0, v1.8.0, v1.7.1, v1.7.2) the `developerz-ai[bot]` maintainer agent cut a `vX.Y.Z` tag and GitHub Release on a feature merge whose `Wurk::VERSION` was never bumped. `release:check` refused to publish every time — **no incorrect gem ever shipped** — but the release run went red and a gem-less GitHub Release was left marked `Latest` while `gem install wurk` kept serving the previous version. `release.yml` now triggers on a `lib/wurk/version.rb` bump landing on `main`, derives the tag from `Wurk::VERSION` (`ReleaseHelpers.git_tag_for`, the exact inverse of the gate's `tag_matches_version!`), and cuts the tag *last* — only after RubyGems has accepted the `.gem`. A tag and a version can no longer disagree, every tag has a gem behind it, a failed run leaves no tag to force-move, and a `v*` tag from any other source is inert. A new `preflight` job asks RubyGems whether the version already exists, making the lane re-runnable and turning a no-op edit to `version.rb` into a skip rather than a failure.
 - **`.maintainer.yml` no longer authorizes the agent to publish releases.** `manager: none` was not sufficient on its own — the `release.channels: [github-release]` entry let the agent cut releases independently of the manager setting. It is now `channels: []`. This is belt-and-braces with the workflow change above on purpose: the policy file is honoured by a remote platform (and was once silently discarded for being schema-invalid), while the trigger change holds regardless.
+- **The demo image now emits the tag ArgoCD Image Updater actually selects on.** `wurk.demo.developerz.ai` served 1.3.1 while `main` shipped through 1.7.1, with every `deploy-demo` run green: the workflow pushed only `:latest` and a bare 40-char SHA, while infra's Image Updater selects on `^sha-[0-9a-f]{7}$` (`newest-build`), so no candidate ever matched. `deploy-demo.yml` now emits `sha-<7>`, and tags from `inputs.ref` rather than `github.sha` — the latter is the SHA the *workflow* was loaded from, which mislabels the image whenever a tag is being deployed.
+- **The demo worker fetches the queues its producer writes to.** `DemoProducer` registered cron jobs onto two queues the worker never fetched, so that work accumulated unprocessed.
+
+### Changed
+
+- **`RELEASE.md` is rewritten around the tag-as-output rule** — how the lane works step by step, how to recover a gem-less release, and how to verify a release actually shipped (RubyGems is the authority; a green run is necessary, not sufficient). `CLAUDE.md` records the invariant that a `tags:` trigger must never be re-added.
+- **The README's "Why Wurk exists" cites DHH's [Let the agents democratize open source](https://world.hey.com/dhh/let-the-agents-democratize-open-source-9fd630a9)** — his subject is agent-written contributions, Wurk's is agent-driven maintenance, and it is the same economics from the other end: the reason a licence key guards batches and cron is the cost of keeping them working, not the code itself.
 
 ## [1.7.1] - 2026-08-10
 

--- a/lib/wurk/version.rb
+++ b/lib/wurk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wurk
-  VERSION = '1.7.1'
+  VERSION = '1.7.2'
 end


### PR DESCRIPTION
Fixes the last piece of #420 by proving the new lane end to end.

## What makes this release different

**Nobody pushes a tag.** Merging this PR *is* the release. `release.yml` fires on `push: branches: [main], paths: ["lib/wurk/version.rb"]`, `preflight` derives `v1.7.2` from `Wurk::VERSION`, and the tag is cut **last** — only after RubyGems accepts the `.gem`.

This is the first release on the inverted lane, so it doubles as its end-to-end test. Expected sequence:

1. `preflight` — resolves `version=1.7.2`, `tag=v1.7.2`, confirms RubyGems has no 1.7.2 → `proceed=true`
2. `release` — gate → package → OIDC → `gem push` → await propagation
3. `tag & create GitHub Release` — `gh release create v1.7.2 --target <sha>`, author `github-actions[bot]`, `.gem` attached
4. `demo` — `authorize` → `build` → image → ArgoCD Image Updater
5. `/wurk-assets/wurk-manifest.json` flips from `1.7.1` to `1.7.2`

Two negative controls already passed on the #420 merge: the release lane stayed silent (that merge touched `.github/workflows/` but not `version.rb`, so the paths filter held), and **no bogus `v1.7.2` tag appeared** — the first feature merge in a while that didn't produce one.

## Contents

Three delivery defects, no runtime change. A 1.7.1 worker and a 1.7.2 worker can drain the same queue — no Redis key, command sequence, job-JSON field, or public API changed.

- **The release lane no longer takes a tag as input** (#420) — seven gem-less GitHub Releases in three weeks, each a red run and a lying "Latest". The gate caught every one; no incorrect gem ever shipped.
- **`.maintainer.yml` `release.channels: []`** (#420) — `manager: none` wasn't sufficient alone.
- **The demo image emits the `sha-<7>` tag Image Updater selects on** (#418) — the demo served 1.3.1 while main shipped through 1.7.1, with every deploy run green.
- **The demo worker fetches the queues its producer writes to** (#419).

Docs: `RELEASE.md` rewritten around the tag-as-output rule; `CLAUDE.md` records "never re-add a `tags:` trigger"; README cites DHH's [Let the agents democratize open source](https://world.hey.com/dhh/let-the-agents-democratize-open-source-9fd630a9).

## Test plan

- `bin/changelog-section 1.7.2` resolves (exit 0) — this is what becomes the Release notes.
- Gate assertions dry-run locally: `version=1.7.2 tag=v1.7.2`, `tag_matches_version!` and `changelog_has_version!` both pass.
- Full local suite on the #420 tree: 4283 runs, 11833 assertions, 0 failures, 0 errors, 7 skips.
- CI on this PR, then the release lane itself.
- Post-merge verification: RubyGems has 1.7.2 → `gh release view v1.7.2` shows `github-actions[bot]` + `.gem` asset → demo manifest reads 1.7.2.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789043578&installation_model_id=11168&pr_number=421&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F421&signature=0144fb9f169c286015e41b5243c9b661919612a09a208e0c5548dc5f4b9a5914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->