### PR TITLE
fix(swarm): re-relay TERM during the drain so a child forked mid-shutdown isn't lost

### DIFF
--- a/lib/wurk/swarm.rb
+++ b/lib/wurk/swarm.rb
@@ -65,6 +65,25 @@ module Wurk
     # them mid-tail, so its own wait always extends past theirs by this much.
     SHUTDOWN_GRACE = 5
 
+    # How often the drain re-relays TERM to whatever is still in the child
+    # table. A child forked in the instant before the drain can miss the first
+    # one outright: from `Process.fork` returning in the child until ChildBoot
+    # resets the inherited traps, the PARENT's handler is what a TERM finds
+    # there, and it writes the signal into the parent's self-pipe (or, once
+    # `fork_child` has dropped that pipe, into nothing) instead of stopping the
+    # child. The child then boots clean, drains nothing, and `wait_for_children`
+    # burns its whole budget before `hard_kill_stragglers` SIGKILLs it — taking
+    # its in-flight jobs with it. The window is the `_fork` hook chain
+    # (ActiveSupport's ForkTracker and friends all run child-side before
+    # `Process.fork` returns), so it widens with load: measured 10.5s drains
+    # against a 2.6s baseline once that chain is slowed. No child-side fix can
+    # close it — the window precedes any code the child controls — so the
+    # supervisor repeats itself instead. Re-sending is safe: by the second pass
+    # the child owns its handler, TERM to a child already draining is a no-op,
+    # and the pids come from the child table, where an exited child is a zombie
+    # until reaped and so can never be a recycled pid.
+    RETERM_INTERVAL = 1.0
+
     # USR2 is relayed (log reopen) — without a trap, a logrotate config that
     # signals the master pid would hit USR2's default disposition and kill the
     # whole swarm.
@@ -503,8 +522,13 @@ module Wurk
 
     def wait_for_children(timeout)
       deadline = monotonic + timeout
+      reterm_at = monotonic + RETERM_INTERVAL
       while monotonic < deadline && any_children?
         reap_children
+        if monotonic >= reterm_at
+          relay_signal('TERM')
+          reterm_at = monotonic + RETERM_INTERVAL
+        end
         sleep 0.1
       end
     end

--- a/test/unit/swarm_reaping_test.rb
+++ b/test/unit/swarm_reaping_test.rb
@@ -41,6 +41,44 @@ class SwarmReapingTest < Wurk::Test::UnitCase
     end
   end
 
+  # Fork-free AND clock-free: `sleep` advances a fake monotonic clock instead of
+  # the runner, so a ten-second drain resolves in microseconds and the re-TERM
+  # cadence is read off exact times rather than a stopwatch. `exit_after` is how
+  # many polls the fake children survive — nil means they never drain, which is
+  # exactly the child that missed its TERM.
+  class DrainClockSwarm < ReapTestSwarm
+    attr_reader :relays
+    attr_accessor :exit_after
+
+    def initialize(**kwargs)
+      super
+      @clock = 0.0
+      @relays = []
+      @polls = 0
+    end
+
+    private
+
+    def monotonic = @clock
+
+    def sleep(seconds)
+      @clock += seconds
+      0
+    end
+
+    def reap_children
+      @polls += 1
+      @lock.synchronize { @children.clear } if exit_after && @polls >= exit_after
+    end
+
+    def relay_signal(sig)
+      @relays << [monotonic, sig]
+    end
+  end
+
+  # The parent's own worst case, the budget `shutdown` hands the drain.
+  DRAIN_BUDGET = 10.0
+
   def setup
     super
     @config = Wurk::Configuration.new
@@ -116,17 +154,50 @@ class SwarmReapingTest < Wurk::Test::UnitCase
     assert_empty swarm.children, 'an unreapable straggler must still be forgotten'
   end
 
