### PR TITLE
infra#1263 flip verification (scratch, will not merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,3 +315,5 @@ Wurk neither vendors nor links against it. "Sidekiq" is a trademark of
 Contributed Systems, LLC; Wurk is independent and not affiliated with or
 endorsed by them. Full reasoning:
 **[docs/compatibility.md](https://github.com/developerz-ai/wurk/blob/main/docs/compatibility.md)**.
+
+<!-- infra#1263 flip verification 1787051748, will not merge -->


### PR DESCRIPTION
Confirms the wurk-ci/wurk-bench cutover variables actually route wurk's unmodified main workflow files onto the farm.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789643774&installation_model_id=11168&pr_number=435&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F435&signature=f4a0e8f46c3aa0692572a671857a3294a9159b68b3aee99ed5506e5d94d5de53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->