### PR TITLE
fix(check): gems not installed is a precondition, not a verdict on the diff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,14 +69,15 @@ treating it as unknown:
 
 | Exit | Trigger | Source |
 |---|---|---|
-| `0` | Every stage passed, OR `-h` / `--help` / `help` printed the help block without running any stage. | `bin/check:94-97`, `bin/check:23-26` |
-| `1` | At least one stage reported failure. | `bin/check:99-100` |
+| `0` | Every stage passed, OR `-h` / `--help` / `help` printed the help block without running any stage. | `bin/check:112-115`, `bin/check:23-26` |
+| `1` | At least one stage reported failure. | `bin/check:117-118` |
 | `64` | Unrecognised mode argument — anything other than `''`, `pr`, `fast`, `full`, `-h`, `--help`, or `help`. | `bin/check:27-30` |
 | `75` | No bundler on `PATH` — the environment cannot run the Ruby gate at all. | `bin/check:62-66` |
-| `75` | No Redis on `127.0.0.1:6379`. | `bin/check:74-78` |
+| `75` | Bundler is on `PATH` but the gems are not installed — `bin/setup` has never run here. | `bin/check:80-84` |
+| `75` | No Redis on `127.0.0.1:6379`. | `bin/check:92-96` |
 
-`75` is the platform's "preconditions unmet" code, and both triggers share it on
-purpose: neither says anything about the diff. A gate that cannot reach its Redis,
+`75` is the platform's "preconditions unmet" code, and all three triggers share it
+on purpose: none of them says anything about the diff. A gate that cannot reach its Redis,
 or cannot find the bundler it runs every stage through, has established NOTHING —
 so it must not exit `1`, which means "the gate ran and judged the change". An
 automated maintainer reads `1` as a red diff and sends its agent hunting a bug
@@ -84,8 +85,8 @@ nobody wrote.
 
 ### Env knobs
 
