### PR TITLE
infra#1263 cutover drill: toolchain gate + fan-out under load (scratch, will not merge)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -37,7 +37,7 @@ jobs:
   # independently of the suite box.
   detect:
     name: detect changed paths
-    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.WURK_CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'wurk-ci' || 'ubuntu-latest' }}
     timeout-minutes: 5
     outputs:
       bench: ${{ steps.filter.outputs.bench }}
@@ -63,7 +63,7 @@ jobs:
     name: bench vs base
     needs: detect
     if: needs.detect.outputs.bench == 'true'
-    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.WURK_BENCH_RUNNER || 'ubuntu-latest' }}
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'wurk-bench' || 'ubuntu-latest' }}
     timeout-minutes: 45
     permissions:
       contents: read
@@ -192,4 +192,6 @@ jobs:
             echo "::warning::could not post the bench comment; the delta is in the job summary"
           exit $code
 
-# infra#1263 cutover drill trigger (scratch, reverted on close)
+# infra#1263 cutover drill: runs-on hardcoded for this scratch branch ONLY,
+# bypassing the (still-unset) WURK_CI_RUNNER/WURK_BENCH_RUNNER variables so steps 1-4
+# exercise our farm before the real flip. Reverted on close, never merged.

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -191,3 +191,5 @@ jobs:
           gh api -X "$method" "$endpoint" -F body=@/tmp/bench-comment.md > /dev/null ||
             echo "::warning::could not post the bench comment; the delta is in the job summary"
           exit $code
+
+# infra#1263 cutover drill trigger (scratch, reverted on close)

--- a/.github/workflows/drill1263.yml
+++ b/.github/workflows/drill1263.yml
@@ -1,0 +1,8 @@
+name: drill1263
+on: push
+jobs:
+  j:
+    name: DRILL_watchdog_1263
+    runs-on: wurk-ci
+    steps:
+      - run: sleep 300

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
   # which lands on the same fallback.
   detect:
     name: detect changed paths
-    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.WURK_CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'wurk-ci' || 'ubuntu-latest' }}
     timeout-minutes: 5
     outputs:
       ruby: ${{ steps.filter.outputs.ruby }}
@@ -87,7 +87,7 @@ jobs:
   test:
     name: test + coverage (latest ruby/rails)
     needs: detect
-    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.WURK_CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'wurk-ci' || 'ubuntu-latest' }}
     timeout-minutes: 25
     services:
       redis:
@@ -194,7 +194,7 @@ jobs:
     name: parity (oracle)
     needs: detect
     if: github.event_name != 'pull_request' || needs.detect.outputs.ruby == 'true'
-    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.WURK_CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'wurk-ci' || 'ubuntu-latest' }}
     timeout-minutes: 25
     services:
       redis:
@@ -257,7 +257,7 @@ jobs:
     name: lint (rubocop)
     needs: detect
     if: github.event_name != 'pull_request' || needs.detect.outputs.ruby == 'true'
-    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.WURK_CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'wurk-ci' || 'ubuntu-latest' }}
     timeout-minutes: 10
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}:lint
@@ -295,7 +295,7 @@ jobs:
     name: frontend (vitest)
     needs: detect
     if: github.event_name != 'pull_request' || needs.detect.outputs.frontend == 'true'
-    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || vars.WURK_CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'wurk-ci' || 'ubuntu-latest' }}
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -342,4 +342,6 @@ jobs:
         run: bun run test
         working-directory: frontend
 
-# infra#1263 cutover drill trigger (scratch, reverted on close)
+# infra#1263 cutover drill: runs-on hardcoded to wurk-ci for this scratch branch ONLY,
+# bypassing the (still-unset) WURK_CI_RUNNER variable so steps 1-4 exercise our farm
+# before the real flip. Reverted on close, never merged.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -345,3 +345,4 @@ jobs:
 # infra#1263 cutover drill: runs-on hardcoded to wurk-ci for this scratch branch ONLY,
 # bypassing the (still-unset) WURK_CI_RUNNER variable so steps 1-4 exercise our farm
 # before the real flip. Reverted on close, never merged.
+# concurrency-proof trigger 1787050207

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -341,3 +341,5 @@ jobs:
       - name: vitest
         run: bun run test
         working-directory: frontend
+
+# infra#1263 cutover drill trigger (scratch, reverted on close)


### PR DESCRIPTION
Scratch drill for developerz-ai/infrastructure#1263 steps 1-3 (toolchain gate, concurrency proof, fan-out under load). This PR's workflow files hardcode runs-on to our farm ONLY on this branch — main is untouched, WURK_CI_RUNNER/WURK_BENCH_RUNNER stay unset for everyone else. Will be closed without merging and the branch deleted once evidence is recorded.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789640452&installation_model_id=11168&pr_number=433&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F433&signature=dacfe08ef8fc54d0376f39a49908fe3bd02104f910fcf0d43412ac8f004f7d0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated benchmark, testing, linting, parity, and frontend workflows to use dedicated CI runners for non-fork changes.
  * Fork pull requests continue running on hosted Ubuntu runners.
  * Preserved hosted-runner fallback behavior to support reliable validation across contribution types.
  * Added workflow guidance for the temporary runner transition used during the current rollout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->