### PR TITLE
test(review): native review-lane first live verification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,10 @@ bin/check          # rubocop + full suite + parity  — run this before opening 
 bin/check full     # ...plus the ecosystem suites
 ```
 
+The default `bin/check` is also reachable as `bin/check pr` — the script accepts
+both, since the PR gate is the only one anyone outside of greenfield work actually
+wants. `bin/check fast` and `bin/check full` are the two narrower scopes.
+
 It refuses to start without a local Redis and tells you how to get one. A green
 `bin/check` is the answer CI will give you.
 


### PR DESCRIPTION
Trivial doc-only note that `bin/check` and `bin/check pr` are equivalent, so the contributor-facing mode names match the script's accepted keyword set. One file, one paragraph; real but minimal.

This is the purpose-built PR for the developerz.ai native review-lane acceptance test (developerz-ai/developerz.ai#1335). The change is intentionally small enough that a zero-finding review is plausible, and real enough that a finding would be informative rather than ambiguous. Not production code; close without merging.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789220217&installation_model_id=11168&pr_number=424&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F424&signature=4fc82e3945480cbb55266ce65c3b44255929c89683aecee6610d1a2576f9d5fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->