### PR TITLE
test: seed the API mutation sorted-set fixtures not-yet-due

### DIFF
--- a/test/engine/api_mutations_test.rb
+++ b/test/engine/api_mutations_test.rb
@@ -295,9 +295,15 @@ class ApiMutationsTest < Wurk::Test::EngineCase
   end
 
   # Returns [score, jid] so callers can build the "<score>|<jid>" route key.
+  #
+  # Seeded an hour OUT, never due: no test in this file depends on the entry
+  # being due (the API acts on the key, not the clock), and a due entry in the
+  # worker's shared Redis DB is exactly what a scheduled poller still running
+  # from an earlier class pops before the request lands — `count: 0` on
+  # `test_bulk_deduplicates_repeated_keys` on main, 2026-09-03.
   def push_to_zset(name)
     payload = job_payload
-    score = ::Time.now.to_f
+    score = ::Time.now.to_f + 3600
     ::Wurk.redis { |c| c.call('ZADD', name, score.to_s, ::Wurk.dump_json(payload)) }
     [score, payload['jid']]
   end


### PR DESCRIPTION
**What**

`test/engine/api_mutations_test.rb` seeds its sorted-set fixtures an hour out instead of at `now`.

**Why**

`main` went red at 2ea17d4 on `ApiMutationsTest#test_bulk_deduplicates_repeated_keys` (`count` 0, expected 1). The fixture was due the instant it was written, and a due `retry` entry in the worker's shared Redis DB is what a scheduled poller still alive from an earlier class in the same process promotes before the request lands. Same class as the `UniqueTest` kill fixture fixed in #519.

**Changes**

- `push_to_zset` scores entries at `now + 3600`. No test in the file depends on the entry being due: the API acts on the `<score>|<jid>` key, never on the clock.

**Verification**

`ruby -c`; CI on this PR and `main`'s next `test` run.

**Follow-up**

The consumer itself, a poller thread or swarm child that outlives its test class, is still unidentified. Fixtures that do not need dueness now no longer depend on it, but a test that DOES need a due entry (`test_unique_retry_job_survives_promotion` keeps one) still can. Worth a leak detector on `Thread.list` names at class teardown.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791050334&installation_model_id=11168&pr_number=520&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F520&signature=c257d36b29d810471cdcafd9069f74fde82d498c06ddd6303c6aa6110f00c8a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test scheduling data to prevent future entries from being processed prematurely during API mutation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->