### PR TITLE
test: seed the unique kill entries not-yet-due, and push the deadline job only once its child is fetching

### DIFF
--- a/test/integration/timeout_hang_test.rb
+++ b/test/integration/timeout_hang_test.rb
@@ -142,8 +142,13 @@ class TimeoutHangTest < Wurk::Test::UnitCase
   # (private list empty — nothing left in flight), which flushes it deterministically.
   def test_a_genuinely_sleeping_job_past_its_deadline_is_abandoned_and_booked_expired
     run_swarm(shutdown_timeout: 10) do |swarm|
-      # Pushed AFTER boot: the deadline is absolute from the push, and a fork +
-      # boot on a loaded runner must not spend it before the job is fetched.
+      # Pushed only once the child is FETCHING: the deadline is absolute from
+      # the push, and `swarm.boot` returning is not the child being ready — on a
+      # loaded runner the fork + dummy-app boot outlived a 2 s cutoff and the
+      # job was expired at dequeue, never started (2026-09-03, twice). The
+      # child's first heartbeat lands after its processors start, so its
+      # identity in the live `processes` set is the readiness signal.
+      assert wait_for_child_identity, "no child fetching #{@queue_name} within the #{START_TIMEOUT}s startup timeout"
       jid = push(DeadlineHangWorker)
 
       assert wait_for_key(@started_key), "job never started within the #{START_TIMEOUT}s startup timeout"
@@ -245,6 +250,20 @@ class TimeoutHangTest < Wurk::Test::UnitCase
 
   def wait_for_key(key, timeout: START_TIMEOUT)
     wait_for(timeout: timeout) { @observer.call('GET', key) }
+  end
+
+  # This test's child in the live `processes` set, found by the unique queue
+  # it fetches (parallel test methods share one Redis DB). Same probe
+  # swarm_cli_test.rb uses.
+  def wait_for_child_identity(timeout: START_TIMEOUT)
+    wait_for(timeout: timeout) do
+      @observer.call('SMEMBERS', Wurk::Keys::PROCESSES).find do |id|
+        info = @observer.call('HGET', id, 'info')
+        info && Array(Wurk.load_json(info)['queues']).include?(@queue_name)
+      rescue ::JSON::ParserError
+        false
+      end
+    end
   end
 
   def wait_for_retry_entry(jid, timeout: POLL_TIMEOUT)

--- a/test/unit/unique_test.rb
+++ b/test/unit/unique_test.rb
@@ -606,7 +606,7 @@ class UniqueTest < Wurk::Test::UnitCase
     ENABLE_MUTEX.synchronize do
       Wurk::Unique.enable!
       job = build_job(jid: 'kill-1', ttl: 600, queue: "kill#{@suffix}")
-      key = seed_locked_retry_entry(job)
+      key = seed_locked_retry_entry(job, due: false)
       # FLUSHDB only runs per test class, so the DEAD zset can already hold
       # entries from earlier `die_unretryable` tests — assert the delta.
       before = redis_call('ZCARD', Wurk::Keys::DEAD)
@@ -626,7 +626,7 @@ class UniqueTest < Wurk::Test::UnitCase
     ENABLE_MUTEX.synchronize do
       Wurk::Unique.enable!
       job = build_job(jid: 'kill-2', ttl: 600, queue: "kill2#{@suffix}")
-      key = seed_locked_retry_entry(job)
+      key = seed_locked_retry_entry(job, due: false)
 
       observe_death_handlers do |observed|
         Wurk::RetrySet.new.find_job('kill-2').kill
@@ -929,12 +929,19 @@ class UniqueTest < Wurk::Test::UnitCase
   # Simulate a failed `unique_until: :success` job: the enqueue-time lock is
   # still held by its own jid while the payload waits in `retry`. Returns the
   # lock key (tracked for teardown).
-  def seed_locked_retry_entry(job)
+  #
+  # `due:` decides the score. A test that PROMOTES the entry needs it due; a
+  # test that looks it up by jid must NOT seed it due — this worker's Redis DB
+  # is shared with every class in the process, and a due entry is exactly what
+  # a scheduled poller left running by an earlier class pops before
+  # `find_job` runs ("undefined method 'kill' for nil", 2026-09-03).
+  def seed_locked_retry_entry(job, due: true)
     key = Wurk::Unique.lock_key_for(job)
     @keys << key
+    score = due ? ::Time.now.to_f - 1 : ::Time.now.to_f + 3600
     Wurk.redis do |c|
       c.call('SET', key, job['jid'], 'EX', 3600)
-      c.call('ZADD', Wurk::Keys::RETRY, (::Time.now.to_f - 1).to_s, Wurk.dump_json(job))
+      c.call('ZADD', Wurk::Keys::RETRY, score.to_s, Wurk.dump_json(job))
     end
     key
   end


### PR DESCRIPTION
**What**

Two more CI flakes on the loaded self-hosted runners, both in tests that were right about the behaviour and wrong about the clock.

**Why**

`main` went red on `UniqueTest#test_manual_ui_kill_retains_lock` (`undefined method 'kill' for nil`) and #517's rebased run went red on `TimeoutHangTest#..._past_its_deadline_...` (`job never started within the 90.0s startup timeout`) even after #518 pushed the job after boot.

**Changes**

- `test/unit/unique_test.rb`: `seed_locked_retry_entry(job, due: true)` gains a `due:` switch. The two UI-kill tests seed an entry an hour out, because a due entry in this worker's shared Redis DB is exactly what a scheduled poller left running by an earlier class pops before `find_job` runs. The promotion test keeps the due score.
- `test/integration/timeout_hang_test.rb`: the deadline test waits for its child's identity in the live `processes` set (matched on the test's unique queue, the same probe `swarm_cli_test.rb` uses) before pushing. `swarm.boot` returning is not the child fetching, and the deadline is absolute from the push.

**Verification**

`ruby -c` on both files. The behaviour under test is unchanged; only when the fixture is seeded moved. CI on this PR is the proof, and `main`'s next `test` run after merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791049348&installation_model_id=11168&pr_number=519&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F519&signature=7fc7d6926d4f2145ef94c5297159e7d59b0c0110866712ca759916053c970bb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->