### PR TITLE
chore(rubocop): remove directives for Minitest/MultipleAssertions, a cop disabled repo-wide (closes #478)

### DIFF
--- a/test/engine/active_job_sidekiq_adapter_test.rb
+++ b/test/engine/active_job_sidekiq_adapter_test.rb
@@ -51,7 +51,6 @@ class ActiveJobSidekiqAdapterEngineTest < Wurk::Test::EngineCase
     assert_equal @job_class.name, payload['wrapped']
     assert_equal @queue, payload['queue']
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   def test_job_record_unwraps_wrapper_to_user_class
     @job_class.perform_later(42)

--- a/test/integration/reaper_full_sweep_test.rb
+++ b/test/integration/reaper_full_sweep_test.rb
@@ -50,13 +50,11 @@ class ReaperFullSweepTest < Wurk::Test::UnitCase
     assert_equal 0, @observer.call('LLEN', priv), 'private list drained'
     assert_equal 1, @observer.call('LLEN', @orphan_q), 'job re-queued onto its public queue'
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   # Migration window: a private list written before the PROCESS_NONCE upgrade
   # (`<host>|<pid>|<idx>`, no nonce segment) must stay reclaimable by the full
   # sweep. No fork needed here — the owner pid is simply gone, exactly like a
   # pre-upgrade process that crashed and was never replaced under that pid.
-  # rubocop:disable-next Minitest/MultipleAssertions
   def test_full_sweep_reclaims_a_legacy_pre_nonce_orphan_in_an_unserved_queue
     legacy_priv = "#{@orphan_q}|#{Socket.gethostname}|#{DEAD_PID}|0"
     @observer.call('RPUSH', legacy_priv, payload('job-legacy'))

--- a/test/integration/redis_outage_recovery_test.rb
+++ b/test/integration/redis_outage_recovery_test.rb
@@ -110,7 +110,6 @@ class RedisOutageRecoveryTest < Wurk::Test::UnitCase
     assert_equal @capsule.fetch_redis_pool.size, @capsule.fetch_redis_pool.available,
                  'idle worker must hold zero fetch-pool connections once fetching goes idle'
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   # 04-redis-retry-idempotency, F5 regression: Heartbeat#drain_signals is
   # deliberately excluded from `idempotent: true` (LPOP is destructive — see

--- a/test/integration/rolling_restart_test.rb
+++ b/test/integration/rolling_restart_test.rb
@@ -75,7 +75,6 @@ class RollingRestartTest < Wurk::Test::UnitCase
       shutdown_supervisor(parent_pid)
     end
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   private
 

--- a/test/unit/active_job_adapter_test.rb
+++ b/test/unit/active_job_adapter_test.rb
@@ -59,7 +59,6 @@ class ActiveJobAdapterTest < Wurk::Test::UnitCase
     assert_equal @queue, payload['queue']
     assert_match JID_PATTERN, payload['jid']
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   def test_enqueue_wraps_args_as_single_aj_data_hash
     job = @job_class.new('x')

--- a/test/unit/active_job_sidekiq_adapter_test.rb
+++ b/test/unit/active_job_sidekiq_adapter_test.rb
@@ -73,7 +73,6 @@ class ActiveJobSidekiqAdapterTest < Wurk::Test::UnitCase
     assert_equal @queue, payload['queue']
     assert_match JID_PATTERN, payload['jid']
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   def test_enqueue_wraps_args_as_single_aj_data_hash
     job = @job_class.new('x')

--- a/test/unit/client_buffered_test.rb
+++ b/test/unit/client_buffered_test.rb
@@ -241,7 +241,6 @@ class ClientBufferedTest < Wurk::Test::UnitCase
     assert_includes queued, ['newest']
     assert_includes queued, ['fresh']
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   # --- batch bypass ------------------------------------------------------
 
@@ -316,7 +315,6 @@ class ClientBufferedTest < Wurk::Test::UnitCase
 
   # The cap splits a single bulk push: what fits is buffered, the rest rides on
   # the exception. Nothing may fall between the two.
-  # rubocop:disable-next Minitest/MultipleAssertions
   def test_overflow_raise_fills_remaining_capacity_and_reports_the_rest
     Wurk::Client.reliable_push_buffer = 3
     Wurk::Client.reliable_push_overflow = :raise
@@ -386,7 +384,6 @@ class ClientBufferedTest < Wurk::Test::UnitCase
 
   # Batched payloads never buffer, so an overflow that pre-empts their
   # connection-error re-raise would strand them without a trace.
-  # rubocop:disable-next Minitest/MultipleAssertions
   def test_overflow_carries_batched_payloads_from_a_mixed_push
     Wurk::Client.reliable_push_buffer = 1
     Wurk::Client.reliable_push_overflow = :raise

--- a/test/unit/client_partial_delivery_test.rb
+++ b/test/unit/client_partial_delivery_test.rb
@@ -83,12 +83,10 @@ class ClientPartialDeliveryTest < Wurk::Test::UnitCase
     # group that never went out is absent from `queues` too.
     assert_equal [@queue], registered_queues
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   # The point of the whole exercise: a push that dies partway through two
   # queues and a batch, replayed against a healthy Redis, leaves every job in
   # existence exactly once.
-  # rubocop:disable-next Minitest/MultipleAssertions
   def test_drain_after_partial_delivery_enqueues_each_job_exactly_once
     client = Wurk::Client.new(pool: dropping_pool(deliver: 1))
     payloads = [item(args: ['a'], jid: 'j-a'),

--- a/test/unit/client_push_test.rb
+++ b/test/unit/client_push_test.rb
@@ -55,7 +55,6 @@ class ClientPushTest < Wurk::Test::UnitCase
     assert_match JID_PATTERN, payload['jid']
     assert payload['retry'], 'retry defaults to true (Wurk.default_job_options)'
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   # `pool` is a transient enqueue-time attribute (spec §2.2) — it selects the
   # Redis pool but must never reach the wire. Issue #95.

--- a/test/unit/fetcher_reaper_test.rb
+++ b/test/unit/fetcher_reaper_test.rb
@@ -142,11 +142,9 @@ class FetcherReaperTest < Wurk::Test::UnitCase
   ensure
     Wurk.redis { |c| c.call('DEL', recovery_key(jid)) }
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   # --- poison-pill cap ---------------------------------------------------
 
-  # rubocop:disable-next Minitest/MultipleAssertions
   def test_recovery_past_threshold_kills_to_dead_set_instead_of_requeue
     jid = SecureRandom.hex(12)
     job = payload('poison', jid: jid)
@@ -354,7 +352,6 @@ class FetcherReaperTest < Wurk::Test::UnitCase
   # The headline gap: a private list whose public queue this process does NOT
   # serve (renamed/decommissioned queue, or a dead host's queue no survivor
   # consumes) is invisible to the scoped sweep but recovered by the full one.
-  # rubocop:disable Minitest/MultipleAssertions
   # One scenario: scoped sweep misses it, full sweep recovers it onto the
   # foreign public queue and drains the private list. Cohesive — keep together.
   def test_reclaim_full_reclaims_orphan_in_an_unserved_queue
@@ -370,7 +367,6 @@ class FetcherReaperTest < Wurk::Test::UnitCase
     assert_equal 0, llen(private_key), 'orphan private list drained'
     assert_equal 2, llen(foreign_q), 'jobs re-queued onto the foreign public queue'
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   def test_reclaim_full_leaves_a_live_owners_list_untouched
     foreign_q = Wurk::Keys.queue("#{@ns}-live")
@@ -445,7 +441,7 @@ class FetcherReaperTest < Wurk::Test::UnitCase
 
   # --- thread lifecycle --------------------------------------------------
 
-  def test_start_is_idempotent_and_stop_joins # rubocop:disable Minitest/MultipleAssertions
+  def test_start_is_idempotent_and_stop_joins
     refute_predicate @reaper, :running?
     first = @reaper.start
     second = @reaper.start

--- a/test/unit/iterable_job_query_test.rb
+++ b/test/unit/iterable_job_query_test.rb
@@ -36,7 +36,6 @@ class IterableJobQueryTest < Wurk::Test::UnitCase
     assert_in_delta 12.5, state.runtime
     assert_equal [42, 'page'], state.cursor
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   def test_cancelled_is_nil_when_not_cancelled
     jid = seed(ex: 1, rt: 0.0, cursor: nil)

--- a/test/unit/lua_test.rb
+++ b/test/unit/lua_test.rb
@@ -131,7 +131,6 @@ class LuaTest < Wurk::Test::UnitCase
     end
   end
 
-  # rubocop:disable Minitest/MultipleAssertions
   def test_reliable_schedule_promote_moves_due_jobs_to_their_queues
     sset = "#{@ns}:schedule"
     qset = "#{@ns}:queues"
@@ -235,7 +234,7 @@ class LuaTest < Wurk::Test::UnitCase
   # or scheduled promotion re-enqueueing a job that never left the batch) must
   # re-LPUSH the payload but must NOT recount total/pending — else pending
   # inflates past the acks and :success never fires (spec §2.3/§2.5).
-  def test_batch_push_repush_of_live_jid_does_not_recount # rubocop:disable Minitest/MultipleAssertions
+  def test_batch_push_repush_of_live_jid_does_not_recount
     bkey = "#{@ns}:b-rp"
     jids = "#{@ns}:b-rp-jids"
     list = "#{@ns}:queue:default"
@@ -280,7 +279,7 @@ class LuaTest < Wurk::Test::UnitCase
   # BATCH_SCHEDULE registers a scheduled-in-batch job at creation: counts
   # total/pending (SADD guard), SADDs the jid live, and ZADDs the payload onto
   # `schedule` — so `total` moves even though nothing hits a queue yet.
-  def test_batch_schedule_registers_counts_jid_and_zadds # rubocop:disable Minitest/MultipleAssertions
+  def test_batch_schedule_registers_counts_jid_and_zadds
     sched = "#{@ns}:schedule"
     bkey  = "#{@ns}:b-s"
     jids  = "#{@ns}:b-s-jids"
@@ -300,7 +299,7 @@ class LuaTest < Wurk::Test::UnitCase
 
   # Same SADD-guard idempotency as batch_push: a jid already live re-ZADDs the
   # payload (a promotion that rescheduled, say) but must not recount.
-  def test_batch_schedule_repush_of_live_jid_does_not_recount # rubocop:disable Minitest/MultipleAssertions
+  def test_batch_schedule_repush_of_live_jid_does_not_recount
     sched = "#{@ns}:schedule"
     bkey  = "#{@ns}:b-sr"
     jids  = "#{@ns}:b-sr-jids"
@@ -320,7 +319,7 @@ class LuaTest < Wurk::Test::UnitCase
   # job — it rejoins the live set without recounting (total/pending already
   # include it), and draining the died set clears the death mark so a later
   # full drain can fire :success.
-  def test_batch_push_dead_jid_rejoins_live_set_without_recount # rubocop:disable Minitest/MultipleAssertions
+  def test_batch_push_dead_jid_rejoins_live_set_without_recount
     bkey = "#{@ns}:b-dr"
     jids = "#{@ns}:b-dr-jids"
     died = "#{@ns}:b-dr-died"
@@ -456,7 +455,6 @@ class LuaTest < Wurk::Test::UnitCase
       assert_equal 0, second_first
     end
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   # A job that was failing (in the failed set) then dies moves out of
   # currently-failing: failures decrements and the jid leaves the failed set.

--- a/test/unit/middleware_builtins_test.rb
+++ b/test/unit/middleware_builtins_test.rb
@@ -388,7 +388,6 @@ class MiddlewareBuiltinsTest < Wurk::Test::UnitCase
     assert_equal 'queue:mine', key
     assert_equal job, ::JSON.parse(payload)
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   def test_interrupt_handler_raises_skip_subclass_of_handled
     assert_operator Wurk::JobRetry::Skip, :<, Wurk::JobRetry::Handled

--- a/test/unit/middleware_expiry_test.rb
+++ b/test/unit/middleware_expiry_test.rb
@@ -138,7 +138,6 @@ class MiddlewareExpiryTest < Wurk::Test::UnitCase
       assert_equal ['class:MyJob'], tags
     end
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   def test_no_statsd_call_on_non_expired_job
     future = ::Time.now.to_f + 60

--- a/test/unit/middleware_poison_pill_test.rb
+++ b/test/unit/middleware_poison_pill_test.rb
@@ -211,7 +211,6 @@ class MiddlewarePoisonPillTest < Wurk::Test::UnitCase
     assert_equal 'PoisonPillTestJob was recovered 3 times without completing', ex.message
     refute_nil ex.backtrace, 'error services expect a backtrace'
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   # Falls back to a generic subject when the payload carries no class name.
   def test_poisoned_error_message_without_a_class
@@ -225,7 +224,6 @@ class MiddlewarePoisonPillTest < Wurk::Test::UnitCase
 
   # --- callback hooks -----------------------------------------------------
 
-  # rubocop:disable Minitest/MultipleAssertions
   # One test pinning the entire callback contract — splitting would
   # obscure the pill-hash shape vs. fire-count constraint.
   def test_on_poison_fires_with_pill_hash
@@ -240,7 +238,6 @@ class MiddlewarePoisonPillTest < Wurk::Test::UnitCase
     assert_equal @queue, pill[:queue]
     assert_equal 3, pill[:count]
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   def test_on_poison_swallows_callback_errors
     Wurk::Middleware::PoisonPill.on_poison { |_| raise 'boom' }
@@ -314,7 +311,6 @@ class MiddlewarePoisonPillTest < Wurk::Test::UnitCase
     assert_equal [['not-json{{', nil]], recorded
   end
 
-  # rubocop:disable-next Minitest/MultipleAssertions
   def test_super_fetch_callback_receives_pill_on_poison_kill
     recorded = []
     cfg = recovery_config { |jobstr, pill| recorded << [jobstr, pill] }

--- a/test/unit/process_set_test.rb
+++ b/test/unit/process_set_test.rb
@@ -75,7 +75,6 @@ class ProcessSetTest < Wurk::Test::UnitCase
     assert_equal 4096,     process['rss']
     assert_equal 900,      process['rtt_us']
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   def test_lookup_returns_nil_when_info_expired_but_identity_present
     @identities << @identity
@@ -214,7 +213,6 @@ class ProcessSetTest < Wurk::Test::UnitCase
 
   # --- Wurk::Process -----------------------------------------------------
 
-  # rubocop:disable Minitest/MultipleAssertions
   # One test, one Process shape: identity / id / tag / labels are all
   # public contract surface.
   def test_process_attributes_passthrough
@@ -225,7 +223,6 @@ class ProcessSetTest < Wurk::Test::UnitCase
     assert_equal @identity, process.id
     assert_equal %w[a b], process.labels
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   def test_process_labels_defaults_to_empty_array
     assert_empty Wurk::Process.new({}).labels

--- a/test/unit/scheduled_poller_test.rb
+++ b/test/unit/scheduled_poller_test.rb
@@ -202,7 +202,6 @@ class ScheduledPollerTest < Wurk::Test::UnitCase
     assert_equal 1, captured.size
     assert_equal 'push blew up', captured.first.message
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   # ZPOPBYSCORE claims no apply-safety, so a read timeout reaches #drain_set
   # instead of being replayed. The outcome of that pop is unknown, so the set's

--- a/test/unit/stats_test.rb
+++ b/test/unit/stats_test.rb
@@ -213,7 +213,6 @@ class StatsTest < Wurk::Test::UnitCase
     assert_kind_of Float,   summary.latency
     assert_includes [true, false], summary.paused?
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   def test_queue_summary_latency_uses_oldest_enqueued_at_ms
     push_my_job(enqueued_at: ms_now - 5_000)

--- a/test/unit/transaction_aware_client_test.rb
+++ b/test/unit/transaction_aware_client_test.rb
@@ -77,7 +77,6 @@ class TransactionAwareClientTest < Wurk::Test::UnitCase
       assert_equal jid, first_queued['jid'], 'the deferred push must persist the pre-allocated jid'
     end
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   def test_rollback_drops_the_push
     client = Wurk::TransactionAwareClient.new
@@ -145,7 +144,6 @@ class TransactionAwareClientTest < Wurk::Test::UnitCase
 
   # --- end-to-end through the worker DSL ---------------------------------
 
-  # rubocop:disable Minitest/MultipleAssertions
   # End-to-end acceptance: one perform_async, deferred, committed, asserting the
   # full payload shape lands correctly. Cohesive — keep it as one scenario.
   def test_perform_async_defers_when_transactional_push_enabled
@@ -169,7 +167,6 @@ class TransactionAwareClientTest < Wurk::Test::UnitCase
       refute payload.key?('client_class'), 'client_class must never reach the wire'
     end
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   # A class whose sidekiq_options memoized BEFORE the global opt-in must still
   # route through the transactional client — transactional_push! lives in an

--- a/test/unit/work_set_test.rb
+++ b/test/unit/work_set_test.rb
@@ -71,7 +71,6 @@ class WorkSetTest < Wurk::Test::UnitCase
     assert_equal 't1',     tid
     assert_equal jid,      work.job.jid
   end
-  # rubocop:enable Minitest/MultipleAssertions
 
   def test_each_skips_empty_work_hashes
     register!(@identity)


### PR DESCRIPTION
## What

Remove every rubocop directive (disable, enable, disable-next) naming `Minitest/MultipleAssertions` from the test suite. Where a directive sat on a bare comment line, the line goes; where it was a trailing annotation on a `def`, the annotation goes; meaningful "why this test has many asserts" comments stay. `.rubocop.yml:110-113` is untouched, so the cop remains disabled repo-wide — the directives had been inert noise implying the cop was live.

## Why

The cop is disabled for the whole repo (`.rubocop.yml:112-113`, with the rationale at :110-111: "One behaviour per test, but a behaviour is rarely one assertion"). The 38 surviving directives across the test suite could not have suppressed anything — they were vestigial, and they misled readers into thinking the cop was live somewhere.

## Changes

20 files touched, 40 lines deleted, 5 lines added (the 5 added are because the trailing directive on a `def foo` line gets replaced with the same line minus the annotation; net -35).

Affected files:
- test/engine/active_job_sidekiq_adapter_test.rb
- test/integration/reaper_full_sweep_test.rb
- test/integration/redis_outage_recovery_test.rb
- test/integration/rolling_restart_test.rb
- test/unit/active_job_adapter_test.rb
- test/unit/active_job_sidekiq_adapter_test.rb
- test/unit/client_buffered_test.rb
- test/unit/client_partial_delivery_test.rb
- test/unit/client_push_test.rb
- test/unit/fetcher_reaper_test.rb
- test/unit/iterable_job_query_test.rb
- test/unit/lua_test.rb
- test/unit/middleware_builtins_test.rb
- test/unit/middleware_expiry_test.rb
- test/unit/middleware_poison_pill_test.rb
- test/unit/process_set_test.rb
- test/unit/scheduled_poller_test.rb
- test/unit/stats_test.rb
- test/unit/transaction_aware_client_test.rb
- test/unit/work_set_test.rb

The issue's `Affected paths` lists 11 files; the broader sweep (process_set_test, lua_test, work_set_test, middleware_expiry_test, middleware_poison_pill_test's three extra sites, client_partial_delivery_test, reaper_full_sweep_test, rolling_restart_test, redis_outage_recovery_test, fetcher_reaper_test's extra sites, and test/engine/active_job_sidekiq_adapter_test) was needed to satisfy the acceptance criterion `grep -rn 'Minitest/MultipleAssertions' test lib` returns nothing. None were added after the issue was filed to test new behaviour — all are the same kind of vestigial directive, just for tests written since.

## Verification

This box has NO ruby, bundler or redis, so the ruby gates cannot run locally. **The ruby gates ran in CI only.** Manual checks performed locally:

- `grep -rn 'Minitest/MultipleAssertions' test lib` → no matches (was 38 across 20 files). The only remaining reference is `.rubocop.yml:112`, which is the repo-wide disable and is intentionally preserved per the acceptance criterion.
- `git diff` reviewed: every change removes a single directive line (or annotation on a `def`) and nothing else. No unrelated code touched.
- No directive line carried more than one cop, so no companion cop was lost.

Closes #478

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791024657&installation_model_id=11168&pr_number=506&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F506&signature=d88bd3be22f7dab3398eb4232ab1c1ef5e3a4b29d9668fd5fb0a294c506e12b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->