### PR TITLE
feat(policy): auto-merge on, now that the ruleset and not this file is the gate

### DIFF
--- a/.maintainer.yml
+++ b/.maintainer.yml
@@ -3,18 +3,19 @@
 #
 # Dogfood pass with coding handoff live. The bot triages (qualifies, labels,
 # asks reporters for repro) and, once a task is ready, dispatches coding to the
-# fleet (handoff.mode: fleet). Auto-merge is OFF (pinned 2026-08-01 — see the
-# pr: block): this file was schema-invalid until now, so the platform ran
-# defaultPolicy (auto_merge false), and making the file valid must not change
-# the merge posture. `pr.auto_merge: false` is in fact the ONLY merge gate this
-# repo has — the live `main-protection` ruleset carries deletion +
-# non_fast_forward and a pull_request rule with
-# required_approving_review_count: 0 and no required-status-checks rule, so
-# nothing outside this file holds a merge back. (Read off the ruleset
-# 2026-08-27. The note that stood here — "legacy branch protection exists (1
-# required review + the test matrix)" — has been false since that ruleset
-# replaced it on 2026-08-07; wurk#445 flagged it, wurk#388 was the outage it
-# was created to end.) We still wait
+# fleet (handoff.mode: fleet). Auto-merge is ON as of 2026-09-01 — see the pr:
+# block for the history and for what stands behind it. It is NOT this file: the
+# live `main-protection` ruleset now carries a required_status_checks rule
+# (dz#2798), so CI green is enforced by the repo, not by a line in here. That
+# sentence has been rewritten twice for the same reason and the reason is worth
+# keeping: a note here claiming what protects `main` goes stale the moment
+# someone edits the ruleset, and a stale one reads as a guarantee. Read the
+# ruleset before trusting any sentence in this file about it —
+# `gh api repos/developerz-ai/wurk/rulesets`. (Prior wrong versions: "legacy
+# branch protection exists (1 required review + the test matrix)", false from
+# 2026-08-07 when the ruleset replaced it — wurk#445 flagged it, wurk#388 was
+# the outage it caused; then "no required-status-checks rule", false from
+# 2026-09-01T05:12Z.) We still wait
 # for reviewer bots (coderabbit/copilot) to settle before acting. The native
 # review: block below activates the developerz review lane alongside CodeRabbit
 # (force: true, advisory — never requests changes, never approves). Everything
@@ -52,25 +53,40 @@ handoff:
 
 pr:
   wait_for_other_bots: [coderabbit, copilot]
-  # PINNED OFF 2026-08-01 (operator decision, developerz-ai/wurk#345). Until
-  # wurk#432/#445 the file was semantically invalid (handoff.webhook_ref named
-  # no registered webhook), so the platform discarded it whole and ran
-  # defaultPolicy — whose pr.auto_merge is false. Activating the file with the
-  # previously declared `true` would have flipped auto-merge ON with nothing
-  # behind it: the `main-protection` ruleset requires zero approving reviews and
-  # no status checks, so a routine PR would merge on green CI alone, no human in
-  # the loop. This line IS the gate. Activation must be behavior-preserving on
-  # the merge posture; every other declared value activates as written. The dz#789
-  # dependency-PR lane posture (green routine PRs merge on CI + gates) is
-  # restored only behind a ruleset or a fresh explicit operator decision.
+  # UNPINNED 2026-09-01, on the exit condition the pin itself named: "restored
+  # only behind a ruleset or a fresh explicit operator decision". Both arrived.
+  #
+  # HISTORY, kept because it is why this line was ever `false`. Pinned off
+  # 2026-08-01 (operator decision, developerz-ai/wurk#345): until wurk#432/#445
+  # the file was semantically invalid (handoff.webhook_ref named no registered
+  # webhook), so the platform discarded it whole and ran defaultPolicy — whose
+  # pr.auto_merge is false. Activating the file with the previously declared
+  # `true` would have flipped auto-merge ON with nothing behind it, because the
+  # `main-protection` ruleset then required zero approving reviews AND no status
+  # checks. That is no longer true, and leaving the old sentence here would be a
+  # comment asserting a state the repo no longer has.
+  #
+  # WHAT IS BEHIND IT NOW (dz#2798, ruleset 20556704, updated 2026-09-01T05:12Z,
+  # read back before this change): a `required_status_checks` rule requiring
+  # `test + coverage (latest ruby/rails)`, `lint (rubocop)` and `parity (oracle)`
+  # — the three the 15-PR inventory found ALWAYS created, so none can wedge a PR
+  # by never reporting. `strict_required_status_checks_policy: false`, so `main`
+  # moving does not force a rebase on every open PR. Still no classic branch
+  # protection behind the ruleset (404), so the ruleset IS the gate.
+  #
+  # WHAT IS STILL NOT BEHIND IT, stated rather than assumed:
+  # `required_approving_review_count` is 0. Merges are gated by MACHINES — CI
+  # green plus the ruleset — never by a human review, which is the platform's
+  # documented auto-merge posture and not an oversight. The shape wurk#450 got
+  # through (a red `test + coverage`, merged 24 seconds later) is no longer
+  # expressible.
   # NOTE (wurk#347): this governs the platform BOT only. Non-major Dependabot
   # updates are also targeted by a separate GitHub-native GHA lane
   # (.github/workflows/dependabot-automerge.yml, dz#789) that this policy does
