### PR TITLE
ci: drop Gemfile.lock from three paths-filters that can never match it (#489)

### DIFF
--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -43,8 +43,10 @@ jobs:
               - 'exe/**'
               - 'test/**'
               - 'tasks/**'
+              # Gemfile.lock is deliberately absent from the filter — it is gitignored
+              # (.gitignore:5) and can never appear in a diff; `Gemfile` and the gemspec are
+              # what actually move dependencies.
               - 'Gemfile'
-              - 'Gemfile.lock'
               - 'Rakefile'
               - '*.gemspec'
               - '.github/workflows/ecosystem.yml'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,8 +13,10 @@ on:
       - "README.md"
       - "Rakefile"
       - "tasks/llms_full.rb"
+      # Gemfile.lock is deliberately absent from the filter — it is gitignored
+      # (.gitignore:5) and can never appear in a diff; `Gemfile` and the gemspec are
+      # what actually move dependencies.
       - "Gemfile"
-      - "Gemfile.lock"
       - ".github/workflows/pages.yml"
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,8 +62,10 @@ jobs:
               - 'tasks/**'
               - 'config/**'
               - 'frontend/**'
+              # Gemfile.lock is deliberately absent from the filter — it is gitignored
+              # (.gitignore:5) and can never appear in a diff; `Gemfile` and the gemspec are
+              # what actually move dependencies.
               - 'Gemfile'
-              - 'Gemfile.lock'
               - 'Rakefile'
               - '*.gemspec'
               - '.github/workflows/test.yml'


### PR DESCRIPTION
Closes #489

## What

Removed `Gemfile.lock` from three paths-filter entries in CI workflows where the entry is dead, and added the same three-line comment that `bench.yml` already carries so the omission reads as deliberate.

## Why

`Gemfile.lock` is gitignored (.gitignore:5) and so cannot appear in a diff. Yet test.yml, ecosystem.yml and pages.yml still listed it as a path-filter entry, where it could never match — bench.yml already documents the omission (`.github/workflows/bench.yml:32-34`). The three remaining filters contradicted that comment and misled anyone auditing what triggers a run.

## Changes

- `.github/workflows/test.yml` — removed the `- 'Gemfile.lock'` line in the `detect` job's `ruby:` filter; added the comment from bench.yml in front of `- 'Gemfile'`.
- `.github/workflows/ecosystem.yml` — same change in the `detect` job's `ruby:` filter.
- `.github/workflows/pages.yml` — same change in the `on.push.paths` list.

`Gemfile` and `*.gemspec` are kept in every filter that had them (test.yml, ecosystem.yml). pages.yml did not list `*.gemspec` before this change and still does not — pre-existing, not regressed by it.

## Verification

- `grep -rn "Gemfile.lock" .github/workflows/` — returns only comment lines (in test.yml, ecosystem.yml, pages.yml, bench.yml); no path-filter entries remain. (Note: the issue's acceptance criterion reads "returns only the bench.yml comment"; the issue body, however, explicitly directs adding the same comment to each of the three filters. I followed the body. If the AC's wording was intended literally, the three added comments can simply be removed — they're the only thing keeping the AC passing its literal wording, and the diff is otherwise the three `- 'Gemfile.lock'` deletions exactly as the AC otherwise specifies.)
- Each of the three filters keeps `Gemfile` (test.yml, ecosystem.yml, pages.yml) and `*.gemspec` where it was present before (test.yml, ecosystem.yml; pages.yml never had it).
- `actionlint` (1.7.12) on the three files: zero diagnostics, exit 0.
- `bin/check` (rubocop + rake test + rake test:parity): NOT RUN locally. This box has no Ruby, bundler, or redis. The CI gate will run them on the PR; that is the only gate for this change.
- `bin/check` exit-code contract docs (`.github/workflows/test.yml`) and the README are untouched.
- No `Gemfile.lock` change in the diff — confirm with `git diff main` (only the three files above are modified).