### PR TITLE
chore(release): v1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Wurk are recorded here. Format: [Keep a Changelog](https:
 
 ## [Unreleased]
 
+## [1.7.3] - 2026-08-18
+
+A correctness release about how Wurk boots inside a Rails host. One bug, but it made the default invocation for a Rails app silently wrong: `bundle exec wurk` ran **two** workers, so every job — every cron tick included — was executed twice. No Redis key, command sequence, job-JSON field, or public API changed: a 1.7.2 worker and a 1.7.3 worker can drain the same queue.
+
 ### Fixed
 
 - **`bundle exec wurk` inside a Rails app no longer runs two workers.** The CLI boots the host application itself, which fires the railtie's `after_initialize` hook, which forked a worker swarm — and then the CLI started its own Launcher in the parent. Both drained the same queue, so every job ran twice, every cron tick fired twice, and any job that was not idempotent raced itself; one Rails app surfaced this as a flood of duplicate-key errors from two processes importing the same records, each with independent `I18n` state so the same failure was reported twice in two languages. `WURK_DISABLED=1` was the documented escape hatch, but nothing in the CLI path set it and nothing warned, so the default invocation for a Rails host was silently wrong. The CLI now claims the worker boot (`Wurk.claim_worker_boot!`) before it loads the app, and `RailsBoot.skip_boot?` honours the claim. The claim deliberately does not live in `enter_server_mode`: the railtie enters server mode too, and claiming there would make it skip its own boot and leave the app with no workers at all.
@@ -448,7 +452,9 @@ First public (pre-1.0) release. Wurk is a 100% API-compatible drop-in replacemen
 - ActiveJob adapter, `IterableJob`, embedded mode, and a standalone `exe/wurk` runner.
 - Sidekiq client/server middleware contract; third-party ecosystem suites (sidekiq-cron, sidekiq-unique-jobs, sidekiq-scheduler, sidekiq-status, sidekiq-failures, sidekiq-throttled) pass against Wurk.
 
-[Unreleased]: https://github.com/developerz-ai/wurk/compare/v1.7.1...HEAD
+[Unreleased]: https://github.com/developerz-ai/wurk/compare/v1.7.3...HEAD
+[1.7.3]: https://github.com/developerz-ai/wurk/compare/v1.7.2...v1.7.3
+[1.7.2]: https://github.com/developerz-ai/wurk/compare/v1.7.1...v1.7.2
 [1.7.1]: https://github.com/developerz-ai/wurk/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/developerz-ai/wurk/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/developerz-ai/wurk/compare/v1.5.0...v1.6.0

--- a/lib/wurk/version.rb
+++ b/lib/wurk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wurk
-  VERSION = '1.7.2'
+  VERSION = '1.7.3'
 end


### PR DESCRIPTION
Releases #437.

One fix, but it made the default invocation for a Rails host silently wrong: `bundle exec wurk` ran **two** workers, so every job — every cron tick included — executed twice, and any job that wasn't idempotent raced itself.

No Redis key, command sequence, job-JSON field, or public API changed: a 1.7.2 worker and a 1.7.3 worker can drain the same queue.

## Also in this release

The CHANGELOG link refs, which 1.7.2 left behind — `[Unreleased]` still compared from `v1.7.1` and there was no `[1.7.2]` entry at all. Both added.

## Gate

```
bundle exec rake release:check     4285 runs, 11839 assertions, 0 failures, 0 errors, 7 skips
bundle exec rake frontend:build    ✓ built in 3.59s
bundle exec rake release:package   ✓ wurk-1.7.3.gem ships the dashboard bundle
```

Merging this fires the release lane: it derives the tag from `Wurk::VERSION`, publishes to RubyGems via Trusted Publishing, and cuts `v1.7.3` last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ek7LXBLqpbhgUKGpp1Vkbw

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789657895&installation_model_id=11168&pr_number=438&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F438&signature=8fb5eb76afb6a9239591f75924c0ed80d8820e1ebd390d0a10e9a7b75b06fa35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the product version to 1.7.3.
  * Added release notes for fixes addressing Rails double-worker startup and release-lane authorization.
  * Updated changelog comparison links for the latest releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->