### PR TITLE
ci: resync all four bun-version inputs to 1.4.0, matching the Dockerfile

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -56,7 +56,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.4.0"
       - name: regenerate bun.lock
         run: bun install --lockfile-only
         working-directory: frontend

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
           bundler-cache: true
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.4.0"
 
       # Precompile the SolidJS SPA into vendor/assets/ (bun install + vite build).
       - name: build dashboard SPA

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,7 +140,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         if: env.RUN == 'true'
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.4.0"
       # Pin Node too. Bun runs the scripts, but vitest executes test files in
       # Node worker threads and Vite's toolchain resolves against Node — so an
       # unpinned Node is a silent, moving dependency of every frontend run. It
@@ -310,7 +310,7 @@ jobs:
           persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.4.0"
       # See the `test` job for why Node is pinned alongside Bun. This is the
       # job that actually runs vitest, so it is the one the pin exists for.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0


### PR DESCRIPTION
## What

All four CI `bun-version` inputs are bumped from `"1.3.14"` to `"1.4.0"` to match `Dockerfile:13` (`FROM oven/bun:1.4.0-slim AS spa`), which PR #510 moved via Dependabot.

Closes #513

## Why

Dependabot bumped the Dockerfile's SPA build stage to bun 1.4.0 in #510 but cannot edit the workflow `bun-version` inputs — `.github/dependabot.yml:43-47` names all four sites and says the merging party must move them by hand. That hand-edit never happened, so `main` builds the shipped dashboard image with 1.4.0 while every CI job builds the same SPA with 1.3.14. A bun minor that changes bundling output is exactly the class of difference CI then fails to catch, because CI is not running the version that ships.

## Changes

- `.github/workflows/test.yml:143` — `"1.3.14"` → `"1.4.0"` (`test` job's frontend build)
- `.github/workflows/test.yml:313` — `"1.3.14"` → `"1.4.0"` (`frontend` vitest job)
- `.github/workflows/release.yml:120` — `"1.3.14"` → `"1.4.0"` (gem publish builds the SPA that ships in the gem)
- `.github/workflows/dependabot-lockfile.yml:59` — `"1.3.14"` → `"1.4.0"` (bun.lock reconciliation)

Nothing else — no shared variable, per the issue's explicit scoping (that is the follow-up issue, not this one).

## Verification

**Ruby/frontend gates ran in CI only** — this box has no ruby, bundler, or redis, so `bin/check`, rubocop, and the test suite could not run locally and were not attempted. The changes are four version-string literals in YAML; the longest line written is 29 characters (Layout/LineLength max 120), no Gemfile was touched (Bundler/OrderedGems n/a), and no rubocop:disable directives were added.

Acceptance criterion 1 — all four sites on 1.4.0, nothing on 1.3.14 under `.github/workflows`:

```
$ grep -rn 'bun-version' .github/workflows
.github/workflows/release.yml:120:          bun-version: "1.4.0"
.github/workflows/test.yml:143:          bun-version: "1.4.0"
.github/workflows/test.yml:313:          bun-version: "1.4.0"
.github/workflows/dependabot-lockfile.yml:59:          bun-version: "1.4.0"
```

Acceptance criterion 2 — mechanical comparison against `Dockerfile:13`, not eyeballing (script extracts the Dockerfile version and diffs it against the set of versions found in the workflows):

```
$ sed -n '13p' Dockerfile
FROM oven/bun:1.4.0-slim AS spa

$ docker_ver=$(sed -n 's/^FROM oven/bun:\([0-9.]*\)-slim .*/\1/p' Dockerfile); echo "Dockerfile bun: $docker_ver"
Dockerfile bun: 1.4.0

$ grep -rhoP 'bun-version: "\K[0-9.]+' .github/workflows | sort -u | while read -r v; do ... done
OK: workflows 1.4.0 == Dockerfile 1.4.0

$ grep -rc '1\.3\.14' .github/workflows/*.yml | grep -v ':0$' || echo "no 1.3.14 left under .github/workflows"
no 1.3.14 left under .github/workflows
```

Acceptance criterion 3 (gates green in CI) is what this PR's own checks run.

### Out-of-scope staleness noticed while verifying (not touched)

Two further `1.3.14` references went stale with #510 and remain, both outside this issue's affected paths:

- `.github/dependabot.yml:43` — comment parenthetical `(oven/bun:1.3.14-slim)`; the line-reference part of that comment (`test.yml:143` etc.) is still accurate after this PR since no lines were added or removed.
- `docs/deployment.md:302` — a doc excerpt of the Dockerfile SPA stage still reads `FROM oven/bun:1.3.14-slim AS spa`.

Both are comment/doc text, not executable inputs; they'd suit the issue's suggested follow-up (single source for the bun version) rather than this resync.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791033583&installation_model_id=11168&pr_number=514&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F514&signature=631983ee98e8ae4eabee7820e9151a54c83ff7ab00f4feabcca3d7463f50b3ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Bun runtime used for dependency updates, releases, tests, and coverage workflows to version 1.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->