### PR TITLE
fix(policy,docs): activate .maintainer.yml, correct residual CI-fact drift in docs/idea

### DIFF
--- a/.maintainer.yml
+++ b/.maintainer.yml
@@ -3,13 +3,18 @@
 #
 # Dogfood pass with coding handoff live. The bot triages (qualifies, labels,
 # asks reporters for repro) and, once a task is ready, dispatches coding to the
-# fleet over the webhook handoff. Auto-merge is OFF (pinned 2026-08-01 — see
-# the pr: block): this file was schema-invalid until now, so the platform ran
+# fleet (handoff.mode: fleet). Auto-merge is OFF (pinned 2026-08-01 — see the
+# pr: block): this file was schema-invalid until now, so the platform ran
 # defaultPolicy (auto_merge false), and making the file valid must not change
-# the merge posture: legacy branch protection exists (1 required review + the
-# test matrix), but an approving bot review satisfies the required review, so
-# auto_merge:true would merge routine PRs on bot-approval + green CI with no
-# human. We still wait
+# the merge posture. `pr.auto_merge: false` is in fact the ONLY merge gate this
+# repo has — the live `main-protection` ruleset carries deletion +
+# non_fast_forward and a pull_request rule with
+# required_approving_review_count: 0 and no required-status-checks rule, so
+# nothing outside this file holds a merge back. (Read off the ruleset
+# 2026-08-27. The note that stood here — "legacy branch protection exists (1
+# required review + the test matrix)" — has been false since that ruleset
+# replaced it on 2026-08-07; wurk#445 flagged it, wurk#388 was the outage it
+# was created to end.) We still wait
 # for reviewer bots (coderabbit/copilot) to settle before acting. The native
 # review: block below activates the developerz review lane alongside CodeRabbit
 # (force: true, advisory — never requests changes, never approves). Everything
@@ -31,26 +36,31 @@ triage:
   confidence_threshold: 0.4
 
 handoff:
-  mode: webhook
-  # Validation placeholder only — the fleet `direct` sink claims the durable
-  # tasks row and never fires an external webhook (developerz-ai/developerz.ai#1026).
-  # Same pattern as developerz-ai/developerz.ai's own live policy. Without this
-  # line the WHOLE file fails semantic validation and is silently discarded.
-  webhook_ref: wh_fleet_placeholder
+  # `fleet`, not `webhook`: both grant HandoffWebhook
+  # (developerz-ai/developerz.ai packages/tools/src/policy-gate.ts:83) but `fleet`
+  # needs no `webhook_ref` (packages/policy/src/validate.ts:130, dz#1026), and the
+  # `wh_fleet_placeholder` ref that used to sit here resolved to no row and threw
+  # WebhookRefNotFoundError — the org account has zero registered webhooks, so
+  # the ingest graded the WHOLE file INVALID and served defaultPolicy instead
+  # (wurk#432). Every declared value below only takes effect once this is gone.
+  # This key is also the opt-in for the autonomous scout backlog-drain
+  # (apps/worker/src/cron/scout-backlog-drain.ts:22-29), which stays inert until
+  # dz#1249 and dz#1530 close. Enrolling wurk was authorized by Ivan (ivndev001)
+  # 2026-08-21 on wurk#445.
+  mode: fleet
   ask_reporter_first: false
 
 pr:
   wait_for_other_bots: [coderabbit, copilot]
   # PINNED OFF 2026-08-01 (operator decision, developerz-ai/wurk#345). Until
