### PR TITLE
chore(pipeline): grant standing merge authorization

### DIFF
--- a/.agent-pipeline.json
+++ b/.agent-pipeline.json
@@ -1,6 +1,7 @@
 {
   "repo": "developerz-ai/wurk",
   "merge": {
-    "reviewGate": "ci-only"
+    "reviewGate": "ci-only",
+    "standingAuthorization": true
   }
 }


### PR DESCRIPTION
## What

Grants the pipeline standing merge authorization on this repo, keeping the `ci-only` review gate.
One key added to `.agent-pipeline.json`: `merge.standingAuthorization: true`.

## Why

Two reasons, and the second was only found today.

1. **Unattended draining of the wurk-CI chain.** wurk#389 heads a chain that continues into
   developerz-ai/infrastructure (#1322 -> #1263 -> #1323, epic #1259). Without a standing grant,
   every merge here stops for a per-run human yes.
2. **The post-merge live-test stage would otherwise park.** wurk declares neither `policy.module`
   nor `policy.defaultTier`, so a run reaching the live-test stage on a fenceless issue throws and
   parks — meaning a `ready` label on wurk#389 promises autonomy that stage cannot deliver. This PR
   is the first half of closing that; `policy.defaultTier: "GREEN"` is a separate follow-up.

## Changes

`.agent-pipeline.json` — one key. `reviewGate: "ci-only"` unchanged; no `policy.module`,
`ciOnlyPolicyAck` or `classificationParks` added.

## Verification

Parse-verified against agent-pipeline 0.1.193's own `loadConfig`, not by inspection:

```
parsed OK; standingAuthorizationFor = true | reviewGate = ci-only
```

Two negative cases were also confirmed to throw, which is why neither shape appears here:
`standingAuthorization: "true"` (string) is refused, and adding `merge.ciOnlyPolicyAck` throws
because this repo commits no `policy.module` — the ack would be dead config reading as an active
authorization while gating nothing.

What `true` means, precisely: it removes the per-run human yes and **nothing else**. Fail-closed
CI-green, the empty-diff refusal, the unconditional pipeline-config park and the branch ruleset all
still gate. It is authorization, not approval.

## Merge note

This PR touches `.agent-pipeline.json`, so the gate parks it unconditionally
(`pipeline-config-park`) — no posture, standing authorization or review gate lifts that park. Its
stated exit is that **a human reviews the config change deliberately and merges it themselves**.
Precedent: #425, the last change to this file, was human-merged for the same reason.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789307878&installation_model_id=11168&pr_number=427&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F427&signature=7ada1156c49f53d98730721546d35fe6e3eacdd8e676335ac09df7436213f2b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated merge authorization settings while retaining the CI-only review requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->