### PR TITLE
fix(check): a missing bundler refuses with 75, instead of exiting 1 as a verdict on the diff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,15 +69,23 @@ treating it as unknown:
 
 | Exit | Trigger | Source |
 |---|---|---|
-| `0` | Every stage passed, OR `-h` / `--help` / `help` printed the help block without running any stage. | `bin/check:80-83`, `bin/check:23-26` |
-| `1` | At least one stage reported failure. | `bin/check:85-86` |
+| `0` | Every stage passed, OR `-h` / `--help` / `help` printed the help block without running any stage. | `bin/check:94-97`, `bin/check:23-26` |
+| `1` | At least one stage reported failure. | `bin/check:99-100` |
 | `64` | Unrecognised mode argument — anything other than `''`, `pr`, `fast`, `full`, `-h`, `--help`, or `help`. | `bin/check:27-30` |
-| `75` | No Redis on `127.0.0.1:6379` — the platform's "preconditions unmet" code. | `bin/check:60-64` |
+| `75` | No bundler on `PATH` — the environment cannot run the Ruby gate at all. | `bin/check:62-66` |
+| `75` | No Redis on `127.0.0.1:6379`. | `bin/check:74-78` |
+
+`75` is the platform's "preconditions unmet" code, and both triggers share it on
+purpose: neither says anything about the diff. A gate that cannot reach its Redis,
+or cannot find the bundler it runs every stage through, has established NOTHING —
+so it must not exit `1`, which means "the gate ran and judged the change". An
+automated maintainer reads `1` as a red diff and sends its agent hunting a bug
+nobody wrote.
 
 ### Env knobs
 
-- `SKIP_LINT=1` — drop the rubocop stage (`bin/check:66`).
-- `SKIP_PARITY=1` — drop the parity oracles stage (`bin/check:73`).
+- `SKIP_LINT=1` — drop the rubocop stage (`bin/check:80`).
+- `SKIP_PARITY=1` — drop the parity oracles stage (`bin/check:87`).
 - `NCPU=<n>` — see [Worker count](#worker-count) below for the trade-off (ceiling 14).
 
 The individual tasks, when you want one:

--- a/bin/check
+++ b/bin/check
@@ -51,6 +51,20 @@ stage() {
   fi
 }
 
+# Bundler is not optional either, and its absence is NOT a verdict on a diff.
+# Every stage below is `bundle exec`, and `stage()` runs its command inside an
+# `if`, so a missing bundler does not abort under `set -e`: the shell's 127 is
+# swallowed into `failed[]` and this script exits 1. Exit 1 means "the gate ran
+# and judged the change", so an environment with no Ruby toolchain would tell a
+# coding agent its edit is RED and send it hunting a bug it did not write
+# (developerz-ai/developerz.ai#3067). Refuse with 75 instead — the same
+# preconditions-unmet contract the Redis guard below uses.
+if ! command -v bundle >/dev/null 2>&1; then
+  echo "bin/check: no bundler on PATH — this environment cannot run the Ruby gate." >&2
+  echo "  install Ruby and bundler, then:  bundle install" >&2
+  exit 75
+fi
+
 # Redis is not optional — integration and parity tests use a real server, never
 # a mock (CLAUDE.md). Refuse with the platform's preconditions-unmet contract
 # code (apps/runner/src/modes/setup/base.ts, CHECK_EXIT_PRECONDITIONS_UNMET =


### PR DESCRIPTION
## What

`bin/check` exited `1` when bundler was missing. `1` means "the gate ran and judged your change", so an environment with no Ruby toolchain told an automated maintainer the diff was RED. It now refuses with `75`.

## Why

Every stage is `bundle exec`, and `stage()` runs its command inside an `if`:

```sh
stage() {
  ...
  if "$@"; then ... else failed+=("$name"); fi
}
```

That is deliberate — it is how the script collects every failing stage instead of stopping at the first. But it also means `set -euo pipefail` does not abort on the shell's `127`, so `bundle: command not found` is swallowed into `failed[]` and the script reaches `exit 1` at the bottom.

The Redis precondition above already refuses correctly with `75` (#472). Bundler had no guard at all, so the more fundamental missing dependency produced the worse answer.

**Why 75 and not 1.** The platform grades a gate's exit code: `75` is `EX_TEMPFAIL`, read as `preconditions_unmet` — the gate established nothing about the diff, and the coding agent is told not to change anything in response. `1` is a verdict. Handing back `1` for a missing toolchain sends an agent hunting a bug nobody wrote — which is not hypothetical: it is the failure mode behind developerz-ai/developerz.ai#2923, where an agent concluded the gate was the problem and rewrote `bin/check` to `exit 0` on a PR with auto-merge on.

## Changes

- `bin/check` — a `command -v bundle` guard above the Redis guard, refusing `75` with the two stderr lines telling a local developer how to fix it. Placed first because it is the more fundamental precondition: without bundler no stage can run at all, while Redis is only needed once tests start.
- `CONTRIBUTING.md` — the exit-code table gains the new `75` trigger, and every line citation in it is re-pointed (the insertion shifted them). Added a paragraph on why both `75` triggers share a code: neither says anything about the diff.

## Verification

Measured, with Redis up on `127.0.0.1:6379` so its guard does not fire first, and `bundle` off `PATH`:

```
$ env PATH="/usr/bin:/bin" bash <origin/main's bin/check>
==> parity oracles
bin/check: line 46: bundle: command not found
    x parity oracles (0s)
bin/check x failed: rubocop test suite (unit + integration + engine) parity oracles  (0s)
exit: 1                <-- "the gate judged your diff"

$ env PATH="/usr/bin:/bin" bash bin/check
bin/check: no bundler on PATH — this environment cannot run the Ruby gate.
  install Ruby and bundler, then:  bundle install
exit: 75               <-- "preconditions unmet"
```

No false positive when bundler IS present: `bin/check fast` proceeds past the guard to `==> rubocop` as before.

Every line citation in the `CONTRIBUTING.md` table was checked to resolve to the construct it names after the shift.

## Known second rung, deliberately not in this PR

A box that has bundler but has not run `bundle install` hits the same laundering: `bundle exec` exits `1` with `Bundler::GemNotFound`, and the gate again reports a red diff.

`bundle check` detects it, but this repo gitignores `Gemfile.lock`, so `bundle check` resolves against rubygems.org on every invocation — a network round trip added to the inner loop, on every run, to catch a state that provisioning should prevent. That trade is not obviously worth it and is not made here. It belongs with the provisioning half (developerz-ai/developerz.ai#3067), where `bundle install` is the box's job rather than the gate's.

Noting it rather than leaving it for someone to rediscover from a confusing red.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790987908&installation_model_id=11168&pr_number=496&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F496&signature=b8b9cc5536ce5919d626dbec561e8018b2749e146ccfac2a6321d9ee3ab4c5df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a preflight check that verifies Bundler is available before running Ruby-related checks.
  - Missing Bundler now provides installation guidance and exits with status 75.

- **Documentation**
  - Clarified that missing Bundler and missing Redis are separate precondition failures.
  - Updated documentation references for exit codes, source lines, and environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->