-  # this PR the file was schema-invalid (handoff.mode=webhook without
-  # webhook_ref), so the platform discarded it whole and ran defaultPolicy —
-  # whose pr.auto_merge is false. Activating the file with the previously
-  # declared `true` would have flipped auto-merge ON: legacy branch protection
-  # is in place (1 required approving review + the test matrix, strict), but an
-  # approving bot review satisfies the required review, so a bot approval plus
-  # green CI would merge a routine PR with no human in the loop. Activation must
-  # be behavior-preserving on the
-  # merge posture; every other declared value activates as written. The dz#789
+  # wurk#432/#445 the file was semantically invalid (handoff.webhook_ref named
+  # no registered webhook), so the platform discarded it whole and ran
+  # defaultPolicy — whose pr.auto_merge is false. Activating the file with the
+  # previously declared `true` would have flipped auto-merge ON with nothing
+  # behind it: the `main-protection` ruleset requires zero approving reviews and
+  # no status checks, so a routine PR would merge on green CI alone, no human in
+  # the loop. This line IS the gate. Activation must be behavior-preserving on
+  # the merge posture; every other declared value activates as written. The dz#789
   # dependency-PR lane posture (green routine PRs merge on CI + gates) is
   # restored only behind a ruleset or a fresh explicit operator decision.
   # NOTE (wurk#347): this governs the platform BOT only. Non-major Dependabot

--- a/docs/idea/00-seed.md
+++ b/docs/idea/00-seed.md
@@ -20,7 +20,7 @@
 - Includes a dummy Rails app at `test/dummy/` for engine integration testing.
 - Modern dashboard: right-side menu, mobile-friendly, dark + light themes, i18n with extensible locales.
 - Minitest with multi-CPU parallel runner.
-- GitHub Actions on Blacksmith runners.
+- GitHub Actions, on whichever runner `vars.WURK_CI_RUNNER` / `vars.WURK_BENCH_RUNNER` names (`ubuntu-latest` when unset).
 - Public docs site on GitHub Pages.
 
 ## Doc index
@@ -37,7 +37,7 @@
 | 08-dashboard.md | SolidJS SPA, right-side menu, mobile, dark theme, i18n, AI |
 | 09-precompiled-assets.md | Assets baked into the gem at build time |
 | 10-dummy-app.md | `test/dummy/` Rails app for engine tests |
-| 11-testing-ci.md | Minitest parallel + Blacksmith GitHub workers |
+| 11-testing-ci.md | Minitest parallel + GitHub Actions CI |
 | 12-docs-site.md | GitHub Pages docs site |
 | 13-roadmap.md | MVP → 1.0 sequencing |
 | 14-ecosystem-compat.md | Tests against sidekiq-cron, sidekiq-unique-jobs, etc. |

--- a/docs/idea/06-performance.md
+++ b/docs/idea/06-performance.md
@@ -47,7 +47,7 @@ Precompiled dashboard assets ship inside the gem — see 09-precompiled-assets.m
 
 ## Benchmark suite (required)
 
-Every release must run, and must not regress on:
+`rake bench` covers, and must not regress on, five shapes. It runs per PR (`bench.yml`), not per release — nothing in `rake release:check` invokes it:
 
 1. Enqueue throughput, single-client, single-queue.
 2. Fetch + execute throughput, no-op perform.
@@ -59,7 +59,7 @@ The benchmark job runs in CI wherever the `vars.WURK_BENCH_RUNNER` repository va
 
 ## What actually gates a merge
 
-`rake bench` is the regression gate: it compares Wurk against **its own past self** on enqueue, fetch+execute, bulk enqueue, swarm boot, and memory. A regression greater than 5% on any of those blocks the merge.
+`rake bench` is the regression gate: it compares Wurk against **its own past self** on enqueue, fetch+execute, bulk enqueue, swarm boot, and memory. A regression greater than 5% on any of those is what the gate is for — though `bench.yml` is deliberately not a required check, so in CI it flags the PR rather than mechanically blocking the merge button.
 
 `rake bench:vs_sidekiq` is the comparison suite against stock Sidekiq. It gates nothing. A green CI run says nothing about how Wurk compares to Sidekiq — only that Wurk has not regressed by more than 5% against its own baseline on the measured metrics. A 4% regression still passes.
 

--- a/docs/idea/11-testing-ci.md
+++ b/docs/idea/11-testing-ci.md
@@ -10,9 +10,9 @@ Reasons:
 
 ## Parallel execution (multi-CPU)
 
-Minitest's parallel executor uses all available CPU cores. Each test class opts in via `parallelize_me!`. Per-test Redis namespace isolation prevents cross-test interference — each test gets a unique key prefix tied to PID plus object id, cleaned up in teardown.
+Minitest's parallel executor forks `NCPU` workers, which `test_helper` defaults to 4 — deliberately below core count, because the integration layer boots real swarms and one worker per core oversubscribes into wall-clock failures. `NCPU` is the knob for a box with headroom. Each test class opts in via `parallelize_me!`. Per-test Redis namespace isolation prevents cross-test interference — each test gets a unique key prefix tied to PID plus object id, cleaned up in teardown.
 
