### PR TITLE
fix(docs): seven places still said parity tests were 'lifted from Sidekiq' (#494)

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -49,9 +49,11 @@ reviews:
         stock Sidekiq. Same for Redis key schema and job JSON shape.
     - path: 'test/parity/**'
       instructions: >
-        Parity tests lifted from Sidekiq's own suite. Flag any modification
-        to assertions — these are the source of truth for "drop-in." Adding
-        skips needs a justification linking to a tracked compat issue.
+        Independently written oracles for the documented Sidekiq behaviour,
+        pinned to the upstream revision in test/parity/.sidekiq_sha. Flag any
+        modification to assertions — these are the source of truth for
+        "drop-in." Adding skips needs a justification linking to a tracked
+        compat issue.
     - path: 'bench/**'
       instructions: >
         Performance benchmarks. Flag any change that removes a bench or weakens

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -192,11 +192,12 @@ jobs:
           path: coverage/coverage.xml
           if-no-files-found: warn
 
-  # Oracle suite lifted from upstream Sidekiq (SHA-pinned in
-  # test/parity/.sidekiq_sha). Its own dedicated job so a parity divergence is
-  # legible at a glance rather than buried in the main suite's output. Needs
-  # neither the dashboard bundle nor a Node toolchain, which is why it stays a
-  # 4vcpu job that finishes in well under a minute.
+  # Oracle suite: independently written oracles for the documented Sidekiq
+  # behaviour, pinned to the upstream revision in test/parity/.sidekiq_sha.
+  # Its own dedicated job so a parity divergence is legible at a glance rather
+  # than buried in the main suite's output. Needs neither the dashboard bundle
+  # nor a Node toolchain, which is why it stays a 4vcpu job that finishes in
+  # well under a minute.
   parity:
     name: parity (oracle)
     needs: detect

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Three pillars, all must stay true:
 | Full test suite (parallel) | `bin/rake test` |
 | Single file | `bin/rake test TEST=test/path/to/file_test.rb` |
 | Single test by name | `bin/rake test TEST=test/foo_test.rb TESTOPTS="--name=/pattern/"` |
-| Parity tests (lifted from Sidekiq) | `bin/rake test:parity` |
+| Parity tests (independently written oracles) | `bin/rake test:parity` |
 | Ecosystem compat | `bin/rake test:ecosystem` |
 | Benchmarks | `bin/rake bench` |
 | Dummy app | `cd test/dummy && bin/rails s` |
@@ -92,7 +92,7 @@ Skip step 3 → leaked sockets in children. Skip step 5 → children corrupt eac
 
 - **Minitest**, parallel runner. Each class opts in via `parallelize_me!`.
 - **Per-worker Redis DB isolation.** Each `minitest-parallel_fork` worker runs against its own Redis logical DB (1–14, with 15 reserved for fixed-DB tests; never DB 0), assigned in `test_helper`'s `after_parallel_fork` hook; `teardown` runs `FLUSHDB` so each test gets a clean slate. Tests that build a pool explicitly use `Wurk::Test.redis_url`. Required for parallel safety — concurrent test classes never see each other's keys.
-- **Layers:** unit · engine (boots `test/dummy/`) · integration (real forks + real Redis) · parity (`test/parity/`, lifted from Sidekiq, SHA-pinned) · ecosystem (third-party gem suites run against Wurk) · benchmarks.
+- **Layers:** unit · engine (boots `test/dummy/`) · integration (real forks + real Redis) · parity (`test/parity/`, independently written oracles for the documented Sidekiq behaviour, pinned to the upstream revision in test/parity/.sidekiq_sha) · ecosystem (third-party gem suites run against Wurk) · benchmarks.
 - **Parity tests are oracles.** When Wurk diverges from a parity test, Wurk is wrong unless the divergence is explicitly documented as intentional.
 - **Never mock Redis** in integration or parity tests. Real Redis, unique namespace.
 - **Coverage gate.** SimpleCov **line** and **branch** coverage on `lib/` must both stay ≥90% (blocking; `minimum_coverage line: 90, branch: 90`). Branch was ratcheted from ~78% to ≥90% in #67 — keep new code at parity. The Cobertura report is still uploaded for per-file inspection. Coverage runs merge across the `minitest-parallel_fork` workers via `SimpleCov.at_fork`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ The individual tasks, when you want one:
 | Full suite (parallel) | `bin/rake test` |
 | A single file | `bin/rake test TEST=test/path/to/file_test.rb` |
 | A single test by name | `bin/rake test TEST=test/foo_test.rb TESTOPTS="--name=/pattern/"` |
-| Parity suite (oracles lifted from Sidekiq) | `bin/rake test:parity` |
+| Parity suite (independently written oracles) | `bin/rake test:parity` |
 | Ecosystem compatibility | `bin/rake test:ecosystem` |
 | Coverage gate | `COVERAGE=1 bin/rake test` |
 | Benchmarks | `bin/rake bench` |
@@ -134,7 +134,8 @@ Test layers:
 - **unit** — plain Ruby classes in isolation.
 - **engine** — boots the dummy Rails app in `test/dummy/`.
 - **integration** — real forks + real Redis.
-- **parity** (`test/parity/`) — tests lifted from upstream Sidekiq, SHA-pinned.
+- **parity** (`test/parity/`) — independently written oracles for the documented
+  Sidekiq behaviour, pinned to the upstream revision in `test/parity/.sidekiq_sha`.
   These are **oracles**: if Wurk diverges, Wurk is wrong unless the divergence
   is explicitly documented as intentional.
 - **ecosystem** — third-party Sidekiq gem suites run against Wurk.

--- a/Rakefile
+++ b/Rakefile
@@ -57,7 +57,10 @@ namespace :test do
   Rake::TestTask.new(:parity) do |t|
     t.libs << 'test' << 'lib'
     t.test_files = FileList['test/parity/**/*_test.rb']
-    t.description = 'Run Sidekiq parity tests (independently written oracles for the documented Sidekiq behaviour, pinned to the upstream revision in test/parity/.sidekiq_sha)'
+    t.description = 'Run Sidekiq parity tests ' \
+                    '(independently written oracles ' \
+                    'for the documented Sidekiq behaviour, ' \
+                    'pinned to the upstream revision in test/parity/.sidekiq_sha)'
   end
 
   desc 'Run ecosystem gem suites against Wurk (sidekiq-cron, sidekiq-unique-jobs, ...)'

--- a/Rakefile
+++ b/Rakefile
@@ -57,7 +57,7 @@ namespace :test do
   Rake::TestTask.new(:parity) do |t|
     t.libs << 'test' << 'lib'
     t.test_files = FileList['test/parity/**/*_test.rb']
-    t.description = 'Run Sidekiq parity tests (lifted from upstream, SHA pinned in test/parity/.sidekiq_sha)'
+    t.description = 'Run Sidekiq parity tests (independently written oracles for the documented Sidekiq behaviour, pinned to the upstream revision in test/parity/.sidekiq_sha)'
   end
 
   desc 'Run ecosystem gem suites against Wurk (sidekiq-cron, sidekiq-unique-jobs, ...)'

--- a/docs/idea/11-testing-ci.md
+++ b/docs/idea/11-testing-ci.md
@@ -27,7 +27,7 @@ Tests that exercise the swarm itself fork real processes and need a Redis DB per
 
 ## Sidekiq parity tests
 
-For each public class we implement, the equivalent test from upstream Sidekiq is ported and adapted. The ported tests live under `test/parity/`. A pin file records the upstream Sidekiq SHA the parity tests were lifted from.
+The parity oracles under `test/parity/` are independently written against the documented Sidekiq behaviour — they are not copies of upstream test files (Sidekiq is LGPL-3.0, this repo is MIT). A pin file at `test/parity/.sidekiq_sha` records the upstream Sidekiq revision the oracles target.
 
 ## Ecosystem gem tests
 

--- a/test/parity/.sidekiq_sha
+++ b/test/parity/.sidekiq_sha
@@ -1,4 +1,7 @@
-# Pin the upstream Sidekiq SHA that the parity tests were lifted from.
+# Pin the upstream Sidekiq SHA whose documented behaviour the parity oracles
+# were written against. The oracles are not copies of upstream test files (see
+# test/parity/README.md); the pin marks the Sidekiq revision the assertions
+# target.
 # Bump this only after reviewing the diff and re-running the parity suite.
 sha: e1f808a08645f9b8a194852a171b5667f5f877bd
 date: 2026-08-03


### PR DESCRIPTION
Closes #494

## What
Replaced the seven remaining places that claimed the parity test suite was "lifted from upstream Sidekiq" / "lifted from Sidekiq's own suite" / "ported and adapted" with the wording already correct in test/parity/README.md since 1.7.1.

## Why
1.7.1 corrected the provenance story (test/parity/README.md:3-5; CHANGELOG.md:63 — Sidekiq is LGPL-3.0 and this repo is MIT, so copying is off the table). Seven places still said the opposite and contradicted the README.

Files updated:
- Rakefile — `test:parity` task description
- test/parity/.sidekiq_sha — header comment (the SHA pin itself is unchanged)
- CLAUDE.md — Commands table + Testing layers bullet
- CONTRIBUTING.md — Commands table + Test layers bullet
- .coderabbit.yml — `test/parity/**` path instruction (intent preserved: flag modified assertions, justify skips)
- .github/workflows/test.yml — parity job comment
- docs/idea/11-testing-ci.md — Sidekiq parity tests section

## Changes
22 insertions, 15 deletions across 7 files. No code, no logic, no schema touched.

Replacement wording per the README: "independently written oracles for the documented Sidekiq behaviour, pinned to the upstream revision in test/parity/.sidekiq_sha". The SHA-pin phrasing is preserved everywhere; only the "lifted/ported/copied" claim is gone.

test/parity/README.md is unchanged (already correct).

## Verification
- `grep -rn -iE "lifted from (upstream|sidekiq)|ported and adapted" Rakefile CLAUDE.md CONTRIBUTING.md .coderabbit.yml .github/workflows/test.yml test/parity docs/idea` → no matches (acceptance criterion 1)
- test/parity/README.md untouched in the diff (acceptance criterion 2)
- `bundle exec rake -T test:parity` shows the new description — **could not run locally**: this box has no Ruby/Bundler/Redis, so the gates (rubocop, rake test, rake test:parity, bin/check) run in CI only (acceptance criterion 3 and 4 are CI-verified, not locally)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791023280&installation_model_id=11168&pr_number=503&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F503&signature=d57388f24ab4e1383c3ba2c1ddfd907f5ee4a432852b87f2bfeb501ddc30d6df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->