### PR TITLE
fix(policy): note that unattributed commits need one human approval

### DIFF
--- a/.maintainer.yml
+++ b/.maintainer.yml
@@ -99,10 +99,24 @@ pr:
   #
   # WHAT IS STILL NOT BEHIND IT, stated rather than assumed:
   # `required_approving_review_count` is 0. Merges are gated by MACHINES — CI
-  # green plus the ruleset — never by a human review, which is the platform's
+  # green plus the ruleset — not by a human review, which is the platform's
   # documented auto-merge posture and not an oversight. The shape wurk#450 got
   # through (a red `test + coverage`, merged 24 seconds later) is no longer
   # expressible.
+  #
+  # ONE EXCEPTION the count of 0 hides (wurk#488): the ruleset's pull_request
+  # rule sets `require_extra_approval_for_unattributed_changes: true` (read
+  # back via `gh api repos/developerz-ai/wurk/rulesets/20556704`, ruleset id
+  # stable since 2026-08-07), so a PR whose commits include any not attributed
+  # to a GitHub account needs one human approval before the bot's auto-merge
+  # will fire. Every squash on main to date is attributed (author.login
+  # non-null on the last 40), so this has not gated a PR yet — the day a fleet
+  # box commits with an email not linked to a GitHub account, that PR silently
+  # parks and the bot cannot move it. CONTRIBUTING.md tells contributors to
+  # commit with a GitHub-linked email for exactly this reason. The rule here
+  # (.maintainer.yml:10-14) says this file must not assert a ruleset state it
+  # does not have, and the count-of-0 sentence above would be one of those
+  # assertions without this caveat.
   # NOTE (wurk#347): this governs the platform BOT only. Non-major Dependabot
   # updates are also targeted by a separate GitHub-native GHA lane
   # (.github/workflows/dependabot-automerge.yml, dz#789) that this policy does

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,14 +162,22 @@ These are non-negotiable — they're what keep Wurk a true drop-in:
 
 ## Pull requests
 
-1. Branch off `main`.
-2. Keep the change focused; add tests at the right layer.
-3. Run `bin/check` (or `bin/check full` if you touched the compat surface).
-4. Open the PR — CI runs one Ruby suite on the newest Ruby + Rails with the
+1. Commit with an email linked to your GitHub account
+   (`git config user.email` matches the address on
+   <https://github.com/settings/emails>). The repo's `main-protection` ruleset
+   sets `require_extra_approval_for_unattributed_changes: true`, so any commit
+   in your PR not attributed to a GitHub account adds a human approval
+   requirement on top of the zero the ruleset otherwise asks for — this repo
+   otherwise never asks for one, so the PR will silently park instead of
+   auto-merging. See `.maintainer.yml` for the ruleset citation.
+2. Branch off `main`.
+3. Keep the change focused; add tests at the right layer.
+4. Run `bin/check` (or `bin/check full` if you touched the compat surface).
+5. Open the PR — CI runs one Ruby suite on the newest Ruby + Rails with the
    coverage gate folded in, plus the parity oracles, rubocop, the frontend
    suite, and benchmarks. The bench bot comments per-benchmark deltas; a real
    regression fails the check.
-5. Don't `--no-verify` past a failing hook — fix the hook.
+6. Don't `--no-verify` past a failing hook — fix the hook.
 
 By contributing you agree your work is licensed under the project's
 [MIT License](LICENSE).


### PR DESCRIPTION
## What
- `.maintainer.yml` `pr:` comment drops the unqualified "never by a human
  review" and adds the caveat: the ruleset's `pull_request` rule sets
  `require_extra_approval_for_unattributed_changes: true`, so a PR with any
  commit not attributed to a GitHub account needs one human approval before
  the bot can auto-merge. Names the parameter and ruleset id 20556704.
- `CONTRIBUTING.md` "Pull requests" step 1 (new) tells contributors to commit
  with an email linked to their GitHub account, and says why.

## Why
The `pr:` block comment was the load-bearing fact behind `auto_merge: true`,
stating merges are "never" human-gated. The live `main-protection` ruleset
(verified via `gh api repos/developerz-ai/wurk/rulesets/20556704` — same id,
`require_extra_approval_for_unattributed_changes: true` confirmed) hides an
extra human approval requirement behind the count-of-0. Every squash on main
to date is attributed (last 40 had `author.login` non-null), so the case has
not fired yet; the day a fleet box commits with an email not linked to a
GitHub account, that PR silently parks. The repo's own rule
(`.maintainer.yml:10-14`) says this file must not assert a ruleset state it
does not have — the count-of-0 sentence was doing exactly that without the
caveat. CONTRIBUTING.md was also missing the contributor-side guidance.

## Changes
- `.maintainer.yml` — replaced "never by a human review" with "not by a human
  review"; appended a 14-line caveat paragraph naming the parameter,
  ruleset id, the GH API command to verify, and the link to CONTRIBUTING.md.
- `CONTRIBUTING.md` — added step 1 in "Pull requests" (GitHub-linked email +
  why), renumbered 2-6.

## Verification
- `gh api repos/developerz-ai/wurk/rulesets/20556704` — confirmed live:
  `require_extra_approval_for_unattributed_changes: true`, ruleset id
  20556704, same as the issue cited.
- `python3 -c "import yaml; yaml.safe_load(open('.maintainer.yml'))"` —
  parses cleanly; top-level keys + `pr.auto_merge: True` and
  `pr.wait_for_other_bots: ['coderabbit','copilot']` intact.
- `bin/check` / `rubocop` / `rake test` / `rake test:parity` — NOT RUN.
  This box has no ruby, bundler, or redis. The acceptance criterion
  ("gates green: rubocop, rake test, rake test:parity (bin/check exit 0)")
  will run in CI on the PR; that is the only path available for this
  environment, per the project's own gate policy.
- The `.maintainer.yml` YAML-load check in the acceptance criteria was
  run via Python's YAML loader (Ruby unavailable here). Output: top-level
  keys present, `pr.auto_merge` and `pr.wait_for_other_bots` intact.

Closes #488

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791022871&installation_model_id=11168&pr_number=501&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F501&signature=9ed4ad5d7b4a2c1a1cda8bca1dd4f703708e8e4c1dfc9f5f20edf9f48a4b668c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->