### PR TITLE
docs: align coverage-gate and PR-checklist wording (#479)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,10 +7,10 @@
 ## Checklist
 
 - [ ] Tests added/updated at the right layer (unit · engine · integration · parity)
-- [ ] `bin/rake test`, `bin/rake test:parity`, and `bundle exec rubocop` pass locally
+- [ ] `bin/check` passes locally (use `bin/check full` if you touched the compat surface)
 - [ ] No Redis key, JSON field, or sorted-set score format changed (wire-compat is sacred)
 - [ ] Public Sidekiq surface still matches `docs/target/sidekiq-{free,pro,ent}.md`
-- [ ] Coverage on `lib/` stays ≥ 90%
+- [ ] Coverage on `lib/` stays ≥ 90% (both line and branch, the blocking gate)
 
 ## How to test in prod
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,8 +157,10 @@ These are non-negotiable — they're what keep Wurk a true drop-in:
 - **Frozen string literals everywhere**; per-fork Redis pools (never share a
   socket across a fork).
 - **Comments explain non-obvious _why_**, never restate the code.
-- **Coverage**: line coverage on `lib/` must stay ≥ 90% (the gate blocks PRs
-  below it). Branch coverage is tracked and ratcheting toward 90%.
+- **Coverage**: SimpleCov **line** and **branch** coverage on `lib/` must both
+  stay ≥ 90% (both are blocking; `minimum_coverage line: 90, branch: 90` in
+  `test/test_helper.rb`). Branch was ratcheted from ~78% to ≥90% in #67 —
+  keep new code at parity.
 
 ## Pull requests
 

--- a/Rakefile
+++ b/Rakefile
@@ -65,7 +65,7 @@ namespace :test do
     sh 'bin/test-ecosystem'
   end
 
-  desc 'Coverage gate: branch coverage on lib/ must stay >= 90%'
+  desc 'Coverage gate: SimpleCov line and branch coverage on lib/ must both stay >= 90% (both blocking)'
   task :coverage do
     ENV['COVERAGE'] = '1'
     Rake::Task['test'].invoke


### PR DESCRIPTION
Closes #479

## What

- `CONTRIBUTING.md` — coverage line now states both SimpleCov **line** and **branch** coverage on `lib/` stay ≥ 90% (both blocking), citing `test/test_helper.rb` `minimum_coverage line: 90, branch: 90` and the #67 branch ratchet, matching the wording already in `CLAUDE.md:98`.
- `Rakefile` `test:coverage` desc — now reads 'Coverage gate: SimpleCov line and branch coverage on lib/ must both stay >= 90% (both blocking)' instead of only mentioning branch.
- `.github/PULL_REQUEST_TEMPLATE.md` — checklist line 10 replaced the three separate commands (`bin/rake test`, `bin/rake test:parity`, `bundle exec rubocop`) with `bin/check` (plus `bin/check full` for compat-surface PRs, per `CONTRIBUTING.md` step 4), and the coverage line now reads '≥ 90% (both line and branch, the blocking gate)'.

## Why

The real gate is `minimum_coverage line: 90, branch: 90` (`test/test_helper.rb:14`; both blocking per the :7-9 comment), but three docs contradicted each other and one contradicted the gate: `CONTRIBUTING.md` described branch as still ratcheting; `Rakefile`'s desc omitted line entirely; the PR template's checklist told contributors to run three commands manually instead of the `bin/check` already documented as the unified gate in `CONTRIBUTING.md:49` and the PR step.

## Changes

- `CONTRIBUTING.md` — conventions bullet on coverage (lines ~160-161).
- `Rakefile` — `test:coverage` desc (line 68).
- `.github/PULL_REQUEST_TEMPLATE.md` — checklist items at :10 and :13.

## Verification

- `git diff --stat` and `git diff` reviewed against the issue's acceptance criteria.
- **Could not run locally:** this box has no Ruby, bundler, or Redis, so `bin/check`, `bundle exec rubocop -T test:coverage`, `bin/rake test`, and `bin/rake test:parity` could not be exercised here. Per the task instructions, these gates will run in CI only; the PR body and the commit message state that explicitly. `bundle exec rake -T test:coverage` will print the corrected desc once CI runs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791023741&installation_model_id=11168&pr_number=504&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F504&signature=6839783d20768687ae819341339af24a281f9853a0cd74c58b6f6729f8fd91d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->