### PR TITLE
docs: fix three docs still claiming CI runs on Blacksmith

### DIFF
--- a/docs/idea/06-performance.md
+++ b/docs/idea/06-performance.md
@@ -55,7 +55,7 @@ Every release must run, and must not regress on:
 4. Swarm boot time, Rails-app baseline.
 5. Memory per worker post-boot, Rails-app baseline.
 
-The benchmark job runs in CI wherever the `vars.WURK_BENCH_RUNNER` repository variable points (`ubuntu-latest` when unset). Results are published to the job summary and a sticky PR comment showing the delta vs main. Greater than 5% regression flags the PR.
+The benchmark job runs in CI wherever the `vars.WURK_BENCH_RUNNER` repository variable points (`ubuntu-latest` when unset; fork PRs are pinned to `ubuntu-latest`, and the job only runs when a bench input changed). Results are published to the job summary and a sticky PR comment showing the delta vs the PR's base. Greater than 5% regression flags the PR.
 
 ## What actually gates a merge
 

--- a/docs/idea/06-performance.md
+++ b/docs/idea/06-performance.md
@@ -55,7 +55,7 @@ Every release must run, and must not regress on:
 4. Swarm boot time, Rails-app baseline.
 5. Memory per worker post-boot, Rails-app baseline.
 
-The benchmark job runs in CI wherever the `vars.WURK_BENCH_RUNNER` repository variable points (`ubuntu-latest` when unset). Results uploaded as artifacts. PR comment shows delta vs main. Greater than 5% regression flags the PR.
+The benchmark job runs in CI wherever the `vars.WURK_BENCH_RUNNER` repository variable points (`ubuntu-latest` when unset). Results are published to the job summary and a sticky PR comment showing the delta vs main. Greater than 5% regression flags the PR.
 
 ## What actually gates a merge
 

--- a/docs/idea/06-performance.md
+++ b/docs/idea/06-performance.md
@@ -55,7 +55,7 @@ Every release must run, and must not regress on:
 4. Swarm boot time, Rails-app baseline.
 5. Memory per worker post-boot, Rails-app baseline.
 
-The benchmark job runs in CI on Blacksmith. Results uploaded as artifacts. PR comment shows delta vs main. Greater than 5% regression flags the PR.
+The benchmark job runs in CI wherever the `vars.WURK_BENCH_RUNNER` repository variable points (`ubuntu-latest` when unset). Results uploaded as artifacts. PR comment shows delta vs main. Greater than 5% regression flags the PR.
 
 ## What actually gates a merge
 