-Tests that exercise the swarm itself fork real processes and need a Redis DB per worker. CI provisions enough Redis DBs (or separate Redis containers) for the parallel worker count.
+Tests that exercise the swarm itself fork real processes and need a Redis DB per worker. CI runs one Redis service container and hands each worker its own logical DB (1-15, never DB 0), assigned in `test_helper`'s `after_parallel_fork` hook — which is also why `NCPU` is capped at 15.
 
 ## Test layers
 
@@ -23,7 +23,7 @@ Tests that exercise the swarm itself fork real processes and need a Redis DB per
 | Integration | End-to-end: real forks, real Redis, real perform |
 | Parity | Ported tests from upstream Sidekiq's own test suite |
 | Ecosystem | Real third-party Sidekiq gems' test suites, run against Wurk (see 14-ecosystem-compat.md) |
-| Benchmarks | Throughput, latency, memory — must not regress vs main |
+| Benchmarks | Throughput, latency, memory — must not regress vs the PR's base |
 
 ## Sidekiq parity tests
 
@@ -46,9 +46,10 @@ The test workflow's suite job:
 
 - Checks out the repo.
 - Sets up Ruby via `ruby/setup-ruby` with bundler cache.
-- Boots a Redis service container.
+- Boots a Redis service container and resolves its mapped port.
+- Sets up bun and builds the dashboard SPA into `vendor/assets/`.
 - Runs the dummy app setup.
-- Runs the full Minitest suite in parallel mode.
+- Runs the full Minitest suite in parallel mode, with the coverage gate folded into the same invocation (`COVERAGE=1`).
 
 The benchmark job runs wherever `vars.WURK_BENCH_RUNNER` points and publishes the delta vs the PR's base to the job summary and a sticky PR comment, on PRs that touch a bench input (`lib/`, `exe/`, `bench/`, `bin/bench-compare`, the Rakefile, Gemfile/gemspec, or the workflow itself). Regressions greater than 5% flag the PR.
 
@@ -62,6 +63,6 @@ Before a tag is cut:
 
 - Test suite green.
 - Ecosystem compat suite green.
-- Benchmark suite reports no regressions vs the previous tag.
+- Benchmark deltas reviewed on the PRs that landed since the last tag. There is no tag-time bench run: `bench.yml` is `on: pull_request` and compares the PR's base, and `rake release:check` never invokes bench.
 - Precompiled assets bundle is fresh.
 - Parity test SHA pin matches the latest Sidekiq main we've reviewed.

--- a/docs/idea/12-docs-site.md
+++ b/docs/idea/12-docs-site.md
@@ -1,5 +1,11 @@
 # Docs Site (GitHub Pages)
 
+> **Status: superseded — design intent, not head.** None of the generator
+> choice or the `docs-site/` layout below was built. What ships is a
+> hand-written static site in `docs/site/`, published by
+> `.github/workflows/pages.yml`. Only "Build and deploy" has been corrected to
+> what CI does; the rest is kept as the original reasoning.
+
 Public-facing documentation served on GitHub Pages, with the option to CNAME to a custom domain later.
 
 ## Generator choice: VitePress
@@ -24,9 +30,9 @@ Public-facing documentation served on GitHub Pages, with the option to CNAME to 
 
 ## Build and deploy
 
-A docs workflow on GitHub Actions runs when `docs-site/**` changes. It builds the VitePress site on a Blacksmith runner, uploads the static output as a Pages artifact, and deploys via the official pages deploy action.
+`.github/workflows/pages.yml` runs on pushes to `main` that touch `docs/**`, `lib/**`, `.yardopts`, `README.md`, the Rakefile, `tasks/llms_full.rb`, the Gemfile pair, or the workflow itself. It runs on `ubuntu-latest`, generates the YARD API docs into `docs/site/api/`, uploads `docs/site/` as a Pages artifact, and deploys via the official pages deploy action. There is no VitePress build and no `docs-site/` trigger path.
 
