### PR TITLE
docs: document bin/check exit codes and env knobs (#474)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Three pillars, all must stay true:
 | Task | Command |
 |---|---|
 | Install | `bundle install` |
-| Pre-PR gate (lint + suite + parity) | `bin/check` (`fast` = lint + unit, `full` = + ecosystem) |
+| Pre-PR gate (lint + suite + parity) | `bin/check` (`fast` = lint + unit, `full` = + ecosystem; `SKIP_LINT=1`, `SKIP_PARITY=1`, `NCPU=<n>` opt-outs) |
 | Full test suite (parallel) | `bin/rake test` |
 | Single file | `bin/rake test TEST=test/path/to/file_test.rb` |
 | Single test by name | `bin/rake test TEST=test/foo_test.rb TESTOPTS="--name=/pattern/"` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Three pillars, all must stay true:
 | Task | Command |
 |---|---|
 | Install | `bundle install` |
-| Pre-PR gate (lint + suite + parity) | `bin/check` (`fast` = lint + unit, `full` = + ecosystem; `SKIP_LINT=1`, `SKIP_PARITY=1`, `NCPU=<n>` opt-outs) |
+| Pre-PR gate (lint + suite + parity) | `bin/check` (`fast` = lint + unit, `full` = + ecosystem; `SKIP_LINT=1` / `SKIP_PARITY=1` skip a stage, `NCPU=<n>` sets parallel test workers) |
 | Full test suite (parallel) | `bin/rake test` |
 | Single file | `bin/rake test TEST=test/path/to/file_test.rb` |
 | Single test by name | `bin/rake test TEST=test/foo_test.rb TESTOPTS="--name=/pattern/"` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,13 +61,17 @@ It refuses to start without a local Redis and tells you how to get one. A green
 ### Exit codes
 
 `bin/check` exits with one of four codes — CI treats anything but `0` as a
-failed run:
+failed run.
+
+With no argument, mode defaults to `pr` (the same path `bin/check pr` takes) —
+the case dispatch at `bin/check:20-31` matches `''` to `pr` rather than
+treating it as unknown:
 
 | Exit | Trigger | Source |
 |---|---|---|
-| `0` | Every stage passed. | `bin/check:80-83` |
+| `0` | Every stage passed, OR `-h` / `--help` / `help` printed the help block without running any stage. | `bin/check:80-83`, `bin/check:23-26` |
 | `1` | At least one stage reported failure. | `bin/check:85-86` |
-| `64` | Unknown mode argument (anything but `fast` / `pr` / `full`). | `bin/check:27-30` |
+| `64` | Unrecognised mode argument — anything other than `''`, `pr`, `fast`, `full`, `-h`, `--help`, or `help`. | `bin/check:27-30` |
 | `75` | No Redis on `127.0.0.1:6379` — the platform's "preconditions unmet" code. | `bin/check:60-64` |
 
 ### Env knobs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,24 @@ bin/check full     # ...plus the ecosystem suites
 It refuses to start without a local Redis and tells you how to get one. A green
 `bin/check` is the answer CI will give you.
 
+### Exit codes
+
+`bin/check` exits with one of four codes — CI treats anything but `0` as a
+failed run:
+
+| Exit | Trigger | Source |
+|---|---|---|
+| `0` | Every stage passed. | `bin/check:80-83` |
+| `1` | At least one stage reported failure. | `bin/check:85-86` |
+| `64` | Unknown mode argument (anything but `fast` / `pr` / `full`). | `bin/check:27-30` |
+| `75` | No Redis on `127.0.0.1:6379` — the platform's "preconditions unmet" code. | `bin/check:60-64` |
+
+### Env knobs
+
+- `SKIP_LINT=1` — drop the rubocop stage (`bin/check:66`).
+- `SKIP_PARITY=1` — drop the parity oracles stage (`bin/check:73`).
+- `NCPU=<n>` — see [Worker count](#worker-count) below for the trade-off (ceiling 14).
+
 The individual tasks, when you want one:
 
 | Task | Command |
@@ -70,6 +88,8 @@ The individual tasks, when you want one:
 | Coverage gate | `COVERAGE=1 bin/rake test` |
 | Benchmarks | `bin/rake bench` |
 | Lint | `bundle exec rubocop --parallel` |
+
+### Worker count
 
 The suite forks 4 parallel workers, each on its own Redis logical DB. That is
 deliberately below most machines' core count: the integration layer boots real


### PR DESCRIPTION
Closes #474

## What

Documents `bin/check`'s four-value exit contract and the three env knobs it honours — both currently live only in `bin/check`'s source. The exit code table and env knobs land under a new "Exit codes" / "Env knobs" subsection in CONTRIBUTING.md (under "Running the tests"); CLAUDE.md's `bin/check` row picks up a one-phrase mention of the three knobs.

## Why

A contributor running `bin/check` and getting anything but `0` has no doc to look at: `SKIP_LINT` / `SKIP_PARITY` appear nowhere in `*.md` and CONTRIBUTING.md:49-59 covers modes + the Redis refusal without naming the exit codes or the skip knobs. CI treats non-zero as failure, so the codes are part of the contract — they belong in docs.

## Changes

- `CONTRIBUTING.md`
  - New `### Exit codes` subsection after the "A green `bin/check` is the answer CI will give you." paragraph: 4-row table covering `0`, `1`, `64`, `75` with the trigger and the `bin/check` line range that emits each code.
  - New `### Env knobs` subsection: one-line entries for `SKIP_LINT=1`, `SKIP_PARITY=1`, and `NCPU=<n>`. The `NCPU` entry links to a new `### Worker count` subheading instead of re-stating the trade-off paragraph.
  - Promoted the existing worker-count paragraph to a `### Worker count` heading so the link target exists; text is unchanged.
- `CLAUDE.md`
  - The Commands table row for `bin/check` now ends with `; SKIP_LINT=1, SKIP_PARITY=1, NCPU=<n> opt-outs` — a single phrase, no new table.

Every `bin/check` line cited in the new table (27-30, 60-64, 80-83, 85-86) was read off the file in this checkout; the env-knob citations (`bin/check:66` for SKIP_LINT, `bin/check:73` for SKIP_PARITY) match the source. None of the cited ranges have drifted.

## Verification

- `grep -n SKIP_PARITY CONTRIBUTING.md CLAUDE.md` returns CONTRIBUTING.md:76 and CLAUDE.md:20 — one hit in each file, per acceptance criterion #3.
- `grep -n SKIP_LINT CONTRIBUTING.md CLAUDE.md` returns CONTRIBUTING.md:75 and CLAUDE.md:20.
- `grep -n NCPU CONTRIBUTING.md CLAUDE.md` returns hits in both files (CONTRIBUTING.md:77, :97, :98; CLAUDE.md:20, :100).
- `bash -n bin/check` passes — the script still parses; no edits were made to it.
- `git diff --stat` confirms only `CONTRIBUTING.md` (+20) and `CLAUDE.md` (+1/-1) changed. `bin/check` is untouched.
- `test/unit/docs_links_test.rb` gates links in `docs/*.md` only and does not read `CONTRIBUTING.md`, so the new intra-file `[Worker count](#worker-count)` link does not pass through it. The new exit-code table uses backtick-wrapped prose, not markdown links, so it is not gated at all.
- `bin/check` itself was **not run** — this box has no Ruby and no Redis. The acceptance criterion's `gates green: rubocop, rake test, rake test:parity (bin/check exit 0)` leg is for CI, not local.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790961521&installation_model_id=11168&pr_number=495&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F495&signature=cbe41b2946bcc08d3ebf94cdc47aae3a14b4dff8a6dd090ebf1ae5327dc77a60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented the default behavior, exit codes, and trigger conditions for pre-PR checks.
  * Added guidance for skipping lint and parity checks.
  * Documented configuration for adjusting the number of workers used by checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->