### PR TITLE
feat(policy): declare the Redis this repo's gate refuses to run without

### DIFF
--- a/.maintainer.yml
+++ b/.maintainer.yml
@@ -24,6 +24,29 @@
 # described a lane this repo does not run.
 version: 1
 
+# THE SERVICES THIS REPO'S OWN GATE NEEDS BEFORE IT CAN GRADE A DIFF
+# (developerz-ai/developerz.ai#2918, mechanism in #2919).
+#
+# `bin/check` refuses without a Redis on 127.0.0.1:6379 -- integration and parity
+# tests use a real server, never a mock -- and that refusal is correct. What was
+# wrong is what happened next: every box in the fleet claimed this repo's coding
+# work, the agent produced the correct edit, passed its own guard, and the gate
+# discarded it in 60 ms for want of a service the box never had. Three attempts,
+# three times, each one filed as a bad diff.
+#
+# Declaring it turns "claimed and thrown away" into "claimed by a box that can
+# actually grade it". The platform mints a `service:redis` capability token into
+# the claim gate's requirement set, and a box adverts that token only by opening
+# a real connection to the port -- so this line routes the work rather than
+# describing an intention. A task no box can serve is HELD with
+# `no_service_capacity` naming the gap (#2920), instead of sitting pending and
+# silent.
+#
+# CLOSED VOCABULARY (`redis` | `postgres`): this key can never name an image or a
+# command, which is what keeps a `.maintainer.yml` from being a way to start a
+# process on somebody's box.
+services: [redis]
+
 tone:
   voice: friendly
   language: en


### PR DESCRIPTION
## What

`services: [redis]` — this repo tells the platform what its own verify gate needs before it can grade a diff.

`bin/check` exits without a Redis on 127.0.0.1:6379, and that refusal is right --
integration and parity tests use a real server, never a mock. What was wrong is
what happened next: every box in the fleet claimed this repo's coding work, the
agent produced the correct edit, passed its own guard, and the gate discarded it
in 60 ms for want of a service the box never had. Three attempts, three times,
each filed as a bad diff (developerz-ai/developerz.ai#2918).

`services: [redis]` mints a `service:redis` token into the platform's claim gate,
and a box adverts that token only by opening a real connection to the port -- so
this line ROUTES work rather than describing an intention.

## What changes today, honestly

Measured on prod at the time of writing: the `developerz-ai` account has 10 online
boxes and NONE adverts `service:redis` (the three that do belong to another
account). So this does not start the work flowing. It stops the platform from
claiming work it cannot grade, and it makes the reason legible: a task no box can
serve is HELD with `no_service_capacity` naming the gap
(developerz-ai/developerz.ai#2920) instead of failing three times as a bad diff.

Zero throughput either way -- the attempts were futile by construction. The
difference is that the waste stops and the cause is on the row. The moment any
developerz-ai box runs a Redis, its next heartbeat adverts the token and this
repo's work flows with no further change here.

## The vocabulary is closed

`redis` | `postgres`, never an image or a command. That is what keeps a
`.maintainer.yml` from being a way to start a process on somebody's box.

## Verification

Parsed against the live schema from the platform checkout, both legs -- this file
being invalid is a failure this repo has already had, and it served `defaultPolicy`
silently for its entire life until 2026-08-27:

    parseYaml   ->  SHAPE VALID
    validate()  ->  {"ok":true,"errors":[]}
    services = ["redis"] | pr.auto_merge = true | handoff.mode = fleet

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

## Live test

After merge, this repo's coding tasks should stop failing and start being **held**:

```sh
bun run infra psql "SELECT status, failure_kind, hold_reason, count(*) FROM tasks
                    WHERE repo_full_name='developerz-ai/wurk' GROUP BY 1,2,3"
```

A new `failed / verify_failed` after this lands means the fence is not applying — check `policies.parsed->'services'` carries the value. A `pending / no_service_capacity` row is the expected and correct outcome until a `developerz-ai` box runs a Redis.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790905351&installation_model_id=11168&pr_number=473&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F473&signature=bf51b99e040f1299c1c4886795aa907fe2f01d7e28c2120900f1a706a1d81ab2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Redis service requirements for repository gate execution.
  * Work is routed to available environments with a live Redis service.
  * Jobs are held when suitable service capacity is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->