-The workflow is a separate file from the main test workflow so docs deploys don't depend on the full matrix turning green.
+The workflow is a separate file from the test workflow so docs deploys don't depend on the suite turning green.
 
 ## API ref generation
 

--- a/docs/idea/13-roadmap.md
+++ b/docs/idea/13-roadmap.md
@@ -7,7 +7,7 @@ Ship parity incrementally. Every milestone produces a usable gem.
 - Gemspec, engine class, version, MIT license.
 - Dummy Rails app under `test/dummy/` boots.
 - Minitest parallel runner configured.
-- Blacksmith CI workflow green on a smoke test.
+- CI workflow green on a smoke test.
 - Docs site (`docs/site/`, hand-written static HTML — not VitePress; a
   VitePress build was never adopted) published to GitHub Pages.
 


### PR DESCRIPTION
Two kinds of stale fact in repo metadata, both verified against head rather than asserted.

## `.maintainer.yml` could never take effect (#445, #432)

`handoff.webhook_ref: wh_fleet_placeholder` named no registered webhook — the org account has zero — so the policy ingest graded the **whole file** INVALID on every re-read and served `defaultPolicy` instead. Every declared value in it, `release.manager: none` and `release.channels: []` included, was inert.

`handoff.mode: fleet` grants the same `HandoffWebhook` and needs no `webhook_ref`, so dropping the ref with the mode switch is the entire fix. `fleet` is also the opt-in for the autonomous scout backlog-drain, which stays inert until dz#1249 and dz#1530 close; enrolling wurk was **authorized by Ivan (ivndev001) 2026-08-21** on #445.

### Merge-gate posture, checked leg by leg

`pr.auto_merge: false` is present and untouched. But two comments in this file claimed *"legacy branch protection exists (1 required review + the test matrix)"* — flagged in #445 as out of scope there, and false. Read off the live `main-protection` ruleset today:

```
required_approving_review_count: 0
required_status_checks: (no such rule)
rules: deletion, non_fast_forward, pull_request
```

So `pr.auto_merge: false` is **the only merge gate this repo has**, not belt-and-braces on top of one. The comments now say that. (#388 was the outage the ruleset was created to end — its single-rate-limited-approver failure mode is gone with it.)

## `docs/idea` CI-fact drift (#444)

All eight lines #444 catalogued, each re-stated against `.github/workflows/*.yml`:

| | was | now |
|---|---|---|
| `12-docs-site.md:27` | "builds the VitePress site on a Blacksmith runner" when `docs-site/**` changes | pages.yml on `ubuntu-latest`, YARD into `docs/site/api/`, uploads `docs/site/` |
| `00-seed.md:23,40` | "Blacksmith runners" / "Blacksmith GitHub workers" | the runner variables, `ubuntu-latest` when unset |
| `11-testing-ci.md:13` | "uses all available CPU cores" | `NCPU` defaults to 4, deliberately below core count |
| `11-testing-ci.md:15` | "enough Redis DBs (or separate Redis containers)" | one container, per-worker logical DBs 1-15 |
| `11-testing-ci.md:26` | benchmarks "must not regress vs main" | vs the PR's base |
| `11-testing-ci.md:45-51` | suite steps omitted bun + SPA build | both listed, plus the folded-in coverage gate |
| `11-testing-ci.md:65` | release gate: "Benchmark suite reports no regressions vs the previous tag" | no tag-time bench run exists; bench is `on: pull_request` |
| `06-performance.md:50,62` | "Every release must run" / "blocks the merge" | runs per PR; deliberately not a required check, so it flags |

`12-docs-site.md` is marked **superseded** rather than rewritten — the generator comparison below it is design intent that was never built, and #444 allows clearly-marked aspiration to stay.

`git grep -in blacksmith docs/idea/` now returns nothing (#444 offered leaving the two history lines; swept instead).

Closes #444
Closes #445
Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790446585&installation_model_id=11168&pr_number=449&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F449&signature=7f034271e846506442c637634579272944dd923a9a1fd6e92ea31e820e2433d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->