### PR TITLE
ci(lint): clear the 14 offenses rubocop 1.90 added

### DIFF
--- a/lib/wurk/api/validation.rb
+++ b/lib/wurk/api/validation.rb
@@ -94,13 +94,12 @@ module Wurk
       # one without reopening this file. Baked into the literal rather than
       # appended at load, so the parallel test runner never observes a
       # half-built list.
-      # rubocop:disable Style/MutableConstant
+      # rubocop:disable-next Style/MutableConstant
       JOB_KEYS = %w[
         class args queue at retry jid backtrace tags dead
         retry_for retry_queue expires_in track timeout deadline
         encrypt unique_for unique_until collapse log_level locale wrapped
       ]
-      # rubocop:enable Style/MutableConstant
 
       # `push_bulk`'s envelope keys, on top of the job keys it shares.
       BULK_KEYS = %w[batch_size spread_interval].freeze

--- a/lib/wurk/stats.rb
+++ b/lib/wurk/stats.rb
@@ -116,9 +116,9 @@ module Wurk
     # Single pipeline for the cheap counters. Eagerly invoked at initialize
     # so callers can read many fields without paying per-method round trips.
     FAST_QUERIES = [
-      ['GET',   'stat:processed'],
-      ['GET',   'stat:failed'],
-      ['GET',   Keys::STAT_EXPIRED],
+      ['GET', 'stat:processed'],
+      ['GET', 'stat:failed'],
+      ['GET', Keys::STAT_EXPIRED],
       ['ZCARD', Keys::SCHEDULE],
       ['ZCARD', Keys::RETRY],
       ['ZCARD', Keys::DEAD],

--- a/test/dummy/seed_demo_profiles.rb
+++ b/test/dummy/seed_demo_profiles.rb
@@ -7,12 +7,12 @@ require 'json'
 
 samples = [
   ['Demo::ReportJob', 15_200, 4],
-  ['Demo::FastJob',            120, 11],
-  ['Demo::RateLimitedJob',     890, 23],
+  ['Demo::FastJob', 120, 11],
+  ['Demo::RateLimitedJob', 890, 23],
   ['Demo::BatchChildJob', 3_400, 47],
   ['ThrottledApiJob', 540, 95],
   ['Demo::SlowReportJob', 7_600, 140],
-  ['MailerJob',                250, 320]
+  ['MailerJob', 250, 320]
 ]
 
 now = Time.now.to_i

--- a/test/integration/reaper_full_sweep_test.rb
+++ b/test/integration/reaper_full_sweep_test.rb
@@ -56,7 +56,7 @@ class ReaperFullSweepTest < Wurk::Test::UnitCase
   # (`<host>|<pid>|<idx>`, no nonce segment) must stay reclaimable by the full
   # sweep. No fork needed here — the owner pid is simply gone, exactly like a
   # pre-upgrade process that crashed and was never replaced under that pid.
-  # rubocop:disable Minitest/MultipleAssertions
+  # rubocop:disable-next Minitest/MultipleAssertions
   def test_full_sweep_reclaims_a_legacy_pre_nonce_orphan_in_an_unserved_queue
     legacy_priv = "#{@orphan_q}|#{Socket.gethostname}|#{DEAD_PID}|0"
     @observer.call('RPUSH', legacy_priv, payload('job-legacy'))
@@ -66,7 +66,6 @@ class ReaperFullSweepTest < Wurk::Test::UnitCase
     assert_equal 0, @observer.call('LLEN', legacy_priv), 'private list drained'
     assert_equal 1, @observer.call('LLEN', @orphan_q), 'job re-queued onto its public queue'
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   private
 

--- a/test/unit/api_fast_test.rb
+++ b/test/unit/api_fast_test.rb
@@ -108,9 +108,8 @@ class APIFastTest < Wurk::Test::UnitCase
   def test_scan_arity_one_entry_can_be_deleted
     jid = SecureRandom.hex(12)
     add_member(jid: jid)
-    # rubocop:disable Style/SymbolProc -- explicit 1-arg block exercises arity dispatch.
+    # rubocop:disable-next Style/SymbolProc -- explicit 1-arg block exercises arity dispatch.
     @set.scan(jid) { |entry| entry.delete }
-    # rubocop:enable Style/SymbolProc
 
     assert_equal 0, @set.size
   end

--- a/test/unit/batch_test.rb
+++ b/test/unit/batch_test.rb
@@ -23,7 +23,7 @@ class BatchTest < Wurk::Test::UnitCase
     # Redis Set; parallel tests touching it cross-contaminate.
     @tag_customer = "customer:42:#{Process.pid}:#{object_id}"
     @tag_job      = "job:fulfill:#{Process.pid}:#{object_id}"
-    @bids      = []
+    @bids         = []
   end
 
   def teardown

--- a/test/unit/client_buffered_test.rb
+++ b/test/unit/client_buffered_test.rb
@@ -316,7 +316,7 @@ class ClientBufferedTest < Wurk::Test::UnitCase
 
   # The cap splits a single bulk push: what fits is buffered, the rest rides on
   # the exception. Nothing may fall between the two.
-  # rubocop:disable Minitest/MultipleAssertions
+  # rubocop:disable-next Minitest/MultipleAssertions
   def test_overflow_raise_fills_remaining_capacity_and_reports_the_rest
     Wurk::Client.reliable_push_buffer = 3
     Wurk::Client.reliable_push_overflow = :raise
@@ -331,7 +331,6 @@ class ClientBufferedTest < Wurk::Test::UnitCase
     assert_equal [[0], [1], [2]], buffered_args
     assert_equal [[3], [4], [5]], payload_args(err.payloads)
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   # Plan 03/S2's stated case: a 1000-payload bulk push against a buffer one slot
   # short of the cap used to buffer that one payload, raise on the second and
@@ -387,7 +386,7 @@ class ClientBufferedTest < Wurk::Test::UnitCase
 
   # Batched payloads never buffer, so an overflow that pre-empts their
   # connection-error re-raise would strand them without a trace.
-  # rubocop:disable Minitest/MultipleAssertions
+  # rubocop:disable-next Minitest/MultipleAssertions
   def test_overflow_carries_batched_payloads_from_a_mixed_push
     Wurk::Client.reliable_push_buffer = 1
     Wurk::Client.reliable_push_overflow = :raise
@@ -400,7 +399,6 @@ class ClientBufferedTest < Wurk::Test::UnitCase
     assert_equal [['keep']], buffered_args, 'batched payload must not reach the buffer'
     assert_instance_of RedisClient::ConnectionError, err.cause
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   # With room left, the mixed push keeps the documented split: bidless buffers,
   # batched re-raises the connection error.

--- a/test/unit/client_partial_delivery_test.rb
+++ b/test/unit/client_partial_delivery_test.rb
@@ -88,7 +88,7 @@ class ClientPartialDeliveryTest < Wurk::Test::UnitCase
   # The point of the whole exercise: a push that dies partway through two
   # queues and a batch, replayed against a healthy Redis, leaves every job in
   # existence exactly once.
-  # rubocop:disable Minitest/MultipleAssertions
+  # rubocop:disable-next Minitest/MultipleAssertions
   def test_drain_after_partial_delivery_enqueues_each_job_exactly_once
     client = Wurk::Client.new(pool: dropping_pool(deliver: 1))
     payloads = [item(args: ['a'], jid: 'j-a'),
@@ -103,7 +103,6 @@ class ClientPartialDeliveryTest < Wurk::Test::UnitCase
     assert_equal [['a'], ['c']], queued_args(@queue).reverse
     assert_equal [['b']], queued_args(@other_queue)
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   # Nothing acknowledged — the pre-existing behavior has to survive: every
   # bidless payload buffers, whatever queue it was headed for.

--- a/test/unit/fetcher_reaper_test.rb
+++ b/test/unit/fetcher_reaper_test.rb
@@ -146,7 +146,7 @@ class FetcherReaperTest < Wurk::Test::UnitCase
 
   # --- poison-pill cap ---------------------------------------------------
 
-  # rubocop:disable Minitest/MultipleAssertions
+  # rubocop:disable-next Minitest/MultipleAssertions
   def test_recovery_past_threshold_kills_to_dead_set_instead_of_requeue
     jid = SecureRandom.hex(12)
     job = payload('poison', jid: jid)
@@ -163,7 +163,6 @@ class FetcherReaperTest < Wurk::Test::UnitCase
   ensure
     Wurk.redis { |c| c.call('DEL', recovery_key(jid)) }
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   def test_under_threshold_recovery_requeues_and_bumps_counter
     jid = SecureRandom.hex(12)

--- a/test/unit/iterable_job_test.rb
+++ b/test/unit/iterable_job_test.rb
@@ -3,8 +3,9 @@
 require_relative '../test_helper'
 
 # `cursor:` keyword is part of the build_enumerator contract; many tests
-# don't read it but must still accept it. Disable the file-wide warning.
-# rubocop:disable Lint/UnusedMethodArgument
+# don't read it but must still accept it. Disabled for the whole class below,
+# which is all this file holds.
+# rubocop:disable-next Lint/UnusedMethodArgument
 class IterableJobTest < Wurk::Test::UnitCase
   parallelize_me!
 
@@ -999,4 +1000,3 @@ class IterableJobTest < Wurk::Test::UnitCase
     end
   end
 end
-# rubocop:enable Lint/UnusedMethodArgument

--- a/test/unit/middleware_poison_pill_test.rb
+++ b/test/unit/middleware_poison_pill_test.rb
@@ -314,7 +314,7 @@ class MiddlewarePoisonPillTest < Wurk::Test::UnitCase
     assert_equal [['not-json{{', nil]], recorded
   end
 
-  # rubocop:disable Minitest/MultipleAssertions
+  # rubocop:disable-next Minitest/MultipleAssertions
   def test_super_fetch_callback_receives_pill_on_poison_kill
     recorded = []
     cfg = recovery_config { |jobstr, pill| recorded << [jobstr, pill] }
@@ -332,7 +332,6 @@ class MiddlewarePoisonPillTest < Wurk::Test::UnitCase
     assert_equal 3, pill.count
     assert_equal @queue, pill.queue
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   # The two-arg super_fetch block and the legacy on_poison Hash callback are
   # independent registries; both must fire on a poison kill.

--- a/test/unit/web_extension_test.rb
+++ b/test/unit/web_extension_test.rb
@@ -21,7 +21,7 @@ class WebExtensionTest < Wurk::Test::UnitCase
   # nested `def` inside `app.helpers` is the documented Sidekiq extension
   # idiom, and the route count is the fixture's whole point — both cops are
   # off for this faithful replica.
-  # rubocop:disable Lint/NestedMethodDefinition
+  # rubocop:disable-next Lint/NestedMethodDefinition
   module DemoExt
     def self.registered(app)
       app.helpers do
@@ -51,7 +51,6 @@ class WebExtensionTest < Wurk::Test::UnitCase
       end
     end
   end
-  # rubocop:enable Lint/NestedMethodDefinition
 
   def setup
     super


### PR DESCRIPTION
`lint (rubocop)` is red on every Ruby-touching PR, including ones that change nothing it covers ([448](https://github.com/developerz-ai/wurk/pull/448)). None of the 14 offenses was introduced by a PR — they appeared on `main` when rubocop 1.90 shipped.

`Gemfile.lock` is gitignored (`.gitignore:5`), which is deliberate: the lint job resolves rubocop fresh on every run, so it inherits each release's new cops the day they land. 1.90 added `Style/DirectiveScope` and tightened `Layout/ExtraSpacing`.

## Ten × `Style/DirectiveScope`

A `# rubocop:disable X` / `# rubocop:enable X` pair wrapped around a **single expression** becomes `# rubocop:disable-next X`. Mechanical, and in every case the one expression is exactly what the pair already scoped — a constant literal, a class body, a module, one assertion-heavy test. Checked each rather than trusting the autocorrect; `iterable_job_test.rb`'s comment said "the file-wide warning", which stopped being the right description, so it now says what it does.

## Four × `Layout/ExtraSpacing` — corrected by hand, not by `-a`

`rubocop -a` **deletes** alignment rather than repairing it, and here that made things worse: it unaligned the first two rows of `Stats::FAST_QUERIES` and left the third aligned to `'ZCARD'`, i.e. a half-aligned table. So:

- `Stats::FAST_QUERIES` and `seed_demo_profiles.rb`'s `samples` drop column alignment **outright** — `samples` was already inconsistent about it, so there was no column to preserve.
- `@bids` in `batch_test.rb` was one column short of the `@tag_customer` / `@tag_job` group it visually belongs to. Padded **into** the group rather than pulled out of it.

## Verification

```
494 files inspected, no offenses detected
4285 runs, 11840 assertions, 0 failures, 0 errors, 6 skips
```

Merging this unblocks #448's lint job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790447486&installation_model_id=11168&pr_number=450&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F450&signature=e549964f4b6efa146dcc43e5c82c197a609e99ee71b762d70bfaf15bc66405d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->