--- a/docs/idea/11-testing-ci.md
+++ b/docs/idea/11-testing-ci.md
@@ -35,22 +35,22 @@ A dedicated CI job runs the test suites of widely-used Sidekiq ecosystem gems (s
 
 ## CI: GitHub Actions
 
-Runner selection is a repository variable, not a hard-coded label: `vars.WURK_CI_RUNNER` for the test, parity, lint, frontend, and ecosystem jobs, `vars.WURK_BENCH_RUNNER` for the benchmark job. Both fall through to stock `ubuntu-latest` when unset, and fork PRs are pinned to `ubuntu-latest` unconditionally. CI runs:
+Runner selection is a repository variable, not a hard-coded label: `vars.WURK_CI_RUNNER` for the detect, test, parity, lint, frontend, and ecosystem jobs, `vars.WURK_BENCH_RUNNER` for the benchmark job. Both fall through to stock `ubuntu-latest` when unset, and fork PRs are pinned to `ubuntu-latest` unconditionally. Release, pages, and dependabot workflows stay on `ubuntu-latest` by design (credential containment). CI runs:
 
 - Test suite (one full run on the newest Ruby + newest Rails, coverage gate folded in — no version matrix)
 - Ecosystem compat suite
 - Benchmark suite
-- Docs site build
+- Docs site build (pages.yml, `ubuntu-latest`)
 
 The test workflow's suite job:
 
 - Checks out the repo.
 - Sets up Ruby via `ruby/setup-ruby` with bundler cache.
-- Boots Redis and Postgres service containers.
+- Boots a Redis service container.
 - Runs the dummy app setup.
 - Runs the full Minitest suite in parallel mode.
 
-The benchmark job runs wherever `vars.WURK_BENCH_RUNNER` points and uploads results as artifacts. A bot comments deltas vs main on every PR. Regressions greater than 5% flag the PR.
+The benchmark job runs wherever `vars.WURK_BENCH_RUNNER` points and publishes the delta vs main to the job summary and a sticky PR comment, on PRs that touch a bench input (`lib/`, `exe/`, `bench/`, `bin/bench-compare`, the Rakefile, Gemfile/gemspec, or the workflow itself). Regressions greater than 5% flag the PR.
 
 ## Coverage
 
@@ -60,8 +60,8 @@ SimpleCov with branch coverage. CI fails when branch coverage on the gem's main 
 
 Before a tag is cut:
 
-- Full matrix green.
-- Ecosystem compat matrix green.
+- Test suite green.
+- Ecosystem compat suite green.
 - Benchmark suite reports no regressions vs the previous tag.
 - Precompiled assets bundle is fresh.
 - Parity test SHA pin matches the latest Sidekiq main we've reviewed.

--- a/docs/idea/11-testing-ci.md
+++ b/docs/idea/11-testing-ci.md
@@ -35,7 +35,7 @@ A dedicated CI job runs the test suites of widely-used Sidekiq ecosystem gems (s
 
 ## CI: GitHub Actions
 
-Runner selection is a repository variable, not a hard-coded label: `vars.WURK_CI_RUNNER` for the detect, test, parity, lint, frontend, and ecosystem jobs, `vars.WURK_BENCH_RUNNER` for the benchmark job. Both fall through to stock `ubuntu-latest` when unset, and fork PRs are pinned to `ubuntu-latest` unconditionally. Release, pages, and dependabot workflows stay on `ubuntu-latest` by design (credential containment). CI runs:
+Runner selection is a repository variable, not a hard-coded label: `vars.WURK_CI_RUNNER` for the detect, test, parity, lint, frontend, and ecosystem jobs, `vars.WURK_BENCH_RUNNER` for the benchmark job. Both fall through to stock `ubuntu-latest` when unset, and fork PRs are pinned to `ubuntu-latest` unconditionally. Release, deploy-demo, pages, and dependabot workflows stay on `ubuntu-latest` by design (credential containment), as does test.yml's `spec-docs` job, which needs neither Ruby nor Redis. The headline suites:
 
 - Test suite (one full run on the newest Ruby + newest Rails, coverage gate folded in — no version matrix)
 - Ecosystem compat suite
@@ -50,7 +50,7 @@ The test workflow's suite job:
 - Runs the dummy app setup.
 - Runs the full Minitest suite in parallel mode.
 
-The benchmark job runs wherever `vars.WURK_BENCH_RUNNER` points and publishes the delta vs main to the job summary and a sticky PR comment, on PRs that touch a bench input (`lib/`, `exe/`, `bench/`, `bin/bench-compare`, the Rakefile, Gemfile/gemspec, or the workflow itself). Regressions greater than 5% flag the PR.
+The benchmark job runs wherever `vars.WURK_BENCH_RUNNER` points and publishes the delta vs the PR's base to the job summary and a sticky PR comment, on PRs that touch a bench input (`lib/`, `exe/`, `bench/`, `bin/bench-compare`, the Rakefile, Gemfile/gemspec, or the workflow itself). Regressions greater than 5% flag the PR.
 
 ## Coverage
 

--- a/docs/idea/11-testing-ci.md
+++ b/docs/idea/11-testing-ci.md
@@ -33,24 +33,24 @@ For each public class we implement, the equivalent test from upstream Sidekiq is
 
 A dedicated CI job runs the test suites of widely-used Sidekiq ecosystem gems (sidekiq-cron, sidekiq-unique-jobs, sidekiq-scheduler, etc.) against Wurk. See `14-ecosystem-compat.md`. These are the strongest possible drop-in proof.
 
-## CI: GitHub Actions on Blacksmith runners
+## CI: GitHub Actions
 
-Blacksmith (https://blacksmith.sh) provides faster runners than stock ubuntu-latest with better caching. We use Blacksmith for:
+Runner selection is a repository variable, not a hard-coded label: `vars.WURK_CI_RUNNER` for the test, parity, lint, frontend, and ecosystem jobs, `vars.WURK_BENCH_RUNNER` for the benchmark job. Both fall through to stock `ubuntu-latest` when unset, and fork PRs are pinned to `ubuntu-latest` unconditionally. CI runs:
 
-- Test matrix (Ruby × Redis × Rails versions)
+- Test suite (one full run on the newest Ruby + newest Rails, coverage gate folded in — no version matrix)
 - Ecosystem compat suite
 - Benchmark suite
 - Docs site build
 
-The test workflow runs the matrix on a 4-vCPU Blacksmith runner. Each matrix cell:
+The test workflow's suite job:
 
 - Checks out the repo.
-- Sets up Ruby via Blacksmith's setup action with bundler cache.
+- Sets up Ruby via `ruby/setup-ruby` with bundler cache.
 - Boots Redis and Postgres service containers.
 - Runs the dummy app setup.
 - Runs the full Minitest suite in parallel mode.
 
-Benchmark job runs on an 8-vCPU Blacksmith runner and uploads results as artifacts. A bot comments deltas vs main on every PR. Regressions greater than 5% flag the PR.
+The benchmark job runs wherever `vars.WURK_BENCH_RUNNER` points and uploads results as artifacts. A bot comments deltas vs main on every PR. Regressions greater than 5% flag the PR.
 
 ## Coverage
 

--- a/docs/plans/2026/08/06/101-faster-than-sidekiq/08-bench-gate-verify.md
+++ b/docs/plans/2026/08/06/101-faster-than-sidekiq/08-bench-gate-verify.md
@@ -1,7 +1,7 @@
 # 08 — Bench harness, CI gate, final verification
 
-> **Executed; one instruction superseded (2026-08-21).** This plan step predates #430, which removed
-> hard-coded runner labels from CI. Step 1's `blacksmith-8vcpu-ubuntu-2404` instruction and its
+> **Executed; the runner instruction is superseded (2026-08-21).** This plan step predates #430, which
+> removed hard-coded runner labels from CI. Step 1's `blacksmith-8vcpu-ubuntu-2404` instruction and its
 > "Per CI standard (CLAUDE.md)" citation are stale: `CLAUDE.md` now states runner selection is a
 > repository variable (`vars.WURK_BENCH_RUNNER` for bench, `ubuntu-latest` fallback) — do not
 > hard-code a runner label on the bench job. `bench.yml` already exists on `main`. Kept unedited

--- a/docs/plans/2026/08/06/101-faster-than-sidekiq/08-bench-gate-verify.md
+++ b/docs/plans/2026/08/06/101-faster-than-sidekiq/08-bench-gate-verify.md
@@ -1,10 +1,11 @@
 # 08 — Bench harness, CI gate, final verification
 
-> **Superseded (2026-08-21).** This plan step predates #430, which removed hard-coded runner labels
-> from CI. Step 1's `blacksmith-8vcpu-ubuntu-2404` instruction and its "Per CI standard (CLAUDE.md)"
-> citation are stale: `CLAUDE.md` now states runner selection is a repository variable
-> (`vars.WURK_BENCH_RUNNER` for bench, `ubuntu-latest` fallback) — do not hard-code a runner label.
-> `bench.yml` already exists on `main`. Kept unedited below as an executed-plan record.
+> **Executed; one instruction superseded (2026-08-21).** This plan step predates #430, which removed
+> hard-coded runner labels from CI. Step 1's `blacksmith-8vcpu-ubuntu-2404` instruction and its
+> "Per CI standard (CLAUDE.md)" citation are stale: `CLAUDE.md` now states runner selection is a
+> repository variable (`vars.WURK_BENCH_RUNNER` for bench, `ubuntu-latest` fallback) — do not
+> hard-code a runner label on the bench job. `bench.yml` already exists on `main`. Kept unedited
+> below as an executed-plan record.
 
 > Part of [`overview.md`](overview.md). Depends on: 02–07 (this is the proof). Do the gate restoration (step 1) FIRST, before any perf commits land, so deltas attribute per commit — it's independent of the other slices.
 

--- a/docs/plans/2026/08/06/101-faster-than-sidekiq/08-bench-gate-verify.md
+++ b/docs/plans/2026/08/06/101-faster-than-sidekiq/08-bench-gate-verify.md
@@ -1,5 +1,11 @@
 # 08 — Bench harness, CI gate, final verification
 
+> **Superseded (2026-08-21).** This plan step predates #430, which removed hard-coded runner labels
+> from CI. Step 1's `blacksmith-8vcpu-ubuntu-2404` instruction and its "Per CI standard (CLAUDE.md)"
+> citation are stale: `CLAUDE.md` now states runner selection is a repository variable
+> (`vars.WURK_BENCH_RUNNER` for bench, `ubuntu-latest` fallback) — do not hard-code a runner label.
+> `bench.yml` already exists on `main`. Kept unedited below as an executed-plan record.
+
 > Part of [`overview.md`](overview.md). Depends on: 02–07 (this is the proof). Do the gate restoration (step 1) FIRST, before any perf commits land, so deltas attribute per commit — it's independent of the other slices.
 
 ## Files to change


### PR DESCRIPTION
## What

Fixes the three documents #431 enumerates that still stated, in the present tense, that this repo's CI runs on Blacksmith — #430 removed Blacksmith from every executable surface, so these were false rather than merely dated.

## Why

One of the three (`08-bench-gate-verify.md`) actively instructs hard-coding `blacksmith-8vcpu-ubuntu-2404`, citing "Per CI standard (CLAUDE.md)" — a citation that now points at a document saying the opposite. Anyone following that step would reintroduce exactly what #430 removed.

## Changes

- `docs/idea/11-testing-ci.md` — CI section rewritten to the current facts: runner selection is a repository variable (`vars.WURK_CI_RUNNER` / `vars.WURK_BENCH_RUNNER`, `ubuntu-latest` fallback, fork PRs pinned unconditionally; release/deploy-demo/pages/dependabot and the `spec-docs` job stay on `ubuntu-latest` by design), Ruby via `ruby/setup-ruby`, one full suite run (no version matrix) per the CLAUDE.md CI standard, Redis-only service container, bench results to job summary + sticky PR comment on PRs matching bench.yml's paths filter. The "Test matrix (Ruby × Redis × Rails versions)" list item became "Test suite" and the release-gate "matrix" bullets were de-matrixed, because keeping them under rewritten present-tense text would reassert a second stale fact.
- `docs/idea/06-performance.md` — benchmark job runs where `vars.WURK_BENCH_RUNNER` points (fork pin, paths-filter condition), results to job summary + sticky comment vs the PR's base.
- `docs/plans/2026/08/06/101-faster-than-sidekiq/08-bench-gate-verify.md` — "Executed; the runner instruction is superseded" banner naming the stale runner instruction and citation; the step text itself is preserved unedited as an executed-plan record (`bench.yml` exists on `main`; status.yml marks the slice `complete`), per the issue's suggested scope.
- Left alone per the issue's scope: the changelog entry and the seed/roadmap mentions (history), and `docs/idea/12-docs-site.md:27` (describes a VitePress/`docs-site/` plan that shipped differently — design intent, classed harmless in #431; a follow-up could sweep it together with `00-seed.md:40`'s index row for this file).

## Verification

- Diff is three markdown files only, no code.
- `grep -in blacksmith` over the two idea docs: 0 hits. Remaining hits in the plan file are the banner itself and the preserved superseded step.
- Runner facts re-verified against `.github/workflows/` at head: 8 `vars.WURK_CI_RUNNER` + 1 `vars.WURK_BENCH_RUNNER` expression sites, all with fork pinning and `ubuntu-latest` fallback; `ruby/setup-ruby` confirmed; bench paths filter matched item-for-item against bench.yml:52-60; deploy-demo/release/pages/dependabot/spec-docs `runs-on: ubuntu-latest` confirmed.
- Two independent deep-review lenses (correctness + adversarial) ran on each head; every MINOR they raised was fixed in a follow-up commit and re-reviewed.
- `bin/check` was not run locally: this box has no Ruby toolchain outside the Docker verify harness, and a markdown-only diff cannot affect the Ruby suite. The PR's CI run is the gate, and the merge path is fail-closed on CI green.

Closes #431