### PR TITLE
ci: finish an existing release instead of failing after gem push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,17 +154,47 @@ jobs:
       # a tag always has a gem behind it, so "Latest" on GitHub can never
       # disagree with RubyGems. Notes come from the CHANGELOG section, the .gem
       # is attached.
+      #
+      # It reconciles rather than aborting when a release for the tag is already
+      # there. `gem push` above is irreversible, so anything that fails after it
+      # leaves the version live on RubyGems, the run red, and nothing on GitHub
+      # to show for it — which is exactly what v1.7.3 did when a release for the
+      # tag was hand-cut while this job was running. A release someone else
+      # started is finished here instead: published at this commit, notes reset
+      # from the CHANGELOG, the .gem attached. The one case that still fails is a
+      # tag already pointing at a different commit — moving it is never this
+      # job's call.
       - name: tag & create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.preflight.outputs.tag }}
         run: |
+          set -euo pipefail
           bin/changelog-section "$VERSION" > "${RUNNER_TEMP}/notes.md"
+
           flags=(--title "wurk ${TAG}" --notes-file "${RUNNER_TEMP}/notes.md" --target "$GITHUB_SHA")
           if [ "$(ruby -e 'require "rubygems"; print Gem::Version.new(ARGV[0]).prerelease?' "$VERSION")" = "true" ]; then
             flags+=(--prerelease)
           fi
-          gh release create "$TAG" "${flags[@]}" "pkg/wurk-${VERSION}.gem"
+
+          # A draft has no tag ref, so the releases listing — not `git ls-remote`
+          # — is what sees one.
+          existing="$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+            -q ".[] | select(.tag_name == \"${TAG}\") | .id" | tr -d '[:space:]')"
+          if [ -z "$existing" ]; then
+            gh release create "$TAG" "${flags[@]}" "pkg/wurk-${VERSION}.gem"
+            exit 0
+          fi
+
+          tagged="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" -q .object.sha 2>/dev/null || true)"
+          if [ -n "$tagged" ] && [ "$tagged" != "$GITHUB_SHA" ]; then
+            echo "::error::${TAG} already exists and points at ${tagged}, not ${GITHUB_SHA} — refusing to move it."
+            exit 1
+          fi
+
+          echo "::warning::${TAG} already existed — completing that release instead of creating one."
+          gh release edit "$TAG" "${flags[@]}" --draft=false
+          gh release upload "$TAG" "pkg/wurk-${VERSION}.gem" --clobber
 
   # Ship the released tag to wurk.demo.developerz.ai. Runs only after the gem is
   # published, so the demo never advertises a version RubyGems does not have.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Wurk is wire-compatible with Sidekiq — same Redis keys, same job JSON, same Ru
 
 **On speed:** Wurk is not currently faster than stock Sidekiq — it runs at roughly 0.87×–1.02× depending on workload shape, with parity on CPU and I/O but still behind on framework overhead (noop) and boot time. Numbers, method, and the reproduction command are in [docs/benchmarks.md](docs/benchmarks.md); run them yourself with `rake bench:vs_sidekiq`.
 
