### PR TITLE
docs(demo): align demo-deploy texts with the tag-as-output release

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,7 +1,8 @@
 name: deploy-demo
 
 # Deploy of the public demo (wurk.demo.developerz.ai) — run it by hand, or let
-# release.yml call it after publishing a `v*` tag.
+# release.yml call it after publishing the gem for a `lib/wurk/version.rb` bump
+# landing on main (the tag is an output there, cut last).
 #
 # DEPLOY MODEL: this workflow only BUILDS + PUSHES the image. Infra deploys it
 # via the in-cluster ArgoCD Image Updater, which selects the newest DOCR tag

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,6 @@
 # exercises cron, unique, batch, rate-limited, and failing jobs. One image runs
 # either the read-only dashboard (`web`) or the swarm (`worker`), selected by the
 # argument to bin/demo-entrypoint.
-#
-# NOTE: this is the starting scaffold for the deploy (#32). The build still
-# needs a verification pass with infra — see docs/demo-deploy.md.
 
 # ---- Stage 1: build the dashboard SPA (no Node/bun at runtime) ----
 FROM oven/bun:1.4.0-slim AS spa

--- a/docs/demo-deploy.md
+++ b/docs/demo-deploy.md
@@ -37,14 +37,18 @@ holds no cluster credentials. The in-cluster **ArgoCD Image Updater** selects th
 newest DOCR tag matching `^sha-[0-9a-f]{7}$` and syncs the deployment
 automatically; the pushed digest
 *is* the deploy trigger. It runs two ways — `workflow_dispatch` by hand, or
-called by `release.yml` after a `v*` tag publishes — and is gated three ways so
-only the org can ship an image:
+called by `release.yml` after it publishes the gem for a
+`lib/wurk/version.rb` bump landing on `main` (the tag is an output there, cut
+last; see [RELEASE.md](../RELEASE.md)) — and is gated three ways so only the
+org can ship an image:
 
 1. **Public repo + `workflow_dispatch`** → only users with *write* access (org
-   members) can trigger it; external forks cannot. A release-triggered run is
-   attributed to whoever pushed the tag, so gate 2 still applies to it.
+   members) can trigger it; external forks cannot.
 2. **`DEMO_DEPLOYERS` repo variable** (comma-separated GitHub usernames) → the
-   `authorize` job rejects anyone not listed.
+   `authorize` job rejects anyone not listed. Guards the `workflow_dispatch`
+   door only: a run called by `release.yml` passes `trusted: true`, which waives
+   the allowlist (honoured only from the `release` workflow on `main`) — by then
+   that caller has already published this commit's gem.
 3. **Protected `demo` environment** → add Required Reviewers. The gate sits on the
    `build` job (not a separate deploy job) because the digest push is what
    triggers the deploy, so approval must pause the run *before* the image ships.


### PR DESCRIPTION
Closes #480

## What

Three demo-side texts still described the retired tag-as-input release model.
This PR rewrites them against `release.yml` / `deploy-demo.yml` as they stand on
`main`. Comment/doc changes only — no workflow keys change.

## Why

The release lane switched to tag-as-output in 1.7.2 and gained the
`trusted: true` waiver in 1.7.3 (RELEASE.md:14-30, :61-66; release.yml:3-21,
:199-213). `release.yml` fires on a `lib/wurk/version.rb` push to `main` and
cuts the tag *last*, after the gem is live — nobody pushes a tag. Three texts
predate that:

- `docs/demo-deploy.md:40` said deploy-demo is "called by `release.yml` after a
  `v*` tag publishes".
- `docs/demo-deploy.md:44-45` said "A release-triggered run is attributed to
  whoever pushed the tag, so gate 2 still applies to it" — nobody pushes a tag,
  and gate 2 (the `DEMO_DEPLOYERS` allowlist) is explicitly waived on the
  release path by `trusted: true` (deploy-demo.yml authorize job).
- `Dockerfile:9-10` still carried the "starting scaffold for the deploy (#32)"
  NOTE, stale since docs/demo-deploy.md recorded every infra item live as of
  2026-07-21.

## Changes

- **docs/demo-deploy.md** — the trigger sentence now reads "called by
  `release.yml` after it publishes the gem for a `lib/wurk/version.rb` bump
  landing on `main` (the tag is an output there, cut last)" with a link to
  RELEASE.md. The three-gate list now states gate 1 is the `workflow_dispatch`
  write-access gate, and gate 2 **guards `workflow_dispatch` only**: a run
  called by `release.yml` passes `trusted: true`, which waives the allowlist —
  honoured only from the `release` workflow on `main`, because that caller has
  already published this commit's gem. Gate 3 (protected `demo` environment) is
  unchanged.
- **.github/workflows/deploy-demo.yml** — header comment lines 3-4 now say
  "after publishing the gem for a `lib/wurk/version.rb` bump landing on main
  (the tag is an output there, cut last)". No YAML keys, inputs, jobs, or steps
  touched.
- **Dockerfile** — deleted the stale "starting scaffold" NOTE (and its trailing
  blank line, leaving one blank before Stage 1). No build changes.

## Verification

The ruby gates **ran in CI only** — this box has no ruby, bundler, or redis, so
`bin/check` (rubocop / `rake test` / `rake test:parity`) could not be run
locally and was not attempted. What I did run here, with real output:

- Acceptance grep from the issue — **no matches** (exit 1):
  ```
  $ grep -n -E "v\*|pushed the tag|starting scaffold" \
      docs/demo-deploy.md .github/workflows/deploy-demo.yml Dockerfile
  (no output, exit 1)
  ```
- `actionlint .github/workflows/deploy-demo.yml` — **exit 0, zero diagnostics**.
- YAML parse of deploy-demo.yml — valid (parsed clean after the comment edit).
- Line length on every added line — longest is 81 chars, all under the
  Layout/LineLength 120 limit; no `rubocop:disable` directives added.
- `test/unit/docs_links_test.rb` — could not be executed (no ruby). Its only
  exposure to this change is the one new relative link `[RELEASE.md](../RELEASE.md)`
  in docs/demo-deploy.md; I mirrored the test's relative-link resolution
  (code-span stripping + fenced-block skipping + `File.exist?` against `docs/`)
  in a script and got **"broken relative links: none"** for the whole file. The
  two anchor tests don't apply — the link has no `#anchor`. CI runs the real test.
- Issue citations were checked against the tree before editing — all four line
  references matched HEAD (`511299f`); nothing was stale.

One commit, single-authored, no trailers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791033720&installation_model_id=11168&pr_number=515&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F515&signature=96504d9ef52cd89ca9d6c176a13179c10d2fbc3be7d11e17402912c0b850177c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->