### PR TITLE
fix(policy): drop explicit escalate.always, let the schema default apply

### DIFF
--- a/.dz/maintainer/maintainer.yml
+++ b/.dz/maintainer/maintainer.yml
@@ -178,7 +178,6 @@ release:
   channels: []
 
 escalate:
-  always: [security, license, cla]
   ask_before_acting: [breaking_change, major_dep_bump, first_time_contributor, large_pr]
 
 limits:


### PR DESCRIPTION
## What

One-line policy edit in `.dz/maintainer/maintainer.yml`: remove the explicit `escalate.always: [security, license, cla]` line so the schema default applies. `ask_before_acting` is untouched. Nothing else in the file or the repo changes.

On its face this reads like someone deleting security escalation. It is not — it is strictly more escalation, not less. The reasoning:

## Why this is safe (and an increase)

- `security`, `license` and `cla` are `HARDCODED_ALWAYS` (`packages/domain/src/entities/escalation.ts:19` in developerz-ai/developerz.ai) — a **code** constant. Immediacy is computed as `fires_immediately: HARDCODED_ALWAYS_SET.has(category)` (`packages/mcp/src/army/issue.ts:260`) — from that set, **not** from this policy file. Listing them here changes nothing about whether they escalate.
- What listing them **does** do is override the schema default for `escalate.always`, which drops `hostile_tone` and `direct_mention` coverage. The explicit list is redundant on its face and quietly **reduces** escalation.
- Removing it therefore keeps security/license/cla escalating exactly as now, and **restores** hostile_tone/direct_mention.

## Convergence with developerz-ai/developerz.ai#3400

It also makes wurk converge with the autonomous posture `renderAutonomousPolicy` emits, which #3400 requires of wurk as the reference repo: `AI_MANAGED` with `changes: []`. This one key was the only delta.

Note on #3400's wording: it says "if wurk does not converge, the renderer or the ruleset client is wrong, not wurk". That note was written before the `HARDCODED_ALWAYS` mechanism above was traced. The repo owner (ivndev001) reviewed both readings on 2026-09-11 and chose to change wurk's policy rather than the renderer, precisely because the renderer's value is the safer one.

## Gates

`bin/check fast` was **not run**: this environment has no Ruby toolchain, and the gate refused on its own — `bin/check: no bundler on PATH — this environment cannot run the Ruby gate.` No gate is claimed that was not executed. The change touches no Ruby (a single YAML line), so the Ruby suite would not exercise it in any case; CI will run it on this PR regardless.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/developerz-ai/codesmith/wurk/pr/529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791705518&installation_model_id=11168&pr_number=529&repository=developerz-ai%2Fwurk&return_to=https%3A%2F%2Fgithub.com%2Fdeveloperz-ai%2Fwurk%2Fpull%2F529&signature=b12c6910607077292c64be25a054ece212f7b8f14dd9e3b456188288a56f2a67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Removed the setting that enabled escalation in all cases.
  - Escalation remains available for specifically configured conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->