### PR TITLE
chore(pipeline): declare policy.defaultTier GREEN

### DIFF
--- a/.agent-pipeline.json
+++ b/.agent-pipeline.json
@@ -3,5 +3,8 @@
   "merge": {
     "reviewGate": "ci-only",
     "standingAuthorization": true
+  },
+  "policy": {
+    "defaultTier": "GREEN"
   }
 }


### PR DESCRIPTION
## What

Declare `policy.defaultTier: "GREEN"` in `.agent-pipeline.json`, next to the `merge.*` keys that
landed in #427.

## Why

Without it an unattended agent-pipeline run on this repo completes its work, merges, and then throws
at the post-merge live-test stage instead of closing out. The merge still lands — the runner marks
the PR merged before it calls the live-test stage — so the breakage is "AFK to done", not a bad
merge: the run parks and a human has to reconcile an already-merged PR against an unfinished run.

Mechanism (plugin `0.1.193`, `scripts/execute-prd/live-test.ts`): with no machine-runnable
`## Live test` fenced block in the governing issue, the stage needs a tier. An explicit GREEN claim
records NOT_REQUIRED; with no explicit tier and no repo-declared fallback it takes the fail-closed
branch and throws `... has no machine-runnable live-test block and the diff is not claimed GREEN`.
`policy.defaultTier: "GREEN"` is exactly the fallback that branch consults
(`opts.tier === undefined && opts.fallbackTier === "GREEN"` -> `notRequired()`), honoured only when
the config's `repo:` governs this repo.

Not hypothetical: #389 is `ready` + `afk` and selectable, and its body carries no `## Live test`
heading, so the first unattended run here hits the throw.

The claim is about this repo's own deploy surface — wurk is a gem plus a dashboard, released by CI;
merging a PR here does not itself deploy anything, which is what GREEN asserts.

## Changes

- `.agent-pipeline.json`: add `"policy": { "defaultTier": "GREEN" }`.

## Verification

Parse-verified against the plugin's own loader before commit, from this checkout:

```
source: <repo .agent-pipeline.json>
governsRepo: true
standingAuthorizationFor: true
policy.defaultTier: "GREEN"
reviewGate: "ci-only"
policy.module: undefined
```

`loadConfig` did not throw, so the loud `validateDefaultTier` check passed: the value is the only
accepted one (`"GREEN"`), and it is not paired with a `policy.module` (this repo commits none), which
is the combination that validation refuses outright.

No runtime code changes; nothing in the gem, the dashboard or the workflows is touched.

## Merge

Human merge required, structurally. This diff touches `.agent-pipeline.json`, which fires the
pipeline's unconditional `pipeline-config-park` — nothing lifts it on any repo, and its stated exit
is a human reviewing the config change deliberately and merging it. Same reason #425 and #427 were
human-merged.

Closes #428

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789310613&installation_model_id=11168&pr_number=429&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F429&signature=d28f7faafcee1ad555a3ad68fb2b8787d305997f54896338055b965c4deb5689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->