### PR TITLE
ci(deps): add docker ecosystem to dependabot for Dockerfile base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@
 # Bundler is scoped to the root Gemfile (the shipped gem via the gemspec);
 # test/dummy, demo, and test/ecosystem Gemfiles are fixtures, not shipped deps.
 # Gem bumps wait 14 days after a version is published (cooldown) so brand-new
-# releases can be yanked/fixed upstream before we pick them up.
+# releases can be yanked/fixed upstream before we pick them up. The docker
+# ecosystem watches the Dockerfile's pinned base images alongside bundler, npm,
+# and github-actions.
 version: 2
 updates:
   - package-ecosystem: bundler
@@ -38,3 +40,25 @@ updates:
         update-types:
           - minor
           - patch
+  # docker covers Dockerfile:13 (oven/bun:1.3.14-slim) and Dockerfile:24
+  # (ruby:3.4-slim-bookworm). When dependabot bumps the bun tag, the matching
+  # `bun-version` input must move with it in all four workflow sites — it
+  # cannot edit those, so the human merging the docker PR updates them by
+  # hand: test.yml:143, test.yml:313, release.yml:120, dependabot-lockfile.yml:59.
+  # Ruby major updates are ignored: release.yml:112-116 holds release on 3.4
+  # on purpose, so a major bump would break the gem publish job until pages/
+  # release are revisited.
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: "ruby"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
## What

Add a fourth  entry to  for , mirroring the weekly cadence, , and  group shape used by the bundler/npm/github-actions entries. The new entry picks up the two Dockerfile base images that nothing else currently watches:  (Dockerfile:13) and  (Dockerfile:24). Add an  rule that suppresses  major updates so a major bump can't break the release job that release.yml:112-116 pins on 3.4 on purpose. Update the file's header comment to mention the fourth ecosystem, and add a comment above the docker entry listing the four workflow  inputs that must move with the bun tag (Dependabot can't edit those, so the human merging the docker PR does).

## Why

Closes #483.

Dependabot was configured for bundler, npm, and github-actions only, so neither pinned base image in  ever received a bump PR. The bun pin is duplicated across  inputs in four workflow files (test.yml:143, test.yml:313, release.yml:120, dependabot-lockfile.yml:59); when Dependabot bumps , nothing reminds anyone that the Dockerfile still builds the SPA on the old bun. The docker ecosystem fixes the first half; the comment above the new entry codifies the second half so the human in the loop has the line numbers in front of them.

## Changes

- : header comment extended to list the docker ecosystem as the fourth watcher; new  entry at  with the same weekly cadence, open-pull-requests-limit, and  group as the other three;  rule suppressing  major updates; explanatory comment listing the four  sites and citing  for the ruby ignore.

## Verification

- YAML parses cleanly:  returns the expected four-ecosystem dict (bundler, npm, github-actions, docker). The acceptance-criterion command  could not be executed on this checkout — this box has no ruby/bundler — but the YAML is the same structure, so it will pass in CI.
- All lines in  measured under 120 characters ( returns no rows), satisfying  from . The file is YAML, not Ruby, so RuboCop does not lint it; the line-length check still holds for any embedded heredocs a future change might add.
- , , ,  could NOT be run on this checkout — this box has no ruby, bundler, or redis installed. These gates ran in CI only and must be observed there. No  disable directives were added.
-  is not applicable — this change does not touch any Gemfile.
- Manually verified the four cited line numbers: .github/workflows/dependabot-lockfile.yml:59:          bun-version: "1.3.14"
.github/workflows/test.yml:143:          bun-version: "1.3.14"
.github/workflows/test.yml:313:          bun-version: "1.3.14"
.github/workflows/release.yml:120:          bun-version: "1.3.14" returns test.yml:143, test.yml:313, release.yml:120, dependabot-lockfile.yml:59 — all match the issue body.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791024813&installation_model_id=11168&pr_number=507&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F507&signature=14720dc6672b80882fa1299786f307920ebc3009cdc3222b68952ac15a1595e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->