### PR TITLE
chore(bench-compare): drop dead (TODO)-label skip (closes #487)

### DIFF
--- a/bin/bench-compare
+++ b/bin/bench-compare
@@ -42,11 +42,6 @@ def parse(path)
     next unless m
 
     label = m[1].strip
-    # Skip stub benches tagged "(TODO)" — they aren't measuring real work and
-    # their cross-run jitter false-positives the noise gate (e.g. a `1 + 1`
-    # ips report swings ~14% on a ~50M i/s baseline, well past ±5.7%).
-    next if label.include?('(TODO)')
-
     value = m[2].delete(',').to_f * SCALE[m[3]]
     keep_fastest(results, label, value, m[4].delete(',').to_f)
   end

--- a/test/unit/bench_compare_test.rb
+++ b/test/unit/bench_compare_test.rb
@@ -142,4 +142,20 @@ class BenchCompareTest < Wurk::Test::UnitCase
     assert_includes out, "_New on head: #{RETENTION_LABEL}_"
     refute_includes out, 'Missing on head'
   end
+
+  # Regression guard for #487: a bench labelled "(TODO)" must be compared like any
+  # other — no bench under bench/ emits that label today (closed #259/#265/#266
+  # replaced every stub), and the comparator must not let a future stub bench
+  # silently opt out of the gate by naming itself "(TODO)".
+  def test_todo_labelled_bench_is_compared_not_skipped
+    todo_label = 'wurk foo (TODO)'
+    base = write_runs(todo_label, [1000.0, 0.0])
+    head = write_runs(todo_label, [800.0, 0.0])
+
+    out, code = compare(base, head)
+
+    assert_equal 1, code, 'a -20% drop on a (TODO)-labelled bench must still trip the gate'
+    assert_includes out, "Regression: `#{todo_label}` -20.0%"
+    assert_includes out, "| `#{todo_label}` | 1.00k | 800 |"
+  end
 end


### PR DESCRIPTION
Closes #487

## What
Remove the `(TODO)`-label skip in `bin/bench-compare:45-48` and add a regression test in `test/unit/bench_compare_test.rb` proving a `(TODO)`-labelled bench is compared like any other (so a future stub bench cannot silently opt out of the gate by naming itself `(TODO)`).

## Why
Every stub bench that the original skip was protecting has since been replaced by a real driver (closed #259, #265, #266). `grep -rn TODO bench/` is empty — no script under `bench/` emits that label any more. The skip was also the only untested branch in the comparator that gates merges, since `grep -in todo test/unit/bench_compare_test.rb` was empty.

## Changes
- `bin/bench-compare`: drop the 4-line `next if label.include?('(TODO)')` block in `parse`. Comment also removed (it only restated what the dead branch did).
- `test/unit/bench_compare_test.rb`: add `test_todo_labelled_bench_is_compared_not_skipped` — feeds `wurk foo (TODO)` at 1000 i/s base vs 800 i/s head, asserts the gate trips (exit 1, "Regression: …", row in the table).
- `Rakefile:100-125` checked; the comment block there lists scripts opted out of the gate entirely (`vs_sidekiq`, `command_count`, `fetch_capped`, `debounce_enqueue`) and does not mention the `(TODO)` skip. No edit needed.

## Self-gating
`bench.yml:105` does `cp bin/bench-compare /tmp/bench-compare` — the comparator is transported from the PR head verbatim, so this change gates itself on the bench CI job. No existing bench label contains `(TODO)`, so removing the skip produces byte-identical output for every bench that runs today; only a future stub bench that names itself `(TODO)` would be affected, and it would now correctly fail the gate.

## Verification
Gates **did not** run locally — this box has no ruby, bundler, or redis (per issue instruction). CI only.
- `grep -n TODO bin/bench-compare` → no matches (exit 1). Confirms acceptance criterion.
- `grep -rn TODO bench/` → no matches. Confirms the skip is dead in practice.
- New test exercises the formerly-untested branch.

Rubocop, `rake test`, `rake test:parity`, and the bench CI job will run on the PR. The bench job is the load-bearing one for this change and runs against the PR-head comparator (`bench.yml:105`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791023822&installation_model_id=11168&pr_number=505&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F505&signature=8e9e4febaddceafdf061df862e4de140d4fad1150347b7773b0c01e7878a4e60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->