### PR TITLE
fix(encryption): drop the quirks_mode kwarg json 3.0.0 removed

### DIFF
--- a/lib/wurk/encryption.rb
+++ b/lib/wurk/encryption.rb
@@ -150,7 +150,13 @@ module Wurk
         version = Integer(envelope['v'])
         cipher = build_decrypt_cipher(envelope, key_for(version))
         plain = cipher.update(::Base64.strict_decode64(envelope['ct'])) + cipher.final
-        ::JSON.parse(plain, quirks_mode: true)
+        # No `quirks_mode:` — an encrypted arg may be a bare scalar ("hi", 42,
+        # null), and every json the gemspec's `>= 3.2` floor can resolve parses
+        # those at the top level by default (RFC 7159, json >= 2.0). The option
+        # was therefore already a no-op, and json 3.0.0 removed it outright:
+        # passing it raises ArgumentError and every encrypted job dies in the
+        # server middleware.
+        ::JSON.parse(plain)
       end
 
       # @return [Boolean] true if `value` looks like a Wurk crypto envelope.


### PR DESCRIPTION
## What

`Encryption.decrypt` called `JSON.parse(plain, quirks_mode: true)`. **json 3.0.0 removed that keyword**, so the call now raises `ArgumentError: unknown keyword: quirks_mode`. This drops the keyword.

## Why `main` is red with no PR at fault

`Gemfile.lock` is gitignored, so every fresh resolve — CI's and a new contributor's — now picks json 3.0.0. The `test + coverage` job on `a80034b` (`main` HEAD, the merge of #523) failed with **10 errors, all `EncryptionTest`**, while lint, parity and frontend stayed green:

```
EncryptionTest#test_encrypt_decrypt_roundtrip_hash:
ArgumentError: unknown keyword: quirks_mode
EncryptionTest#test_server_middleware_propagates_perform_return:
Wurk::JobRetry::Skip: encryption_error: ArgumentError
4303 runs, 11860 assertions, 0 failures, 10 errors, 6 skips
```

This is the shape #471 describes for rubocop, one dependency release later: an unpinned dependency reddens a required check with no diff to blame. The user-visible impact is worse than CI, though — **every encrypted job fails in the server middleware** on json 3, since `decrypt` is on the job path, not just the test path.

## Why dropping it is safe, not just expedient

The option was already a no-op here. It mattered only before json 2.0, when `JSON.parse` rejected a top-level scalar; RFC 7159 made any JSON value legal at the top level and json has parsed bare scalars by default ever since. An encrypted arg can be a bare scalar, so that is the case worth checking — and I checked it on both sides rather than assuming:

| json | `JSON.parse("\"hello\"")` | `JSON.parse("123")` | `JSON.parse("null")` |
|---|---|---|---|
| 2.7.2 | `"hello"` | `123` | `nil` |
| 3.0.0 | `"hello"` | `123` | `nil` |

So the behaviour is identical across every json the gemspec's `>= 3.2` Ruby floor can resolve. No `Gemfile` pin is needed, and pinning would only defer this.

## Tests

No new test. `test/unit/encryption_test.rb` already covers the string / array / hash round-trips, rotation, and both middleware — those are precisely the ten CI reported failing. They fail before this change and pass after, which is the regression guard.

## Verification

Local, Ruby 3.4.10, against real `redis:7.4` (the image `test.yml` runs):

- `bin/check` (rubocop + unit + integration + engine + parity) — **all green in 192s**, `4303 runs, 11882 assertions, 0 failures, 0 errors`. Same 4303 runs CI counted, now with zero errors.
- `test/unit/encryption_test.rb` alone: `47 runs, 107 assertions, 0 failures` (was 11 errors).

## Assumptions

- Fixing the call site beats pinning `json < 3` in the `Gemfile`: the gem is a library, a pin would propagate a needless constraint to every host app, and the keyword genuinely buys nothing.
- Scope kept to the one line. The broader "an unpinned dependency release can redden `main`" problem is #471's, not this PR's.

🤖 Done with [ai-maxxing](https://github.com/developerz-ai/ai-maxxing) on ovh-1b · anthropic/claude-sonnet-4.5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791390373&installation_model_id=11168&pr_number=524&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F524&signature=64fbb81e9ff6805caa1cbc072f22b5bac8da0e92356c9013492edbb4471c9bcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decryption compatibility with newer JSON parsing behavior.
  * Decrypted data now correctly supports top-level scalar values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->