-- `SKIP_LINT=1` — drop the rubocop stage (`bin/check:80`).
-- `SKIP_PARITY=1` — drop the parity oracles stage (`bin/check:87`).
+- `SKIP_LINT=1` — drop the rubocop stage (`bin/check:98`).
+- `SKIP_PARITY=1` — drop the parity oracles stage (`bin/check:106`).
 - `NCPU=<n>` — see [Worker count](#worker-count) below for the trade-off (ceiling 14).
 
 The individual tasks, when you want one:

--- a/bin/check
+++ b/bin/check
@@ -65,6 +65,24 @@ if ! command -v bundle >/dev/null 2>&1; then
   exit 75
 fi
 
+# Bundler ON PATH is not the same as the bundle being INSTALLED, and the gap
+# between them is the third way this gate can report a verdict it never reached.
+# A box that has ruby and bundler but has never run `bin/setup` fails every
+# `bundle exec` stage below with "Could not find gem ..." — swallowed into
+# `failed[]` exactly like the 127 above, and exiting 1: "the gate ran and judged
+# the change". It did not. Same laundering as the two guards either side of this
+# one, one layer further in.
+#
+# `bundle check` is the probe `bin/setup:18` already trusts for this exact
+# question (`bundle check >/dev/null 2>&1 || bundle install`), so this adds no
+# new technique and no new dependency — it asks the question the setup script
+# asks, at the moment the gate needs the answer.
+if ! bundle check >/dev/null 2>&1; then
+  echo "bin/check: gems are not installed — this environment cannot run the Ruby gate." >&2
+  echo "  run bin/setup first, or:  bundle install" >&2
+  exit 75
+fi
+
 # Redis is not optional — integration and parity tests use a real server, never
 # a mock (CLAUDE.md). Refuse with the platform's preconditions-unmet contract
 # code (apps/runner/src/modes/setup/base.ts, CHECK_EXIT_PRECONDITIONS_UNMET =


### PR DESCRIPTION
## What & why

Closes #497.

`bin/check` had two `exit 75` preconditions guards and needed a third. Bundler being **on `PATH`** is not the same as the bundle being **installed**, and the gap between them was the remaining way this gate could report a verdict it never reached.

A box with ruby and bundler that has never run `bin/setup` fails every `bundle exec` stage with `Could not find gem …`. `stage()` runs its command inside an `if` (`bin/check:46`), so that failure does not abort under `set -e` — it is swallowed into `failed[]` and the script exits **1**. Exit 1 means *"the gate ran and judged the change"*. It did not. Same laundering #495 and #496 already fixed either side of this one, one layer further in.

**This is not hypothetical for this repo.** `developerz-ai/developerz.ai` runs its maintainer agent against wurk, and its runner grades a gate purely by exit code: `1` is a red diff and the agent is told its edit is wrong. Measured on that platform's prod, 7 days: every wurk coding task that reached the gate died with every stage failing in **0s** and exit 1 — the signature of absent tooling, not of a bad change. The agent then spends its full attempt ladder hunting a bug it did not write.

## The change

Four lines of guard, beside the two that already exist, using the probe this repo already trusts for exactly this question — `bin/setup:18` is `bundle check >/dev/null 2>&1 || bundle install`, so no new technique and no new dependency:

```sh
if ! bundle check >/dev/null 2>&1; then
  echo "bin/check: gems are not installed — this environment cannot run the Ruby gate." >&2
  echo "  run bin/setup first, or:  bundle install" >&2
  exit 75
fi
```

Placed after the `command -v bundle` guard and before the Redis one, which is the dependency order: bundler on PATH → gems installed → Redis reachable.

`CONTRIBUTING.md`'s exit-code table gains the row, and its prose moves from "both triggers share it" to "all three".

## Verification

Run against a fake `bundle` that reports the exact gap — `check` exits 1, `exec` exits 7 with `Could not find gem` — which is precisely a box with the binary and no gems:

**Without the guard (the bug):**
```
bin/check ✗ failed: rubocop test suite (unit + integration + engine) parity oracles  (0s)
exit code: 1
```
Every stage failing in `(0s)` and exit 1 — byte-for-byte the signature seen in the platform's prod.

**With the guard:**
```
bin/check: gems are not installed — this environment cannot run the Ruby gate.
  run bin/setup first, or:  bundle install
exit code: 75
```

And the guard above it still wins when there is no bundler at all — `PATH=/usr/bin:/bin bin/check` still exits 75 with the `no bundler on PATH` message, so the new guard does not shadow it.

`bash -n bin/check` clean. No Ruby code changed, so no test layer applies — the change is a shell precondition and it is proven by running the script both ways.

## Line references

Adding the guard shifted `bin/check`, so every `bin/check:NN` citation in `CONTRIBUTING.md` was re-checked against the new file, not just the ones in the table. Two outside the table had gone stale and are corrected: `SKIP_LINT` (`:80` → `:98`) and `SKIP_PARITY` (`:87` → `:106`). All ten citations now resolve to the construct they name.

## Checklist

- [x] Tests added/updated at the right layer — n/a, shell precondition; verified by running `bin/check` both ways (above)
- [x] `bin/check` passes locally — cannot be run to completion here (no Ruby toolchain in this environment); both guard arms exercised directly and `bash -n` is clean. CI runs the real gate.
- [x] No Redis key, JSON field, or sorted-set score format changed
- [x] Public Sidekiq surface unchanged
- [x] Coverage on `lib/` unaffected — no `lib/` change

## How to test in prod

On any box that has ruby and bundler but no installed bundle:

```sh
cd <a wurk checkout>
bundle check || echo "gems missing — the case this guards"
./bin/check pr; echo "exit=$?"     # expect 75, not 1
```

On the developerz.ai platform side, a wurk coding run that hits this now reports
`no_verdict` / `preconditions_unmet` rather than a red diff, which that platform
gives a full attempt ladder rather than a terminal failure.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791095419&installation_model_id=11168&pr_number=521&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F521&signature=eecd31fabd72be95165fdf6e4daafa5d862472dc3f59c36b24f523ecc592d793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved environment checks to detect missing Ruby gems before validation runs.
  - Added clear setup guidance when required gems are unavailable.
  - Standardized this condition to return exit code 75, consistent with other local environment prerequisites.

- **Documentation**
  - Updated contributor guidance to describe dependency and local Redis prerequisites.
  - Clarified exit-code behavior and refreshed environment-variable references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->