### PR TITLE
chore: declare the ruby toolchain in mise.toml and install it from bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -3,6 +3,11 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+# The toolchain is text (mise.toml): a fleet box carries `mise` and no ruby of
+# its own, and installs the declared version into the runner user's home here.
+# Guarded, so a machine without mise (CI's setup-ruby, a laptop on rbenv) skips it.
+command -v mise >/dev/null && mise install
+
 echo "==> bundle install (gem)"
 bundle check >/dev/null 2>&1 || bundle install
 

--- a/bin/setup
+++ b/bin/setup
@@ -6,7 +6,13 @@ cd "$(dirname "$0")/.."
 # The toolchain is text (mise.toml): a fleet box carries `mise` and no ruby of
 # its own, and installs the declared version into the runner user's home here.
 # Guarded, so a machine without mise (CI's setup-ruby, a laptop on rbenv) skips it.
-command -v mise >/dev/null && mise install
+# `mise install` writes to the tool dir and changes nothing about THIS shell's
+# PATH, so the `bundle` / `bin/rails` calls below would otherwise run on whatever
+# ruby the caller had; the env eval activates the declared toolchain here.
+if command -v mise >/dev/null; then
+  mise install
+  eval "$(mise env -s bash)"
+fi
 
 echo "==> bundle install (gem)"
 bundle check >/dev/null 2>&1 || bundle install

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,6 @@
+# Toolchain, as text: the fleet box provides `mise` and nothing per-language, and
+# `bin/setup` runs `mise install` (guarded, so a box without mise skips it). The
+# version is the one the Dockerfile and the pages/ecosystem CI lanes run; the main
+# test lane runs 4.0 — change this line, not a box, to move the fleet.
+[tools]
+ruby = "3.4"


### PR DESCRIPTION
## What

Adds `mise.toml` pinning `ruby = "3.4"` and makes `bin/setup` run `command -v mise >/dev/null && mise install` before bundling.

## Why

The developerz.ai fleet installer stops apt-installing ruby on every box: the box provides `mise`, and a repo declares its toolchain as text. The line is guarded, so it is a no-op on boxes that still carry apt ruby and installs the pinned ruby on boxes that carry mise. 3.4 is the Dockerfile and pages CI version; flip to 4.0 if the main test lane should win.

## Verification

Two files, +11 lines. `bash -n bin/setup` clean. No behaviour change where mise is absent.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791034012&installation_model_id=11168&pr_number=517&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F517&signature=8060a467ba9fa5274cb61f747bc4aec3f6df0d94ceb1bd6b28a1c9540797680a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Project setup now automatically installs the configured development toolchain when `mise` is available.
  - Environments without `mise` continue setup without interruption.
  - Added centralized toolchain configuration using Ruby 3.4 to keep local development, containers, and continuous integration aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->