### PR TITLE
infra#1263 7a rollback verification (scratch, will not merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,3 +315,4 @@ Wurk neither vendors nor links against it. "Sidekiq" is a trademark of
 Contributed Systems, LLC; Wurk is independent and not affiliated with or
 endorsed by them. Full reasoning:
 **[docs/compatibility.md](https://github.com/developerz-ai/wurk/blob/main/docs/compatibility.md)**.
+<!-- infra#1263 7a rollback verification 1787053605, will not merge -->


### PR DESCRIPTION
Confirms clearing WURK_CI_RUNNER falls back to ubuntu-latest.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789645610&installation_model_id=11168&pr_number=436&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F436&signature=e617bc91189fe3256550b92c40c5147b25145322529927f0632186010c083e21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the license section with additional verification notes to improve documentation accuracy and traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->