### PR TITLE
fix(ci): point issue-chooser question link at a pre-labelled issue (closes #481)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,9 @@ contact_links:
   - name: Security vulnerability
     url: https://github.com/developerz-ai/wurk/security/advisories/new
     about: Report security issues privately, not as a public issue.
+  # Discussions are disabled for this repo, so the contact link points at a
+  # pre-labelled issue instead. If the operator later enables Discussions,
+  # flip the url back to https://github.com/developerz-ai/wurk/discussions.
   - name: Question or discussion
-    url: https://github.com/developerz-ai/wurk/discussions
+    url: https://github.com/developerz-ai/wurk/issues/new?labels=question&title=Question%3A+
     about: Usage questions, ideas, and general discussion.


### PR DESCRIPTION
## What
.github/ISSUE_TEMPLATE/config.yml:6-8 — replace the GitHub Discussions contact link with a link to open an issue pre-labelled `question`. Add a comment above the entry noting how to flip it back if the operator enables Discussions later.

## Why
Discussions are disabled for this repo (`gh api repos/developerz-ai/wurk --jq .has_discussions` returns `false`), so the old `/discussions` URL returned 404. With `blank_issues_enabled: false` on config.yml:1 that left a user with a usage question no working path. The `question` label already exists (`gh label list` shows `question — Further information is requested`), so a pre-labelled issue opener is a working drop-in.

## Changes
- .github/ISSUE_TEMPLATE/config.yml: repoint `url` for the "Question or discussion" entry from `https://github.com/developerz-ai/wurk/discussions` to `https://github.com/developerz-ai/wurk/issues/new?labels=question&title=Question%3A+`.
- Same file: add a comment above that entry noting the one-line revert path if Discussions are later enabled.
- Security contact link (config.yml:3-5) unchanged, as instructed.

## Verification
This box has no Ruby, bundler, or Redis, so `bin/check`, rubocop, and the test suite could not run locally (per task instruction not to install them). All gates — rubocop, `rake test`, `rake test:parity` — run in CI only.

Local checks actually run:

```
$ curl -sI https://github.com/developerz-ai/wurk/security/advisories/new | head -1
HTTP/2 302

$ curl -sI 'https://github.com/developerz-ai/wurk/issues/new?labels=question&title=Question%3A+' | head -1
HTTP/2 302

$ curl -sIL https://github.com/developerz-ai/wurk/security/advisories/new | grep '^HTTP'
HTTP/2 302
HTTP/2 200

$ curl -sIL 'https://github.com/developerz-ai/wurk/issues/new?labels=question&title=Question%3A+' | grep '^HTTP'
HTTP/2 302
HTTP/2 200
```

Both URLs reach HTTP 200 after redirect (the 302 is GitHub's auth gate on HEAD for unauthenticated requests — both URLs are recognized and reachable, none 404). The old `/discussions` URL was 404 and is gone.

`gh api repos/developerz-ai/wurk --jq .has_discussions` → `false` (citation in issue confirmed live).
`gh label list` → `question    Further information is requested    #d876e3` (citation in issue confirmed live).

Closes #481

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791022828&installation_model_id=11168&pr_number=500&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F500&signature=cc3e20e0efd45f0789cef1d67b4880be6fd8937d0b4de272cb85000f9a382a22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->