+  # --- the drain repeats itself -------------------------------------------
+
+  # A child forked in the instant before the drain never sees the first TERM:
+  # until ChildBoot resets them, the PARENT's traps are what a signal finds in
+  # the fresh child, and they route it into the parent's self-pipe instead of
+  # stopping it. Unanswered, that child costs the whole drain budget and then
+  # takes a SIGKILL with its in-flight jobs still on it. Reproduced against a
+  # real fork by slowing the `_fork` hook chain the way a loaded box does: a
+  # 10.5s drain where the baseline is 2.6s.
+  def test_drain_re_terms_a_child_that_missed_the_first_one
+    swarm = drain_swarm
+
+    swarm.send(:wait_for_children, DRAIN_BUDGET)
+
+    assert_operator swarm.relays.size, :>, 1,
+                    'a child still alive mid-drain must be TERMed again, not just waited on'
+    assert_in_delta (DRAIN_BUDGET / Wurk::Swarm::RETERM_INTERVAL).floor, swarm.relays.size, 1,
+                    'the repeat must be paced by RETERM_INTERVAL, not sent on every poll'
+  end
+
+  # The repeat is for the child that missed the signal, not a second TERM for
+  # everyone: a fleet that drains inside the first interval is never re-signalled.
+  def test_drain_does_not_re_term_children_that_answered_the_first_one
+    swarm = drain_swarm
+    swarm.exit_after = 1
+
+    swarm.send(:wait_for_children, DRAIN_BUDGET)
+
+    assert_empty swarm.relays, 'children that drained promptly must not be signalled twice'
+  end
+
   private
 
   def topology
     Wurk::Topology.flat(count: SLOTS, queues: ['default'], concurrency: 1)
   end
 
-  def boot_swarm
-    swarm = ReapTestSwarm.new(topology: topology, config: @config)
+  def boot_swarm(klass = ReapTestSwarm)
+    swarm = klass.new(topology: topology, config: @config)
     swarm.boot(install_signals: false)
     swarm
   end
+
+  def drain_swarm = boot_swarm(DrainClockSwarm)
 
   def respawn_pending?(swarm, idx)
     swarm.instance_variable_get(:@respawn_backoff).pending?(idx)


### PR DESCRIPTION
Fixes the red `test` run on `main` ([32466771294](https://github.com/developerz-ai/wurk/actions/runs/32466771294)) — and the production bug behind it.

## The bug

A child forked in the instant before a drain never sees the TERM. Between `Process.fork` returning in the child and `ChildBoot#reset_inherited_signals`, the **parent's** trap is what a signal finds there — `emit_signal`, which writes into the parent's self-pipe (or, once `fork_child` has dropped that pipe, into nothing) instead of stopping the child.

The child then boots clean and drains nothing. `wait_for_children` burns its full `shutdown_timeout + SHUTDOWN_GRACE` budget on it, and `hard_kill_stragglers` SIGKILLs it **with its in-flight jobs still on it**.

The window is the `_fork` hook chain — `ActiveSupport::ForkTracker`, `SQLite3::ForkSafety`, `ConnectionPool::ForkTracker`, `RedisClient::PIDCache`, `Wurk::PidCache` all run child-side before `Process.fork` returns — so it widens with load. That is why it only ever showed on CI.

## Evidence

The CI failure was "supervisor never exited after TERM mid-restart (waited 10s)". That 10s is not a slow box; it is `wait_for_children`'s own budget (5 + 5) elapsing on a child that will never answer.

Reproduced deterministically by slowing the `_fork` hook chain the way a loaded box does, then TERMing a supervisor mid-rolling-restart:

| | drain |
|---|---|
| baseline (no widening) | 2.6s |
| widened window, before | **10.55s** — child hard-killed |
| widened window, after | **3.15s** — child drained gracefully |
| widened window ×2.5, after | 5.15s — still graceful |

## The fix

No child-side fix can close it: the window precedes any code the child controls. So the supervisor repeats itself — `wait_for_children` re-relays TERM every `RETERM_INTERVAL` (1s) while it waits.

Safe to repeat: by the second pass the child owns its own handler, TERM to a child already draining is a no-op, and the pids come from the child table, where an exited child is a zombie until reaped and so can never be a recycled pid.

## Test

Fork-free **and** clock-free, per the existing `swarm_reaping_test.rb` pattern: `sleep` advances a fake monotonic clock, so a ten-second drain resolves in microseconds and the cadence is read off exact times rather than a stopwatch. Two cases — a child that never answers is re-TERMed on the interval (and only on the interval, not every poll); a fleet that drains inside the first interval is never signalled twice.

`bin/rake test` green locally: 4287 runs, 0 failures. Rubocop clean.

Closes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790446548&installation_model_id=11168&pr_number=448&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F448&signature=e74849c12868a27cdfa11e10370c2d49981ca806838ff01366d16c45f3fe18f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->