+**Also from us:** [Ultimate](https://github.com/developerz-ai/ultimate) — the AI-first full-stack framework, for a weekend pet project or the system a company runs on. What a whole stack looks like when the one writing the code is an agent, not a human: [`bunx create-ultimate myapp`](#also-from-developerzai-ultimate).
+
 ## Install
 
 ```ruby
@@ -298,6 +300,18 @@ Wurk is MIT and stays that way. If what you need is a commercial support contrac
 `bundle install && restart`. Wurk reads and writes the same Redis schema, so a rolling deploy can run Sidekiq and Wurk against the same Redis during the cutover. Third-party gems (sidekiq-cron, sidekiq-unique-jobs, sidekiq-scheduler, sidekiq-status, sidekiq-failures, sidekiq-throttled, …) are exercised by running their own upstream suites against Wurk in the [`ecosystem` CI job](https://github.com/developerz-ai/wurk/blob/main/.github/workflows/ecosystem.yml) (see [`test/ecosystem/`](https://github.com/developerz-ai/wurk/tree/main/test/ecosystem)).
 
 Full walkthrough — config side-by-side, the Redis key/`sidekiq_options` mapping, known incompatibilities, and a one-page cutover checklist: **[docs/migrate-from-sidekiq.md](https://github.com/developerz-ai/wurk/blob/main/docs/migrate-from-sidekiq.md)**.
+
+## Also from developerz.ai: Ultimate
+
+**[Ultimate](https://github.com/developerz-ai/ultimate) — the AI-first full-stack framework.** Rails' opinions, Bun's speed, one command that means shippable. Wurk is what one AI-maintained *library* looks like; Ultimate is the whole stack built on the same bet — the best framework you can hand a coding agent, whether what you are building is a weekend pet project or the system a company runs on.
+
+```bash
+bunx create-ultimate myapp && cd myapp && x dev
+```
+
+Every framework of the last fifteen years optimised for a human typing the code. Ultimate assumes an agent writes it, and that rewrites the defaults: **one way to do each thing**, so there is nothing to choose between; conventions that are **build errors**, so the compiler corrects the agent instead of a reviewer; errors carrying a stable code, a cause, and the exact command that fixes it, so a failure costs one round-trip; docs shipped in `node_modules` and `--json` on every command, so nothing reaches for a wiki. `x verify` is the whole contract — green means shippable.
+
+TypeScript end to end, MIT, and as measured about its own claims as this file is: what is proven, what is not, and what it refuses to claim yet are all in [its README](https://github.com/developerz-ai/ultimate#readme).
 
 ## Contributing
 

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -23,6 +23,11 @@ export default defineConfig({
     // tests never leak signals or the document between suites.
     pool: 'threads',
     isolate: true,
+    // Above vitest's 5s default: TimezonePicker renders the full IANA zone list
+    // (~400 rows) and asserts through `getAllByRole`, which computes an
+    // accessible name per row. That lands around a second locally and has timed
+    // out at 5s on a loaded shared runner — a real hang still fails, just later.
+    testTimeout: 20_000,
     // Stylesheets are stubbed to `""` by default, which silently empties a
     // `?raw` import too — styles/palette.test.ts greps the SCSS source and
     // would pass by scanning nothing. Letting `?raw` through hands it to Vite's


### PR DESCRIPTION
## Why

`main` was red on the **release** lane. Run [32153723617](https://github.com/developerz-ai/wurk/actions/runs/32153723617) published `wurk 1.7.3` to RubyGems and then failed on its very next step:

```
a release with the same tag name already exists: v1.7.3
```

A release for `v1.7.3` was hand-cut while the job was running, so `gh release create` collided with it — *after* the irreversible `gem push`. Worst possible point to abort: the gem is live, the run is red, and the lane can do nothing about it on a re-run.

(The red run itself is already cleared — re-running it resolved `preflight` to `proceed=false`, since RubyGems now has 1.7.3, so the release job skipped and the run is green. This PR is the structural fix so it cannot recur.)

## What

**`release.yml` — the tag & Release step reconciles instead of aborting.**

- No release for the tag → `gh release create` as before.
- One already there → publish it at this commit, reset notes from the CHANGELOG, attach the `.gem` with `--clobber`, and emit a `::warning::`. A **draft** is what actually collided, and a draft has no tag ref, so detection goes through the releases listing rather than `git ls-remote`.
- Tag already points at a **different** commit → hard fail. Moving a tag is never this job's call.

All four paths (none / same-commit / moved / draft) were exercised locally against a stubbed `gh`.

**`frontend/vitest.config.ts` — `testTimeout: 20_000`.** The other red run on `main` ([32150582460](https://github.com/developerz-ai/wurk/actions/runs/32150582460), commit 7ba456f) was `TimezonePicker.test.tsx` hitting vitest's 5s default. That file renders the full IANA zone list (~400 rows) and asserts through `getAllByRole`, which computes an accessible name per row; the slowest test measures ~840ms locally, so 5s is thin on a loaded shared runner. A real hang still fails, just later.

**`README.md`** — a short pointer to [Ultimate](https://github.com/developerz-ai/ultimate), the AI-first full-stack framework from the same team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789833808&installation_model_id=11168&pr_number=440&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F440&signature=8603bcf8797cb9044e9c7f65160daed033c3af9e364c71510e73367d3c108522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->