### PR TITLE
fix(swarm): stop one child's signal from draining the whole fleet

### DIFF
--- a/lib/wurk/swarm.rb
+++ b/lib/wurk/swarm.rb
@@ -360,7 +360,20 @@ module Wurk
     # stall signal delivery if the pipe fills. `exception: false` returns
     # :wait_writable instead of raising when full (drop the coalescible
     # duplicate); a closed pipe during shutdown is ignored too.
+    #
+    # The owner check is what keeps ONE child's signal from draining the whole
+    # fleet. A forked child inherits both this trap and the parent's live pipe,
+    # and `fork_child` cannot drop them until `Process.fork` RETURNS — the
+    # `_fork` hook chain runs child-side before that, so there is a window
+    # where an operator's `kill <child_pid>` writes TERM into the PARENT's
+    # supervise loop and drains every sibling. Measured: with that chain slowed
+    # the way a loaded box does, TERMing a single child killed the supervisor
+    # and all of it. Comparing pids instead closes it with no window at all —
+    # the inherited trap is inert in the child from its first instruction,
+    # because `@owner_pid` was stamped before the fork.
     def emit_signal(sig)
+      return unless owner?
+
       @signal_write&.write_nonblock("#{sig}\n", exception: false)
     rescue ::IOError, ::Errno::EPIPE, ::Errno::EBADF
       nil

--- a/test/unit/swarm_signals_test.rb
+++ b/test/unit/swarm_signals_test.rb
@@ -166,6 +166,37 @@ class SwarmSignalsTest < Wurk::Test::UnitCase
     assert_nil swarm.instance_variable_get(:@signal_read)
   end
 
+  # --- one child's signal is not the fleet's ------------------------------
+
+  # A forked child inherits this trap AND the parent's still-open pipe:
+  # `fork_child` cannot drop either until `Process.fork` RETURNS, and the
+  # `_fork` hook chain runs child-side before that. Unguarded, an operator's
+  # `kill <child_pid>` landing in that window writes TERM into the PARENT's
+  # supervise loop and drains every sibling. Proven against real forks by
+  # slowing that chain the way a loaded box does: TERMing one child took the
+  # supervisor and the whole fleet down with it. Comparing pids closes the
+  # window entirely — `@owner_pid` is stamped before the fork, so the inherited
+  # trap is inert in the child from its first instruction.
+  def test_emit_signal_from_a_forked_child_never_reaches_the_parents_pipe
+    swarm = draining
+    read, = inject_pipe(swarm)
+    swarm.instance_variable_set(:@owner_pid, ::Process.pid + 1) # what a child sees
+
+    swarm.send(:emit_signal, 'TERM')
+
+    refute read.wait_readable(0),
+           "a child's signal must never surface in the parent's supervise loop"
+  end
+
+  def test_emit_signal_still_writes_for_the_owner
+    swarm = draining
+    read, = inject_pipe(swarm)
+
+    swarm.send(:emit_signal, 'TERM')
+
+    assert_equal 'TERM', read.gets&.strip
+  end
+
   # The traps stay installed after a drain; a late signal must not raise out of
   # trap context into the supervise thread.
   def test_emit_signal_after_shutdown_is_a_noop


### PR DESCRIPTION
`kill <child_pid>` on a single worker could take down the supervisor and every sibling with it.

## The bug

`fork_child` already named this risk:

> Drop the parent's self-pipe first: the inherited traps still write to it, so a signal landing in the window before ChildBoot resets them would surface in the PARENT's supervise loop (an operator TERMing one child pid would drain the whole swarm).

The mitigation was incomplete. `close_signal_pipe` is the first statement in the child branch — but that branch only starts running **after `Process.fork` returns**, and the `_fork` hook chain (`ActiveSupport::ForkTracker`, `SQLite3::ForkSafety`, `ConnectionPool::ForkTracker`, `RedisClient::PIDCache`, `Wurk::PidCache`) runs child-side *before* it returns. Through all of that the child still holds the parent's trap **and** the parent's open pipe, so a TERM landing there wrote `"TERM\n"` into the pipe the **parent** reads, and the supervise loop drained everything.

## Evidence

Slowing the `_fork` chain the way a loaded box does, then TERMing exactly one of two children:

| | supervisor after 20s |
|---|---|
| before | **dead** — one child's TERM drained the fleet |
| after | alive; the signal stayed with the child it was aimed at |

Same window as #447, which is why it has stayed invisible: it widens with load and forks happen at boot, on crash respawn, on rolling restart, and on memory recycle.

## The fix

One guard. `emit_signal` compares pids before writing; `@owner_pid` is stamped in `boot` *before* any fork, so in a child the inherited trap is inert from its very first instruction. The window is **gone**, not narrowed — unlike a child-side reset, which can never run early enough.

No legitimate caller is affected: `install_signal_handlers` only ever runs in the owner, and `supervise` / `shutdown` already guard on `owner?`.

## Test

Fork-free and fast (13 runs, 0.03s). A swarm whose `@owner_pid` is not this process is exactly what a forked child inherits; its `emit_signal` must leave the parent's pipe unreadable. Positive control asserts the owner still writes.

`bin/rake test` green: 4289 runs, 0 failures. Rubocop clean.

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790450723&installation_model_id=11168&pr_number=454&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F454&signature=9e125c723f34c6a7c3a949aad38246520352eadfeb12cb7c215c3a272635edf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->