-  # not govern. Repo auto-merge is enabled, so that lane is not inert by config
-  # — yet every Dependabot PR so far (#299-304) was merged by hand, so in
-  # practice a human still gates merges on this repo. auto_merge: false scopes
-  # the platform bot; it does not control the GHA lane.
-  auto_merge: false
+  # not govern. Repo auto-merge is enabled, so that lane is not inert by config.
+  # `auto_merge` here scopes the platform BOT; it does not control the GHA lane,
+  # and flipping it to `true` did not change that lane's behaviour either way.
+  auto_merge: true
 
 review:
   enabled: true


### PR DESCRIPTION
## What

`pr.auto_merge: false -> true`, and both prose blocks in this file that described what protects `main` rewritten, because both were false the moment the ruleset changed.

This is **R1** on developerz-ai/developerz.ai#2770.

## Why now

The pin named its own exit condition — *"restored only behind a ruleset or a fresh explicit operator decision"* — and both arrived.

dz#2798 put a `required_status_checks` rule on `main-protection` (ruleset `20556704`, `updated_at: 2026-09-01T05:12:42Z`). Read back immediately before opening this PR rather than quoted from the issue:

```
$ gh api repos/developerz-ai/wurk/rulesets/20556704 --jq '[.rules[].type]'
["deletion","non_fast_forward","pull_request","required_status_checks"]

$ gh api repos/developerz-ai/wurk/rulesets/20556704 \
    --jq '.rules[]|select(.type=="required_status_checks")|.parameters'
{
  "required_status_checks": [
    {"context":"test + coverage (latest ruby/rails)","integration_id":15368},
    {"context":"lint (rubocop)","integration_id":15368},
    {"context":"parity (oracle)","integration_id":15368}
  ],
  "strict_required_status_checks_policy": false,
  "do_not_enforce_on_create": false
}

$ gh api repos/developerz-ai/wurk/branches/main/protection
HTTP 404          # no classic protection behind it — the ruleset IS the gate
```

Those three checks were chosen because a 15-PR inventory found them **always created**. A required check that never reports wedges a PR forever, so presence mattered more than pass rate; the path-filtered jobs report `skipped` rather than going missing, and GitHub counts a skipped run as passing, so a docs-only PR does not stall. `strict` stayed `false`, so `main` moving does not force a rebase on every open PR.

## What changes in practice

CI green is now enforced by the **repository**. Before today it was enforced by nothing outside this file: `main-protection` carried `deletion` + `non_fast_forward` + a `pull_request` rule with `required_approving_review_count: 0` and no status-check rule. That is how #450 merged **24 seconds after** its `test + coverage` job went red. That shape is no longer expressible.

**`required_approving_review_count` is still 0, and that is deliberate.** The platform's posture is that merge gates are machines — CI green plus branch protections — not human review. Stating it here so nobody reads the flip as assuming a human approval that does not exist.

## The comments changed with it

Two blocks asserted a state the repo no longer has, and leaving either would be a comment claiming a guarantee the code does not provide:

- The header said *"`pr.auto_merge: false` is in fact the ONLY merge gate this repo has … no required-status-checks rule"*.
- The `pr:` block said flipping this would merge *"on green CI alone, no human in the loop"* with nothing behind it.

**This is the second time a sentence in this file has gone stale this way.** The first claimed *"legacy branch protection exists (1 required review + the test matrix)"*, false from 2026-08-07 when the ruleset replaced it — wurk#445 flagged it, wurk#388 was the outage it caused. So the header now tells the reader to **read the ruleset** rather than trust this file, and records both wrong versions; the recurrence is the point, not the correction.

The wurk#347 note is narrowed to what it can still claim: this key scopes the platform **bot** and does not govern the GitHub-native Dependabot lane (`.github/workflows/dependabot-automerge.yml`), either way.

## Verification

Parsed against the live schema from the platform checkout, **both legs** — this file being invalid is a failure mode this repo has already had. It was semantically invalid for its entire life until `a796a674` on 2026-08-27 (`handoff.webhook_ref` named no registered webhook), and the platform silently served `defaultPolicy` the whole time, so every number measured on this repo before that date describes the default and not this file.

```
parseYaml   ->  SHAPE VALID   (pr.auto_merge = true, handoff.mode = fleet)
validate()  ->  {"ok":true,"errors":[]}
```

No code changes, so there is nothing else to gate. Ruleset re-read before opening.

## Live test

This changes deployed behaviour — the platform bot may now merge on this repo. After merge:

1. The next routine PR the bot handles should merge itself once the three required checks are green, with a bot-disclosed merge in the timeline.
2. A PR with any of the three red must **not** merge — that is the guarantee dz#2798 installed, and it is the half worth watching first.
3. If the bot merges something with a red check, the ruleset is not what this PR claims: re-read it and revert this line.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790853795&installation_model_id=11168&pr_number=468&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F468&signature=d39a97bca68ccf89af432f5bf734a3d935f191c19718b5e007baab42569532f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated maintainer policy documentation to reflect current merge protection rules.
  - Documented required CI checks, approval requirements, and distinctions between automated maintenance tools.

- **Chores**
  - Enabled automatic merging for eligible pull requests.
  - Updated repository automation settings to align with the documented ruleset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->